### PR TITLE
Fix fsspec_apply to work with LocalStore and add some tests for UpdateProgressTracker

### DIFF
--- a/src/reformatters/common/fsspec.py
+++ b/src/reformatters/common/fsspec.py
@@ -29,12 +29,14 @@ def fsspec_apply(
     """
     for attempt in range(max_attempts):
         try:
-            if hasattr(fs, f"_{method}"):
+            try:
+                # First try the async method if it exists
                 # Zarr's FsspecStore creates async fsspec filesystems, so use their sync method
                 return zarr.core.sync.sync(
                     getattr(fs, f"_{method}")(*args, **kwargs), timeout=120
                 )
-            else:
+            except (NotImplementedError, AttributeError):
+                # Fall back to the sync method
                 return getattr(fs, method)(*args, **kwargs)
         except Exception:
             if attempt == max_attempts - 1:  # Last attempt failed

--- a/src/reformatters/common/fsspec.py
+++ b/src/reformatters/common/fsspec.py
@@ -29,14 +29,11 @@ def fsspec_apply(
     """
     for attempt in range(max_attempts):
         try:
-            try:
-                # First try the async method if it exists
-                # Zarr's FsspecStore creates async fsspec filesystems, so use their sync method
+            if fs.async_impl:
                 return zarr.core.sync.sync(
                     getattr(fs, f"_{method}")(*args, **kwargs), timeout=120
                 )
-            except (NotImplementedError, AttributeError):
-                # Fall back to the sync method
+            else:
                 return getattr(fs, method)(*args, **kwargs)
         except Exception:
             if attempt == max_attempts - 1:  # Last attempt failed

--- a/tests/common/test_update_progress_tracker.py
+++ b/tests/common/test_update_progress_tracker.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import zarr
+from pytest import MonkeyPatch
+
+from reformatters.common import zarr as common_zarr_module
+from reformatters.common.update_progress_tracker import UpdateProgressTracker
+from reformatters.common.zarr import get_zarr_store
+
+
+def test_update_progress_tracker_close_with_local_store(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test UpdateProgressTracker loads existing progress with LocalStore (sync filesystem)"""
+    monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
+    store = get_zarr_store("test", "dev")
+    assert not store.fs.async_impl
+
+    # Create an existing progress file
+    progress_file = (
+        tmp_path
+        / "test"
+        / Path(store.path).name
+        / "_internal_update_progress_test-job_0.json"
+    )
+    progress_file.parent.mkdir(parents=True, exist_ok=True)
+    progress_file.write_text(json.dumps({"processed_variables": ["existing_var"]}))
+
+    # Create tracker - should load existing progress using fsspec_apply cat_file
+    tracker = UpdateProgressTracker(store, "test-job", 0)
+    tracker.close()
+
+    assert not progress_file.exists()
+
+
+def test_update_progress_tracker_close_with_async_store(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test UpdateProgressTracker loads existing progress with FsspecStore (async filesystem)"""
+    monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
+    store = get_zarr_store("test", "dev")
+    store = zarr.storage.FsspecStore.from_url(store.path)
+    assert store.fs.async_impl
+
+    # Create an existing progress file
+    progress_file = (
+        tmp_path
+        / "test"
+        / Path(store.path).name
+        / "_internal_update_progress_test-job_0.json"
+    )
+    progress_file.parent.mkdir(parents=True, exist_ok=True)
+    progress_file.write_text(json.dumps({"processed_variables": ["existing_var"]}))
+
+    # Create tracker - should load existing progress using fsspec_apply cat_file
+    tracker = UpdateProgressTracker(store, "test-job", 0)
+    tracker.close()
+
+    assert not progress_file.exists()

--- a/tests/common/test_update_progress_tracker.py
+++ b/tests/common/test_update_progress_tracker.py
@@ -28,7 +28,6 @@ def test_update_progress_tracker_close_with_local_store(
     progress_file.parent.mkdir(parents=True, exist_ok=True)
     progress_file.write_text(json.dumps({"processed_variables": ["existing_var"]}))
 
-    # Create tracker - should load existing progress using fsspec_apply cat_file
     tracker = UpdateProgressTracker(store, "test-job", 0)
     tracker.close()
 
@@ -55,7 +54,6 @@ def test_update_progress_tracker_close_with_async_store(
     progress_file.parent.mkdir(parents=True, exist_ok=True)
     progress_file.write_text(json.dumps({"processed_variables": ["existing_var"]}))
 
-    # Create tracker - should load existing progress using fsspec_apply cat_file
     tracker = UpdateProgressTracker(store, "test-job", 0)
     tracker.close()
 


### PR DESCRIPTION
This PR makes a fix to `fsspec_apply` to allow it to work with zarr stores that do not have an async implementation.