### PR TITLE
Initial encodings

### DIFF
--- a/noaa/gefs/forecast/template.py
+++ b/noaa/gefs/forecast/template.py
@@ -31,7 +31,7 @@ _CHUNKS_ORDERED = tuple(_CHUNKS[dim] for dim in _DIMS)
 _FLOAT_DEFAULT = {
     "dtype": np.float32,
     "chunks": _CHUNKS_ORDERED,
-    "filters": [BitRound(keepbits=8)],
+    "filters": [BitRound(keepbits=7)],
     "compressor": Blosc(cname="zstd", clevel=3, shuffle=Blosc.SHUFFLE),
 }
 _CATEGORICAL_WITH_MISSING_DEFAULT = {
@@ -46,15 +46,15 @@ _ENCODING = {
     "crain": _CATEGORICAL_WITH_MISSING_DEFAULT,
     "csnow": _CATEGORICAL_WITH_MISSING_DEFAULT,
     "d2m": {**_FLOAT_DEFAULT, "add_offset": 273.15},
-    "gh": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=9)]},
-    "gust": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=7)]},
+    "gh": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=8)]},
+    "gust": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=6)]},
     "hlcy": _FLOAT_DEFAULT,
     "mslet": {**_FLOAT_DEFAULT, "add_offset": 101_000.0},
-    "mslhf": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=7)]},
-    "msshf": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=7)]},
+    "mslhf": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=6)]},
+    "msshf": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=6)]},
     "prmsl": {**_FLOAT_DEFAULT, "add_offset": 101_000.0},
     "pwat": _FLOAT_DEFAULT,
-    "r2": {**_FLOAT_DEFAULT, "add_offset": 50.0, "filters": [BitRound(keepbits=7)]},
+    "r2": {**_FLOAT_DEFAULT, "add_offset": 50.0, "filters": [BitRound(keepbits=6)]},
     "sde": _FLOAT_DEFAULT,
     "sdlwrf": {**_FLOAT_DEFAULT, "add_offset": 300.0},
     "sdswrf": _FLOAT_DEFAULT,
@@ -69,8 +69,8 @@ _ENCODING = {
     "tmax": {**_FLOAT_DEFAULT, "add_offset": 273.15},
     "tmin": {**_FLOAT_DEFAULT, "add_offset": 273.15},
     "tp": _FLOAT_DEFAULT,
-    "u10": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=7)]},
-    "v10": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=7)]},
+    "u10": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=6)]},
+    "v10": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=6)]},
     "vis": {**_FLOAT_DEFAULT, "add_offset": 15_000.0},
 }
 

--- a/noaa/gefs/forecast/template.py
+++ b/noaa/gefs/forecast/template.py
@@ -1,9 +1,10 @@
 from collections.abc import Hashable
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import xarray as xr
-import zarr  # type: ignore
+from numcodecs import BitRound, Blosc  # type: ignore
 
 from common.config import Config  # noqa:F401
 from common.download_directory import cd_into_download_directory
@@ -15,12 +16,62 @@ TEMPLATE_PATH = "noaa/gefs/forecast/templates/latest.zarr"
 _DATASET_ID = "noaa-gefs-forecast"
 _INIT_TIME_START = pd.Timestamp("2024-09-01T00:00")
 _INIT_TIME_FREQUENCY = pd.Timedelta("6h")
