### PR TITLE
Add our own binary rounding implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "zarr>=3.0.3",
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+
 [project.scripts]
 main = "reformatters.__main__:app"
 
@@ -69,5 +74,5 @@ init_forbid_extra = true
 init_typed = true
 warn_required_dynamic_aliases = true
 
-[tool.setuptools.package-data]
-reformatters = ["common/py.typed"]
+[project.package-data]
+reformatters = ["py.typed"]

--- a/src/reformatters/common/binary_rounding.py
+++ b/src/reformatters/common/binary_rounding.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from reformatters.common.types import ArrayFloat32
 
-# IEEE 754 binary32 constants
+# IEEE 754 binary32 (float32) constants
 MANTISSA_BITS: Final[int] = 23
 MANTISSA_MASK: Final[np.uint32] = np.uint32((1 << MANTISSA_BITS) - 1)
 EXPONENT_MASK: Final[np.uint32] = np.uint32(((1 << 8) - 1) << (32 - 8 - 1))
@@ -25,6 +25,8 @@ def round_float32_inplace(value: ArrayFloat32, keep_mantissa_bits: int) -> Array
     Returns:
         Rounded float32 array
     """
+    if keep_mantissa_bits < 0:
+        raise ValueError("keep_mantissa_bits must be at least 0")
     if keep_mantissa_bits > MANTISSA_BITS:
         raise ValueError(f"keep_mantissa_bits must be less than {MANTISSA_BITS}")
     if keep_mantissa_bits == MANTISSA_BITS:

--- a/src/reformatters/common/binary_rounding.py
+++ b/src/reformatters/common/binary_rounding.py
@@ -1,0 +1,89 @@
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+
+# Type aliases
+FloatArray = npt.NDArray[np.float32]
+IntArray = npt.NDArray[np.uint32]
+
+# IEEE 754 binary32 constants
+MANTISSA_BITS: Final[int] = 23
+MANTISSA_MASK: Final[np.uint32] = np.uint32((1 << MANTISSA_BITS) - 1)
+EXPONENT_MASK: Final[np.uint32] = np.uint32(((1 << 8) - 1) << (32 - 8 - 1))
+SIGN_MASK: Final[np.uint32] = np.uint32(1 << 31)
+
+
+def round_float32(value: FloatArray, keep_mantissa_bits: int) -> FloatArray:
+    """Round float32 values to keep a specific number of mantissa bits.
+
+    Vectorized implementation that works on numpy float32 arrays.
+
+    Args:
+        value: The float32 array to round
+        keep_mantissa_bits: Number of mantissa bits to keep (1-23)
+
+    Returns:
+        Rounded float32 array
+    """
+    if keep_mantissa_bits >= MANTISSA_BITS:
+        return value
+
+    # Early return for any NaN or Inf values
+    if np.any(~np.isfinite(value)):
+        return value.copy()
+
+    bits: IntArray = value.view(np.uint32)
+
+    # Number of trailing bits to drop
+    drop_bits = MANTISSA_BITS - keep_mantissa_bits
+
+    # Extract components
+    sign: IntArray = bits & SIGN_MASK
+    exponent: IntArray = bits & EXPONENT_MASK
+    mantissa: IntArray = bits & MANTISSA_MASK
+
+    # Get rounding bits
+    round_bit: IntArray = bits & np.uint32(
+        1 << drop_bits
+    )  # nth place - smallest bit kept
+    half_bit: IntArray = bits & np.uint32(1 << (drop_bits - 1))  # n+1th place
+    sticky_mask = np.uint32((1 << (drop_bits - 1)) - 1)
+    sticky_bits: IntArray = bits & sticky_mask  # n+2 and beyond
+
+    # Vectorized rounding logic
+    round_down_mask = half_bit == 0
+    round_up_mask = (~round_down_mask) & (sticky_bits != 0)
+    round_even_mask = (~round_down_mask) & (sticky_bits == 0)
+
+    # Apply rounding rules
+    keep_mask = ~np.uint32((1 << drop_bits) - 1)
+    increment = np.uint32(1 << drop_bits)
+
+    # Round down (clear lower bits)
+    mantissa &= keep_mask
+
+    # Round up where needed
+    mantissa[round_up_mask] += increment
+
+    # Round to even where needed (if round bit is 1)
+    round_even_up_mask = round_even_mask & (round_bit != 0)
+    mantissa[round_even_up_mask] += increment
+
+    # Handle mantissa overflow
+    overflow_mask = mantissa > MANTISSA_MASK
+    if np.any(overflow_mask):
+        # Increment exponent and wrap mantissa
+        exponent[overflow_mask] += np.uint32(1 << MANTISSA_BITS)
+        mantissa[overflow_mask] &= MANTISSA_MASK
+
+        # Check for exponent overflow
+        inf_mask = exponent >= EXPONENT_MASK
+        if np.any(inf_mask):
+            result = value.copy()
+            result[inf_mask] = np.where(sign[inf_mask] == 0, np.inf, -np.inf)
+            return result
+
+    # Recombine components
+    result_bits = sign | exponent | mantissa
+    return result_bits.view(np.float32)

--- a/src/reformatters/common/binary_rounding.py
+++ b/src/reformatters/common/binary_rounding.py
@@ -44,12 +44,10 @@ def round_float32(value: FloatArray, keep_mantissa_bits: int) -> FloatArray:
     mantissa: IntArray = bits & MANTISSA_MASK
 
     # Get rounding bits
-    round_bit: IntArray = bits & np.uint32(
-        1 << drop_bits
-    )  # nth place - smallest bit kept
-    half_bit: IntArray = bits & np.uint32(1 << (drop_bits - 1))  # n+1th place
+    round_bit: IntArray = bits & np.uint32(1 << drop_bits)
+    half_bit: IntArray = bits & np.uint32(1 << (drop_bits - 1))
     sticky_mask = np.uint32((1 << (drop_bits - 1)) - 1)
-    sticky_bits: IntArray = bits & sticky_mask  # n+2 and beyond
+    sticky_bits: IntArray = bits & sticky_mask
 
     # Vectorized rounding logic
     round_down_mask = half_bit == 0

--- a/src/reformatters/common/types.py
+++ b/src/reformatters/common/types.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 type DatetimeLike = pd.Timestamp | np.datetime64 | str
+type ArrayFloat32 = np.ndarray[tuple[int, ...], np.dtype[np.float32]]
 type Array1D[D: np.generic] = np.ndarray[tuple[int], np.dtype[D]]
 type Array2D[D: np.generic] = np.ndarray[tuple[int, int], np.dtype[D]]
 

--- a/tests/common/test_binary_rounding.py
+++ b/tests/common/test_binary_rounding.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from src.reformatters.common.binary_rounding import round_float32
+from reformatters.common.binary_rounding import round_float32
 
 
 def test_round_float32_negative_values() -> None:

--- a/tests/common/test_binary_rounding.py
+++ b/tests/common/test_binary_rounding.py
@@ -231,6 +231,20 @@ def test_round_keep_all_bits() -> None:
     assert rounded_values[0] == original
 
 
+def test_round_keep_zero_bits() -> None:
+    # Format: 0|10000001|10000000000000000000111
+    bits = np.uint32(0b0_10000001_10000000000000000000000)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 6.0
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=0)
+
+    expected_bits = np.uint32(0b0_10000010_00000000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+
+
 def test_round_keep_all_but_one_bits_trailing_1() -> None:
     # Format: 0|10000001|10000000000000000000111
     bits = np.uint32(0b0_10000001_10000000000000000000111)

--- a/tests/common/test_binary_rounding.py
+++ b/tests/common/test_binary_rounding.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+from src.reformatters.common.binary_rounding import round_float32
+
+
+def test_round_float32_negative_values() -> None:
+    values = np.linspace(-1000, -1, num=1000, dtype=np.float32)
+    rounded_values = round_float32(values, keep_mantissa_bits=9)
+    # All within 2% of the original value
+    assert np.allclose(values, rounded_values, rtol=0.02)
+    # Near zero bias introduced by rounding
+    assert np.isclose(np.mean(values), np.mean(rounded_values))
+
+
+def test_round_float32_positive_values() -> None:
+    values = np.linspace(1, 1000, num=1000, dtype=np.float32)
+    rounded_values = round_float32(values, keep_mantissa_bits=9)
+    assert np.allclose(values, rounded_values, rtol=0.02)
+    assert np.isclose(np.mean(values), np.mean(rounded_values))
+
+
+def test_round_float32_negative_to_positive_values() -> None:
+    values = np.linspace(-1e7, 1e7, num=2000, dtype=np.float32)
+    rounded_values = round_float32(values, keep_mantissa_bits=9)
+    assert np.allclose(values, rounded_values, rtol=0.02)
+    assert np.isclose(np.mean(values), np.mean(rounded_values), rtol=0.02, atol=0.5)
+
+
+def test_round_float32_special_values() -> None:
+    special_values = np.array([0.0, np.nan, np.inf, -np.inf], dtype=np.float32)
+    rounded_values = round_float32(special_values, keep_mantissa_bits=2)
+    assert np.array_equal(special_values, rounded_values, equal_nan=True)
+
+
+def test_round_float32_overflow_to_inf() -> None:
+    # np.finfo(np.float32).max is the largest representable float32 value
+    max_float32 = np.array([np.finfo(np.float32).max], dtype=np.float32)
+    # With only 3 mantissa bits kept, this should overflow to infinity
+    rounded_values = round_float32(max_float32, keep_mantissa_bits=3)
+    assert np.all(np.isinf(rounded_values))
+
+
+def test_round_float32_overflow_to_neg_inf() -> None:
+    # np.finfo(np.float32).min is the most negative representable float32 value
+    min_float32 = np.array([np.finfo(np.float32).min], dtype=np.float32)
+    # With only 3 mantissa bits kept, this should overflow to negative infinity
+    rounded_values = round_float32(min_float32, keep_mantissa_bits=3)
+    assert np.all(np.isinf(rounded_values))
+    assert np.all(rounded_values < 0)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/common/test_binary_rounding.py
+++ b/tests/common/test_binary_rounding.py
@@ -1,12 +1,11 @@
 import numpy as np
-import pytest
 
-from reformatters.common.binary_rounding import round_float32
+from reformatters.common.binary_rounding import round_float32_inplace
 
 
 def test_round_float32_negative_values() -> None:
     values = np.linspace(-1000, -1, num=1000, dtype=np.float32)
-    rounded_values = round_float32(values, keep_mantissa_bits=9)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=9)
     # All within 2% of the original value
     assert np.allclose(values, rounded_values, rtol=0.02)
     # Near zero bias introduced by rounding
@@ -15,21 +14,21 @@ def test_round_float32_negative_values() -> None:
 
 def test_round_float32_positive_values() -> None:
     values = np.linspace(1, 1000, num=1000, dtype=np.float32)
-    rounded_values = round_float32(values, keep_mantissa_bits=9)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=9)
     assert np.allclose(values, rounded_values, rtol=0.02)
     assert np.isclose(np.mean(values), np.mean(rounded_values))
 
 
 def test_round_float32_negative_to_positive_values() -> None:
     values = np.linspace(-1e7, 1e7, num=2000, dtype=np.float32)
-    rounded_values = round_float32(values, keep_mantissa_bits=9)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=9)
     assert np.allclose(values, rounded_values, rtol=0.02)
     assert np.isclose(np.mean(values), np.mean(rounded_values), rtol=0.02, atol=0.5)
 
 
 def test_round_float32_special_values() -> None:
     special_values = np.array([0.0, np.nan, np.inf, -np.inf], dtype=np.float32)
-    rounded_values = round_float32(special_values, keep_mantissa_bits=2)
+    rounded_values = round_float32_inplace(special_values, keep_mantissa_bits=2)
     assert np.array_equal(special_values, rounded_values, equal_nan=True)
 
 
@@ -37,7 +36,7 @@ def test_round_float32_overflow_to_inf() -> None:
     # np.finfo(np.float32).max is the largest representable float32 value
     max_float32 = np.array([np.finfo(np.float32).max], dtype=np.float32)
     # With only 3 mantissa bits kept, this should overflow to infinity
-    rounded_values = round_float32(max_float32, keep_mantissa_bits=3)
+    rounded_values = round_float32_inplace(max_float32, keep_mantissa_bits=3)
     assert np.all(np.isinf(rounded_values))
 
 
@@ -45,10 +44,301 @@ def test_round_float32_overflow_to_neg_inf() -> None:
     # np.finfo(np.float32).min is the most negative representable float32 value
     min_float32 = np.array([np.finfo(np.float32).min], dtype=np.float32)
     # With only 3 mantissa bits kept, this should overflow to negative infinity
-    rounded_values = round_float32(min_float32, keep_mantissa_bits=3)
+    rounded_values = round_float32_inplace(min_float32, keep_mantissa_bits=3)
     assert np.all(np.isinf(rounded_values))
     assert np.all(rounded_values < 0)
 
 
-if __name__ == "__main__":
-    pytest.main()
+def test_round_float32_mixed_overflow() -> None:
+    # Create a float32 with all 1s in mantissa (23 bits)
+    # Format: 0|00000000|11111111111111111111111
+    # Sign: 0 (positive)
+    # Exponent: 00000000 (0, leaving plenty of room for mantissa overflow)
+    # Mantissa: All 1s - These all ones will guarantee the mantissa overflows when rounding
+    bits = np.uint32(0b0_00000000_11111111111111111111111)
+    mantissa_overflow = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+
+    bits = np.uint32(0b0_00000000_0000000000000010110100)
+    will_round_down = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    bits = np.uint32(0b0_00000000_00000000000000000000000)
+    expected_rounded_down = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+
+    # Create an array with one normal value and one that will overflow
+    values = np.array(
+        [mantissa_overflow, will_round_down, np.finfo(np.float32).max],
+        dtype=np.float32,
+    )
+
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=4)
+
+    # Check that the normal value remains approximately the same
+    assert np.isclose(rounded_values[0], mantissa_overflow)
+    # But not exactly the same (it's rounded)
+    assert rounded_values[0] != mantissa_overflow
+
+    # Check the value that should round down, did
+    assert rounded_values[1] == expected_rounded_down
+
+    # Check that the large value overflowed to infinity
+    assert np.isinf(rounded_values[2])
+    assert rounded_values[2] > 0  # Positive infinity
+
+
+def test_round_up_no_tie_positive() -> None:
+    # Create a float32 with specific bit pattern
+    # Format: 0|10000000|10101010101010101010101
+    # Sign: 0 (positive)
+    # Exponent: 10000000
+    # Mantissa: 10101010101010101010101
+    bits = np.uint32(0b0_10000000_10101010101010101010101)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 3.3333333
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=4)
+
+    # Should round up
+    assert rounded_values[0] > original
+
+    expected_bits = np.uint32(0b0_10000000_10110000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+    assert rounded_values[0] == 3.375
+
+
+def test_round_up_no_tie_negative() -> None:
+    # Format: 1|10000000|10101010101010101010101
+    bits = np.uint32(0b1_10000000_10101010101010101010101)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == -3.3333333
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=4)
+
+    expected_bits = np.uint32(0b1_10000000_10110000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+    assert rounded_values[0] == -3.375
+
+    # "up" means away from zero for negative numbers
+    assert rounded_values[0] < original
+
+    # Check that rounding down would have been further from original
+    rounded_down_bits = np.uint32(0b1_10000000_10100000000000000000000)
+    rounded_down = np.frombuffer(rounded_down_bits.tobytes(), dtype=np.float32)[0]
+    assert abs(original - expected) < abs(original - rounded_down)
+
+
+def test_round_down_no_tie_positive() -> None:
+    # Format: 0|10000011|10101010101010101010101
+    bits = np.uint32(0b0_10000011_10101010101010101010101)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 26.666666
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=5)
+
+    expected_bits = np.uint32(0b0_10000011_10101000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+    assert rounded_values[0] == 26.5
+
+    assert rounded_values[0] < original
+
+    # Check that rounding up would have been further from original
+    rounded_up_bits = np.uint32(0b0_10000011_10111000000000000000000)
+    rounded_up = np.frombuffer(rounded_up_bits.tobytes(), dtype=np.float32)[0]
+    assert abs(original - expected) < abs(original - rounded_up)
+
+
+def test_round_down_no_tie_negative() -> None:
+    # Format: 1|10000011|10101010101010101010101
+    bits = np.uint32(0b1_10000011_10101010101010101010101)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == -26.666666
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=5)
+
+    expected_bits = np.uint32(0b1_10000011_10101000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+    assert rounded_values[0] == -26.5
+
+    assert rounded_values[0] > original
+
+    # Check that rounding up would have been further from original
+    rounded_up_bits = np.uint32(0b1_10000011_10111000000000000000000)
+    rounded_up = np.frombuffer(rounded_up_bits.tobytes(), dtype=np.float32)[0]
+    assert abs(original - expected) < abs(original - rounded_up)
+
+
+def test_round_tie_down_to_even_positive() -> None:
+    # Format: 0|10000010|00100000000000000000000
+    bits = np.uint32(0b0_10000010_00100000000000000000000)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 9.0
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=2)
+
+    expected_bits = np.uint32(0b0_10000010_00000000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+    assert rounded_values[0] == 8.0
+
+    assert rounded_values[0] < original
+
+    # Check equidistant rounding
+    rounded_up_bits = np.uint32(0b0_10000010_01000000000000000000000)
+    rounded_up = np.frombuffer(rounded_up_bits.tobytes(), dtype=np.float32)[0]
+    assert abs(original - expected) == abs(original - rounded_up)
+
+
+def test_round_tie_up_to_even_positive() -> None:
+    # Format: 0|10000010|00110000000000000000000
+    bits = np.uint32(0b0_10000010_00110000000000000000000)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 9.5
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=3)
+
+    expected_bits = np.uint32(0b0_10000010_01000000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+    assert rounded_values[0] == 10.0
+
+    assert rounded_values[0] > original
+
+    # Check equidistant rounding
+    rounded_down_bits = np.uint32(0b0_10000010_00100000000000000000000)
+    rounded_down = np.frombuffer(rounded_down_bits.tobytes(), dtype=np.float32)[0]
+    assert abs(original - expected) == abs(original - rounded_down)
+
+
+def test_round_keep_all_bits() -> None:
+    # Format: 0|10000001|10000000000000000000111
+    bits = np.uint32(0b0_10000001_10000000000000000000111)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 6.0000033
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(
+        values, keep_mantissa_bits=23
+    )  # Keep all bits
+
+    assert rounded_values[0] == original
+
+
+def test_round_keep_all_but_one_bits_trailing_1() -> None:
+    # Format: 0|10000001|10000000000000000000111
+    bits = np.uint32(0b0_10000001_10000000000000000000111)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 6.0000033
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=22)
+
+    expected_bits = np.uint32(0b0_10000001_10000000000000000001000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+
+
+def test_round_keep_all_but_one_bits_trailing_0() -> None:
+    # Format: 0|10000001|10000000000000000000110
+    bits = np.uint32(0b0_10000001_10000000000000000000110)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 6.000003
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=22)
+
+    expected_bits = np.uint32(0b0_10000001_10000000000000000000110)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+
+
+def test_round_mantissa_overflow() -> None:
+    # Format: 0|10000001|11111111111111111111111
+    bits = np.uint32(0b0_10000001_11111111111111111111111)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 7.9999995
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=15)
+
+    expected_bits = np.uint32(0b0_10000010_00000000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert rounded_values[0] == expected
+    assert rounded_values[0] == 8.0
+
+
+def test_round_exponent_and_mantissa_overflow_positive() -> None:
+    # Format: 0|11111110|11111111111111111111111
+    bits = np.uint32(0b0_11111110_11111111111111111111111)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=20)
+
+    assert np.isinf(rounded_values[0])
+    assert rounded_values[0] > 0
+
+
+def test_round_exponent_and_mantissa_overflow_negative() -> None:
+    # Format: 1|11111110|11111111111111111111111
+    bits = np.uint32(0b1_11111110_11111111111111111111111)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=20)
+
+    assert np.isinf(rounded_values[0])
+    assert rounded_values[0] < 0
+
+
+def test_round_zero() -> None:
+    values = np.array([0.0], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=20)
+    assert rounded_values[0] == 0.0
+
+
+def test_round_subnormal_to_normal() -> None:
+    # Format: 0|00000000|11111111111111111111111
+    bits = np.uint32(0b0_00000000_11111111111111111111111)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 1.1754942e-38
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=20)
+
+    expected_bits = np.uint32(0b0_00000001_00000000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert expected == 1.1754944e-38
+    assert rounded_values[0] == expected
+
+
+def test_round_subnormal_to_subnormal() -> None:
+    # Format: 0|00000000|00011111111111111111111
+    bits = np.uint32(0b0_00000000_00011111111111111111111)
+    original = np.frombuffer(bits.tobytes(), dtype=np.float32)[0]
+    assert original == 1.469367e-39
+
+    values = np.array([original], dtype=np.float32)
+    rounded_values = round_float32_inplace(values, keep_mantissa_bits=3)
+
+    expected_bits = np.uint32(0b0_00000000_00100000000000000000000)
+    expected = np.frombuffer(expected_bits.tobytes(), dtype=np.float32)[0]
+    assert expected == 1.469368e-39
+    assert rounded_values[0] == expected
+
+
+def test_wide_logspace_percent_difference() -> None:
+    values = np.logspace(-127, 127, num=2000, base=2, dtype=np.float32)
+    max_diff = 0.0
+    rounded = round_float32_inplace(values, keep_mantissa_bits=9)
+    diff_percent = np.abs((values - rounded) / values) * 100
+    max_diff = np.max(diff_percent)
+
+    assert max_diff < 0.5  # Less than 1/2 of 1% error

--- a/tests/common/test_zarr.py
+++ b/tests/common/test_zarr.py
@@ -11,7 +11,8 @@ def test_get_zarr_store_dev() -> None:
     Config.env = Env.dev
     store = get_zarr_store("test-dataset", "1.0.0")
     assert isinstance(store, zarr.storage.LocalStore)
-    assert store.path == str(Path("data/output/test-dataset/vdev.zarr").absolute())
+    # LocalStore doesn't normally have a path attribute, we set it for consistency with FsspecStore
+    assert store.path == str(Path("data/output/test-dataset/vdev.zarr").absolute())  # type: ignore[attr-defined]
 
 
 def test_get_zarr_store_prod() -> None:
@@ -30,8 +31,8 @@ def test_get_mode() -> None:
     dev_store = zarr.storage.LocalStore(Path("test-dev.zarr"))
     assert get_mode(dev_store) == "w"
 
-    prod_store = zarr.storage.FsspecStore.from_url("s3://test-bucket/test.zarr")
-    assert get_mode(prod_store) == "w-"
-
     tmp_store = Path("test-tmp.zarr")
     assert get_mode(tmp_store) == "w"
+
+    prod_store = zarr.storage.FsspecStore.from_url("s3://test-bucket/test.zarr")
+    assert get_mode(prod_store) == "w-"

--- a/tests/common/test_zarr.py
+++ b/tests/common/test_zarr.py
@@ -7,16 +7,13 @@ from reformatters.common.zarr import get_mode, get_zarr_store
 
 
 def test_get_zarr_store_dev() -> None:
-    # Test dev environment store creation
     Config.env = Env.dev
     store = get_zarr_store("test-dataset", "1.0.0")
     assert isinstance(store, zarr.storage.LocalStore)
-    # LocalStore doesn't normally have a path attribute, we set it for consistency with FsspecStore
-    assert store.path == str(Path("data/output/test-dataset/vdev.zarr").absolute())  # type: ignore[attr-defined]
+    assert store.path == str(Path("data/output/test-dataset/vdev.zarr").absolute())
 
 
 def test_get_zarr_store_prod() -> None:
-    # Test prod environment store creation
     Config.env = Env.prod
     store = get_zarr_store("test-dataset", "1.0.0")
     assert isinstance(store, zarr.storage.FsspecStore)
@@ -27,7 +24,7 @@ def test_get_zarr_store_prod() -> None:
 
 
 def test_get_mode() -> None:
-    # Test mode selection for different store types
+    # Dev and temp stores can be overwritten, everything else should not overwrite.
     dev_store = zarr.storage.LocalStore(Path("test-dev.zarr"))
     assert get_mode(dev_store) == "w"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -1222,7 +1223,7 @@ wheels = [
 [[package]]
 name = "reformatters"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "dask" },
     { name = "numcodecs" },


### PR DESCRIPTION
translated from the Rust reformatters. To allow us to get the space savings from binary rounding without warnings about numcodecs.