### PR TITLE
Break up jobs to process groups of data variables

### DIFF
--- a/src/reformatters/noaa/gefs/read_data.py
+++ b/src/reformatters/noaa/gefs/read_data.py
@@ -199,7 +199,7 @@ def parse_index_byte_ranges(
             index_contents,
         )
         assert len(matches) == 1, (
-            f"Expected exactly 1 match, found {matches}, {var_info=}"
+            f"Expected exactly 1 match, found {matches}, {var_info.name} {idx_local_path}"
         )
         match = matches[0]
         start_byte = int(match[0])


### PR DESCRIPTION
This makes each job smaller and we loose less work if a pod is restarted