### PR TITLE
Implement SWANN operational updates

### DIFF
--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -38,7 +38,7 @@ from reformatters.common.types import (
 from reformatters.common.update_progress_tracker import UpdateProgressTracker
 from reformatters.common.zarr import copy_data_var, get_mode
 
-logger = get_logger(__name__)
+log = get_logger(__name__)
 
 type CoordinateValueOrRange = slice | int | float | pd.Timestamp | pd.Timedelta | str
 
@@ -474,7 +474,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             ThreadPoolExecutor(max_workers=1) as download_executor,
             ThreadPoolExecutor(max_workers=2) as upload_executor,
         ):
-            logger.info(f"Starting {repr(self)}")
+            log.info(f"Starting {repr(self)}")
 
             # Submit all download tasks to the executor
             download_futures = {}
@@ -491,7 +491,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             for download_future in concurrent.futures.as_completed(download_futures):
                 data_var_group = download_futures[download_future]
                 source_file_coords = download_future.result()
-                logger.info(f"Downloaded: {[v.name for v in data_var_group]}")
+                log.info(f"Downloaded: {[v.name for v in data_var_group]}")
 
                 # Process one data variable at a time to ensure a single user of
                 # the shared buffer at a time and to reduce peak memory usage
@@ -594,9 +594,9 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                     and isinstance(append_dim_coord, np.datetime64 | pd.Timestamp)
                     and append_dim_coord > day_ago
                 ):
-                    logger.info(" ".join(str(e).split("\n")[:2]))
+                    log.info(" ".join(str(e).split("\n")[:2]))
                 else:
-                    logger.exception(f"Download failed {coord.get_url()}")
+                    log.exception(f"Download failed {coord.get_url()}")
 
                 return updated_coord
 
@@ -621,7 +621,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 out.loc[coord.out_loc()] = self.read_data(coord, data_var)
                 return replace(coord, status=SourceFileStatus.Succeeded)
             except Exception:
-                logger.exception(f"Read failed {coord.downloaded_path}")
+                log.exception(f"Read failed {coord.downloaded_path}")
                 return replace(coord, status=SourceFileStatus.ReadFailed)
 
         # Skip coords where the download failed

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import os
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import suppress
 from copy import deepcopy
@@ -474,6 +474,8 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             ThreadPoolExecutor(max_workers=1) as download_executor,
             ThreadPoolExecutor(max_workers=2) as upload_executor,
         ):
+            logger.info(f"Starting {repr(self)}")
+
             # Submit all download tasks to the executor
             download_futures = {}
             for data_var_group in data_var_groups:
@@ -489,6 +491,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             for download_future in concurrent.futures.as_completed(download_futures):
                 data_var_group = download_futures[download_future]
                 source_file_coords = download_future.result()
+                logger.info(f"Downloaded: {[v.name for v in data_var_group]}")
 
                 # Process one data variable at a time to ensure a single user of
                 # the shared buffer at a time and to reduce peak memory usage
@@ -561,7 +564,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         ]
 
     def _download_processing_group(
-        self, source_file_coords: Iterable[SOURCE_FILE_COORD]
+        self, source_file_coords: Sequence[SOURCE_FILE_COORD]
     ) -> list[SOURCE_FILE_COORD]:
         """
         Download specified source files in parallel.
@@ -573,6 +576,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         """
 
         def _call_download_file(coord: SOURCE_FILE_COORD) -> SOURCE_FILE_COORD:
+            # TODO: move exception handling to the download_file method
             try:
                 path = self.download_file(coord)
                 return replace(coord, downloaded_path=path)
@@ -652,5 +656,5 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 with suppress(FileNotFoundError):
                     coord.downloaded_path.unlink()
 
-    def summary(self) -> str:
-        return f"({self.region.start} - {self.region.stop}) {[d.name for d in self.data_vars]}"
+    def __repr__(self) -> str:
+        return f"RegionJob(region=({self.region.start}, {self.region.stop}), data_vars={[v.name for v in self.data_vars]})"

--- a/src/reformatters/u_arizona/swann/region_job.py
+++ b/src/reformatters/u_arizona/swann/region_job.py
@@ -82,12 +82,10 @@ class SWANNRegionJob(RegionJob[SWANNDataVar, SWANNSourceFileCoord]):
         all_data_vars: Sequence[SWANNDataVar],
         reformat_job_name: str,
     ) -> tuple[Sequence[RegionJob[SWANNDataVar, SWANNSourceFileCoord]], xr.Dataset]:
