### PR TITLE
Operational writes

### DIFF
--- a/deploy/kubernetes_ingest_job.yaml
+++ b/deploy/kubernetes_ingest_job.yaml
@@ -48,10 +48,10 @@ spec:
             cpu: $CPU
             memory: $MEMORY
         volumeMounts:
-        - mountPath: "/app/data/download"
-          name: ephemeral-download-vol
+        - mountPath: "/app/data"
+          name: ephemeral-vol
       volumes:
-      - name: ephemeral-download-vol
+      - name: ephemeral-vol
         ephemeral:
           volumeClaimTemplate:
             metadata:

--- a/noaa/gefs/forecast/cli.py
+++ b/noaa/gefs/forecast/cli.py
@@ -36,8 +36,8 @@ def reformat_chunks(
 
 
 @app.command()
-def reformat_operational() -> None:
-    reformat.reformat_operational()
+def reformat_operational_update() -> None:
+    reformat.reformat_operational_update()
 
 
 if __name__ == "__main__":

--- a/noaa/gefs/forecast/cli.py
+++ b/noaa/gefs/forecast/cli.py
@@ -35,5 +35,10 @@ def reformat_chunks(
     )
 
 
+@app.command()
+def reformat_operational() -> None:
+    reformat.reformat_operational()
+
+
 if __name__ == "__main__":
     app()

--- a/noaa/gefs/forecast/read_data.py
+++ b/noaa/gefs/forecast/read_data.py
@@ -245,6 +245,7 @@ def read_rasterio(
         assert len(matching_bands) == 1, f"Expected exactly 1 matching band, found {matching_bands}. {grib_element=}, {grib_description=}, {path=}"  # fmt: skip
         rasterio_band_index = matching_bands[0]
 
+        # TODO: resample b and a (their resolution is lower than s)
         return reader.read(rasterio_band_index, out_dtype=np.float32)  # type: ignore
 
 

--- a/noaa/gefs/forecast/read_data.py
+++ b/noaa/gefs/forecast/read_data.py
@@ -245,7 +245,6 @@ def read_rasterio(
         assert len(matching_bands) == 1, f"Expected exactly 1 matching band, found {matching_bands}. {grib_element=}, {grib_description=}, {path=}"  # fmt: skip
         rasterio_band_index = matching_bands[0]
 
-        # TODO: resample b and a (their resolution is lower than s)
         return reader.read(rasterio_band_index, out_dtype=np.float32)  # type: ignore
 
 

--- a/noaa/gefs/forecast/reformat.py
+++ b/noaa/gefs/forecast/reformat.py
@@ -33,7 +33,7 @@ from noaa.gefs.forecast.read_data import (
 _PROCESSING_CHUNK_DIMENSION = "init_time"
 
 
-def reformat_operational() -> None:
+def reformat_operational_update() -> None:
     final_store = get_store()
     tmp_store = get_local_tmp_store()
     # Get the dataset, check what data is already present
@@ -331,12 +331,13 @@ def reformat_init_time_i_slices(
                     else:
                         var_coords_and_paths = coords_and_paths
                     data_array = xr.full_like(chunk_template_ds[data_var.name], np.nan)
-                    # valid_time is a coordinate and already written with different chunks
+                    # Drop all non-dimension coordinates.
+                    # They are already written with different chunks.
                     data_array = data_array.drop_vars(
                         [
-                            "valid_time",
-                            "ingested_forecast_length",
-                            "expected_forecast_length",
+                            coord
+                            for coord in data_array.coords
+                            if coord not in data_array.dims
                         ]
                     )
                     data_array.load()  # preallocate backing numpy arrays (for performance?)

--- a/noaa/gefs/forecast/template.py
+++ b/noaa/gefs/forecast/template.py
@@ -68,11 +68,11 @@ def get_template(init_time_end: DatetimeLike) -> xr.Dataset:
         ), f"Expected {coordinate.name} to be np.ndarray, but was {type(coordinate.data)}"
 
     # Uncomment to make smaller zarr while developing
-    # if Config.is_dev():
-    #     ds = ds[["u100", "v100", "u10", "v10", "t2m", "tp"]].sel(
-    #         ensemble_member=slice(3),
-    #         lead_time=["0h", "3h", "90h", "240h", "840h"],
-    #     )
+    if Config.is_dev():
+        ds = ds[["u100", "v100", "u10", "v10", "t2m", "tp"]].sel(
+            ensemble_member=slice(3),
+            lead_time=["0h", "3h", "90h", "240h", "840h"],
+        )
     # ds = ds[["u100", "v100", "u10", "v10", "t2m", "tp", "sdswrf", "gh", "tcc", "pwat", "r2", ]]
 
     return ds

--- a/noaa/gefs/forecast/template.py
+++ b/noaa/gefs/forecast/template.py
@@ -68,11 +68,11 @@ def get_template(init_time_end: DatetimeLike) -> xr.Dataset:
         ), f"Expected {coordinate.name} to be np.ndarray, but was {type(coordinate.data)}"
 
     # Uncomment to make smaller zarr while developing
-    if Config.is_dev():
-        ds = ds[["u100", "v100", "u10", "v10", "t2m", "tp"]].sel(
-            ensemble_member=slice(3),
-            lead_time=["0h", "3h", "90h", "240h", "840h"],
-        )
+    # if Config.is_dev():
+    #     ds = ds[["u100", "v100", "u10", "v10", "t2m", "tp"]].sel(
+    #         ensemble_member=slice(3),
+    #         lead_time=["0h", "3h", "90h", "240h", "840h"],
+    #     )
     # ds = ds[["u100", "v100", "u10", "v10", "t2m", "tp", "sdswrf", "gh", "tcc", "pwat", "r2", ]]
 
     return ds
@@ -136,7 +136,6 @@ def write_metadata(
     mode: Literal["w", "w-", "a", "a-", "r+", "r"],
 ) -> None:
     template_ds.to_zarr(store, mode=mode, compute=False)
-    # TODO: this doesn't print anything useful if the store is an FSMap
     print(f"Wrote metadata to {store} with mode {mode}.")
 
 

--- a/noaa/gefs/forecast/template.py
+++ b/noaa/gefs/forecast/template.py
@@ -71,7 +71,7 @@ def get_template(init_time_end: DatetimeLike) -> xr.Dataset:
     # if Config.is_dev():
     #     ds = ds[["u100", "v100", "u10", "v10", "t2m", "tp"]].sel(
     #         ensemble_member=slice(3),
-    #         lead_time=["0h", "3h", "90h", "240h", "243h", "840h"],
+    #         lead_time=["0h", "3h", "90h", "240h", "840h"],
     #     )
     # ds = ds[["u100", "v100", "u10", "v10", "t2m", "tp", "sdswrf", "gh", "tcc", "pwat", "r2", ]]
 
@@ -136,6 +136,7 @@ def write_metadata(
     mode: Literal["w", "w-", "a", "a-", "r+", "r"],
 ) -> None:
     template_ds.to_zarr(store, mode=mode, compute=False)
+    # TODO: this doesn't print anything useful if the store is an FSMap
     print(f"Wrote metadata to {store} with mode {mode}.")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -511,11 +511,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2024.10.0"
+version = "2024.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a0/52/f16a068ebadae42526484c31f4398e62962504e5724a8ba5dc3409483df2/fsspec-2024.10.0.tar.gz", hash = "sha256:eda2d8a4116d4f2429db8550f2457da57279247dd930bb12f821b58391359493", size = 286853 }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/11/de70dee31455c546fbc88301971ec03c328f3d1138cfba14263f651e9551/fsspec-2024.12.0.tar.gz", hash = "sha256:670700c977ed2fb51e0d9f9253177ed20cbde4a3e5c0283cc5385b5870c8533f", size = 291600 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/b2/454d6e7f0158951d8a78c2e1eb4f69ae81beb8dca5fee9809c6c99e9d0d0/fsspec-2024.10.0-py3-none-any.whl", hash = "sha256:03b9a6785766a4de40368b88906366755e2819e758b83705c88cd7cb5fe81871", size = 179641 },
+    { url = "https://files.pythonhosted.org/packages/de/86/5486b0188d08aa643e127774a99bac51ffa6cf343e3deb0583956dca5b22/fsspec-2024.12.0-py3-none-any.whl", hash = "sha256:b520aed47ad9804237ff878b504267a3b0b441e97508bd6d2d8774e3db85cee2", size = 183862 },
 ]
 
 [[package]]
