### PR TITLE
Revert "Fix mypy warning: `NewGenericSyntax is already enabled by default`"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ ignore = [
 files = "."
 plugins = ["pydantic.mypy", "numpy.typing.mypy_plugin"]
 strict = true
+enable_incomplete_feature = "NewGenericSyntax"
 
 [tool.pydantic-mypy]
 init_forbid_extra = true


### PR DESCRIPTION
Reverts dynamical-org/reformatters#17