### PR TITLE
Refactor pt 5 - reformat_kubernetes, validate_zarr, and operational_kubernetes_resources

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -46,7 +46,7 @@ for dataset in DYNAMICAL_DATASETS:
 def deploy_operational_updates(
     docker_image: str | None = None,
 ) -> None:
-    deploy.deploy_operational_updates(docker_image=docker_image)
+    deploy.deploy_operational_updates(DYNAMICAL_DATASETS, docker_image)
 
 
 if __name__ == "__main__":

--- a/src/reformatters/common/deploy.py
+++ b/src/reformatters/common/deploy.py
@@ -1,9 +1,11 @@
 import json
 import subprocess
 from collections.abc import Iterable
-from typing import Protocol
+from typing import Any, Protocol
 
 from reformatters.common import docker, kubernetes
+from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.logging import get_logger
 from reformatters.noaa.gefs.analysis.reformat import (
     operational_kubernetes_resources as noaa_gefs_analysis_operational_kubernetes_resources,
 )
@@ -11,25 +13,38 @@ from reformatters.noaa.gefs.forecast_35_day.reformat import (
     operational_kubernetes_resources as noaa_gefs_forecast_35_day_operational_kubernetes_resources,
 )
 
+log = get_logger(__name__)
+
 
 class OperationalKubernetesResources(Protocol):
     def __call__(self, image_tag: str) -> Iterable[kubernetes.Job]: ...
 
 