+_DIMS = ("init_time", "ensemble_member", "lead_time", "latitude", "longitude")
 _CHUNKS = {
     "init_time": 1,
     "ensemble_member": 31,  # all ensemble members in one chunk
     "lead_time": 125,  # all lead times in one chunk
     "latitude": 73,  # 10 chunks over 721 pixels
     "longitude": 72,  # 20 chunks over 1440 pixels
+}
+_CHUNKS_ORDERED = tuple(_CHUNKS[dim] for dim in _DIMS)
+
+# Use this with an additional add_offset: <median> option
+# to minimize loss from binary rounding
+_FLOAT_DEFAULT = {
+    "dtype": np.float32,
+    "chunks": _CHUNKS_ORDERED,
+    "filters": [BitRound(keepbits=8)],
+    "compressor": Blosc(cname="zstd", clevel=3, shuffle=Blosc.SHUFFLE),
+}
+_CATEGORICAL_DEFAULT = {
+    "dtype": np.uint8,
+    "chunks": _CHUNKS_ORDERED,
+    "compressor": Blosc(cname="zstd", clevel=3, shuffle=Blosc.SHUFFLE),
+}
+_ENCODING = {
+    "cfrzr": _CATEGORICAL_DEFAULT,
+    "cicep": _CATEGORICAL_DEFAULT,
+    "cpofp": _FLOAT_DEFAULT,
+    "crain": _CATEGORICAL_DEFAULT,
+    "csnow": _CATEGORICAL_DEFAULT,
+    "d2m": {**_FLOAT_DEFAULT, "add_offset": 273.15},
+    "gh": {**_FLOAT_DEFAULT, "filters": [BitRound(keepbits=9)]},
+    "gust": _FLOAT_DEFAULT,
+    "hlcy": _FLOAT_DEFAULT,
+    "mslet": {**_FLOAT_DEFAULT, "add_offset": 101_000.0},
+    "mslhf": _FLOAT_DEFAULT,
+    "msshf": _FLOAT_DEFAULT,
+    "prmsl": {**_FLOAT_DEFAULT, "add_offset": 101_000.0},
+    "pwat": _FLOAT_DEFAULT,
+    "r2": {**_FLOAT_DEFAULT, "add_offset": 50.0},
+    "sde": _FLOAT_DEFAULT,
+    "sdlwrf": {**_FLOAT_DEFAULT, "add_offset": 300.0},
+    "sdswrf": _FLOAT_DEFAULT,
+    "sdwe": _FLOAT_DEFAULT,
+    "sithick": _FLOAT_DEFAULT,
+    "soilw": _FLOAT_DEFAULT,
+    "sp": {**_FLOAT_DEFAULT, "add_offset": 100_000.0},
+    "st": {**_FLOAT_DEFAULT, "add_offset": 273.15},
+    "suswrf": _FLOAT_DEFAULT,
+    "t2m": {**_FLOAT_DEFAULT, "add_offset": 273.15},
+    "tcc": {**_FLOAT_DEFAULT, "add_offset": 50.0},
+    "tmax": {**_FLOAT_DEFAULT, "add_offset": 273.15},
+    "tmin": {**_FLOAT_DEFAULT, "add_offset": 273.15},
+    "tp": _FLOAT_DEFAULT,
+    "u10": _FLOAT_DEFAULT,
+    "v10": _FLOAT_DEFAULT,
+    "vis": {**_FLOAT_DEFAULT, "add_offset": 15_000.0},
 }
 
 
@@ -33,8 +84,16 @@ def get_template(init_time_end: DatetimeLike) -> xr.Dataset:
     ds = ds.chunk(init_time=_CHUNKS["init_time"])
 
     # Uncomment to make smaller zarr while developing
-    # if Config.is_dev():
-    #     ds = ds.isel(ensemble_member=slice(5), lead_time=slice(24))
+    if Config.is_dev():
+        ds = ds.isel(ensemble_member=slice(5), lead_time=slice(24))
+
+    ds["gh"].encoding = {
+        "dtype": np.float32,
+        "chunks": [_CHUNKS[str(dim)] for dim in ds["sp"].dims],
+        "filters": [BitRound(keepbits=9)],
+        "compressor": Blosc(cname="zstd", clevel=3, shuffle=Blosc.SHUFFLE),
+    }
+    ds = ds[["gh"]]
 
     return ds
 