-        append_dim_end = cls._operational_append_dim_end()
-
-        template_ds = get_template_fn(append_dim_end)
         existing_ds = xr.open_zarr(final_store)
-
-        append_dim_start = cls._operational_append_dim_start(existing_ds)
+        append_dim_start = cls._update_append_dim_start(existing_ds)
+        append_dim_end = cls._update_append_dim_end()
+        template_ds = get_template_fn(append_dim_end)
 
         jobs = cls.get_jobs(
             kind="operational-update",
@@ -132,11 +130,11 @@ class SWANNRegionJob(RegionJob[SWANNDataVar, SWANNSourceFileCoord]):
             return result
 
     @classmethod
-    def _operational_append_dim_end(cls) -> pd.Timestamp:
+    def _update_append_dim_end(cls) -> pd.Timestamp:
         return pd.Timestamp.now()
 
     @classmethod
-    def _operational_append_dim_start(cls, existing_ds: xr.Dataset) -> pd.Timestamp:
+    def _update_append_dim_start(cls, existing_ds: xr.Dataset) -> pd.Timestamp:
         ds_max_time = existing_ds["time"].max().item()
         # UArizona updates the data, renamining files to reflect their status (early, provisional, stable)
         # We go back a year to try to pull in the latest stable data.

--- a/tests/u_arizona/swann/dataset_integration_test.py
+++ b/tests/u_arizona/swann/dataset_integration_test.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
@@ -21,3 +22,29 @@ def test_reformat_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     subset_ds = ds.sel(latitude=48.583335, longitude=-94, method="nearest")
     assert subset_ds.snow_depth.values == 190.0
     assert subset_ds.snow_water_equivalent.values == 35.0
+
+
+def test_reformat_operational_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    dataset = SWANNDataset()
+    # Dataset starts at 1981-10-01
+    dataset.reformat_local(append_dim_end=pd.Timestamp("1981-10-02"))
+    ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    assert ds.time.max() == pd.Timestamp("1981-10-01")
+
+    monkeypatch.setattr(
+        dataset.region_job_class,
+        "_operational_append_dim_end",
+        lambda: pd.Timestamp("1981-10-04"),
+    )
+
+    monkeypatch.setattr(
+        dataset.region_job_class,
+        "_operational_append_dim_start",
+        lambda existing_ds: pd.Timestamp(existing_ds.time.max().item()),
+    )
+
+    dataset.reformat_operational_update("test-reformat-operational-update")
+    updated_ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    np.testing.assert_array_equal(
+        updated_ds.time, pd.date_range("1981-10-01", "1981-10-03")
+    )

--- a/tests/u_arizona/swann/dataset_integration_test.py
+++ b/tests/u_arizona/swann/dataset_integration_test.py
@@ -49,6 +49,11 @@ def test_reformat_operational_update(monkeypatch: MonkeyPatch, tmp_path: Path) -
     np.testing.assert_array_equal(
         updated_ds.time, pd.date_range("1981-10-01", "1981-10-03")
     )
+    subset_ds = updated_ds.sel(latitude=48.583335, longitude=-94, method="nearest")
+    np.testing.assert_array_equal(subset_ds.snow_depth.values, [190.0, 163.0, 135.0])
+    np.testing.assert_array_equal(
+        subset_ds.snow_water_equivalent.values, [35.0, 33.0, 29.0]
+    )
 
 
 def test_reformat_operational_update_template_trimming(
@@ -89,3 +94,6 @@ def test_reformat_operational_update_template_trimming(
     np.testing.assert_array_equal(
         updated_ds.time, pd.date_range("1981-10-01", "1981-10-02")
     )
+    subset_ds = updated_ds.sel(latitude=48.583335, longitude=-94, method="nearest")
+    np.testing.assert_array_equal(subset_ds.snow_depth.values, [190.0, 163.0])
+    np.testing.assert_array_equal(subset_ds.snow_water_equivalent.values, [35.0, 33.0])

--- a/tests/u_arizona/swann/dataset_integration_test.py
+++ b/tests/u_arizona/swann/dataset_integration_test.py
@@ -34,13 +34,13 @@ def test_reformat_operational_update(monkeypatch: MonkeyPatch, tmp_path: Path) -
 
     monkeypatch.setattr(
         dataset.region_job_class,
-        "_operational_append_dim_end",
+        "_update_append_dim_end",
         lambda: pd.Timestamp("1981-10-04"),
     )
 
     monkeypatch.setattr(
         dataset.region_job_class,
-        "_operational_append_dim_start",
+        "_update_append_dim_start",
         lambda existing_ds: pd.Timestamp(existing_ds.time.max().item()),
     )
 
@@ -67,13 +67,13 @@ def test_reformat_operational_update_template_trimming(
 
     monkeypatch.setattr(
         dataset.region_job_class,
-        "_operational_append_dim_end",
+        "_update_append_dim_end",
         lambda: pd.Timestamp("1981-10-04"),
     )
 
     monkeypatch.setattr(
         dataset.region_job_class,
-        "_operational_append_dim_start",
+        "_update_append_dim_start",
         lambda existing_ds: pd.Timestamp(existing_ds.time.max().item()),
     )
 

--- a/tests/u_arizona/swann/dataset_integration_test.py
+++ b/tests/u_arizona/swann/dataset_integration_test.py
@@ -7,6 +7,7 @@ import xarray as xr
 from _pytest.monkeypatch import MonkeyPatch
 
 from reformatters.u_arizona.swann import SWANNDataset
+from reformatters.u_arizona.swann.region_job import SWANNRegionJob, SWANNSourceFileCoord
 
 pytestmark = pytest.mark.slow
 
@@ -47,4 +48,44 @@ def test_reformat_operational_update(monkeypatch: MonkeyPatch, tmp_path: Path) -
     updated_ds = xr.open_zarr(dataset._final_store(), chunks=None)
     np.testing.assert_array_equal(
         updated_ds.time, pd.date_range("1981-10-01", "1981-10-03")
+    )
+
+
+def test_reformat_operational_update_template_trimming(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    dataset = SWANNDataset()
+    # Dataset starts at 1981-10-01
+    dataset.reformat_local(append_dim_end=pd.Timestamp("1981-10-02"))
+    ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    assert ds.time.max() == pd.Timestamp("1981-10-01")
+
+    monkeypatch.setattr(
+        dataset.region_job_class,
+        "_operational_append_dim_end",
+        lambda: pd.Timestamp("1981-10-04"),
+    )
+
+    monkeypatch.setattr(
+        dataset.region_job_class,
+        "_operational_append_dim_start",
+        lambda existing_ds: pd.Timestamp(existing_ds.time.max().item()),
+    )
+
+    original_download_file = dataset.region_job_class.download_file
+
+    def mock_download_file(self: SWANNRegionJob, coord: SWANNSourceFileCoord) -> Path:
+        # Simulate download failure for 1981-10-03 (the last day we're trying to process)
+        if coord.time == pd.Timestamp("1981-10-03"):
+            raise FileNotFoundError(f"File not found for {coord.time}")
+        return original_download_file(self, coord)
+
+    monkeypatch.setattr(dataset.region_job_class, "download_file", mock_download_file)
+
+    dataset.reformat_operational_update("test-reformat-operational-update")
+    updated_ds = xr.open_zarr(dataset._final_store(), chunks=None)
+
+    # The dataset should only extend to 1981-10-02 because 1981-10-03 failed to download
+    np.testing.assert_array_equal(
+        updated_ds.time, pd.date_range("1981-10-01", "1981-10-02")
     )

--- a/tests/u_arizona/swann/region_job_test.py
+++ b/tests/u_arizona/swann/region_job_test.py
@@ -1,7 +1,9 @@
 import pandas as pd
 import pytest
+import xarray as xr
 
 from reformatters.u_arizona.swann.region_job import (
+    SWANNRegionJob,
     SWANNSourceFileCoord,
 )
 
@@ -61,3 +63,10 @@ def test_source_file_coord_data_status() -> None:
         coord.get_url()
         == "https://climate.arizona.edu/data/UA_SWE/DailyData_4km/WY2024/UA_SWE_Depth_4km_v1_20231001_provisional.nc"
     )
+
+
+def test_update_append_dim_start() -> None:
+    """Test the update_append_dim_start method."""
+    existing_ds = xr.Dataset(coords={"time": pd.date_range("2023-10-01", "2025-01-03")})
+    expected_start = pd.Timestamp("2024-01-04")
+    assert SWANNRegionJob._update_append_dim_start(existing_ds) == expected_start


### PR DESCRIPTION
This PR implements `SWANNRegionJob.operational_update_jobs` to allow for operational updates to an existing SWANN dataset with the latest available data.