### PR TITLE
[HRRR] Add v1 of reformatting 

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour/cli.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/cli.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 import typer
 
-from reformatters.noaa.hrrr.forecast_48_hour import template
+from reformatters.noaa.hrrr.forecast_48_hour import reformat, template
 from reformatters.noaa.hrrr.forecast_48_hour.template import DATASET_ID as DATASET_ID
 
 app = typer.Typer()
@@ -15,7 +15,7 @@ def update_template() -> None:
 
 @app.command()
 def reformat_local(init_time_end: str) -> None:
-    raise NotImplementedError("reformat_local not implemented")
+    reformat.reformat_local(init_time_end)
 
 
 @app.command()

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/reformat.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/reformat.py
@@ -1,0 +1,128 @@
+import json
+import subprocess
+from itertools import batched, product
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import zarr
+
+from reformatters.common import docker
+from reformatters.common.iterating import (
+    consume,
+    dimension_slices,
+    get_worker_jobs,
+)
+from reformatters.common.kubernetes import Job
+from reformatters.common.logging import get_logger
+from reformatters.common.types import DatetimeLike
+from reformatters.common.zarr import (
+    get_mode,
+    get_zarr_store,
+)
+from reformatters.noaa.hrrr.forecast_48_hour import template
+from reformatters.noaa.hrrr.forecast_48_hour.reformat_internals import (
+    reformat_time_i_slices,
+)
+from reformatters.noaa.hrrr.hrrr_config_models import HRRRDataVar
+
+from .template_config import APPEND_DIMENSION as APPEND_DIMENSION
+
+# More variables than we currently have but have a buffer in case we add more
+_VARIABLES_PER_BACKFILL_JOB = 30
+
+logger = get_logger(__name__)
+
+
+def reformat_local(time_end: DatetimeLike) -> None:
+    template_ds = template.get_template(time_end)
+    store = get_store()
+
+    logger.info("Writing metadata")
+    template.write_metadata(template_ds, store, get_mode(store))
+
+    logger.info("Starting reformat")
+    # Process all chunks by setting worker_index=0 and worker_total=1
+    reformat_chunks(time_end, worker_index=0, workers_total=1)
+    logger.info(f"Done writing to {store}")
+
+
+def reformat_kubernetes(
+    time_end: DatetimeLike,
+    jobs_per_pod: int,
+    max_parallelism: int,
+    docker_image: str | None = None,
+) -> None:
+    image_tag = docker_image or docker.build_and_push_image()
+
+    template_ds = template.get_template(time_end)
+    store = get_store()
+    logger.info(f"Writing zarr metadata to {store.path}")
+    template.write_metadata(template_ds, store, get_mode(store))
+
+    num_jobs = sum(1 for _ in all_jobs_ordered(template_ds))
+    workers_total = int(np.ceil(num_jobs / jobs_per_pod))
+    parallelism = min(workers_total, max_parallelism)
+
+    dataset_id = template_ds.attrs["dataset_id"]
+
+    kubernetes_job = Job(
+        image=image_tag,
+        dataset_id=dataset_id,
+        workers_total=workers_total,
+        parallelism=parallelism,
+        cpu="3.5",  # fit on 4 vCPU node
+        memory="7G",  # fit on 8GB node
+        shared_memory="1.5G",
+        ephemeral_storage="20G",
+        command=[
+            "reformat-chunks",
+            pd.Timestamp(time_end).isoformat(),
+        ],
+    )
+    subprocess.run(  # noqa: S603
+        ["/usr/bin/kubectl", "apply", "-f", "-"],
+        input=json.dumps(kubernetes_job.as_kubernetes_object()),
+        text=True,
+        check=True,
+    )
+
+    logger.info(f"Submitted kubernetes job {kubernetes_job.job_name}")
+
+
+def reformat_chunks(
+    time_end: DatetimeLike, *, worker_index: int, workers_total: int
+) -> None:
+    """Writes out array chunk data. Assumes the dataset metadata has already been written."""
+    assert worker_index < workers_total
+    template_ds = template.get_template(time_end)
+    store = get_store()
+
+    worker_jobs = get_worker_jobs(
+        all_jobs_ordered(template_ds),
+        worker_index,
+        workers_total,
+    )
+
+    logger.info(f"This is {worker_index = }, {workers_total = }, {worker_jobs}")
+    consume(
+        reformat_time_i_slices(
+            worker_jobs,
+            template_ds,
+            store,
+            _VARIABLES_PER_BACKFILL_JOB,
+        )
+    )
+
+
+def all_jobs_ordered(
+    template_ds: xr.Dataset,
+) -> list[tuple[slice, list[HRRRDataVar]]]:
+    append_dim_slices = dimension_slices(template_ds, template.APPEND_DIMENSION)
+    data_vars = [d for d in template.DATA_VARIABLES if d.name in template_ds]
+    data_var_groups = list(batched(data_vars, _VARIABLES_PER_BACKFILL_JOB))
+    return [(s, g) for s, g in product(append_dim_slices, data_var_groups)]
+
+
+def get_store() -> zarr.storage.FsspecStore:
+    return get_zarr_store(template.DATASET_ID, template.DATASET_VERSION)

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/reformat_internals.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/reformat_internals.py
@@ -1,0 +1,287 @@
+import concurrent
+import os
+from collections.abc import Generator, Iterable, Sequence
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
+from functools import partial
+from itertools import batched, groupby, product
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import xarray as xr
+import zarr
+
+from reformatters.common.binary_rounding import round_float32_inplace
+from reformatters.common.config_models import DataVar
+from reformatters.common.iterating import consume
+from reformatters.common.logging import get_logger
+from reformatters.common.reformat_utils import (
+    create_data_array_and_template,
+    create_shared_buffer,
+    write_shards,
+)
+from reformatters.noaa.hrrr.forecast_48_hour import template
+from reformatters.noaa.hrrr.hrrr_config_models import (
+    HRRRDataVar,
+    HRRRDomain,
+    HRRRFileType,
+)
+from reformatters.noaa.hrrr.read_data import SourceFileCoords, download_file, read_into
+from reformatters.noaa.noaa_utils import has_hour_0_values
+
+logger = get_logger(__name__)
+
+type CoordAndPath = tuple[SourceFileCoords, Path | None]
+type CoordsAndPaths = list[CoordAndPath]
+
+
+def reformat_time_i_slices(
+    jobs: Sequence[tuple[slice, list[HRRRDataVar]]],
+    template_ds: xr.Dataset,
+    store: zarr.storage.FsspecStore | Path,
+    var_download_group_size: int,
+) -> Generator[tuple[HRRRDataVar, dict[pd.Timestamp, pd.Timedelta]], None, None]:
+    # The only effective way we've found to fully utilize cpu resources
+    # while writing to zarr is to parallelize across processes (not threads).
+    # Use shared memory to avoid pickling large arrays to share between processes.
+    shared_buffer_size = max(
+        data_var.nbytes
+        for data_var in template_ds.isel(
+            {template.APPEND_DIMENSION: jobs[0][0]}
+        ).values()
+    )
+    with (
+        ThreadPoolExecutor(max_workers=1) as wait_executor,
+        ThreadPoolExecutor(max_workers=(os.cpu_count() or 1) * 2) as io_executor,
+        ThreadPoolExecutor(max_workers=os.cpu_count() or 1) as cpu_executor,
+        ProcessPoolExecutor(max_workers=os.cpu_count() or 1) as cpu_process_executor,
+        create_shared_buffer(shared_buffer_size) as shared_buffer,
+    ):
+        for init_time_i_slice, data_vars in jobs:
+            data_var_names = [data_var.name for data_var in data_vars]
+            chunk_template_ds = template_ds[data_var_names].isel(
+                init_time=init_time_i_slice
+            )
+
+            chunk_init_times = pd.to_datetime(chunk_template_ds["init_time"].values)
+            chunk_lead_times = pd.to_timedelta(chunk_template_ds["lead_time"].values)
+            chunk_domains: Iterable[HRRRDomain] = ["conus"]
+            chunk_file_types = [dv.internal_attrs.hrrr_file_type for dv in data_vars]
+            chunk_coords = generate_chunk_coordinates(
+                chunk_init_times, chunk_lead_times, chunk_domains, chunk_file_types
+            )
+
+            chunk_init_times_str = ", ".join(
+                chunk_init_times.strftime("%Y-%m-%dT%H:%M")
+            )
+            logger.info(f"Starting chunk with init times {chunk_init_times_str}")
+
+            download_var_group_futures = get_download_var_group_futures(
+                chunk_template_ds,
+                chunk_coords,
+                io_executor,
+                wait_executor,
+                var_download_group_size,
+            )
+            for future in concurrent.futures.as_completed(download_var_group_futures):
+                if (e := future.exception()) is not None:
+                    raise e
+
+                coords_and_paths = future.result()
+                completed_data_vars = download_var_group_futures[future]
+
+                max_lead_times = get_max_lead_times(coords_and_paths)
+
+                # Write variable by variable to avoid blowing up memory usage
+                for data_var in completed_data_vars:
+                    data_array, data_array_template = create_data_array_and_template(
+                        chunk_template_ds, data_var.name, shared_buffer
+                    )
+                    var_coords_and_paths = filter_coords_and_paths(
+                        data_var, coords_and_paths
+                    )
+
+                    read_into_data_array(
+                        data_array, data_var, var_coords_and_paths, cpu_executor
+                    )
+                    apply_data_transformations_inplace(data_array, data_var)
+                    write_shards(
+                        data_array_template,
+                        store,
+                        shared_buffer,
+                        cpu_process_executor,
+                    )
+
+                    yield (data_var, max_lead_times)
+
+                # Reclaim space once done.
+                for _, filepath in coords_and_paths:
+                    if filepath is not None:
+                        filepath.unlink()
+
+
+def get_max_lead_times(
+    coords_and_paths: list[tuple[SourceFileCoords, Path | None]],
+) -> dict[pd.Timestamp, pd.Timedelta]:
+    max_lead_times: dict[pd.Timestamp, pd.Timedelta] = {}
+
+    sorted_coords_and_paths = sorted(
+        coords_and_paths, key=lambda coords_and_path: coords_and_path[0]["init_time"]
+    )
+    groups = groupby(
+        sorted_coords_and_paths,
+        key=lambda coords_and_path: coords_and_path[0]["init_time"],
+    )
+    for init_time, init_time_coords_and_paths in groups:
+        ingested_lead_times = [
+            coord["lead_time"]
+            for coord, path in init_time_coords_and_paths
+            if path is not None
+        ]
+
+        max_lead_times[init_time] = max(
+            ingested_lead_times, default=pd.Timedelta("NaT")
+        )
+    return max_lead_times
+
+
+def filter_coords_and_paths(
+    data_var: HRRRDataVar, coords_and_paths: CoordsAndPaths
+) -> CoordsAndPaths:
+    # Skip reading the 0-hour for accumulated or last N hours avg values
+    if not has_hour_0_values(data_var):
+        return [
+            coords_and_path
+            for coords_and_path in coords_and_paths
+            if coords_and_path[0]["lead_time"] > pd.Timedelta(hours=0)
+        ]
+    else:
+        return coords_and_paths
+
+
+def read_into_data_array(
+    out: xr.DataArray,
+    data_var: HRRRDataVar,
+    var_coords_and_paths: CoordsAndPaths,
+    cpu_executor: ThreadPoolExecutor,
+) -> None:
+    logger.info(f"Reading {data_var.name}")
+    consume(
+        cpu_executor.map(
+            partial(
+                read_into,
+                out,
+                data_var=data_var,
+            ),
+            *zip(*var_coords_and_paths, strict=True),
+        )
+    )
+
+
+def apply_data_transformations_inplace(
+    data_array: xr.DataArray, data_var: DataVar[Any]
+) -> None:
+    if data_var.internal_attrs.deaccumulate_to_rates:
+        raise NotImplementedError("Deaccumulation not implemented for HRRR")
+        # logger.info(f"Converting {data_var.name} from accumulations to rates")
+        # try:
+        #     deaccumulate_to_rates_inplace(
+        #         data_array,
+        #         dim="lead_time",
+        #         reset_frequency=GFS_ACCUMULATION_RESET_FREQUENCY,
+        #     )
+        # except ValueError:
+        #     # Log exception so we are notified if deaccumulation errors are larger than expected.
+        #     logger.exception(f"Error deaccumulating {data_var.name}")
+
+    keep_mantissa_bits = data_var.internal_attrs.keep_mantissa_bits
+    if isinstance(keep_mantissa_bits, int):
+        round_float32_inplace(
+            data_array.values,
+            keep_mantissa_bits=keep_mantissa_bits,
+        )
+
+
+type ChunkCoordinates = Sequence[SourceFileCoords]
+
+
+def generate_chunk_coordinates(
+    chunk_init_times: Iterable[pd.Timestamp],
+    chunk_lead_times: Iterable[pd.Timedelta],
+    chunk_domains: Iterable[HRRRDomain],
+    chunk_file_types: Iterable[HRRRFileType],
+) -> ChunkCoordinates:
+    return [
+        {
+            "init_time": init_time,
+            "lead_time": lead_time,
+            "domain": domain,
+            "file_type": file_type,
+        }
+        for init_time, lead_time, domain, file_type in product(
+            chunk_init_times, chunk_lead_times, chunk_domains, chunk_file_types
+        )
+    ]
+
+
+def download_var_group_files(
+    idx_data_vars: Iterable[HRRRDataVar],
+    chunk_coords: Iterable[SourceFileCoords],
+    io_executor: ThreadPoolExecutor,
+) -> list[tuple[SourceFileCoords, Path | None]]:
+    logger.info(f"Downloading {[d.name for d in idx_data_vars]}")
+
+    done, not_done = concurrent.futures.wait(
+        [
+            io_executor.submit(
+                download_file,
+                coord,
+                idx_data_vars=idx_data_vars,
+            )
+            for coord in chunk_coords
+        ]
+    )
+    assert len(not_done) == 0
+
+    for future in done:
+        if (e := future.exception()) is not None:
+            raise e
+
+    logger.info(f"Completed download for {[d.name for d in idx_data_vars]}")
+    return [f.result() for f in done]
+
+
+type DownloadVarGroupFutures = dict[
+    Future[list[tuple[SourceFileCoords, Path | None]]],
+    tuple[HRRRDataVar, ...],
+]
+
+
+def get_download_var_group_futures(
+    chunk_template_ds: xr.Dataset,
+    chunk_coords: ChunkCoordinates,
+    io_executor: ThreadPoolExecutor,
+    wait_executor: ThreadPoolExecutor,
+    group_size: int,
+) -> DownloadVarGroupFutures:
+    download_var_group_futures: DownloadVarGroupFutures = {}
+
+    chunk_data_vars = [
+        d for d in template.DATA_VARIABLES if d.name in chunk_template_ds
+    ]
+    chunk_data_vars = sorted(
+        chunk_data_vars, key=lambda data_var: data_var.internal_attrs.index_position
+    )
+    data_var_groups = batched(chunk_data_vars, group_size)
+
+    for data_vars in data_var_groups:
+        download_var_group_futures[
+            wait_executor.submit(
+                download_var_group_files,
+                data_vars,
+                chunk_coords,
+                io_executor,
+            )
+        ] = data_vars
+
+    return download_var_group_futures

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/reformat_internals.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/reformat_internals.py
@@ -183,6 +183,7 @@ def apply_data_transformations_inplace(
 ) -> None:
     if data_var.internal_attrs.deaccumulate_to_rates:
         raise NotImplementedError("Deaccumulation not implemented for HRRR")