@@ -48,8 +107,7 @@ def _get_init_time_coordinates(
 
 
 def update_template() -> None:
-    dims = ("init_time", "ensemble_member", "lead_time", "latitude", "longitude")
-    assert dims == tuple(_CHUNKS.keys())
+    assert _DIMS == tuple(_CHUNKS.keys())
 
     coords = {
         "init_time": _get_init_time_coordinates(
@@ -62,6 +120,9 @@ def update_template() -> None:
         "latitude": np.flip(np.arange(-90, 90.25, 0.25)),
         "longitude": np.arange(-180, 180, 0.25),
     }
+
+    # Resolve to absolue path before changing directories
+    template_path = Path(TEMPLATE_PATH).absolute()
 
     # Pull a single file to load variable names and metadata.
     # Use a lead time > 0 because not all variables are present at lead time == 0.
@@ -83,13 +144,14 @@ def update_template() -> None:
             ds[var_name].encoding = {
                 "dtype": np.float32,
                 "chunks": [_CHUNKS[str(dim)] for dim in data_var.dims],
-                "compressor": zarr.Blosc(cname="zstd", clevel=4),
+                "filters": [BitRound(keepbits=9)],
+                "compressor": Blosc(cname="zstd", clevel=3, shuffle=Blosc.SHUFFLE),
             }
 
         # TODO
         # Explicit coords encoding
         # Improve metadata
-        ds.to_zarr(TEMPLATE_PATH, mode="w", compute=False)
+        ds.to_zarr(template_path, mode="w", compute=False)
 
 
 def chunk_args(ds: xr.Dataset) -> dict[Hashable, int]:

--- a/noaa/gefs/forecast/templates/latest.zarr/.zmetadata
+++ b/noaa/gefs/forecast/templates/latest.zarr/.zmetadata
@@ -21,7 +21,7 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
@@ -89,7 +89,7 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
@@ -157,14 +157,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -225,7 +230,7 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
@@ -293,7 +298,7 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
@@ -361,14 +366,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -415,145 +425,10 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 273.15,
             "long_name": "2 metre dewpoint temperature",
             "standard_name": "unknown",
             "units": "K"
-        },
-        "dlwrf/.zarray": {
-            "chunks": [
-                1,
-                31,
-                125,
-                73,
-                72
-            ],
-            "compressor": {
-                "blocksize": 0,
-                "clevel": 4,
-                "cname": "zstd",
-                "id": "blosc",
-                "shuffle": 1
-            },
-            "dtype": "<f4",
-            "fill_value": "NaN",
-            "filters": null,
-            "order": "C",
-            "shape": [
-                1,
-                31,
-                81,
-                721,
-                1440
-            ],
-            "zarr_format": 2
-        },
-        "dlwrf/.zattrs": {
-            "GRIB_NV": 0,
-            "GRIB_Nx": 1440,
-            "GRIB_Ny": 721,
-            "GRIB_cfName": "unknown",
-            "GRIB_cfVarName": "dlwrf",
-            "GRIB_dataType": "cf",
-            "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
-            "GRIB_gridType": "regular_ll",
-            "GRIB_iDirectionIncrementInDegrees": 0.25,
-            "GRIB_iScansNegatively": 0,
-            "GRIB_jDirectionIncrementInDegrees": 0.25,
-            "GRIB_jPointsAreConsecutive": 0,
-            "GRIB_jScansPositively": 0,
-            "GRIB_latitudeOfFirstGridPointInDegrees": 90.0,
-            "GRIB_latitudeOfLastGridPointInDegrees": -90.0,
-            "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
-            "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
-            "GRIB_missingValue": 3.4028234663852886e+38,
-            "GRIB_name": "Downward long-wave radiation flux",
-            "GRIB_numberOfPoints": 1038240,
-            "GRIB_paramId": 260097,
-            "GRIB_shortName": "dlwrf",
-            "GRIB_stepType": "avg",
-            "GRIB_stepUnits": 1,
-            "GRIB_totalNumber": 30,
-            "GRIB_typeOfLevel": "surface",
-            "GRIB_units": "W m**-2",
-            "GRIB_uvRelativeToGrid": 0,
-            "_ARRAY_DIMENSIONS": [
-                "init_time",
-                "ensemble_member",
-                "lead_time",
-                "latitude",
-                "longitude"
-            ],
-            "long_name": "Downward long-wave radiation flux",
-            "standard_name": "unknown",
-            "units": "W m**-2"
-        },
-        "dswrf/.zarray": {
-            "chunks": [
-                1,
-                31,
-                125,
-                73,
-                72
-            ],
-            "compressor": {
-                "blocksize": 0,
-                "clevel": 4,
-                "cname": "zstd",
-                "id": "blosc",
-                "shuffle": 1
-            },
-            "dtype": "<f4",
-            "fill_value": "NaN",
-            "filters": null,
-            "order": "C",
-            "shape": [
-                1,
-                31,
-                81,
-                721,
-                1440
-            ],
-            "zarr_format": 2
-        },
-        "dswrf/.zattrs": {
-            "GRIB_NV": 0,
-            "GRIB_Nx": 1440,
-            "GRIB_Ny": 721,
-            "GRIB_cfName": "unknown",
-            "GRIB_cfVarName": "dswrf",
-            "GRIB_dataType": "cf",
-            "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
-            "GRIB_gridType": "regular_ll",
-            "GRIB_iDirectionIncrementInDegrees": 0.25,
-            "GRIB_iScansNegatively": 0,
-            "GRIB_jDirectionIncrementInDegrees": 0.25,
-            "GRIB_jPointsAreConsecutive": 0,
-            "GRIB_jScansPositively": 0,
-            "GRIB_latitudeOfFirstGridPointInDegrees": 90.0,
-            "GRIB_latitudeOfLastGridPointInDegrees": -90.0,
-            "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
-            "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
-            "GRIB_missingValue": 3.4028234663852886e+38,
-            "GRIB_name": "Downward short-wave radiation flux",
-            "GRIB_numberOfPoints": 1038240,
-            "GRIB_paramId": 260087,
-            "GRIB_shortName": "dswrf",
-            "GRIB_stepType": "avg",
-            "GRIB_stepUnits": 1,
-            "GRIB_totalNumber": 30,
-            "GRIB_typeOfLevel": "surface",
-            "GRIB_units": "W m**-2",
-            "GRIB_uvRelativeToGrid": 0,
-            "_ARRAY_DIMENSIONS": [
-                "init_time",
-                "ensemble_member",
-                "lead_time",
-                "latitude",
-                "longitude"
-            ],
-            "long_name": "Downward short-wave radiation flux",
-            "standard_name": "unknown",
-            "units": "W m**-2"
         },
         "ensemble_member/.zarray": {
             "chunks": [
@@ -590,14 +465,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 8
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -658,14 +538,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 6
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -726,14 +611,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -897,14 +787,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -951,6 +846,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 101000.0,
             "long_name": "MSLP (Eta model reduction)",
             "standard_name": "unknown",
             "units": "Pa"
@@ -965,14 +861,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 6
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1033,14 +934,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 6
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1101,14 +1007,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1155,6 +1066,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 101000.0,
             "long_name": "Pressure reduced to MSL",
             "standard_name": "unknown",
             "units": "Pa"
@@ -1169,14 +1081,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1237,14 +1154,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 6
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1291,6 +1213,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 50.0,
             "long_name": "2 metre relative humidity",
             "standard_name": "relative_humidity",
             "units": "%"
@@ -1305,14 +1228,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1363,6 +1291,153 @@
             "standard_name": "lwe_thickness_of_surface_snow_amount",
             "units": "m"
         },
+        "sdlwrf/.zarray": {
+            "chunks": [
+                1,
+                31,
+                125,
+                73,
+                72
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 3,
+                "cname": "zstd",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f4",
+            "fill_value": "NaN",
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
+            "order": "C",
+            "shape": [
+                1,
+                31,
+                81,
+                721,
+                1440
+            ],
+            "zarr_format": 2
+        },
+        "sdlwrf/.zattrs": {
+            "GRIB_NV": 0,
+            "GRIB_Nx": 1440,
+            "GRIB_Ny": 721,
+            "GRIB_cfName": "unknown",
+            "GRIB_cfVarName": "sdlwrf",
+            "GRIB_dataType": "cf",
+            "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
+            "GRIB_gridType": "regular_ll",
+            "GRIB_iDirectionIncrementInDegrees": 0.25,
+            "GRIB_iScansNegatively": 0,
+            "GRIB_jDirectionIncrementInDegrees": 0.25,
+            "GRIB_jPointsAreConsecutive": 0,
+            "GRIB_jScansPositively": 0,
+            "GRIB_latitudeOfFirstGridPointInDegrees": 90.0,
+            "GRIB_latitudeOfLastGridPointInDegrees": -90.0,
+            "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
+            "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
+            "GRIB_missingValue": 3.4028234663852886e+38,
+            "GRIB_name": "Surface downward long-wave radiation flux",
+            "GRIB_numberOfPoints": 1038240,
+            "GRIB_paramId": 260097,
+            "GRIB_shortName": "sdlwrf",
+            "GRIB_stepType": "avg",
+            "GRIB_stepUnits": 1,
+            "GRIB_totalNumber": 30,
+            "GRIB_typeOfLevel": "surface",
+            "GRIB_units": "W m**-2",
+            "GRIB_uvRelativeToGrid": 0,
+            "_ARRAY_DIMENSIONS": [
+                "init_time",
+                "ensemble_member",
+                "lead_time",
+                "latitude",
+                "longitude"
+            ],
+            "add_offset": 300.0,
+            "long_name": "Surface downward long-wave radiation flux",
+            "standard_name": "unknown",
+            "units": "W m**-2"
+        },
+        "sdswrf/.zarray": {
+            "chunks": [
+                1,
+                31,
+                125,
+                73,
+                72
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 3,
+                "cname": "zstd",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f4",
+            "fill_value": "NaN",
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
+            "order": "C",
+            "shape": [
+                1,
+                31,
+                81,
+                721,
+                1440
+            ],
+            "zarr_format": 2
+        },
+        "sdswrf/.zattrs": {
+            "GRIB_NV": 0,
+            "GRIB_Nx": 1440,
+            "GRIB_Ny": 721,
+            "GRIB_cfName": "unknown",
+            "GRIB_cfVarName": "sdswrf",
+            "GRIB_dataType": "cf",
+            "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
+            "GRIB_gridType": "regular_ll",
+            "GRIB_iDirectionIncrementInDegrees": 0.25,
+            "GRIB_iScansNegatively": 0,
+            "GRIB_jDirectionIncrementInDegrees": 0.25,
+            "GRIB_jPointsAreConsecutive": 0,
+            "GRIB_jScansPositively": 0,
+            "GRIB_latitudeOfFirstGridPointInDegrees": 90.0,
+            "GRIB_latitudeOfLastGridPointInDegrees": -90.0,
+            "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
+            "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
+            "GRIB_missingValue": 3.4028234663852886e+38,
+            "GRIB_name": "Surface downward short-wave radiation flux",
+            "GRIB_numberOfPoints": 1038240,
+            "GRIB_paramId": 260087,
+            "GRIB_shortName": "sdswrf",
+            "GRIB_stepType": "avg",
+            "GRIB_stepUnits": 1,
+            "GRIB_totalNumber": 30,
+            "GRIB_typeOfLevel": "surface",
+            "GRIB_units": "W m**-2",
+            "GRIB_uvRelativeToGrid": 0,
+            "_ARRAY_DIMENSIONS": [
+                "init_time",
+                "ensemble_member",
+                "lead_time",
+                "latitude",
+                "longitude"
+            ],
+            "long_name": "Surface downward short-wave radiation flux",
+            "standard_name": "unknown",
+            "units": "W m**-2"
+        },
         "sdwe/.zarray": {
             "chunks": [
                 1,
@@ -1373,14 +1448,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1441,14 +1521,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1509,14 +1594,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1577,14 +1667,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1631,6 +1726,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 100000.0,
             "long_name": "Surface pressure",
             "standard_name": "surface_air_pressure",
             "units": "Pa"
@@ -1645,14 +1741,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1699,9 +1800,83 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 273.15,
             "long_name": "Soil temperature",
             "standard_name": "unknown",
             "units": "K"
+        },
+        "suswrf/.zarray": {
+            "chunks": [
+                1,
+                31,
+                125,
+                73,
+                72
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 3,
+                "cname": "zstd",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f4",
+            "fill_value": "NaN",
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
+            "order": "C",
+            "shape": [
+                1,
+                31,
+                81,
+                721,
+                1440
+            ],
+            "zarr_format": 2
+        },
+        "suswrf/.zattrs": {
+            "GRIB_NV": 0,
+            "GRIB_Nx": 1440,
+            "GRIB_Ny": 721,
+            "GRIB_cfName": "unknown",
+            "GRIB_cfVarName": "suswrf",
+            "GRIB_dataType": "cf",
+            "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
+            "GRIB_gridType": "regular_ll",
+            "GRIB_iDirectionIncrementInDegrees": 0.25,
+            "GRIB_iScansNegatively": 0,
+            "GRIB_jDirectionIncrementInDegrees": 0.25,
+            "GRIB_jPointsAreConsecutive": 0,
+            "GRIB_jScansPositively": 0,
+            "GRIB_latitudeOfFirstGridPointInDegrees": 90.0,
+            "GRIB_latitudeOfLastGridPointInDegrees": -90.0,
+            "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
+            "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
+            "GRIB_missingValue": 3.4028234663852886e+38,
+            "GRIB_name": "Surface upward short-wave radiation flux",
+            "GRIB_numberOfPoints": 1038240,
+            "GRIB_paramId": 260088,
+            "GRIB_shortName": "suswrf",
+            "GRIB_stepType": "avg",
+            "GRIB_stepUnits": 1,
+            "GRIB_totalNumber": 30,
+            "GRIB_typeOfLevel": "surface",
+            "GRIB_units": "W m**-2",
+            "GRIB_uvRelativeToGrid": 0,
+            "_ARRAY_DIMENSIONS": [
+                "init_time",
+                "ensemble_member",
+                "lead_time",
+                "latitude",
+                "longitude"
+            ],
+            "long_name": "Surface upward short-wave radiation flux",
+            "standard_name": "unknown",
+            "units": "W m**-2"
         },
         "t2m/.zarray": {
             "chunks": [
@@ -1713,14 +1888,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1767,6 +1947,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 273.15,
             "long_name": "2 metre temperature",
             "standard_name": "air_temperature",
             "units": "K"
@@ -1781,14 +1962,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1835,6 +2021,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 50.0,
             "long_name": "Total Cloud Cover",
             "standard_name": "unknown",
             "units": "%"
@@ -1849,14 +2036,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1903,6 +2095,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 273.15,
             "long_name": "Maximum temperature",
             "standard_name": "unknown",
             "units": "K"
@@ -1917,14 +2110,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -1971,6 +2169,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 273.15,
             "long_name": "Minimum temperature",
             "standard_name": "unknown",
             "units": "K"
@@ -1985,14 +2184,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -2053,14 +2257,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 6
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -2111,74 +2320,6 @@
             "standard_name": "eastward_wind",
             "units": "m s**-1"
         },
-        "uswrf/.zarray": {
-            "chunks": [
-                1,
-                31,
-                125,
-                73,
-                72
-            ],
-            "compressor": {
-                "blocksize": 0,
-                "clevel": 4,
-                "cname": "zstd",
-                "id": "blosc",
-                "shuffle": 1
-            },
-            "dtype": "<f4",
-            "fill_value": "NaN",
-            "filters": null,
-            "order": "C",
-            "shape": [
-                1,
-                31,
-                81,
-                721,
-                1440
-            ],
-            "zarr_format": 2
-        },
-        "uswrf/.zattrs": {
-            "GRIB_NV": 0,
-            "GRIB_Nx": 1440,
-            "GRIB_Ny": 721,
-            "GRIB_cfName": "unknown",
-            "GRIB_cfVarName": "uswrf",
-            "GRIB_dataType": "cf",
-            "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
-            "GRIB_gridType": "regular_ll",
-            "GRIB_iDirectionIncrementInDegrees": 0.25,
-            "GRIB_iScansNegatively": 0,
-            "GRIB_jDirectionIncrementInDegrees": 0.25,
-            "GRIB_jPointsAreConsecutive": 0,
-            "GRIB_jScansPositively": 0,
-            "GRIB_latitudeOfFirstGridPointInDegrees": 90.0,
-            "GRIB_latitudeOfLastGridPointInDegrees": -90.0,
-            "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
-            "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
-            "GRIB_missingValue": 3.4028234663852886e+38,
-            "GRIB_name": "Upward short-wave radiation flux",
-            "GRIB_numberOfPoints": 1038240,
-            "GRIB_paramId": 260088,
-            "GRIB_shortName": "uswrf",
-            "GRIB_stepType": "avg",
-            "GRIB_stepUnits": 1,
-            "GRIB_totalNumber": 30,
-            "GRIB_typeOfLevel": "surface",
-            "GRIB_units": "W m**-2",
-            "GRIB_uvRelativeToGrid": 0,
-            "_ARRAY_DIMENSIONS": [
-                "init_time",
-                "ensemble_member",
-                "lead_time",
-                "latitude",
-                "longitude"
-            ],
-            "long_name": "Upward short-wave radiation flux",
-            "standard_name": "unknown",
-            "units": "W m**-2"
-        },
         "v10/.zarray": {
             "chunks": [
                 1,
@@ -2189,14 +2330,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 6
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -2257,14 +2403,19 @@
             ],
             "compressor": {
                 "blocksize": 0,
-                "clevel": 4,
+                "clevel": 3,
                 "cname": "zstd",
                 "id": "blosc",
                 "shuffle": 1
             },
             "dtype": "<f4",
             "fill_value": "NaN",
-            "filters": null,
+            "filters": [
+                {
+                    "id": "bitround",
+                    "keepbits": 7
+                }
+            ],
             "order": "C",
             "shape": [
                 1,
@@ -2311,6 +2462,7 @@
                 "latitude",
                 "longitude"
             ],
+            "add_offset": 15000.0,
             "long_name": "Visibility",
             "standard_name": "unknown",
             "units": "m"

--- a/noaa/gefs/forecast/templates/latest.zarr/cfrzr/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/cfrzr/.zarray
@@ -8,7 +8,7 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1

--- a/noaa/gefs/forecast/templates/latest.zarr/cicep/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/cicep/.zarray
@@ -8,7 +8,7 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1

--- a/noaa/gefs/forecast/templates/latest.zarr/cpofp/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/cpofp/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/crain/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/crain/.zarray
@@ -8,7 +8,7 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1

--- a/noaa/gefs/forecast/templates/latest.zarr/csnow/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/csnow/.zarray
@@ -8,7 +8,7 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1

--- a/noaa/gefs/forecast/templates/latest.zarr/d2m/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/d2m/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/d2m/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/d2m/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 273.15,
     "long_name": "2 metre dewpoint temperature",
     "standard_name": "unknown",
     "units": "K"

--- a/noaa/gefs/forecast/templates/latest.zarr/gh/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/gh/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 8
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/gust/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/gust/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 6
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/hlcy/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/hlcy/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/mslet/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/mslet/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/mslet/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/mslet/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 101000.0,
     "long_name": "MSLP (Eta model reduction)",
     "standard_name": "unknown",
     "units": "Pa"

--- a/noaa/gefs/forecast/templates/latest.zarr/mslhf/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/mslhf/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 6
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/msshf/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/msshf/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 6
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/prmsl/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/prmsl/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/prmsl/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/prmsl/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 101000.0,
     "long_name": "Pressure reduced to MSL",
     "standard_name": "unknown",
     "units": "Pa"

--- a/noaa/gefs/forecast/templates/latest.zarr/pwat/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/pwat/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/r2/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/r2/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 6
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/r2/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/r2/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 50.0,
     "long_name": "2 metre relative humidity",
     "standard_name": "relative_humidity",
     "units": "%"

--- a/noaa/gefs/forecast/templates/latest.zarr/sde/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/sde/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/sdlwrf/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/sdlwrf/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/sdlwrf/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/sdlwrf/.zattrs
@@ -3,7 +3,7 @@
     "GRIB_Nx": 1440,
     "GRIB_Ny": 721,
     "GRIB_cfName": "unknown",
-    "GRIB_cfVarName": "dswrf",
+    "GRIB_cfVarName": "sdlwrf",
     "GRIB_dataType": "cf",
     "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
     "GRIB_gridType": "regular_ll",
@@ -17,10 +17,10 @@
     "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
     "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
     "GRIB_missingValue": 3.4028234663852886e+38,
-    "GRIB_name": "Downward short-wave radiation flux",
+    "GRIB_name": "Surface downward long-wave radiation flux",
     "GRIB_numberOfPoints": 1038240,
-    "GRIB_paramId": 260087,
-    "GRIB_shortName": "dswrf",
+    "GRIB_paramId": 260097,
+    "GRIB_shortName": "sdlwrf",
     "GRIB_stepType": "avg",
     "GRIB_stepUnits": 1,
     "GRIB_totalNumber": 30,
@@ -34,7 +34,8 @@
         "latitude",
         "longitude"
     ],
-    "long_name": "Downward short-wave radiation flux",
+    "add_offset": 300.0,
+    "long_name": "Surface downward long-wave radiation flux",
     "standard_name": "unknown",
     "units": "W m**-2"
 }

--- a/noaa/gefs/forecast/templates/latest.zarr/sdswrf/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/sdswrf/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/sdswrf/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/sdswrf/.zattrs
@@ -3,7 +3,7 @@
     "GRIB_Nx": 1440,
     "GRIB_Ny": 721,
     "GRIB_cfName": "unknown",
-    "GRIB_cfVarName": "uswrf",
+    "GRIB_cfVarName": "sdswrf",
     "GRIB_dataType": "cf",
     "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
     "GRIB_gridType": "regular_ll",
@@ -17,10 +17,10 @@
     "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
     "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
     "GRIB_missingValue": 3.4028234663852886e+38,
-    "GRIB_name": "Upward short-wave radiation flux",
+    "GRIB_name": "Surface downward short-wave radiation flux",
     "GRIB_numberOfPoints": 1038240,
-    "GRIB_paramId": 260088,
-    "GRIB_shortName": "uswrf",
+    "GRIB_paramId": 260087,
+    "GRIB_shortName": "sdswrf",
     "GRIB_stepType": "avg",
     "GRIB_stepUnits": 1,
     "GRIB_totalNumber": 30,
@@ -34,7 +34,7 @@
         "latitude",
         "longitude"
     ],
-    "long_name": "Upward short-wave radiation flux",
+    "long_name": "Surface downward short-wave radiation flux",
     "standard_name": "unknown",
     "units": "W m**-2"
 }

--- a/noaa/gefs/forecast/templates/latest.zarr/sdwe/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/sdwe/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/sithick/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/sithick/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/soilw/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/soilw/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/sp/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/sp/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/sp/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/sp/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 100000.0,
     "long_name": "Surface pressure",
     "standard_name": "surface_air_pressure",
     "units": "Pa"

--- a/noaa/gefs/forecast/templates/latest.zarr/st/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/st/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/st/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/st/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 273.15,
     "long_name": "Soil temperature",
     "standard_name": "unknown",
     "units": "K"

--- a/noaa/gefs/forecast/templates/latest.zarr/suswrf/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/suswrf/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/suswrf/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/suswrf/.zattrs
@@ -3,7 +3,7 @@
     "GRIB_Nx": 1440,
     "GRIB_Ny": 721,
     "GRIB_cfName": "unknown",
-    "GRIB_cfVarName": "dlwrf",
+    "GRIB_cfVarName": "suswrf",
     "GRIB_dataType": "cf",
     "GRIB_gridDefinitionDescription": "Latitude/longitude. Also called equidistant cylindrical, or Plate Carree",
     "GRIB_gridType": "regular_ll",
@@ -17,10 +17,10 @@
     "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
     "GRIB_longitudeOfLastGridPointInDegrees": 359.75,
     "GRIB_missingValue": 3.4028234663852886e+38,
-    "GRIB_name": "Downward long-wave radiation flux",
+    "GRIB_name": "Surface upward short-wave radiation flux",
     "GRIB_numberOfPoints": 1038240,
-    "GRIB_paramId": 260097,
-    "GRIB_shortName": "dlwrf",
+    "GRIB_paramId": 260088,
+    "GRIB_shortName": "suswrf",
     "GRIB_stepType": "avg",
     "GRIB_stepUnits": 1,
     "GRIB_totalNumber": 30,
@@ -34,7 +34,7 @@
         "latitude",
         "longitude"
     ],
-    "long_name": "Downward long-wave radiation flux",
+    "long_name": "Surface upward short-wave radiation flux",
     "standard_name": "unknown",
     "units": "W m**-2"
 }

--- a/noaa/gefs/forecast/templates/latest.zarr/t2m/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/t2m/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/t2m/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/t2m/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 273.15,
     "long_name": "2 metre temperature",
     "standard_name": "air_temperature",
     "units": "K"

--- a/noaa/gefs/forecast/templates/latest.zarr/tcc/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/tcc/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/tcc/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/tcc/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 50.0,
     "long_name": "Total Cloud Cover",
     "standard_name": "unknown",
     "units": "%"

--- a/noaa/gefs/forecast/templates/latest.zarr/tmax/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/tmax/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/tmax/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/tmax/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 273.15,
     "long_name": "Maximum temperature",
     "standard_name": "unknown",
     "units": "K"

--- a/noaa/gefs/forecast/templates/latest.zarr/tmin/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/tmin/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/tmin/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/tmin/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 273.15,
     "long_name": "Minimum temperature",
     "standard_name": "unknown",
     "units": "K"

--- a/noaa/gefs/forecast/templates/latest.zarr/tp/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/tp/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/u10/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/u10/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 6
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/v10/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/v10/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 6
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/vis/.zarray
+++ b/noaa/gefs/forecast/templates/latest.zarr/vis/.zarray
@@ -8,14 +8,19 @@
     ],
     "compressor": {
         "blocksize": 0,
-        "clevel": 4,
+        "clevel": 3,
         "cname": "zstd",
         "id": "blosc",
         "shuffle": 1
     },
     "dtype": "<f4",
     "fill_value": "NaN",
-    "filters": null,
+    "filters": [
+        {
+            "id": "bitround",
+            "keepbits": 7
+        }
+    ],
     "order": "C",
     "shape": [
         1,

--- a/noaa/gefs/forecast/templates/latest.zarr/vis/.zattrs
+++ b/noaa/gefs/forecast/templates/latest.zarr/vis/.zattrs
@@ -34,6 +34,7 @@
         "latitude",
         "longitude"
     ],
+    "add_offset": 15000.0,
     "long_name": "Visibility",
     "standard_name": "unknown",
     "units": "m"


### PR DESCRIPTION
Initial data variable encodings which maintain a close to faithful representation but get compression ratio to 0.27.