### PR TITLE
GEFS analysis operational updating

### DIFF
--- a/src/reformatters/common/deploy.py
+++ b/src/reformatters/common/deploy.py
@@ -4,6 +4,9 @@ from collections.abc import Iterable
 from typing import Protocol
 
 from reformatters.common import docker, kubernetes
+from reformatters.noaa.gefs.analysis.reformat import (
+    operational_kubernetes_resources as noaa_gefs_analysis_operational_kubernetes_resources,
+)
 from reformatters.noaa.gefs.forecast_35_day.reformat import (
     operational_kubernetes_resources as noaa_gefs_forecast_35_day_operational_kubernetes_resources,
 )
@@ -13,13 +16,14 @@ class OperationalKubernetesResources(Protocol):
     def __call__(self, image_tag: str) -> Iterable[kubernetes.Job]: ...
 
 
-OPERATIONAL_RESOURCE_FNS: tuple[OperationalKubernetesResources] = (
+OPERATIONAL_RESOURCE_FNS: tuple[OperationalKubernetesResources, ...] = (
     noaa_gefs_forecast_35_day_operational_kubernetes_resources,
+    noaa_gefs_analysis_operational_kubernetes_resources,
 )
 
 
 def deploy_operational_updates(
-    fns: tuple[OperationalKubernetesResources] = OPERATIONAL_RESOURCE_FNS,
+    fns: tuple[OperationalKubernetesResources, ...] = OPERATIONAL_RESOURCE_FNS,
     docker_image: str | None = None,
 ) -> None:
     image_tag = docker_image or docker.build_and_push_image()

--- a/src/reformatters/common/reformat_utils.py
+++ b/src/reformatters/common/reformat_utils.py
@@ -9,12 +9,25 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 import zarr
+from pydantic import BaseModel
 
 from reformatters.common.iterating import consume, shard_slice_indexers
 from reformatters.common.logging import get_logger
 from reformatters.common.types import ArrayFloat32
 
 logger = get_logger(__name__)
+
+
+class ChunkFilters(BaseModel):
+    """
+    Filters for controlling which chunks of data to process.
+    A value of None means no filtering.
+    """
+
+    time_dim: str
+    time_start: str | None = None
+    time_end: str | None = None
+    variable_names: list[str] | None = None
 
 
 def create_data_array_and_template(

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -76,7 +76,7 @@ def check_forecast_current_data(ds: xr.Dataset) -> ValidationResult:
 
 
 def check_forecast_recent_nans(
-    ds: xr.Dataset, max_nan_percentage: float = 5
+    ds: xr.Dataset, max_nan_percentage: float = 30
 ) -> ValidationResult:
     """Check for NaN values in the most recent day of data. Fails if more than max_nan_percentage of sampled data is NaN."""
 

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -76,9 +76,9 @@ def check_forecast_current_data(ds: xr.Dataset) -> ValidationResult:
 
 
 def check_forecast_recent_nans(
-    ds: xr.Dataset, max_nan_percentage: float = 30
+    ds: xr.Dataset, max_nan_percentage: float = 5
 ) -> ValidationResult:
-    """Check for NaN values in the most recent day of data. Fails if more than 70% of sampled data is NaN."""
+    """Check for NaN values in the most recent day of data. Fails if more than max_nan_percentage of sampled data is NaN."""
 
     now = pd.Timestamp.now()
     # We want to show that the latest init time has valid data going out up to 10 days (we may not have forecasts
@@ -107,4 +107,51 @@ def check_forecast_recent_nans(
     return ValidationResult(
         passed=True,
         message=f"All variables have acceptable NaN percentages (<{max_nan_percentage}%) in sampled locations of latest data",
+    )
+
+
+def check_analysis_current_data(ds: xr.Dataset) -> ValidationResult:
+    """Check for data in the most recent day. Fails if no data is found."""
+    now = pd.Timestamp.now()
+    latest_init_time_ds = ds.sel(time=slice(now - timedelta(hours=12), None))
+    if latest_init_time_ds.sizes["time"] == 0:
+        return ValidationResult(
+            passed=False, message="No data found for the latest day"
+        )
+
+    return ValidationResult(
+        passed=True,
+        message="Data found for the latest day",
+    )
+
+
+def check_analysis_recent_nans(
+    ds: xr.Dataset, max_nan_percentage: float = 5
+) -> ValidationResult:
+    """Check for NaN values in the most recent day of data. Fails if more than max_nan_percentage of sampled data is NaN."""
+
+    now = pd.Timestamp.now()
+
+    lon, lat = np.random.uniform(-180, 179), np.random.uniform(-90, 89)
+    sample_ds = ds.sel(
+        time=slice(now - timedelta(hours=12), None),
+        latitude=slice(lat, lat - 2),
+        longitude=slice(lon, lon + 2),
+    )
+
+    problem_vars = []
+    for var_name, da in sample_ds.data_vars.items():
+        nan_percentage = da.isnull().mean().compute() * 100
+        if nan_percentage > max_nan_percentage:
+            problem_vars.append((var_name, nan_percentage))
+
+    if problem_vars:
+        message = "Excessive NaN values found:\n"
+        for var, pct in problem_vars:
+            message += f"- {var}: {pct:.1f}% NaN\n"
+        return ValidationResult(passed=False, message=message)
+
+    return ValidationResult(
+        passed=True,
+        message=f"All variables have acceptable NaN percentages (<{max_nan_percentage}%) in sampled location of latest data",
     )

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -90,11 +90,17 @@ def get_mode(
 
 def copy_data_var(
     data_var_name: str,
-    chunk_index: int,
+    i_slice: slice,
+    template_ds: xr.Dataset,
+    append_dim: str,
     tmp_store: Path,
     final_store: zarr.storage.FsspecStore,
 ) -> None:
-    relative_dir = f"{data_var_name}/c/{chunk_index}/"
+    dim_index = template_ds[data_var_name].dims.index(append_dim)
+    append_dim_shard_size = template_ds[data_var_name].encoding["shards"][dim_index]
+    shard_index = i_slice.start // append_dim_shard_size
+    assert dim_index == 0  # relative_dir format below assumes append dim is first
+    relative_dir = f"{data_var_name}/c/{shard_index}/"
 
     logger.info(
         f"Copying data var chunks to final store ({final_store}) for {relative_dir}."

--- a/src/reformatters/noaa/gefs/analysis/cli.py
+++ b/src/reformatters/noaa/gefs/analysis/cli.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 import typer
 
+from reformatters.common.reformat_utils import ChunkFilters
 from reformatters.noaa.gefs.analysis import reformat, template
 from reformatters.noaa.gefs.analysis.template import DATASET_ID as DATASET_ID
 
@@ -14,8 +15,21 @@ def update_template() -> None:
 
 
 @app.command()
-def reformat_local(time_end: str) -> None:
-    reformat.reformat_local(time_end)
+def reformat_local(
+    time_end: str,
+    filter_time_start: str | None = None,
+    filter_time_end: str | None = None,
+    filter_variable_names: list[str] | None = None,
+) -> None:
+    reformat.reformat_local(
+        time_end,
+        chunk_filters=ChunkFilters(
+            time_dim=template.APPEND_DIMENSION,
+            time_start=filter_time_start,
+            time_end=filter_time_end,
+            variable_names=filter_variable_names,
+        ),
+    )
 
 
 @app.command()
@@ -24,9 +38,21 @@ def reformat_kubernetes(
     jobs_per_pod: int = 1,
     max_parallelism: int = 32,
     docker_image: str | None = None,
+    filter_time_start: str | None = None,
+    filter_time_end: str | None = None,
+    filter_variable_names: list[str] | None = None,
 ) -> None:
     reformat.reformat_kubernetes(
-        time_end, jobs_per_pod, max_parallelism, docker_image=docker_image
+        time_end,
+        jobs_per_pod,
+        max_parallelism,
+        docker_image=docker_image,
+        chunk_filters=ChunkFilters(
+            time_dim=template.APPEND_DIMENSION,
+            time_start=filter_time_start,
+            time_end=filter_time_end,
+            variable_names=filter_variable_names,
+        ),
     )
 
 
@@ -35,21 +61,31 @@ def reformat_chunks(
     time_end: str,
     worker_index: Annotated[int, typer.Argument(envvar="WORKER_INDEX")],
     workers_total: Annotated[int, typer.Argument(envvar="WORKERS_TOTAL")],
+    filter_time_start: str | None = None,
+    filter_time_end: str | None = None,
+    filter_variable_names: list[str] | None = None,
 ) -> None:
     reformat.reformat_chunks(
-        time_end, worker_index=worker_index, workers_total=workers_total
+        time_end,
+        worker_index=worker_index,
+        workers_total=workers_total,
+        chunk_filters=ChunkFilters(
+            time_dim=template.APPEND_DIMENSION,
+            time_start=filter_time_start,
+            time_end=filter_time_end,
+            variable_names=filter_variable_names,
+        ),
     )
 
 
-# Not implemented yet
-# @app.command()
-# def reformat_operational_update() -> None:
-#     reformat.reformat_operational_update()
+@app.command()
+def reformat_operational_update() -> None:
+    reformat.reformat_operational_update()
 
 
-# @app.command()
-# def validate_zarr() -> None:
-#     reformat.validate_zarr()
+@app.command()
+def validate_zarr() -> None:
+    reformat.validate_zarr()
 
 
 if __name__ == "__main__":

--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -1,35 +1,35 @@
-import concurrent.futures  # noqa: F401  # all these imports are used in the commented operational update code
+import concurrent.futures
 import json
-import os  # noqa: F401
+import os
 import subprocess
-from collections.abc import Iterable  # noqa: F401
-from concurrent.futures import ThreadPoolExecutor  # noqa: F401
-from itertools import product, starmap  # noqa: F401
+from collections.abc import Iterable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from itertools import product
 
 import numpy as np
 import pandas as pd
-import sentry_sdk  # noqa: F401
+import sentry_sdk
 import xarray as xr
 import zarr
 
-from reformatters.common import docker, validation  # noqa: F401
-from reformatters.common.config import Config  # noqa:F401
+from reformatters.common import docker, validation
 from reformatters.common.iterating import (
     consume,
     dimension_slices,
     get_worker_jobs,
 )
-from reformatters.common.kubernetes import (  # noqa: F401
+from reformatters.common.kubernetes import (
     Job,
     ReformatCronJob,
     ValidationCronJob,
 )
-from reformatters.common.logging import get_logger  # noqa: F401
-from reformatters.common.types import Array1D, DatetimeLike  # noqa: F401
+from reformatters.common.logging import get_logger
+from reformatters.common.reformat_utils import ChunkFilters
+from reformatters.common.types import DatetimeLike
 from reformatters.common.zarr import (
-    copy_data_var,  # noqa: F401
-    copy_zarr_metadata,  # noqa: F401
-    get_local_tmp_store,  # noqa: F401
+    copy_data_var,
+    copy_zarr_metadata,
+    get_local_tmp_store,
     get_mode,
     get_zarr_store,
 )
@@ -38,16 +38,17 @@ from reformatters.noaa.gefs.analysis.reformat_internals import (
     group_data_vars_by_gefs_file_type,
     reformat_time_i_slices,
 )
+from reformatters.noaa.gefs.gefs_config_models import GEFSDataVar
 
 # 1 makes logic simpler when accessing GEFSv12 reforecast which has a file per variable
 _VARIABLES_PER_BACKFILL_JOB = 1
-_OPERATIONAL_CRON_SCHEDULE = "0 7 * * *"  # At 7:00 UTC every day.
-_VALIDATION_CRON_SCHEDULE = "0 10 * * *"  # At 10:00 UTC every day.
+_OPERATIONAL_CRON_SCHEDULE = "0 0,6,12,18 * * *"  # UTC
+_VALIDATION_CRON_SCHEDULE = "30 7,10,13,19 * * *"  # UTC 1.5 hours after update
 
 logger = get_logger(__name__)
 
 
-def reformat_local(time_end: DatetimeLike) -> None:
+def reformat_local(time_end: DatetimeLike, chunk_filters: ChunkFilters) -> None:
     template_ds = template.get_template(time_end)
     store = get_store()
 
@@ -56,7 +57,9 @@ def reformat_local(time_end: DatetimeLike) -> None:
 
     logger.info("Starting reformat")
     # Process all chunks by setting worker_index=0 and worker_total=1
-    reformat_chunks(time_end, worker_index=0, workers_total=1)
+    reformat_chunks(
+        time_end, worker_index=0, workers_total=1, chunk_filters=chunk_filters
+    )
     logger.info(f"Done writing to {store}")
 
 
@@ -64,6 +67,7 @@ def reformat_kubernetes(
     time_end: DatetimeLike,
     jobs_per_pod: int,
     max_parallelism: int,
+    chunk_filters: ChunkFilters,
     docker_image: str | None = None,
 ) -> None:
     image_tag = docker_image or docker.build_and_push_image()
@@ -73,11 +77,28 @@ def reformat_kubernetes(
     logger.info(f"Writing zarr metadata to {store.path}")
     template.write_metadata(template_ds, store, get_mode(store))
 
-    num_jobs = sum(1 for _ in all_jobs_ordered(template_ds))
+    num_jobs = sum(
+        1
+        for _ in all_jobs_ordered(
+            template_ds,
+            chunk_filters,
+            template.DATA_VARIABLES,
+            _VARIABLES_PER_BACKFILL_JOB,
+        )
+    )
     workers_total = int(np.ceil(num_jobs / jobs_per_pod))
     parallelism = min(workers_total, max_parallelism)
 
     dataset_id = template_ds.attrs["dataset_id"]
+
+    command = ["reformat-chunks", pd.Timestamp(time_end).isoformat()]
+    if chunk_filters.time_start is not None:
+        command.append(f"--filter-time-start={chunk_filters.time_start}")
+    if chunk_filters.time_end is not None:
+        command.append(f"--filter-time-end={chunk_filters.time_end}")
+    if chunk_filters.variable_names is not None:
+        for variable_name in chunk_filters.variable_names:
+            command.append(f"--filter-variable-names={variable_name}")
 
     kubernetes_job = Job(
         image=image_tag,
@@ -88,10 +109,7 @@ def reformat_kubernetes(
         memory="30G",  # fit on 32GB node
         shared_memory="12G",
         ephemeral_storage="30G",
-        command=[
-            "reformat-chunks",
-            pd.Timestamp(time_end).isoformat(),
-        ],
+        command=command,
     )
     subprocess.run(  # noqa: S603
         ["/usr/bin/kubectl", "apply", "-f", "-"],
@@ -104,7 +122,11 @@ def reformat_kubernetes(
 
 
 def reformat_chunks(
-    time_end: DatetimeLike, *, worker_index: int, workers_total: int
+    time_end: DatetimeLike,
+    *,
+    worker_index: int,
+    workers_total: int,
+    chunk_filters: ChunkFilters,
 ) -> None:
     """Writes out array chunk data. Assumes the dataset metadata has already been written."""
     assert worker_index < workers_total
@@ -112,7 +134,12 @@ def reformat_chunks(
     store = get_store()
 
     worker_jobs = get_worker_jobs(
-        all_jobs_ordered(template_ds),
+        all_jobs_ordered(
+            template_ds,
+            chunk_filters,
+            template.DATA_VARIABLES,
+            _VARIABLES_PER_BACKFILL_JOB,
+        ),
         worker_index,
         workers_total,
     )
@@ -128,205 +155,164 @@ def reformat_chunks(
     )
 
 
-# @sentry_sdk.monitor(
-#     monitor_slug=f"{template.DATASET_ID}-reformat-operational-update",
-#     monitor_config={
-#         "schedule": {"type": "crontab", "value": _OPERATIONAL_CRON_SCHEDULE},
-#         "timezone": "UTC",
-#     },
-# )
-# def reformat_operational_update() -> None:
-#     final_store = get_store()
-#     tmp_store = get_local_tmp_store()
-#     # Get the dataset, check what data is already present
-#     ds = xr.open_zarr(final_store, decode_timedelta=True)
-#     for coord in ds.coords.values():
-#         coord.load()
-#     last_existing_init_time = ds.init_time.max()
-#     time_end = _get_operational_update_time_end()
-#     template_ds = template.get_template(time_end)
-#     template_ds.ingested_forecast_length.loc[{"init_time": ds.init_time.values}] = (
-#         ds.ingested_forecast_length
-#     )
+@sentry_sdk.monitor(
+    monitor_slug=f"{template.DATASET_ID}-reformat-operational-update",
+    monitor_config={
+        "schedule": {"type": "crontab", "value": _OPERATIONAL_CRON_SCHEDULE},
+        "timezone": "UTC",
+    },
+)
+def reformat_operational_update() -> None:
+    append_dim = template.APPEND_DIMENSION
 
-#     # Uncomment this line for local testing to scope down the number of init times
-#     # template_ds = template_ds.isel(init_time=slice(0, len(ds.init_time) + 2))
+    final_store = get_store()
+    tmp_store = get_local_tmp_store()
+    # Get the dataset, check what data is already present
+    ds = xr.open_zarr(final_store, decode_timedelta=True)
+    for coord in ds.coords.values():
+        coord.load()
 
-#     # We make some assumptions about what is safe to parallelize and how to
-#     # write the data based on the init_time dimension having a shard size of one.
-#     # If this changes we will need to refactor.
-#     assert all(
-#         1 == da.encoding["shards"][da.dims.index(template.APPEND_DIMENSION)]
-#         for da in ds.data_vars.values()
-#     )
-#     new_init_times = template_ds.init_time.loc[
-#         template_ds.init_time > last_existing_init_time
-#     ]
-#     new_init_time_indices = template_ds.get_index(
-#         template.APPEND_DIMENSION
-#     ).get_indexer(new_init_times)  # type: ignore
-#     new_init_time_i_slices = list(
-#         starmap(
-#             slice,
-#             zip(
-#                 new_init_time_indices,
-#                 list(new_init_time_indices[1:]) + [None],
-#                 strict=False,
-#             ),
-#         )
-#     )
-#     # In addition to new dates, reprocess old dates whose forecasts weren't
-#     # previously fully written.
-#     # On long forecasts, NOAA may fill in the first 10 days first, then publish
-#     # an additional 25 days after a delay.
-#     recent_incomplete_init_times = _get_recent_init_times_for_reprocessing(ds)
-#     recent_incomplete_init_times_indices = template_ds.get_index(
-#         template.APPEND_DIMENSION
-#     ).get_indexer(recent_incomplete_init_times)  # type: ignore
-#     recent_incomplete_init_time_i_slices = list(
-#         starmap(
-#             slice,
-#             zip(
-#                 recent_incomplete_init_times_indices,
-#                 [x + 1 for x in recent_incomplete_init_times_indices],
-#                 strict=False,
-#             ),
-#         )
-#     )
-#     upload_executor = ThreadPoolExecutor(max_workers=(os.cpu_count() or 1) * 2)
+    last_existing_time = ds.time.max()
+    time_end = _get_operational_update_time_end()
+    template_ds = template.get_template(time_end)
 
-#     for init_time_i_slice in (
-#         recent_incomplete_init_time_i_slices + new_init_time_i_slices
-#     ):
-#         truncated_template_ds = template_ds.isel(
-#             init_time=slice(0, init_time_i_slice.stop)
-#         )
-#         # Write through this i_slice. Metadata is required for to_zarr's region="auto" option.
-#         template.write_metadata(
-#             truncated_template_ds,
-#             tmp_store,
-#             get_mode(tmp_store),
-#         )
-#         data_var_upload_futures = []
-#         for data_var, max_lead_times in reformat_time_i_slices(
-#             [(init_time_i_slice, list(template_ds.data_vars.keys()))],
-#             template_ds,
-#             tmp_store,
-#             _VARIABLES_PER_BACKFILL_JOB,
-#         ):
-#             # Writing a chunk without merging in existing data works because
-#             # the init_time dimension chunk size is 1.
-#             data_var_upload_futures.append(
-#                 upload_executor.submit(
-#                     copy_data_var,
-#                     data_var.name,
-#                     init_time_i_slice.start,
-#                     tmp_store,
-#                     final_store,
-#                 )
-#             )
-#             for (init_time, ensemble_member), max_lead_time in max_lead_times.items():
-#                 if np.issubdtype(type(ensemble_member), np.integer):
-#                     truncated_template_ds["ingested_forecast_length"].loc[
-#                         {"init_time": init_time, "ensemble_member": ensemble_member}
-#                     ] = max_lead_time
+    start_time = template_ds.loc[template_ds.time > last_existing_time].time.min()
+    chunk_filters = ChunkFilters(time_dim=append_dim, time_start=start_time)
+    update_jobs = get_worker_jobs(
+        all_jobs_ordered(
+            template_ds,
+            chunk_filters,
+            template.DATA_VARIABLES,
+            len(template.DATA_VARIABLES),
+        ),
+        worker_index=0,
+        workers_total=1,
+    )
+    upload_executor = ThreadPoolExecutor(max_workers=(os.cpu_count() or 1) * 2)
 
-#         concurrent.futures.wait(data_var_upload_futures, return_when="FIRST_EXCEPTION")
-#         for future in data_var_upload_futures:
-#             if (e := future.exception()) is not None:
-#                 raise e
+    for time_i_slice, all_data_var_names in update_jobs:
+        # Write through this i_slice. Metadata is required for to_zarr's region="auto" option.
+        truncated_template_ds = template_ds.isel(time=slice(0, time_i_slice.stop))
+        template.write_metadata(
+            truncated_template_ds,
+            tmp_store,
+            get_mode(tmp_store),
+        )
+        data_var_upload_futures = []
+        for data_var, _ in reformat_time_i_slices(
+            [(time_i_slice, all_data_var_names)],
+            template_ds,
+            tmp_store,
+            _VARIABLES_PER_BACKFILL_JOB,
+        ):
+            # Writing a chunk without merging in existing data works because
+            # the init_time dimension chunk size is 1.
+            data_var_upload_futures.append(
+                upload_executor.submit(
+                    copy_data_var,
+                    data_var.name,
+                    time_i_slice.start,
+                    tmp_store,
+                    final_store,
+                )
+            )
 
-#         # Write metadata again to update the ingested_forecast_length
-#         template.write_metadata(
-#             truncated_template_ds,
-#             tmp_store,
-#             get_mode(tmp_store),
-#         )
-#         # Write the metadata last, the data must be written first
-#         copy_zarr_metadata(truncated_template_ds, tmp_store, final_store)
+        concurrent.futures.wait(data_var_upload_futures, return_when="FIRST_EXCEPTION")
+        for future in data_var_upload_futures:
+            if (e := future.exception()) is not None:
+                raise e
+
+        # Write the metadata last, the data must be written first
+        copy_zarr_metadata(truncated_template_ds, tmp_store, final_store)
 
 
-# def _get_operational_update_time_end() -> pd.Timestamp:
-#     return pd.Timestamp.utcnow().tz_localize(None)
+def _get_operational_update_time_end() -> pd.Timestamp:
+    return pd.Timestamp.utcnow().tz_localize(None)
 
 
-# def _get_recent_init_times_for_reprocessing(ds: xr.Dataset) -> Array1D[np.datetime64]:
-#     # Get the last few days of data
-#     recent_init_times = ds.init_time.where(
-#         ds.init_time > pd.Timestamp.utcnow().tz_localize(None) - np.timedelta64(4, "D"),
-#         drop=True,
-#     ).load()
-#     # Ingested forecast length is along init time and ensemble member.
-#     # We care if any of the ensemble members for this init time
-#     # are not fully ingested.
-#     recent_init_times["reduced_ingested_forecast_length"] = (
-#         ds.ingested_forecast_length.min(dim="ensemble_member")
-#     )
-#     # Get the recent init_times where we have only partially completed
-#     # the ingest.
-#     return recent_init_times.where(  # type: ignore
-#         (recent_init_times.reduced_ingested_forecast_length.isnull())
-#         | (
-#             recent_init_times.reduced_ingested_forecast_length
-#             < recent_init_times.expected_forecast_length
-#         ),
-#         drop=True,
-#     ).init_time.values
+@sentry_sdk.monitor(
+    monitor_slug=f"{template.DATASET_ID}-validation",
+    monitor_config={
+        "schedule": {"type": "crontab", "value": _VALIDATION_CRON_SCHEDULE},
+        "timezone": "UTC",
+    },
+)
+def validate_zarr() -> None:
+    validation.validate_zarr(
+        get_store(),
+        validators=(
+            validation.check_analysis_current_data,
+            validation.check_analysis_recent_nans,
+        ),
+    )
 
 
-# @sentry_sdk.monitor(
-#     monitor_slug=f"{template.DATASET_ID}-validation",
-#     monitor_config={
-#         "schedule": {"type": "crontab", "value": _VALIDATION_CRON_SCHEDULE},
-#         "timezone": "UTC",
-#     },
-# )
-# def validate_zarr() -> None:
-#     validation.validate_zarr(
-#         get_store(),
-#         validators=(
-#             validation.check_forecast_current_data,
-#             validation.check_forecast_recent_nans,
-#         ),
-#     )
+def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
+    operational_update_cron_job = ReformatCronJob(
+        name=f"{template.DATASET_ID}-operational-update",
+        schedule=_OPERATIONAL_CRON_SCHEDULE,
+        image=image_tag,
+        dataset_id=template.DATASET_ID,
+        cpu="6",  # fit on 8 vCPU node
+        memory="60G",  # fit on 64GB node
+        shared_memory="25G",
+        ephemeral_storage="150G",
+    )
+    validation_cron_job = ValidationCronJob(
+        name=f"{template.DATASET_ID}-validation",
+        schedule=_VALIDATION_CRON_SCHEDULE,
+        image=image_tag,
+        dataset_id=template.DATASET_ID,
+        cpu="3",  # fit on 4 vCPU node
+        memory="30G",  # fit on 32GB node
+    )
 
-
-# def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
-#     operational_update_cron_job = ReformatCronJob(
-#         name=f"{template.DATASET_ID}-operational-update",
-#         schedule=_OPERATIONAL_CRON_SCHEDULE,
-#         image=image_tag,
-#         dataset_id=template.DATASET_ID,
-#         cpu="6",  # fit on 8 vCPU node
-#         memory="60G",  # fit on 64GB node
-#         shared_memory="25G",
-#         ephemeral_storage="150G",
-#     )
-#     validation_cron_job = ValidationCronJob(
-#         name=f"{template.DATASET_ID}-validation",
-#         schedule=_VALIDATION_CRON_SCHEDULE,
-#         image=image_tag,
-#         dataset_id=template.DATASET_ID,
-#         cpu="3",  # fit on 4 vCPU node
-#         memory="30G",  # fit on 32GB node
-#     )
-
-#     return [operational_update_cron_job, validation_cron_job]
+    return [operational_update_cron_job, validation_cron_job]
 
 
 def all_jobs_ordered(
     template_ds: xr.Dataset,
+    chunk_filters: ChunkFilters,
+    data_vars: Sequence[GEFSDataVar],
+    group_size: int,
 ) -> list[tuple[slice, list[str]]]:
-    append_dim_slices = dimension_slices(template_ds, template.APPEND_DIMENSION)
+    if chunk_filters.variable_names is not None:
+        template_ds = template_ds[chunk_filters.variable_names]
+
+    time_i_slices = dimension_slices(template_ds, chunk_filters.time_dim)
+
+    if chunk_filters.time_start is not None:
+        time_start = pd.Timestamp(chunk_filters.time_start)
+        time_i_slices = tuple(
+            time_i_slice
+            for time_i_slice in time_i_slices
+            if template_ds.isel({chunk_filters.time_dim: time_i_slice})[
+                chunk_filters.time_dim
+            ].min()
+            >= time_start  # type: ignore[operator]
+        )
+
+    if chunk_filters.time_end is not None:
+        time_end = pd.Timestamp(chunk_filters.time_end)
+        time_i_slices = tuple(
+            time_i_slice
+            for time_i_slice in time_i_slices
+            if template_ds.isel({chunk_filters.time_dim: time_i_slice})[
+                chunk_filters.time_dim
+            ].max()
+            < time_end  # type: ignore[operator]
+        )
+
     data_var_groups = group_data_vars_by_gefs_file_type(
-        [d for d in template.DATA_VARIABLES if d.name in template_ds],
-        group_size=_VARIABLES_PER_BACKFILL_JOB,
+        [d for d in data_vars if d.name in template_ds],
+        group_size=group_size,
     )
     data_var_name_groups = [
         [data_var.name for data_var in data_vars]
         for _, _, _, data_vars in data_var_groups
     ]
-    return list(product(append_dim_slices, data_var_name_groups))
+
+    return list(product(time_i_slices, data_var_name_groups))
 
 
 def get_store() -> zarr.storage.FsspecStore:

--- a/src/reformatters/noaa/gefs/forecast_35_day/cli.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/cli.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 import typer
 
+from reformatters.common.reformat_utils import ChunkFilters
 from reformatters.noaa.gefs.forecast_35_day import reformat, template
 from reformatters.noaa.gefs.forecast_35_day.template import DATASET_ID as DATASET_ID
 
@@ -22,7 +23,7 @@ def reformat_local(
 ) -> None:
     reformat.reformat_local(
         init_time_end,
-        chunk_filters=reformat.ChunkFilters(
+        chunk_filters=ChunkFilters(
             time_dim=template.APPEND_DIMENSION,
             time_start=filter_init_time_start,
             time_end=filter_init_time_end,
@@ -46,7 +47,7 @@ def reformat_kubernetes(
         jobs_per_pod,
         max_parallelism,
         docker_image=docker_image,
-        chunk_filters=reformat.ChunkFilters(
+        chunk_filters=ChunkFilters(
             time_dim=template.APPEND_DIMENSION,
             time_start=filter_init_time_start,
             time_end=filter_init_time_end,
@@ -68,7 +69,7 @@ def reformat_chunks(
         init_time_end,
         worker_index=worker_index,
         workers_total=workers_total,
-        chunk_filters=reformat.ChunkFilters(
+        chunk_filters=ChunkFilters(
             time_dim=template.APPEND_DIMENSION,
             time_start=filter_init_time_start,
             time_end=filter_init_time_end,

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -71,7 +71,7 @@ def reformat_kubernetes(
     logger.info(f"Writing zarr metadata to {store.path}")
     template.write_metadata(template_ds, store, get_mode(store))
 
-    num_jobs = sum(1 for _ in all_jobs_ordered(template_ds, chunk_filters))
+    num_jobs = len(all_jobs_ordered(template_ds, chunk_filters))
     workers_total = int(np.ceil(num_jobs / jobs_per_pod))
     parallelism = min(workers_total, max_parallelism)
 
@@ -228,7 +228,9 @@ def reformat_operational_update() -> None:
                 upload_executor.submit(
                     copy_data_var,
                     data_var.name,
-                    init_time_i_slice.start,
+                    init_time_i_slice,
+                    template_ds,
+                    template.APPEND_DIMENSION,
                     tmp_store,
                     final_store,
                 )
@@ -338,7 +340,7 @@ def all_jobs_ordered(
             for time_i_slice in time_i_slices
             if template_ds.isel({chunk_filters.time_dim: time_i_slice})[
                 chunk_filters.time_dim
-            ].min()
+            ].max()
             >= time_start  # type: ignore[operator]
         )
 
@@ -349,7 +351,7 @@ def all_jobs_ordered(
             for time_i_slice in time_i_slices
             if template_ds.isel({chunk_filters.time_dim: time_i_slice})[
                 chunk_filters.time_dim
-            ].max()
+            ].min()
             < time_end  # type: ignore[operator]
         )
 

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -11,10 +11,8 @@ import pandas as pd
 import sentry_sdk
 import xarray as xr
 import zarr
-from pydantic import BaseModel
 
 from reformatters.common import docker, validation
-from reformatters.common.config import Config  # noqa:F401
 from reformatters.common.iterating import (
     consume,
     dimension_slices,
@@ -22,6 +20,7 @@ from reformatters.common.iterating import (
 )
 from reformatters.common.kubernetes import Job, ReformatCronJob, ValidationCronJob
 from reformatters.common.logging import get_logger
+from reformatters.common.reformat_utils import ChunkFilters
 from reformatters.common.types import Array1D, DatetimeLike
 from reformatters.common.zarr import (
     copy_data_var,
@@ -41,18 +40,6 @@ _OPERATIONAL_CRON_SCHEDULE = "0 7 * * *"  # At 7:00 UTC every day.
 _VALIDATION_CRON_SCHEDULE = "0 10 * * *"  # At 10:00 UTC every day.
 
 logger = get_logger(__name__)
-
-
-class ChunkFilters(BaseModel):
-    """
-    Filters for controlling which chunks of data to process.
-    A value of None means no filtering.
-    """
-
-    time_dim: str
-    time_start: str | None = None
-    time_end: str | None = None
-    variable_names: list[str] | None = None
 
 
 def reformat_local(init_time_end: DatetimeLike, chunk_filters: ChunkFilters) -> None:

--- a/tests/noaa/gefs/analysis/gefs_analysis_cli_integration_test.py
+++ b/tests/noaa/gefs/analysis/gefs_analysis_cli_integration_test.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
@@ -42,7 +41,7 @@ def test_reformat_local_reforecast_period(
 ) -> None:
     monkeypatch.setattr(zarr, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
     time_start = template_config.TIME_START
-    time_end = time_start + timedelta(days=1)
+    time_end = time_start + pd.Timedelta(days=1)
 
     # 1. Backfill archive
     cli.reformat_local(time_end=time_end.isoformat())
@@ -65,7 +64,7 @@ def test_reformat_local_reforecast_period(
     )
 
     point_ds = original_ds.sel(
-        latitude=0, longitude=0, time=time_start + timedelta(hours=3)
+        latitude=0, longitude=0, time=time_start + pd.Timedelta(hours=3)
     )
     assert np.isclose(point_ds["precipitation_surface"], 0.00032806)
     assert np.isclose(point_ds["temperature_2m"], 26.125)
@@ -78,7 +77,7 @@ def test_reformat_local_reforecast_to_pre_v12_transition_period(
     time_start = pd.Timestamp("2019-12-31T00:00")
     # Add 3 more hours to exclusive end point so we end on a 00Z hour
     # during the pre v12 data which is 6 hourly. This will give us no nans after interpolation.
-    time_end = time_start + timedelta(hours=24 * 2 + 3)
+    time_end = time_start + pd.Timedelta(hours=24 * 2 + 3)
 
     # Update the template so this test starts processing at time_start
     monkeypatch.setattr(template_config, "TIME_START", time_start)
@@ -124,11 +123,11 @@ def test_reformat_local_reforecast_to_pre_v12_transition_period(
     )
 
 
-def test_reformat_local_pre_v12_to_v12_transition_period(
+def test_reformat_local_pre_v12_to_v12_transition_period_and_operational_update(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:
     time_start = pd.Timestamp("2020-09-22T00:00")
-    time_end = time_start + timedelta(days=2)
+    time_end = time_start + pd.Timedelta(days=2)
 
     # Update the template so this test starts processing at time_start
     monkeypatch.setattr(template_config, "TIME_START", time_start)
@@ -149,20 +148,56 @@ def test_reformat_local_pre_v12_to_v12_transition_period(
 
     point_ds = original_ds.sel(latitude=0, longitude=0)
 
+    expected_temperature_2m = np.array([22.5, 22.5, 22.5, 22.5, 22.625, 22.75, 22.875, 22.875, 22.875, 22.75, 22.75, 22.875, 23.0, 23.125, 23.375, 23.375])  # fmt: skip
+    assert np.allclose(point_ds["temperature_2m"], expected_temperature_2m)
+
+    expected_precipitation_surface = np.array([2.00195312e-01, 1.00097656e-01, 1.06692314e-05, 7.18235970e-06, 3.71038914e-06, 1.85519457e-06, 0.0, 0.0, 0.0, 0.0, 0.0, 4.61935997e-06, 9.23871994e-06, 9.27597284e-07, 0.0, 0.0])  # fmt: skip
     assert np.allclose(
-        point_ds["temperature_2m"],
-        np.array([22.5, 22.5, 22.5, 22.5, 22.625, 22.75, 22.875, 22.875, 22.875, 22.75, 22.75, 22.875, 23.0, 23.125, 23.375, 23.375])
-    )  # fmt: skip
+        point_ds["precipitation_surface"], expected_precipitation_surface
+    )
+
+    expected_wind_u_100m = np.array([3.34375, 3.875, 4.375, 4.9375, 5.5, 4.9375, 4.3125, 4.375, 4.4375, 3.78125, 3.09375, 1.9375, 0.78125, 1.828125, 2.78125, 3.0625])  # fmt: skip
+    assert np.allclose(point_ds["wind_u_100m"], expected_wind_u_100m)
+
+    # 2. Operational update
+    time_end = time_end + pd.Timedelta(hours=12, minutes=5, seconds=2)
+    monkeypatch.setattr(
+        reformat,
+        "_get_operational_update_time_end",
+        lambda: time_end,
+    )
+
+    cli.reformat_operational_update()
+    updated_ds = xr.open_zarr(reformat.get_store(), decode_timedelta=True, chunks=None)
+
+    # +1 because the extra few minutes we add to time_end gets us one more step
+    assert len(updated_ds.time) == (2 * 24 + 12) // 3 + 1
+    assert updated_ds.time.max() == time_end.floor("3h")
+    assert set(original_ds.keys()) == set(updated_ds.keys())
+
+    # No nans
+    assert (
+        (updated_ds.count() / np.prod(list(updated_ds.sizes.values()))).to_array().all()
+    )
+
+    updated_point_ds = updated_ds.sel(latitude=0, longitude=0)
 
     assert np.allclose(
-        point_ds["precipitation_surface"],
-        np.array([2.00195312e-01, 1.00097656e-01, 1.06692314e-05, 7.18235970e-06, 3.71038914e-06, 1.85519457e-06, 0.0, 0.0, 0.0, 0.0, 0.0, 4.61935997e-06, 9.23871994e-06, 9.27597284e-07, 0.0, 0.0])
-    )  # fmt: skip
+        updated_point_ds["temperature_2m"],
+        np.concatenate([expected_temperature_2m, [23.5, 23.5, 23.5, 23.625, 23.75]]),
+    )
 
     assert np.allclose(
-        point_ds["wind_u_100m"],
-        np.array([3.34375, 3.875, 4.375, 4.9375, 5.5, 4.9375, 4.3125, 4.375, 4.4375, 3.78125, 3.09375, 1.9375, 0.78125, 1.828125, 2.78125, 3.0625])
-    )  # fmt: skip
+        updated_point_ds["precipitation_surface"],
+        np.concatenate(
+            [expected_precipitation_surface, [0.0, 0.0, 0.0, 9.275973e-07, 0.0]]
+        ),
+    )
+
+    assert np.allclose(
+        updated_point_ds["wind_u_100m"],
+        np.concatenate([expected_wind_u_100m, [2.34375, 2.625, 3.59375, 2.09375, 3.0]]),
+    )
 
     # Restore the template
     subprocess.run(  # noqa: S603


### PR DESCRIPTION
Approach
1. update `all_jobs_ordered` to support filtering to chunks in a time range
    - this is also useful for reprocessing specific subsets of the dataset and a pattern already implemented in gefs forecast 35 day -- im expecting to refactor that whole function out into common code
1. filter jobs to shards > the latest already processed time

Unlike forecast datasets where we need to track which forecasts are fully ingested with `ingested_forecast_length` coordinate, in the analysis case things are simpler and we just compare the latest time coord with "now".