### PR TITLE
Remove add_offset and scale_factor from encodings and adjust bit rounding

### DIFF
--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -115,9 +115,6 @@ class Encoding(pydantic.BaseModel):
     # Decoded units for all variables are in DataVarAttrs
     units: TimestampUnits | TimedeltaUnits | None = None
 
-    add_offset: float | None = None
-    scale_factor: float | None = None
-
 
 class Coordinate(FrozenBaseModel):
     name: str

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -493,7 +493,6 @@ def reformat_init_time_i_slices(
 
                         keep_mantissa_bits = data_var.internal_attrs.keep_mantissa_bits
                         if isinstance(keep_mantissa_bits, int):
-                            logger.info(f"Starting bit rounding {data_var.name}")
                             round_float32_inplace(
                                 data_array.values,
                                 keep_mantissa_bits=keep_mantissa_bits,

--- a/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
@@ -328,7 +328,7 @@ COORDINATES: Sequence[Coordinate] = (
 _DATA_VARIABLES = (
     # GEFSDataVar(
     #     name="visibility_surface",
-    #     encoding=replace(ENCODING_FLOAT32_DEFAULT, add_offset=15_000.0),
+    #     encoding=replace(ENCODING_FLOAT32_DEFAULT),
     #     attrs=DataVarAttrs(
     #         short_name="vis",
     #         long_name="Visibility",
@@ -364,7 +364,7 @@ _DATA_VARIABLES = (
     # ),
     # GEFSDataVar(
     #     name="pressure_mean_sea_level",
-    #     encoding=replace(ENCODING_FLOAT32_DEFAULT, add_offset=101_000.0),
+    #     encoding=replace(ENCODING_FLOAT32_DEFAULT),
     #     attrs=DataVarAttrs(
     #         short_name="mslet",
     #         long_name="MSLP (Eta model reduction)",
@@ -377,12 +377,12 @@ _DATA_VARIABLES = (
     #         grib_index_level="mean sea level",
     #         gefs_file_type="s+b",
     #         index_position=3,
-    #         keep_mantissa_bits=GEFS_BITROUND_KEEP_MANTISSA_BITS_DEFAULT,
+    #         keep_mantissa_bits=8,
     #     ),
     # ),
     GEFSDataVar(
         name="pressure_surface",
-        encoding=replace(ENCODING_FLOAT32_DEFAULT, add_offset=100_000.0),
+        encoding=replace(ENCODING_FLOAT32_DEFAULT),
         attrs=DataVarAttrs(
             short_name="sp",
             long_name="Surface pressure",
@@ -396,7 +396,7 @@ _DATA_VARIABLES = (
             grib_index_level="surface",
             gefs_file_type="s+a",
             index_position=4,
-            keep_mantissa_bits=GEFS_BITROUND_KEEP_MANTISSA_BITS_DEFAULT,
+            keep_mantissa_bits=8,
         ),
     ),
     # GEFSDataVar(
@@ -529,7 +529,7 @@ _DATA_VARIABLES = (
     # ),
     GEFSDataVar(
         name="relative_humidity_2m",
-        encoding=replace(ENCODING_FLOAT32_DEFAULT, add_offset=50.0),
+        encoding=replace(ENCODING_FLOAT32_DEFAULT),
         attrs=DataVarAttrs(
             short_name="r2",
             long_name="2 metre relative humidity",
@@ -543,7 +543,7 @@ _DATA_VARIABLES = (
             grib_index_level="2 m above ground",
             gefs_file_type="s+a",
             index_position=12,
-            keep_mantissa_bits=6,
+            keep_mantissa_bits=GEFS_BITROUND_KEEP_MANTISSA_BITS_DEFAULT,
         ),
     ),
     GEFSDataVar(
@@ -823,7 +823,7 @@ _DATA_VARIABLES = (
     ),
     GEFSDataVar(
         name="total_cloud_cover_atmosphere",
-        encoding=replace(ENCODING_FLOAT32_DEFAULT, add_offset=50.0),
+        encoding=replace(ENCODING_FLOAT32_DEFAULT),
         attrs=DataVarAttrs(
             short_name="tcc",
             long_name="Total Cloud Cover",
@@ -878,7 +878,7 @@ _DATA_VARIABLES = (
     ),
     GEFSDataVar(
         name="downward_long_wave_radiation_flux_surface",
-        encoding=replace(ENCODING_FLOAT32_DEFAULT, add_offset=300.0),
+        encoding=replace(ENCODING_FLOAT32_DEFAULT),
         attrs=DataVarAttrs(
             short_name="sdlwrf",
             long_name="Surface downward long-wave radiation flux",
@@ -932,7 +932,7 @@ _DATA_VARIABLES = (
     # ),
     GEFSDataVar(
         name="pressure_reduced_to_mean_sea_level",
-        encoding=replace(ENCODING_FLOAT32_DEFAULT, add_offset=101_000.0),
+        encoding=replace(ENCODING_FLOAT32_DEFAULT),
         attrs=DataVarAttrs(
             short_name="prmsl",
             long_name="Pressure reduced to MSL",
@@ -945,7 +945,7 @@ _DATA_VARIABLES = (
             grib_index_level="mean sea level",
             gefs_file_type="s+a",
             index_position=38,
-            keep_mantissa_bits=GEFS_BITROUND_KEEP_MANTISSA_BITS_DEFAULT,
+            keep_mantissa_bits=8,
         ),
     ),
 )

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/downward_long_wave_radiation_flux_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/downward_long_wave_radiation_flux_surface/zarr.json
@@ -76,7 +76,6 @@
     "units": "W/(m^2)",
     "step_type": "avg",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-    "add_offset": 300.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/downward_long_wave_radiation_flux_surface_avg/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/downward_long_wave_radiation_flux_surface_avg/zarr.json
@@ -74,7 +74,6 @@
     "step_type": "avg",
     "ensemble_statistic": "avg",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
-    "add_offset": 300.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/pressure_reduced_to_mean_sea_level/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/pressure_reduced_to_mean_sea_level/zarr.json
@@ -76,7 +76,6 @@
     "units": "Pa",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-    "add_offset": 101000.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/pressure_reduced_to_mean_sea_level_avg/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/pressure_reduced_to_mean_sea_level_avg/zarr.json
@@ -74,7 +74,6 @@
     "step_type": "instant",
     "ensemble_statistic": "avg",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
-    "add_offset": 101000.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/pressure_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/pressure_surface/zarr.json
@@ -77,7 +77,6 @@
     "units": "Pa",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-    "add_offset": 100000.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/pressure_surface_avg/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/pressure_surface_avg/zarr.json
@@ -75,7 +75,6 @@
     "step_type": "instant",
     "ensemble_statistic": "avg",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
-    "add_offset": 100000.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/relative_humidity_2m/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/relative_humidity_2m/zarr.json
@@ -77,7 +77,6 @@
     "units": "%",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-    "add_offset": 50.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/relative_humidity_2m_avg/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/relative_humidity_2m_avg/zarr.json
@@ -75,7 +75,6 @@
     "step_type": "instant",
     "ensemble_statistic": "avg",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
-    "add_offset": 50.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/total_cloud_cover_atmosphere/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/total_cloud_cover_atmosphere/zarr.json
@@ -76,7 +76,6 @@
     "units": "%",
     "step_type": "avg",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-    "add_offset": 50.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/total_cloud_cover_atmosphere_avg/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/total_cloud_cover_atmosphere_avg/zarr.json
@@ -74,7 +74,6 @@
     "step_type": "avg",
     "ensemble_statistic": "avg",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
-    "add_offset": 50.0,
     "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
@@ -811,7 +811,6 @@
           "units": "W/(m^2)",
           "step_type": "avg",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-          "add_offset": 300.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -901,7 +900,6 @@
           "step_type": "avg",
           "ensemble_statistic": "avg",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
-          "add_offset": 300.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -2592,7 +2590,6 @@
           "units": "Pa",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-          "add_offset": 101000.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -2682,7 +2679,6 @@
           "step_type": "instant",
           "ensemble_statistic": "avg",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
-          "add_offset": 101000.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -2774,7 +2770,6 @@
           "units": "Pa",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-          "add_offset": 100000.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -2865,7 +2860,6 @@
           "step_type": "instant",
           "ensemble_statistic": "avg",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
-          "add_offset": 100000.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -2957,7 +2951,6 @@
           "units": "%",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-          "add_offset": 50.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -3048,7 +3041,6 @@
           "step_type": "instant",
           "ensemble_statistic": "avg",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
-          "add_offset": 50.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -3369,7 +3361,6 @@
           "units": "%",
           "step_type": "avg",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
-          "add_offset": 50.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
@@ -3459,7 +3450,6 @@
           "step_type": "avg",
           "ensemble_statistic": "avg",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
-          "add_offset": 50.0,
           "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [


### PR DESCRIPTION
It appears they are not respected in xarray with zarr v3 and if we adjust bitrounding we can maintain precision and compression without them.