+        # TODO: build deaccumulation?
         # logger.info(f"Converting {data_var.name} from accumulations to rates")
         # try:
         #     deaccumulate_to_rates_inplace(

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/template.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/template.py
@@ -56,6 +56,7 @@ def get_template(init_time_end: DatetimeLike) -> xr.Dataset:
         coordinate.load()
 
     if not Config.is_prod:
+        # TODO: get a good test example
         # Include a variable with:
         # -...
         ds = ds[

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/template_config.py
@@ -22,7 +22,7 @@ from reformatters.noaa.hrrr.hrrr_config_models import HRRRDataVar, HRRRInternalA
 DATASET_ID = "noaa-hrrr-forecast-48-hour"
 DATASET_VERSION = "0.0.0"
 
-INIT_TIME_START = pd.Timestamp("2020-01-01T00:00")
+INIT_TIME_START = pd.Timestamp("2018-07-13T12:00")  # start of HRRR v3
 INIT_TIME_FREQUENCY = pd.Timedelta("6h")
 LEAD_TIME_FREQUENCY = pd.Timedelta("1h")
 

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/template_config.py
@@ -22,7 +22,7 @@ from reformatters.noaa.hrrr.hrrr_config_models import HRRRDataVar, HRRRInternalA
 DATASET_ID = "noaa-hrrr-forecast-48-hour"
 DATASET_VERSION = "0.0.0"
 
-INIT_TIME_START = pd.Timestamp("2014-07-30T18:00")
+INIT_TIME_START = pd.Timestamp("2020-01-01T00:00")
 INIT_TIME_FREQUENCY = pd.Timedelta("6h")
 LEAD_TIME_FREQUENCY = pd.Timedelta("1h")
 
@@ -299,7 +299,7 @@ COORDINATES: Sequence[Coordinate] = (
 
 DATA_VARIABLES: Sequence[HRRRDataVar] = [
     HRRRDataVar(
-        name="Composite reflectivity",
+        name="composite_reflectivity",
         encoding=Encoding(
             dtype="float32",
             fill_value=np.nan,
@@ -315,7 +315,7 @@ DATA_VARIABLES: Sequence[HRRRDataVar] = [
         ),
         internal_attrs=HRRRInternalAttrs(
             grib_element="REFC",
-            grib_description="TODO",  # TODO
+            grib_description="REFC:entire atmosphere",  # TODO
             index_position=0,
             keep_mantissa_bits=10,
             grib_index_level="entire atmosphere",

--- a/src/reformatters/noaa/hrrr/read_data.py
+++ b/src/reformatters/noaa/hrrr/read_data.py
@@ -1,12 +1,19 @@
+import os
 import re
+import warnings
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TypedDict
 
+import numpy as np
 import pandas as pd
+import rasterio  # type: ignore
+import xarray as xr
 
 from reformatters.common.config import Config
 from reformatters.common.download import download_to_disk, http_store
+from reformatters.common.logging import get_logger
+from reformatters.common.types import Array2D
 from reformatters.noaa.hrrr.hrrr_config_models import (
     HRRRDataVar,
     HRRRDomain,
@@ -15,21 +22,39 @@ from reformatters.noaa.hrrr.hrrr_config_models import (
 
 DOWNLOAD_DIR = Path("data/download/")
 
+logger = get_logger(__name__)
+
 
 class SourceFileCoords(TypedDict):
     init_time: pd.Timestamp
     lead_time: pd.Timedelta
     domain: HRRRDomain
+    file_type: HRRRFileType
+
+
+# need to refactor based on the file type being associated with each var
 
 
 def download_file(
     coords: SourceFileCoords,
-    hrrr_file_type: HRRRFileType,
     idx_data_vars: Iterable[HRRRDataVar],
 ) -> tuple[SourceFileCoords, Path | None]:
     init_time = coords["init_time"]
     lead_time = coords["lead_time"]
     domain = coords["domain"]
+    file_type = coords["file_type"]
+
+    # Verify that the variables in the group are all from the same file type.
+    # If not, raise (this should be considered a bug).
+    mismatched_file_types = {
+        var.internal_attrs.hrrr_file_type
+        for var in idx_data_vars
+        if var.internal_attrs.hrrr_file_type != file_type
+    }
+    if mismatched_file_types:
+        mismatched_str = ", ".join(ft for ft in mismatched_file_types)
+        error_msg = f"All variables must be from {file_type}, but found variables from: {mismatched_str}"
+        raise ValueError(error_msg)
 
     lead_time_hours = lead_time.total_seconds() / (60 * 60)
     if lead_time_hours != round(lead_time_hours):
@@ -38,7 +63,7 @@ def download_file(
     init_date_str = init_time.strftime("%Y%m%d")
     init_hour_str = init_time.strftime("%H")
 
-    remote_path = f"hrrr.{init_date_str}/{domain}/hrrr.t{init_hour_str}z.wrf{hrrr_file_type}f{int(lead_time_hours):02d}.grib2"
+    remote_path = f"hrrr.{init_date_str}/{domain}/hrrr.t{init_hour_str}z.wrf{file_type}f{int(lead_time_hours):02d}.grib2"
 
     store = http_store("https://noaa-hrrr-bdp-pds.s3.amazonaws.com")
 
@@ -59,6 +84,8 @@ def download_file(
         byte_range_starts, byte_range_ends = parse_index_byte_ranges(
             idx_local_path, idx_data_vars
         )
+        logger.info("Byte ranges (Start): %s", byte_range_starts)
+        logger.info("Byte ranges (End): %s", byte_range_ends)
 
         download_to_disk(
             store,
@@ -114,3 +141,76 @@ def parse_index_byte_ranges(
         byte_range_starts.append(start_byte)
         byte_range_ends.append(end_byte)
     return byte_range_starts, byte_range_ends
+
+
+def read_into(
+    out: xr.DataArray,
+    coords: SourceFileCoords,
+    path: os.PathLike[str] | None,
+    data_var: HRRRDataVar,
+) -> None:
+    if path is None:
+        return  # in rare case file is missing there's nothing to do
+
+    grib_element = data_var.internal_attrs.grib_element
+
+    try:
+        raw_data = read_rasterio(
+            path,
+            grib_element,
+            data_var.internal_attrs.grib_description,
+            out.rio.shape,
+            out.rio.transform(),
+            out.rio.crs,
+        )
+    except Exception as e:
+        logger.exception("Read failed: %s", e)
+        return
+
+    # Source file coords contain the domain and file_type, which are not coords in the data array,
+    # so we drop them from the coords.
+    out_coords = dict(coords)
+    del out_coords["domain"]
+    del out_coords["file_type"]
+
+    # TODO: Why is the shape of the data not the same as the shape of the data array?
+    # out.rio.shape and out.shape are swapped. Need to track this down.
+    out.loc[out_coords] = raw_data.T
+
+
+def read_rasterio(
+    path: os.PathLike[str],
+    grib_element: str,
+    grib_description: str,
+    out_spatial_shape: tuple[int, int],
+    out_transform: rasterio.transform.Affine,
+    out_crs: rasterio.crs.CRS,
+) -> Array2D[np.float32]:
+    with (
+        warnings.catch_warnings(),
+        rasterio.open(path) as reader,
+    ):
+        matching_bands = [
+            rasterio_band_i
+            for band_i in range(reader.count)
+            if grib_description in reader.descriptions[band_i]
+            and reader.tags(rasterio_band_i := band_i + 1)["GRIB_ELEMENT"]
+            == grib_element
+        ]
+
+        assert len(matching_bands) == 1, f"Expected exactly 1 matching band, found {matching_bands}. {grib_element=}, {grib_description=}, {path=}"  # fmt: skip
+        rasterio_band_index = matching_bands[0]
+
+        assert reader.shape == out_spatial_shape
+        assert reader.transform == out_transform, (
+            f"transforms not equal: {reader.transform} != {out_transform}"
+        )
+        assert reader.crs.to_dict() == out_crs.to_dict(), (
+            f"crs not equal: {reader.crs.to_dict()} != {out_crs.to_dict()}"
+        )
+
+        result: Array2D[np.float32] = reader.read(
+            rasterio_band_index,
+            out_dtype=np.float32,
+        )
+        return result

--- a/src/reformatters/noaa/hrrr/read_data.py
+++ b/src/reformatters/noaa/hrrr/read_data.py
@@ -84,8 +84,10 @@ def download_file(
         byte_range_starts, byte_range_ends = parse_index_byte_ranges(
             idx_local_path, idx_data_vars
         )
-        logger.info("Byte ranges (Start): %s", byte_range_starts)
-        logger.info("Byte ranges (End): %s", byte_range_ends)
+        logger.debug(
+            "reading byte ranges: %s",
+            list(zip(byte_range_starts, byte_range_ends, strict=True)),
+        )
 
         download_to_disk(
             store,


### PR DESCRIPTION
As suggested in #113, I started with the GFS `reformat.py` and `reformat_internals.py` and modified them to work with HRRR. 

There were a few speedbumps here. The first was that this revealed a bug in the lat/lon calculations, which were wrong. I was using the wrong corner coordinates (Bottom Left instead of Top Left), which ended up resulting in a bad transform in the zarr template. I fixed that. 

There's also a very suspect `.T` in the `read_into` function which I narrowed down to the fact that the `.rio` accessor seems to be reporting the x,y dimensions swapped. I'm not sure what to make of that but I'm going to continue to dig in. 

This PR results in a zarr on disk that contains the REFC data. I've not yet actually looked at it, but I suspect it might be flipped around incorrectly due to the `.T`. But the data are there. 

Oh, and finally: I _think_ HRRR revised their domain between v1 and v4. I'm trying to narrow that down now. but tl;dr we probably can't put the whole HRRR archive (v1-v4) in a single ZARR without reprocessing the old domain into the new one, which I doubt we want to do. 

Testing: 

```bash
uv run main noaa-hrrr-forecast-48-hour update-template
uv run main noaa-hrrr-forecast-48-hour reformat-local 2018-07-14
```

---

Copilot summary:
This pull request introduces significant functionality to the NOAA HRRR 48-hour forecast reformatter, including the implementation of local and Kubernetes-based reformatting workflows, enhancements to template handling, and improvements to data downloading and processing. Below is a summary of the most important changes, grouped by theme.

### New Reformatting Workflows
* Added `reformat_local` and `reformat_kubernetes` functions in `reformat.py` to support local and Kubernetes-based reformatting of dataset chunks. These functions handle metadata writing, chunk processing, and job submission for parallel execution.
* Integrated the `reformat_local` function into the CLI by replacing the placeholder in the `reformat_local` command with a call to the new implementation.

### Template Enhancements
* Introduced a `get_template` function in `template.py` to dynamically generate and expand dataset templates based on the end time of initialization (`init_time_end`). This ensures proper handling of coordinates and metadata.
* Updated the CRS (coordinate reference system) in `update_template` to correct the longitude origin from `+lon_0=262.5` to `+lon_0=-97.5`.

### Data Download and Processing Improvements
* Refactored `download_file` in `read_data.py` to associate file types with variables and validate consistency within variable groups. This ensures that all variables in a group belong to the same file type. [[1]](diffhunk://#diff-0bad925d0e2eaa204497c7ef32f06b09838228b19a892f18fe0e296e48e504d1R25-R57) [[2]](diffhunk://#diff-0bad925d0e2eaa204497c7ef32f06b09838228b19a892f18fe0e296e48e504d1L41-R66)
* Added logging for byte range starts and ends during data downloading to improve traceability.

### Configuration Updates
* Changed the `INIT_TIME_START` in `template_config.py` from `2014-07-30T18:00` to `2020-01-01T00:00` to reflect a more recent starting point for initialization times.
* Renamed a data variable from `Composite reflectivity` to `composite_reflectivity` and updated its GRIB description for clarity and consistency. [[1]](diffhunk://#diff-adf9cca1e30e58cd42d7c106f0d3a8aabec7d98982adfe93583e743379720612L302-R302) [[2]](diffhunk://#diff-adf9cca1e30e58cd42d7c106f0d3a8aabec7d98982adfe93583e743379720612L318-R318)

### Internal Refactoring
* Added `reformat_internals.py` with the `reformat_time_i_slices` function to handle parallelized chunk processing using shared memory and process pools. This improves CPU utilization during reformatting.

These changes collectively enhance the functionality, accuracy, and maintainability of the NOAA HRRR 48-hour forecast reformatter.