-OPERATIONAL_RESOURCE_FNS: tuple[OperationalKubernetesResources, ...] = (
+# For datasets which have not yet been implemented as a DynamicalDataset sublcass
+LEGACY_OPERATIONAL_RESOURCE_FNS: tuple[OperationalKubernetesResources, ...] = (
     noaa_gefs_forecast_35_day_operational_kubernetes_resources,
     noaa_gefs_analysis_operational_kubernetes_resources,
 )
 
 
 def deploy_operational_updates(
-    fns: tuple[OperationalKubernetesResources, ...] = OPERATIONAL_RESOURCE_FNS,
+    datasets: Iterable[DynamicalDataset[Any, Any]],
     docker_image: str | None = None,
 ) -> None:
     image_tag = docker_image or docker.build_and_push_image()
 
     reformat_jobs: list[kubernetes.Job] = []
-    for fn in fns:
+
+    for dataset in datasets:
+        try:
+            reformat_jobs.extend(dataset.operational_kubernetes_resources(image_tag))
+        except NotImplementedError:
+            log.info(
+                f"Skipping deploy for {dataset.__class__.__name__}, "
+                "`operational_kubernetes_resources` not implemented."
+            )
+
+    for fn in LEGACY_OPERATIONAL_RESOURCE_FNS:
         reformat_jobs.extend(fn(image_tag))
 
     k8s_resource_list = {
@@ -45,4 +60,8 @@ def deploy_operational_updates(
         input=json.dumps(k8s_resource_list),
         text=True,
         check=True,
+    )
+
+    log.info(
+        f"Deployed {[item['metadata']['name'] for item in k8s_resource_list['items']]}"  # type: ignore[index]
     )

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -281,8 +281,9 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         """Create a CLI app with dataset commands"""
         app = typer.Typer()
         app.command()(self.update_template)
-        app.command()(self.reformat_local)
+        app.command()(self.reformat_operational_update)
         app.command()(self.reformat_kubernetes)
+        app.command()(self.reformat_local)
         app.command()(self.process_region_jobs)
         app.command()(self.validate_zarr)
         return app

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -147,7 +147,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         if filter_start is not None:
             command.append(f"--filter-start={filter_start.isoformat()}")
         if filter_end is not None:
-            command.append(f"--filter-end={filter_end}")
+            command.append(f"--filter-end={filter_end.isoformat()}")
         if filter_variable_names is not None:
             for variable_name in filter_variable_names:
                 command.append(f"--filter-variable-names={variable_name}")

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -1,17 +1,20 @@
+import json
+import subprocess
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Generic, TypeVar
+from typing import Annotated, Any, Generic, TypeVar
 
+import numpy as np
 import pandas as pd
 import typer
 import xarray as xr
 import zarr
 from pydantic import computed_field
 
-from reformatters.common import template_utils
+from reformatters.common import docker, template_utils
 from reformatters.common.config_models import DataVar
-from reformatters.common.kubernetes import Job
+from reformatters.common.kubernetes import Job, ReformatCronJob
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.region_job import RegionJob, SourceFileCoord
@@ -102,9 +105,91 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         """Generate and persist the dataset template using the template_config."""
         self.template_config.update_template()
 
-    def reformat_kubernetes(self) -> None:
+    def reformat_kubernetes(
+        self,
+        append_dim_end: datetime,
+        jobs_per_pod: int,
+        max_parallelism: int,
+        filter_start: datetime | None = None,
+        filter_end: datetime | None = None,
+        filter_variable_names: list[str] | None = None,
+        docker_image: str | None = None,
+    ) -> None:
         """Run dataset reformatting using Kubernetes index jobs."""
-        pass
+        image_tag = docker_image or docker.build_and_push_image()
+
+        template_ds = self._get_template(append_dim_end)
+        final_store = self._final_store()
+        logger.info(f"Writing zarr metadata to {final_store}")
+
+        template_utils.write_metadata(template_ds, final_store, get_mode(final_store))
+
+        num_jobs = len(
+            self.region_job_class.get_jobs(
+                kind="backfill",
+                final_store=final_store,
+                tmp_store=self._tmp_store(),
+                template_ds=template_ds,
+                append_dim=self.template_config.append_dim,
+                all_data_vars=self.template_config.data_vars,
+                # The jobs returned from this call are only counted,
+                # the real job named will be filled in by kubernetes
+                reformat_job_name="placeholder",
+                filter_start=pd.Timestamp(filter_start) if filter_start else None,
+                filter_end=pd.Timestamp(filter_end) if filter_end else None,
+                filter_variable_names=filter_variable_names,
+            )
+        )
+        workers_total = int(np.ceil(num_jobs / jobs_per_pod))
+        parallelism = min(workers_total, max_parallelism)
+
+        command = ["process-region-jobs", pd.Timestamp(append_dim_end).isoformat()]
+        if filter_start is not None:
+            command.append(f"--filter-start={filter_start.isoformat()}")
+        if filter_end is not None:
+            command.append(f"--filter-end={filter_end}")
+        if filter_variable_names is not None:
+            for variable_name in filter_variable_names:
+                command.append(f"--filter-variable-names={variable_name}")
+
+        # In an attempt to keep the subclassing API simpler, we are keeping
+        # all resource needs defined right in `operational_kubernetes_resources`.
+        # If for some reason there are _multiple_ ReformatCronJobs returned from
+        # that we'll need to revisit the logic below or this approach.
+        reformat_jobs = [
+            r
+            for r in self.operational_kubernetes_resources(image_tag)
+            if isinstance(r, ReformatCronJob)
+        ]
+        assert len(reformat_jobs) == 1, (
+            f"Can't infer kubernetes resources for backfill job from {reformat_jobs}."
+        )
+        reformat_job = reformat_jobs[0]
+
+        kubernetes_job = Job(
+            command=command,
+            image=image_tag,
+            dataset_id=self.dataset_id,
+            workers_total=workers_total,
+            parallelism=parallelism,
+            **reformat_job.model_dump(
+                include={
+                    "cpu",
+                    "memory",
+                    "shared_memory",
+                    "ephemeral_storage",
+                    "pod_active_deadline",
+                }
+            ),
+        )
+        subprocess.run(  # noqa: S603
+            ["/usr/bin/kubectl", "apply", "-f", "-"],
+            input=json.dumps(kubernetes_job.as_kubernetes_object()),
+            text=True,
+            check=True,
+        )
+
+        logger.info(f"Submitted kubernetes job {kubernetes_job.job_name}")
 
     def reformat_operational_update(self) -> None:
         """Update an existing dataset with the latest data."""
@@ -157,13 +242,13 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     def process_region_jobs(
         self,
-        append_dim_end: DatetimeLike,
-        reformat_job_name: str,
+        append_dim_end: datetime,
+        reformat_job_name: Annotated[str, typer.Argument(envvar="JOB_NAME")],
         *,
-        worker_index: int,
-        workers_total: int,
-        filter_start: DatetimeLike | None = None,
-        filter_end: DatetimeLike | None = None,
+        worker_index: Annotated[int, typer.Argument(envvar="WORKER_INDEX")],
+        workers_total: Annotated[int, typer.Argument(envvar="WORKERS_TOTAL")],
+        filter_start: datetime | None = None,
+        filter_end: datetime | None = None,
         filter_variable_names: list[str] | None = None,
     ) -> None:
         """Orchestrate running RegionJob instances."""
@@ -198,6 +283,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         app.command()(self.update_template)
         app.command()(self.reformat_local)
         app.command()(self.reformat_kubernetes)
+        app.command()(self.process_region_jobs)
         app.command()(self.validate_zarr)
         return app
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -131,6 +131,8 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         for region_job in region_jobs:
             region_job.process()
 
+    # make a not implemented interface and docstring for validate_zarr that raises NotImplementedError AI!
+
     def get_cli(
         self,
     ) -> typer.Typer:

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -131,7 +131,9 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         for region_job in region_jobs:
             region_job.process()
 
-    # make a not implemented interface and docstring for validate_zarr that raises NotImplementedError AI!
+    def validate_zarr(self) -> None:
+        """Validate the zarr dataset. This method is not implemented in the base DynamicalDataset."""
+        raise NotImplementedError("validate_zarr must be implemented by subclasses")
 
     def get_cli(
         self,

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -41,7 +41,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     def validate_zarr(self) -> None:
         """
-        Validate the zarr dataset, raising an exception if the zarr is invalid.
+        Validate the dataset, raising an exception if it is invalid.
 
         See common/validation.py for existing utilities.
         Implementions should look similar this:
@@ -64,7 +64,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         Return the kubernetes cron job definitions to operationally
         update and validate this dataset.
 
-        Most implementations will look similar to this:
+        Implementions should look similar this:
         ```
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-operational-update",

--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -309,6 +309,7 @@ def get_latest_processed_time(
         "timezone": "UTC",
     },
 )
+# Example validate zarr call here AI
 def validate_zarr() -> None:
     validation.validate_zarr(
         get_store(),

--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -309,7 +309,6 @@ def get_latest_processed_time(
         "timezone": "UTC",
     },
 )
-# Example validate zarr call here AI
 def validate_zarr() -> None:
     validation.validate_zarr(
         get_store(),

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -21,6 +21,7 @@ from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.region_job import RegionJob, SourceFileCoord
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
+from reformatters.common.kubernetes import ReformatCronJob
 
 
 class ExampleDataVar(DataVar[BaseInternalAttrs]):
@@ -75,7 +76,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
     template_config: ExampleConfig = ExampleConfig()
     region_job_class: type[ExampleRegionJob] = ExampleRegionJob
 
-    def operational_kubernetes_resources(self, image_tag: str) -> list:
+    def operational_kubernetes_resources(self, image_tag: str) -> list[ReformatCronJob]:
         from reformatters.common.kubernetes import ReformatCronJob
 
         return [

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -75,7 +75,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
     template_config: ExampleConfig = ExampleConfig()
     region_job_class: type[ExampleRegionJob] = ExampleRegionJob
 
-    def operational_kubernetes_resources(self, image_tag: str):
+    def operational_kubernetes_resources(self, image_tag: str) -> list:
         from reformatters.common.kubernetes import ReformatCronJob
 
         return [

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -1,3 +1,5 @@
+import subprocess
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import ClassVar
 from unittest.mock import Mock
@@ -8,6 +10,7 @@ import pytest
 import xarray as xr
 from pydantic import computed_field
 
+from reformatters.common import template_utils
 from reformatters.common.config_models import (
     BaseInternalAttrs,
     DataVar,
@@ -18,10 +21,6 @@ from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.region_job import RegionJob, SourceFileCoord
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
-import subprocess
-import json
-from datetime import datetime, timedelta
-from reformatters.common import template_utils
 
 
 class ExampleDataVar(DataVar[BaseInternalAttrs]):
@@ -77,7 +76,6 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
     region_job_class: type[ExampleRegionJob] = ExampleRegionJob
 
     def operational_kubernetes_resources(self, image_tag: str):
-        from datetime import timedelta
         from reformatters.common.kubernetes import ReformatCronJob
 
         return [

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -18,10 +18,10 @@ from reformatters.common.config_models import (
     Encoding,
 )
 from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.kubernetes import ReformatCronJob
 from reformatters.common.region_job import RegionJob, SourceFileCoord
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
-from reformatters.common.kubernetes import ReformatCronJob
 
 
 class ExampleDataVar(DataVar[BaseInternalAttrs]):

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -1,26 +1,32 @@
 import json
 import subprocess
-import pytest
+
 from reformatters.common import deploy
+
 
 class DummyJob:
     def __init__(self):
         self.obj = {"metadata": {"name": "dummy-job"}, "spec": {}}
+
     def as_kubernetes_object(self):
         return self.obj
+
 
 class DummyDataset:
     def operational_kubernetes_resources(self, image_tag: str):
         assert image_tag == "test-image-tag"
         return [DummyJob()]
 
+
 def test_deploy_operational_updates(monkeypatch):
     # Prevent legacy resources from polluting test
     monkeypatch.setattr(deploy, "LEGACY_OPERATIONAL_RESOURCE_FNS", ())
     # Capture subprocess.run calls
     calls = []
+
     def fake_run(cmd, input, text, check):
         calls.append({"cmd": cmd, "input": input, "text": text, "check": check})
+
     monkeypatch.setattr(subprocess, "run", fake_run)
     # Invoke deploy with our dummy dataset and image tag
     deploy.deploy_operational_updates([DummyDataset()], docker_image="test-image-tag")

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import pytest
+from reformatters.common import deploy
+
+class DummyJob:
+    def __init__(self):
+        self.obj = {"metadata": {"name": "dummy-job"}, "spec": {}}
+    def as_kubernetes_object(self):
+        return self.obj
+
+class DummyDataset:
+    def operational_kubernetes_resources(self, image_tag: str):
+        assert image_tag == "test-image-tag"
+        return [DummyJob()]
+
+def test_deploy_operational_updates(monkeypatch):
+    # Prevent legacy resources from polluting test
+    monkeypatch.setattr(deploy, "LEGACY_OPERATIONAL_RESOURCE_FNS", ())
+    # Capture subprocess.run calls
+    calls = []
+    def fake_run(cmd, input, text, check):
+        calls.append({"cmd": cmd, "input": input, "text": text, "check": check})
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    # Invoke deploy with our dummy dataset and image tag
+    deploy.deploy_operational_updates([DummyDataset()], docker_image="test-image-tag")
+    # Verify subprocess.run was called exactly once
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["cmd"] == ["/usr/bin/kubectl", "apply", "-f", "-"]
+    # Parse JSON payload
+    payload = json.loads(call["input"])
+    assert payload["apiVersion"] == "v1"
+    assert payload["kind"] == "List"
+    # Verify that our DummyJob's object appears in items
+    assert payload["items"] == [DummyJob().as_kubernetes_object()]

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -33,13 +33,16 @@ def test_deploy_operational_updates(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     # Invoke deploy with our dummy dataset and image tag
-    deploy.deploy_operational_updates([DummyDataset()], docker_image="test-image-tag")  # type: ignore[arg-type]
+    deploy.deploy_operational_updates(
+        cast(list[DynamicalDataset[Any, Any]], [DummyDataset()]),
+        docker_image="test-image-tag",
+    )
     # Verify subprocess.run was called exactly once
     assert len(calls) == 1
     call = calls[0]
     assert call["cmd"] == ["/usr/bin/kubectl", "apply", "-f", "-"]
     # Parse JSON payload
-    payload = json.loads(call["input"])
+    payload = json.loads(cast(str, call["input"]))
     assert payload["apiVersion"] == "v1"
     assert payload["kind"] == "List"
     # Verify that our DummyJob's object appears in items

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -1,8 +1,11 @@
 import json
 import subprocess
-from typing import Any
+
+import pytest
+from typing import Any, cast
 
 from reformatters.common import deploy
+from reformatters.common.dynamical_dataset import DynamicalDataset
 
 
 class DummyJob:
@@ -19,11 +22,11 @@ class DummyDataset:
         return [DummyJob()]
 
 
-def test_deploy_operational_updates(monkeypatch) -> None:
+def test_deploy_operational_updates(monkeypatch: pytest.MonkeyPatch) -> None:
     # Prevent legacy resources from polluting test
     monkeypatch.setattr(deploy, "LEGACY_OPERATIONAL_RESOURCE_FNS", ())
     # Capture subprocess.run calls
-    calls: list[dict[str, object]] = []
+    calls: list[dict[str, Any]] = []
 
     def fake_run(cmd: list[str], input: str, text: bool, check: bool) -> None:
         calls.append({"cmd": cmd, "input": input, "text": text, "check": check})

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -1,15 +1,15 @@
 import json
 import subprocess
-from typing import Any, Dict
+from typing import Any
 
 from reformatters.common import deploy
 
 
 class DummyJob:
     def __init__(self) -> None:
-        self.obj: Dict[str, Any] = {"metadata": {"name": "dummy-job"}, "spec": {}}
+        self.obj: dict[str, Any] = {"metadata": {"name": "dummy-job"}, "spec": {}}
 
-    def as_kubernetes_object(self) -> Dict[str, Any]:
+    def as_kubernetes_object(self) -> dict[str, Any]:
         return self.obj
 
 

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -1,8 +1,8 @@
 import json
 import subprocess
+from typing import Any, cast
 
 import pytest
-from typing import Any, cast
 
 from reformatters.common import deploy
 from reformatters.common.dynamical_dataset import DynamicalDataset

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -1,35 +1,36 @@
 import json
 import subprocess
+from typing import Any, Dict
 
 from reformatters.common import deploy
 
 
 class DummyJob:
-    def __init__(self):
-        self.obj = {"metadata": {"name": "dummy-job"}, "spec": {}}
+    def __init__(self) -> None:
+        self.obj: Dict[str, Any] = {"metadata": {"name": "dummy-job"}, "spec": {}}
 
-    def as_kubernetes_object(self):
+    def as_kubernetes_object(self) -> Dict[str, Any]:
         return self.obj
 
 
 class DummyDataset:
-    def operational_kubernetes_resources(self, image_tag: str):
+    def operational_kubernetes_resources(self, image_tag: str) -> list[DummyJob]:
         assert image_tag == "test-image-tag"
         return [DummyJob()]
 
 
-def test_deploy_operational_updates(monkeypatch):
+def test_deploy_operational_updates(monkeypatch) -> None:
     # Prevent legacy resources from polluting test
     monkeypatch.setattr(deploy, "LEGACY_OPERATIONAL_RESOURCE_FNS", ())
     # Capture subprocess.run calls
-    calls = []
+    calls: list[dict[str, object]] = []
 
-    def fake_run(cmd, input, text, check):
+    def fake_run(cmd: list[str], input: str, text: bool, check: bool) -> None:
         calls.append({"cmd": cmd, "input": input, "text": text, "check": check})
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     # Invoke deploy with our dummy dataset and image tag
-    deploy.deploy_operational_updates([DummyDataset()], docker_image="test-image-tag")
+    deploy.deploy_operational_updates([DummyDataset()], docker_image="test-image-tag")  # type: ignore[arg-type]
     # Verify subprocess.run was called exactly once
     assert len(calls) == 1
     call = calls[0]


### PR DESCRIPTION
The last piece this doesn't implement is sentry cron monitoring on reformat_operational_update and validate_zarr. That'll be a follow up.