### PR TITLE
[HRRR] add selective downloading to HRRR

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour/template.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/template.py
@@ -11,6 +11,7 @@ from reformatters.common.template_utils import assign_var_metadata, make_empty_v
 from reformatters.common.template_utils import (
     write_metadata as write_metadata,  # re-export
 )
+from reformatters.noaa.hrrr.hrrr_config_models import HRRRDataVar
 from reformatters.noaa.hrrr.read_data import (
     SourceFileCoords,
     download_file,
@@ -61,7 +62,7 @@ def update_template() -> None:
 
 
 def derive_coordinates(
-    ds: xr.Dataset,
+    ds: xr.Dataset, data_var: HRRRDataVar = DATA_VARIABLES[0]
 ) -> dict[str, xr.DataArray | tuple[tuple[str, ...], np.ndarray[Any, Any]]]:
     # derivation of HRRR latitude / longitude coordinates is simplest by downloading
     # a sample file and extracting the coordinates from the file itself.
@@ -74,8 +75,7 @@ def derive_coordinates(
     )
 
     # "sfc" is the smallest available file type.
-    # TODO (tony): ensure we only pull down 1 grib message for this to save download time/bdwth
-    _, filepath = download_file(data_coords, "sfc")
+    _, filepath = download_file(data_coords, "sfc", [data_var])
     hrrrds = xr.open_dataset(str(filepath), engine="rasterio")
 
     hrrrds_bounds = hrrrds.rio.bounds(recalc=True)


### PR DESCRIPTION
A bit busier around here these days, less progress than I'd hoped. But wanted to get a small iteration up. 

I saw what I thought was a bunch of duplicated downloading code across the NOAA models (GFS/GEFS/HRRR) and so set out to reduce the duplication across the various `read_data` modules, but ended up getting the runaround with some small differences. So I stashed all that into another branch and just went ahead with this duplicative but simple implementation. 

Obviously the important part here is the regex used to parse variables in the IDX file. The only field I'm not using in the HRRR IDX is the last, e.g the `anl` value: 

```
1:0:d=2025010100:REFC:entire atmosphere:anl:
```

I don' think there's any reason to store + match on that since the grib_element and grib_index_level should uniquely define a layer in the GRIB, but I may be wrong. 

Curious what you think next steps should be here @aldenks after we get the template working. 
