### PR TITLE
Trim the final analysis step because it only contains data for accumulated variables

### DIFF
--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -243,9 +243,14 @@ def reformat_operational_update() -> None:
             )
             continue
 
-        # Trim off any steps that are not yet available and rewrite metadata locally
+        # Trim off any steps that are not yet available and rewrite metadata locally.
+        # We trim one less than the max_processed_time because the last step only has
+        # values for variables that do not have hour 0 data for which we have to use a
+        # longer lead time (eg 3 and 6 hour not 0 and 3 hour).
+        truncated_template_ds = template_ds.sel(
+            time=slice(None, max_processed_time)
+        ).isel(time=slice(None, -1))
         logger.info(f"Writing updated metadata for dataset ending {max_processed_time}")
-        truncated_template_ds = template_ds.sel(time=slice(None, max_processed_time))
         template.write_metadata(
             truncated_template_ds,
             tmp_store,


### PR DESCRIPTION
For accumulated variables which don't have hour 0 values we need to pull the 3 and 6 hour forecast values to make the analysis in the current data archive. That means they will always have a max_processed_time 3 hours later than all the instantaneous variables which we use hour 0 and 3 for. To avoid the final step having nans for most variables, trim it off. This will still mean the latest value is very close to the present because it can be a 0 or 3 hour forecast.