@@ -1369,16 +1369,16 @@ wheels = [
 
 [[package]]
 name = "s3fs"
-version = "2024.10.0"
+version = "2024.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiobotocore" },
     { name = "aiohttp" },
     { name = "fsspec" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/65/4b4c868cff76c036d11dc75dd91e5696dbf16ce626514166f35d5f4a930f/s3fs-2024.10.0.tar.gz", hash = "sha256:58b8c3650f8b99dbedf361543da3533aac8707035a104db5d80b094617ad4a3f", size = 75916 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/88/e2fc4fc2a618126ac3cea9b16a4abc5a37dff2522067c9730b5d72d67ac3/s3fs-2024.12.0.tar.gz", hash = "sha256:1b0f3a8f5946cca5ba29871d6792ab1e4528ed762327d8aefafc81b73b99fd56", size = 76578 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/44/bb9ff095ae7b1b6908480f683b6ca6b71c2105d343a5e5cb25334b01f5fa/s3fs-2024.10.0-py3-none-any.whl", hash = "sha256:7a2025d60d5b1a6025726b3a5e292a8e5aa713abc3b16fd1f81735181f7bb282", size = 29855 },
+    { url = "https://files.pythonhosted.org/packages/f7/af/eaec1466887348d7f6cc9d3a668b30b62a4629fb187d0268146118ba3d5e/s3fs-2024.12.0-py3-none-any.whl", hash = "sha256:d8665549f9d1de083151582437a2f10d5f3b3227c1f8e67a2b0b730db813e005", size = 30196 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a new command (`reformat-operational`) that fetches and saves new data from the end of the current dataset to the present.
This can be run in a cronjob to allow continuous updating of the dataset.