### PR TITLE
Run the deploy action in the `prod` environment

### DIFF
--- a/.github/workflows/deploy-operational-updates.yml
+++ b/.github/workflows/deploy-operational-updates.yml
@@ -11,6 +11,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: prod
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
So it can access the secrets configured for in that env.