### PR TITLE
[GEFS analysis] Prepare for interpolation to 3h from 6h data in pre-v12 archive (Jan-Sept 2020) 

### DIFF
--- a/src/reformatters/noaa/gefs/analysis/reformat_internals.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat_internals.py
@@ -66,7 +66,11 @@ def reformat_time_i_slices(
     shared_buffer_size = max(
         data_var.nbytes
         for data_var in template_ds.isel(
-            {template.APPEND_DIMENSION: jobs[0][0]}
+            {
+                template.APPEND_DIMENSION: slice(
+                    max(0, jobs[-1][0].start - 1), jobs[-1][0].stop + 1
+                )
+            }
         ).values()
     )
     with (

--- a/src/reformatters/noaa/gefs/read_data.py
+++ b/src/reformatters/noaa/gefs/read_data.py
@@ -58,9 +58,9 @@ class ChunkCoordinates(TypedDict):
 # 2. The pre GEFS v12 archive, which is 1.0 degree data that we use from 2020-01-01 to 2020-09-30.
 # 3. The GEFS v12 retrospective (reforecast) archive, which is 0.25 degree data from 2000-01-01 to 2019-12-31.
 #
-GEFS_CURRENT_ARCHIVE_START = pd.Timestamp("2020-10-01T00:00")
-GEFS_REFORECAST_START = pd.Timestamp("2000-01-01T00:00")
+GEFS_CURRENT_ARCHIVE_START = pd.Timestamp("2020-09-23T00:00")
 GEFS_REFORECAST_END = pd.Timestamp("2020-01-01T00:00")  # exclusive end point
+GEFS_REFORECAST_START = pd.Timestamp("2000-01-01T00:00")
 
 GEFS_REFORECAST_INIT_TIME_FREQUENCY = pd.Timedelta("24h")
 GEFS_INIT_TIME_FREQUENCY: Final[pd.Timedelta] = pd.Timedelta("6h")

--- a/src/reformatters/noaa/gefs/read_data.py
+++ b/src/reformatters/noaa/gefs/read_data.py
@@ -67,6 +67,12 @@ GEFS_INIT_TIME_FREQUENCY: Final[pd.Timedelta] = pd.Timedelta("6h")
 
 # Accumulations are reset every 6 hours in all periods of GEFS data
 GEFS_ACCUMULATION_RESET_FREQUENCY: Final[pd.Timedelta] = pd.Timedelta("6h")
+GEFS_ACCUMULATION_RESET_HOURS: Final[int] = int(
+    GEFS_ACCUMULATION_RESET_FREQUENCY.total_seconds() / (60 * 60)
+)
+assert GEFS_ACCUMULATION_RESET_FREQUENCY == pd.Timedelta(
+    hours=GEFS_ACCUMULATION_RESET_HOURS
+)
 
 # Short names are used in the file names of the GEFS v12 reforecast
 GEFS_REFORECAST_LEVELS_SHORT = {
@@ -256,21 +262,14 @@ def parse_index_byte_ranges(
 
 
 def get_hours_str(var_info: GEFSDataVar, lead_time_hours: float) -> str:
-    gefs_accumulation_reset_hours = (
-        GEFS_ACCUMULATION_RESET_FREQUENCY.total_seconds() // (60 * 60)
-    )
-    assert (
-        pd.Timedelta(hours=gefs_accumulation_reset_hours)
-        == GEFS_ACCUMULATION_RESET_FREQUENCY
-    )
     if lead_time_hours == 0:
         hours_str = "anl"  # analysis
     elif var_info.attrs.step_type == "instant":
         hours_str = f"{lead_time_hours:.0f} hour"
     else:
-        diff_hours = lead_time_hours % gefs_accumulation_reset_hours
+        diff_hours = lead_time_hours % GEFS_ACCUMULATION_RESET_HOURS
         if diff_hours == 0:
-            reset_hour = lead_time_hours - gefs_accumulation_reset_hours
+            reset_hour = lead_time_hours - GEFS_ACCUMULATION_RESET_HOURS
         else:
             reset_hour = lead_time_hours - diff_hours
         hours_str = f"{reset_hour:.0f}-{lead_time_hours:.0f} hour"
@@ -304,9 +303,9 @@ def read_into(
     grib_element = data_var.internal_attrs.grib_element
     if data_var.internal_attrs.include_lead_time_suffix:
         lead_hours = coords["lead_time"].total_seconds() / (60 * 60)
-        if lead_hours % 6 == 0:
+        if lead_hours % GEFS_ACCUMULATION_RESET_HOURS == 0:
             grib_element += "06"
-        elif lead_hours % 6 == 3:
+        elif lead_hours % GEFS_ACCUMULATION_RESET_HOURS == 3:
             grib_element += "03"
         else:
             raise AssertionError(f"Unexpected lead time hours: {lead_hours}")

--- a/tests/common/test_deaccumulation.py
+++ b/tests/common/test_deaccumulation.py
@@ -319,3 +319,81 @@ def test_deaccumulate_1d_time_dim_3_and_6_hour_normal_cases() -> None:
     )
 
     np.testing.assert_equal(result.values, expected)
+
+
+def test_deaccumulate_skip_steps_all_false() -> None:
+    reset_frequency = pd.Timedelta(hours=6)
+    sec = float(SECONDS_PER_HOUR)
+
+    # These values will have large accumulations going in and output rates that in the single digits
+    values = [
+        # 3 hourly step:
+        {"lt": 0, "in": np.nan, "out": np.nan},  # no deaccum on first step
+        {"lt": 3, "in": 4 * sec * 3, "out": 4.0},  # standard 3h case
+        {"lt": 6, "in": 4 * sec * 3, "out": 0.0},  # no new accumulation between 3h and 6h steps
+        {"lt": 9, "in": 0 * sec * 3, "out": 0.0},  # no new accumulation between 6h and 3h steps
+        {"lt": 12, "in": 2 * sec * 3, "out": 2.0}, # 0 mm accumulated in first 3 hours, 2 mm accumulated in next 3 hours
+        # Test transition from 3h to 6h accumulation
+        # 6 hourly step:
+        {"lt": 18, "in": 3 * sec * 6, "out": 3.0},  # standard 6h case following a 3h step
+        {"lt": 24, "in": 7 * sec * 6, "out": 7.0},  # standard 6h case
+    ]  # fmt: off
+
+    lead_times = pd.to_timedelta([step["lt"] for step in values], unit="h")
+    # Start time at 03:00 tests reseting works regardless of the start time
+    times = pd.Timestamp("2000-01-01T00:00") + lead_times
+    data = np.array([step["in"] for step in values], dtype=np.float32)
+    expected = np.array([step["out"] for step in values], dtype=np.float32)
+
+    data_array = xr.DataArray(
+        data,
+        coords={"time": times},
+        dims=["time"],
+        attrs={"units": "mm/s"},
+    )
+
+    result = deaccumulate_to_rates_inplace(
+        data_array,
+        dim="time",
+        reset_frequency=reset_frequency,
+        skip_step=np.zeros(len(times), dtype=np.bool),
+    )
+
+    np.testing.assert_equal(result.values, expected)
+
+
+def test_deaccumulate_1d_skip_every_other_step() -> None:
+    reset_frequency = pd.Timedelta(hours=6)
+    sec = float(SECONDS_PER_HOUR)
+    nan = np.nan
+
+    # These values will have large accumulations going in and output rates that in the single digits
+    values = [
+        # 3 hourly step with 6 hourly data
+        {"lt": 0, "in": nan, "out": nan, "skip": False},  # no deaccum on first step
+        {"lt": 3, "in": nan, "out": nan, "skip": True},  # standard 3h case
+        {"lt": 6, "in": 4 * sec * 6, "out": 4.0, "skip": False},  # no new accumulation between 3h and 6h steps
+        {"lt": 9, "in": nan, "out": nan, "skip": True},  # no new accumulation between 6h and 3h steps
+        {"lt": 12, "in": 2 * sec * 6, "out": 2.0, "skip": False}, # 0 mm accumulated in first 3 hours, 2 mm accumulated in next 3 hours
+    ]  # fmt: off
+
+    lead_times = pd.to_timedelta([step["lt"] for step in values], unit="h")
+    skip_step = np.array([step["skip"] for step in values])
+    data = np.array([step["in"] for step in values], dtype=np.float32)
+    expected = np.array([step["out"] for step in values], dtype=np.float32)
+
+    data_array = xr.DataArray(
+        data,
+        coords={"lead_time": lead_times},
+        dims=["lead_time"],
+        attrs={"units": "mm/s"},
+    )
+
+    result = deaccumulate_to_rates_inplace(
+        data_array,
+        dim="lead_time",
+        reset_frequency=reset_frequency,
+        skip_step=skip_step,
+    )
+
+    np.testing.assert_equal(result.values, expected)

--- a/tests/common/test_deaccumulation.py
+++ b/tests/common/test_deaccumulation.py
@@ -371,10 +371,10 @@ def test_deaccumulate_1d_skip_every_other_step() -> None:
     values = [
         # 3 hourly step with 6 hourly data
         {"lt": 0, "in": nan, "out": nan, "skip": False},  # no deaccum on first step
-        {"lt": 3, "in": nan, "out": nan, "skip": True},  # standard 3h case
-        {"lt": 6, "in": 4 * sec * 6, "out": 4.0, "skip": False},  # no new accumulation between 3h and 6h steps
-        {"lt": 9, "in": nan, "out": nan, "skip": True},  # no new accumulation between 6h and 3h steps
-        {"lt": 12, "in": 2 * sec * 6, "out": 2.0, "skip": False}, # 0 mm accumulated in first 3 hours, 2 mm accumulated in next 3 hours
+        {"lt": 3, "in": nan, "out": nan, "skip": True},  # skip step
+        {"lt": 6, "in": 4 * sec * 6, "out": 4.0, "skip": False},  # 4 mm/s accumulation in last 6 hours
+        {"lt": 9, "in": nan, "out": nan, "skip": True},  # skip step
+        {"lt": 12, "in": 2 * sec * 6, "out": 2.0, "skip": False}, # 2 mm/s accumulation in last 6 hours
     ]  # fmt: off
 
     lead_times = pd.to_timedelta([step["lt"] for step in values], unit="h")

--- a/tests/noaa/gefs/analysis/test_reformat_internals.py
+++ b/tests/noaa/gefs/analysis/test_reformat_internals.py
@@ -339,37 +339,31 @@ def test_filter_available_times() -> None:
 
 
 def test_filter_available_times_current_archive_boundary() -> None:
-    start_time = pd.Timestamp("2020-09-30T00:00")
-    end_time = pd.Timestamp("2020-10-01T18:00")
+    start_time = pd.Timestamp("2020-09-22T00:00")
+    end_time = pd.Timestamp("2020-09-24T00:00")
 
     # Create a date range with 3-hourly steps
     times = pd.date_range(start=start_time, end=end_time, freq="3h")
 
     filtered_times = filter_available_times(times)
 
-    # Times before Oct 1 should be 6-hourly
-    before_oct = filtered_times[filtered_times < pd.Timestamp("2020-10-01")]
-    expected_before = pd.DatetimeIndex(
+    expected = pd.DatetimeIndex(
         [
-            pd.Timestamp("2020-09-30T00:00"),
-            pd.Timestamp("2020-09-30T06:00"),
-            pd.Timestamp("2020-09-30T12:00"),
-            pd.Timestamp("2020-09-30T18:00"),
+            # Times before Sept 23 should be 6-hourly
+            pd.Timestamp("2020-09-22T00:00"),
+            pd.Timestamp("2020-09-22T06:00"),
+            pd.Timestamp("2020-09-22T12:00"),
+            pd.Timestamp("2020-09-22T18:00"),
+            # Times from Sept 23 onwards should be 3-hourly
+            pd.Timestamp("2020-09-23T00:00"),
+            pd.Timestamp("2020-09-23T03:00"),
+            pd.Timestamp("2020-09-23T06:00"),
+            pd.Timestamp("2020-09-23T09:00"),
+            pd.Timestamp("2020-09-23T12:00"),
+            pd.Timestamp("2020-09-23T15:00"),
+            pd.Timestamp("2020-09-23T18:00"),
+            pd.Timestamp("2020-09-23T21:00"),
+            pd.Timestamp("2020-09-24T00:00"),
         ]
     )
-    pd.testing.assert_index_equal(before_oct, expected_before)
-
-    # Times from Oct 1 onwards should be 3-hourly
-    after_oct = filtered_times[filtered_times >= pd.Timestamp("2020-10-01")]
-    expected_after = pd.DatetimeIndex(
-        [
-            pd.Timestamp("2020-10-01T00:00"),
-            pd.Timestamp("2020-10-01T03:00"),
-            pd.Timestamp("2020-10-01T06:00"),
-            pd.Timestamp("2020-10-01T09:00"),
-            pd.Timestamp("2020-10-01T12:00"),
-            pd.Timestamp("2020-10-01T15:00"),
-            pd.Timestamp("2020-10-01T18:00"),
-        ]
-    )
-    pd.testing.assert_index_equal(after_oct, expected_after)
+    pd.testing.assert_index_equal(filtered_times, expected)


### PR DESCRIPTION
In order to support correct interpolation this PR
- widens the data processed for each chunk by 3 hours to ensure we have boundary values for proper interpolation later
- skips 3 hourly steps in deaccumulation of 6 hourly data so we properly deaccumulate (which needs to happen before interpolation)

Actual interpolation implementation will come after the PR so it doesn't get too big