### PR TITLE
Fix OOM on write metadata by using one big chunk in template_ds dask arrays

### DIFF
--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -99,10 +99,10 @@ def reformat_operational_update() -> None:
     # template_ds = template_ds.isel(init_time=slice(0, len(ds.init_time) + 2))
 
     # We make some assumptions about what is safe to parallelize and how to
-    # write the data based on the init_time dimension having a chunk size of one.
+    # write the data based on the init_time dimension having a shard size of one.
     # If this changes we will need to refactor.
     assert all(
-        all(1 == val for val in da.chunksizes[_PROCESSING_CHUNK_DIMENSION])
+        1 == da.encoding["shards"][da.dims.index(_PROCESSING_CHUNK_DIMENSION)]
         for da in ds.data_vars.values()
     )
     new_init_times = template_ds.init_time.loc[

--- a/src/reformatters/noaa/gefs/forecast_35_day/template.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/template.py
@@ -213,7 +213,9 @@ def empty_copy_with_reindex(
             fill_value=np.nan,
             shape=[ds.sizes[dim] for dim in var.dims],
             dtype=var.dtype,
-            chunks=var.encoding["chunks"],
+            # Using actual chunk size causes OOM when writing metadata.
+            # Check the chunks/shards in the encoding for the stored sizes.
+            chunks=-1,
         )
         ds[var_name] = (var.dims, nan_array)
         ds[var_name].attrs = var.attrs.copy()


### PR DESCRIPTION
Don't change the actual encodings of stored data.
Make sure we drive processing based on the encodings, not by assuming template dask chunks == encoding.

Dask on the .to_zarr call seems to be trying to cache something for every _dask_ chunk which is a massive amount (18,726,930 per data var) if dask chunks == chunks in our full dataset and causes an OOM.