### PR TITLE
Track progress processing variables within an operational update job

### DIFF
--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -86,6 +86,14 @@ class Job(pydantic.BaseModel):
                                         },
                                     },
                                     {
+                                        "name": "JOB_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "fieldPath": "metadata.labels['job-name']"
+                                            }
+                                        },
+                                    },
+                                    {
                                         "name": "WORKER_INDEX",
                                         "valueFrom": {
                                             "fieldRef": {

--- a/src/reformatters/common/update_progress_tracker.py
+++ b/src/reformatters/common/update_progress_tracker.py
@@ -1,0 +1,75 @@
+import json
+import queue
+import threading
+from collections.abc import Iterable
+
+import zarr.storage
+
+from reformatters.common.logging import get_logger
+
+log = get_logger(__name__)
+
+PROCESSED_VARIABLES_KEY = "processed_variables"
+
+
+class UpdateProgressTracker:
+    """
+    Tracks which variables have been processed within a time slice of a job.
+    Allows for skipping already processed variables in case the process is interrupted.
+    """
+
+    def __init__(
+        self,
+        store: zarr.storage.FsspecStore,
+        job_name: str,
+        time_i_slice_start: int,
+    ):
+        self.store = store
+        self.job_name = job_name
+        self.time_i_slice_start = time_i_slice_start
+        self.queue: queue.Queue[str] = queue.Queue()
+
+        try:
+            with self.store.fs.open(self._get_path(), "r") as f:
+                self.processed_variables: set[str] = set(
+                    json.load(f)[PROCESSED_VARIABLES_KEY]
+                )
+            log.info(
+                f"Loaded {len(self.processed_variables)} processed variables: {self.processed_variables}"
+            )
+        except FileNotFoundError:
+            self.processed_variables = set()
+
+        self.thread = threading.Thread(target=self._process_queue, daemon=True)
+        self.thread.start()
+
+    def record_completion(self, var: str) -> None:
+        self.queue.put(var)
+
+    def get_unprocessed(self, all_vars: Iterable[str]) -> list[str]:
+        return [v for v in all_vars if v not in self.processed_variables]
+
+    def close(self) -> None:
+        try:
+            self.store.fs.rm(self._get_path())
+        except Exception as e:
+            log.warning(f"Could not delete progress file: {e}")
+
+    def _get_path(self) -> str:
+        return f"{self.store.path}/_internal_update_progress_{self.job_name}_{self.time_i_slice_start}.json"
+
+    def _process_queue(self) -> None:
+        """Run as a background thread to process variables from the queue and record progress."""
+        while True:
+            try:
+                var = self.queue.get()
+                self.processed_variables.add(var)
+
+                with self.store.fs.open(self._get_path(), "w") as f:
+                    json.dump(
+                        {PROCESSED_VARIABLES_KEY: list(self.processed_variables)}, f
+                    )
+
+                self.queue.task_done()
+            except Exception as e:
+                log.warning(f"Could not record progress for variable {e}")

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -11,6 +11,7 @@ from fsspec.implementations.local import LocalFileSystem  # type: ignore
 
 from reformatters.common.config import Config
 from reformatters.common.logging import get_logger
+from reformatters.common.update_progress_tracker import UpdateProgressTracker
 
 logger = get_logger(__name__)
 
@@ -95,6 +96,7 @@ def copy_data_var(
     append_dim: str,
     tmp_store: Path,
     final_store: zarr.storage.FsspecStore,
+    progress_tracker: UpdateProgressTracker,
 ) -> None:
     dim_index = template_ds[data_var_name].dims.index(append_dim)
     append_dim_shard_size = template_ds[data_var_name].encoding["shards"][dim_index]
@@ -114,6 +116,8 @@ def copy_data_var(
     source = f"{tmp_store / relative_dir}/"
     dest = f"{final_store.path}/{relative_dir}"
     _copy_to_store("put", source, dest, fs, recursive=True, auto_mkdir=True)
+
+    progress_tracker.record_completion(data_var_name)
 
     try:
         # Delete data to conserve disk space.

--- a/src/reformatters/noaa/gefs/analysis/cli.py
+++ b/src/reformatters/noaa/gefs/analysis/cli.py
@@ -79,8 +79,10 @@ def reformat_chunks(
 
 
 @app.command()
-def reformat_operational_update() -> None:
-    reformat.reformat_operational_update()
+def reformat_operational_update(
+    job_name: Annotated[str, typer.Argument(envvar="JOB_NAME")],
+) -> None:
+    reformat.reformat_operational_update(job_name)
 
 
 @app.command()

--- a/src/reformatters/noaa/gefs/forecast_35_day/cli.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/cli.py
@@ -79,8 +79,10 @@ def reformat_chunks(
 
 
 @app.command()
-def reformat_operational_update() -> None:
-    reformat.reformat_operational_update()
+def reformat_operational_update(
+    job_name: Annotated[str, typer.Argument(envvar="JOB_NAME")],
+) -> None:
+    reformat.reformat_operational_update(job_name)
 
 
 @app.command()

--- a/tests/noaa/gefs/analysis/gefs_analysis_cli_integration_test.py
+++ b/tests/noaa/gefs/analysis/gefs_analysis_cli_integration_test.py
@@ -197,7 +197,7 @@ def test_reformat_local_pre_v12_to_v12_transition_period_and_operational_update(
 
     monkeypatch.setattr(reformat_internals, "download_file", test_download_file)
 
-    cli.reformat_operational_update()
+    cli.reformat_operational_update(job_name="test")
     updated_ds = xr.open_zarr(reformat.get_store(), decode_timedelta=True, chunks=None)
 
     # If we didn't trim the last step, it would be one more than this but we trim to avoid nans on all instantaneous variables

--- a/tests/noaa/gefs/forecast_35_day/gefs_forecast_35_day_cli_integration_test.py
+++ b/tests/noaa/gefs/forecast_35_day/gefs_forecast_35_day_cli_integration_test.py
@@ -65,7 +65,7 @@ def test_reformat_local_and_operational_update(
         lambda: init_time_end + timedelta(days=1),
     )
 
-    cli.reformat_operational_update()
+    cli.reformat_operational_update(job_name="test")
     updated_ds = xr.open_zarr(reformat.get_store(), decode_timedelta=True, chunks=None)
 
     assert len(updated_ds.init_time) == 2


### PR DESCRIPTION
Allows skipping already processed variables if the pod is pre-empted or the process is otherwise interrupted.