### PR TITLE
Fix deaccumulation with trailing dimensions after lead_time dim of length > 1

### DIFF
--- a/src/reformatters/noaa/gefs/deaccumulation.py
+++ b/src/reformatters/noaa/gefs/deaccumulation.py
@@ -26,9 +26,13 @@ def deaccumulate_to_rates_inplace(
     assert np.isin(np.diff(lead_time_seconds), supported_accum_durations).all()
     is_3h_accum = (lead_time_seconds % SECONDS_PER_6_HOUR) != 0
 
-    # Move lead_time to last dimension for simpler numba code
+    # make array 3D with shape (flattend_leading_dims, lead_time, flattend_trailing_dims)
     lead_time_dim_index = data_array.dims.index(dim)
-    values = np.moveaxis(data_array.values, lead_time_dim_index, -1)
+    values = data_array.values.reshape(
+        np.prod(data_array.shape[:lead_time_dim_index] or 1),
+        data_array.shape[lead_time_dim_index],
+        np.prod(data_array.shape[lead_time_dim_index + 1 :] or 1),
+    )
 
     _deaccumulate_to_rates_numba(
         values,
@@ -57,55 +61,61 @@ def _deaccumulate_to_rates_numba(
     If they go down to a *rate* that is less than `invalid_below_threshold`,
     this sets the value to NaN and raises an error.
 
+    Parallel processing is done over the leading dimension of values.
+
     Args:
-        values: Array to modify in place, with lead_time as the last dimension
+        values: Array to modify in place. Must be 3D with lead_time the *middle* dimension
         is_3h_accum: 1D array of booleans indicating if the accumulation is 3h or 6h
         lead_time_seconds: 1D array of seconds since forecast start
         epsilon: Threshold below which values are considered invalid
     """
-    n_lead_times = values.shape[-1]
+    assert values.ndim == 3
+    assert lead_time_seconds.ndim == 1
+    assert is_3h_accum.ndim == 1
+    assert values.shape[1] == lead_time_seconds.size
+    assert values.shape[1] == is_3h_accum.size
 
-    # Flatten all dimensions except lead_time for parallel processing
-    flat_values = values.reshape((-1, n_lead_times))
+    n_lead_times = values.shape[1]
 
     negative_count = 0
     clamped_count = 0
 
-    for i in prange(flat_values.shape[0]):
-        sequence = flat_values[i]
+    for i in prange(values.shape[0]):
+        for j in range(values.shape[2]):
+            sequence = values[i, :, j]
 
-        # Skip first step, no accumulation yet
-        for t in range(1, n_lead_times):
-            time_step = lead_time_seconds[t] - lead_time_seconds[t - 1]
+            # Skip first step, no accumulation yet
+            for t in range(1, n_lead_times):
+                time_step = lead_time_seconds[t] - lead_time_seconds[t - 1]
 
-            if is_3h_accum[t]:
-                # 3h accumulation point - simple division
-                sequence[t] /= time_step
-            else:
-                # 6h accumulation point
-
-                if t > 1 and is_3h_accum[t - 1]:
-                    # There was a 3h accumulation before - calculate rate for just the last 3h
-                    previous_time_step = (
-                        lead_time_seconds[t - 1] - lead_time_seconds[t - 2]
-                    )
-                    previous_accumulation = sequence[t - 1] * previous_time_step
-                    accumulation = sequence[t] - previous_accumulation
-                    sequence[t] = accumulation / time_step
-                else:
-                    # No 3h accumulation before - calculate rate for full 6h period
+                if is_3h_accum[t]:
+                    # 3h accumulation point - simple division
                     sequence[t] /= time_step
-
-            # Accumulations should only go up
-            # If they go down a tiny bit, clamp to 0
-            # If they go down more, set to NaN and then raise
-            if sequence[t] < 0:
-                if sequence[t] > invalid_below_threshold_rate:
-                    clamped_count += 1
-                    sequence[t] = 0
                 else:
-                    negative_count += 1
-                    sequence[t] = np.nan
+                    # 6h accumulation point
+
+                    if t > 1 and is_3h_accum[t - 1]:
+                        # There was a 3h accumulation before - calculate rate for just the last 3h
+                        previous_time_step = (
+                            lead_time_seconds[t - 1] - lead_time_seconds[t - 2]
+                        )
+                        previous_accumulation = sequence[t - 1] * previous_time_step
+                        accumulation = sequence[t] - previous_accumulation
+                        sequence[t] = accumulation / time_step
+                    else:
+                        # No 3h accumulation before - calculate rate for full 6h period
+                        sequence[t] /= time_step
+
+                # Accumulations should only go up
+                # If they go down a tiny bit, clamp to 0
+                # If they go down more, set to NaN and then raise
+                if sequence[t] < 0:
+                    if sequence[t] > invalid_below_threshold_rate:
+                        clamped_count += 1
+                        sequence[t] = 0
+                    else:
+                        negative_count += 1
+                        sequence[t] = np.nan
 
     if negative_count > 0:
         raise ValueError(f"Found {negative_count} values below threshold")

--- a/tests/noaa/gefs/test_deaccumulation.py
+++ b/tests/noaa/gefs/test_deaccumulation.py
@@ -38,7 +38,9 @@ def test_deaccumulate_higher_dimensional() -> None:
         ]
     )
     data = np.stack([data, 2 * data])
-    data = np.expand_dims(data, axis=(3, 4))
+    # Add new dims of > len(1) to trailing dimensions
+    data = np.stack([data, data], axis=-1)
+    data = np.stack([data, data], axis=-1)
 
     data_array = xr.DataArray(
         data,  # Shape will be (2, 3, 5, 1, 1) for (init_time, ensemble_member, lead_time, lat, lon)
@@ -60,7 +62,8 @@ def test_deaccumulate_higher_dimensional() -> None:
         ]
     )
     expected = np.stack([expected, 2 * expected])
-    expected = np.expand_dims(expected, axis=(3, 4))
+    expected = np.stack([expected, expected], axis=-1)
+    expected = np.stack([expected, expected], axis=-1)
 
     result = deaccumulate_to_rates_inplace(data_array, dim="lead_time")
 


### PR DESCRIPTION
This is no longer parallel over _all_ dimensions except lead time, just dimensions proceeding lead time. In practice, with 31 ensemble members before the lead_time dim that's plenty.