### PR TITLE
Subclasses override `validators` not `validate_zarr`

### DIFF
--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -271,7 +271,10 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         for region_job in region_jobs:
             region_job.process()
 
-    def validate_zarr(self) -> None:
+    def validate_zarr(
+        self,
+        reformat_job_name: Annotated[str, typer.Argument(envvar="JOB_NAME")],
+    ) -> None:
         """Validate the dataset, raising an exception if it is invalid."""
         validation.validate_zarr(self._final_store(), validators=self.validators())
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -1,6 +1,6 @@
 import json
 import subprocess
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, Generic, TypeVar
@@ -12,7 +12,7 @@ import xarray as xr
 import zarr
 from pydantic import computed_field
 
-from reformatters.common import docker, template_utils
+from reformatters.common import docker, template_utils, validation
 from reformatters.common.config_models import DataVar
 from reformatters.common.kubernetes import Job, ReformatCronJob
 from reformatters.common.logging import get_logger
@@ -38,26 +38,6 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     template_config: TemplateConfig[DATA_VAR]
     region_job_class: type[RegionJob[DATA_VAR, SOURCE_FILE_COORD]]
-
-    def validate_zarr(self) -> None:
-        """
-        Validate the dataset, raising an exception if it is invalid.
-
-        See common/validation.py for existing utilities.
-        Implementions should look similar this:
-        ```
-        validation.validate_zarr(
-            self._final_store(),
-            validators=(
-                validation.check_analysis_current_data,
-                validation.check_analysis_recent_nans,
-            ),
-        )
-        ```
-        """
-        raise NotImplementedError(
-            f"Implement validate_zarr on {self.__class__.__name__}"
-        )
 
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[Job]:
         """
@@ -91,7 +71,23 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         ```
         """
         raise NotImplementedError(
-            f"Implement operational_kubernetes_resources on {self.__class__.__name__}"
+            f"Implement `operational_kubernetes_resources` on {self.__class__.__name__}"
+        )
+
+    def validators(self) -> Sequence[validation.DataValidator]:
+        """
+        Return a sequence of DataValidators to run on this dataset.
+
+        Implementions should look similar this:
+        ```
+        return (
+            validation.check_analysis_current_data,
+            validation.check_analysis_recent_nans,
+        )
+        ```
+        """
+        raise NotImplementedError(
+            f"Implement `validators` on {self.__class__.__name__}"
         )
 
     # ----- Most subclasses will not need to override the attributes and methods below -----
@@ -274,6 +270,10 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         )
         for region_job in region_jobs:
             region_job.process()
+
+    def validate_zarr(self) -> None:
+        """Validate the dataset, raising an exception if it is invalid."""
+        validation.validate_zarr(self._final_store(), validators=self.validators())
 
     def get_cli(
         self,

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -223,28 +223,6 @@ def test_reformat_kubernetes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     _, kwargs = mock_run.call_args
     input_str = kwargs["input"]
 
-
-def test_validate_zarr_calls_validators_and_uses_final_store(
-    monkeypatch, tmp_path: Path
-) -> None:
-    # Set up mock validators list
-    mock_validators = [Mock(), Mock()]
-    monkeypatch.setattr(ExampleDataset, "validators", lambda self: mock_validators)
-    # Set up mock final store
-    mock_store = tmp_path / "zarr_store"
-    monkeypatch.setattr(ExampleDataset, "_final_store", lambda self: mock_store)
-    # Mock validation.validate_zarr
-    mock_validate = Mock()
-    monkeypatch.setattr(validation, "validate_zarr", mock_validate)
-    # Instantiate dataset and call validate_zarr
-    dataset = ExampleDataset(
-        template_config=ExampleConfig(),
-        region_job_class=ExampleRegionJob,
-    )
-    dataset.validate_zarr()
-    # Ensure validate_zarr was called with correct arguments
-    mock_validate.assert_called_once_with(mock_store, validators=mock_validators)
-
     # workers_total = ceil(5/2) == 3
     assert '"completions": 3' in input_str
     # Command and filters
@@ -255,3 +233,29 @@ def test_validate_zarr_calls_validators_and_uses_final_store(
     assert "--filter-variable-names=b" in input_str
     # Docker image
     assert '"my-docker-image"' in input_str
+
+
+def test_validate_zarr_calls_validators_and_uses_final_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mock_validators = [Mock(), Mock()]
+    monkeypatch.setattr(ExampleDataset, "validators", lambda self: mock_validators)
+
+    mock_store = Mock()
+    monkeypatch.setattr(ExampleDataset, "_final_store", lambda self: mock_store)
+
+    mock_validate = Mock()
+    monkeypatch.setattr(validation, "validate_zarr", mock_validate)
+
+    dataset = ExampleDataset(
+        template_config=ExampleConfig(),
+        region_job_class=ExampleRegionJob,
+    )
+
+    dataset.validate_zarr()
+
+    # Ensure validate_zarr was called with correct arguments
+    # this implies
+    # - self._final_store() was called and returned our mock_store
+    # - self.validators() was called and returned our mock_validators
+    mock_validate.assert_called_once_with(mock_store, validators=mock_validators)

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -11,7 +11,7 @@ import pytest
 import xarray as xr
 from pydantic import computed_field
 
-from reformatters.common import template_utils
+from reformatters.common import template_utils, validation
 from reformatters.common.config_models import (
     BaseInternalAttrs,
     DataVar,
@@ -23,7 +23,6 @@ from reformatters.common.kubernetes import Job, ReformatCronJob
 from reformatters.common.region_job import RegionJob, SourceFileCoord
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
-from reformatters.common import validation
 
 
 class ExampleDataVar(DataVar[BaseInternalAttrs]):
@@ -224,7 +223,10 @@ def test_reformat_kubernetes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     _, kwargs = mock_run.call_args
     input_str = kwargs["input"]
 
-def test_validate_zarr_calls_validators_and_uses_final_store(monkeypatch, tmp_path: Path) -> None:
+
+def test_validate_zarr_calls_validators_and_uses_final_store(
+    monkeypatch, tmp_path: Path
+) -> None:
     # Set up mock validators list
     mock_validators = [Mock(), Mock()]
     monkeypatch.setattr(ExampleDataset, "validators", lambda self: mock_validators)

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -252,7 +252,7 @@ def test_validate_zarr_calls_validators_and_uses_final_store(
         region_job_class=ExampleRegionJob,
     )
 
-    dataset.validate_zarr()
+    dataset.validate_zarr("example-job-name")
 
     # Ensure validate_zarr was called with correct arguments
     # this implies


### PR DESCRIPTION
This way subclassers don't need to worry about typer annotations nor sentry monitoring. Also a little bit less boilerplate.