### PR TITLE
Fix case where gefs/analysis/reformat_internals calculates a shared_buffer_size that is too small

### DIFF
--- a/src/reformatters/noaa/gefs/analysis/reformat_internals.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat_internals.py
@@ -71,14 +71,14 @@ def reformat_time_i_slices(
     # We need to buffer by 1 step to have endpoints for interpolation,
     # but then by 2 steps to ensure accumulation starts at a reset step.
     time_buffer_i_size = 2
-    widest_slice = max(
-        (buffer_slice(j[0], buffer_size=time_buffer_i_size) for j in jobs),
-        key=lambda s: s.stop - s.start,
+    widest_slice_length = max(
+        (s := buffer_slice(j[0], buffer_size=time_buffer_i_size)).stop - s.start
+        for j in jobs
     )
     shared_buffer_size = max(
         data_var.nbytes
         for data_var in template_ds.isel(
-            {template.APPEND_DIMENSION: widest_slice}
+            {template.APPEND_DIMENSION: slice(0, widest_slice_length)}
         ).values()
     )
     with (


### PR DESCRIPTION
This PR fixes a bug in `noaa/gefs/analysis/reformat_internals.py`, where our `shared_buffer_size` calculation is too small.

The too-small buffer leads to an error  in `create_data_array_and_template` when creating the `shared_array`:

```
│ ❱ 388 │   shared_array: ArrayFloat32 = np.ndarray(                                                             │
│   389 │   │   data_array.shape,                                                                                │
│   390 │   │   dtype=data_array.dtype,                                                                          │
│   391 │   │   buffer=shared_buffer.buf,                                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: buffer is too small for requested array
```

The issue occurs when the calculated `widest_slice`  is calculated to cover a period (in the APPEND_DIMENSION) that extends past the number of coordinates actually present in that dimension:

```
(Pdb) widest_slice
slice(2878, 5762, None)
(Pdb) template_ds.dims
FrozenMappingWarningOnValuesAccess({'time': 2928, 'latitude': 721, 'longitude': 1440})
(Pdb) template_ds['temperature_2m'].isel({"time": widest_slice})
<xarray.DataArray 'temperature_2m' (time: 50, latitude: 721, longitude: 1440)> Size: 208MB
```

When we then calculate the max `nbytes`  to determine the size of our buffer

```
    shared_buffer_size = max(
        data_var.nbytes
        for data_var in template_ds.isel(
            {template.APPEND_DIMENSION: widest_slice}
        ).values()
    )
```

we get a value that is too small to hold our chunk data when we later do

```
chunk_template_ds = template_ds[data_var_names].isel(
  {template.APPEND_DIMENSION: append_dim_i_slice}
) 
(Pdb) chunk_template_ds
<xarray.Dataset> Size: 12GB
```

This PR resolves this by calculating the widest slice length, but then determining `shared_buffer_size`  with a slice that goes from 0 to `widest_slice_length`.
