### PR TITLE
SWANN dataset integration test fix: Ensure LOCAL_ZARR_STORE_BASE_PATH is monkeypatched to avoid overwriting real final store

### DIFF
--- a/tests/u_arizona/swann/dataset_integration_test.py
+++ b/tests/u_arizona/swann/dataset_integration_test.py
@@ -6,10 +6,16 @@ import pytest
 import xarray as xr
 from _pytest.monkeypatch import MonkeyPatch
 
+from reformatters.common import zarr as common_zarr_module
 from reformatters.u_arizona.swann import SWANNDataset
 from reformatters.u_arizona.swann.region_job import SWANNRegionJob, SWANNSourceFileCoord
 
 pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(autouse=True)
+def set_test_final_store(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
 
 
 def test_reformat_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
`dataset._final_store()` was resolved to the the "true" final store for my local environment, causing the zarr to be overwritten when the tests run. This PR fixes this by monkeypatching `_LOCAL_ZARR_STORE_BASE_PATH` for all the dataset integration tests.

Broader question: should we configure something at a higher level than this to prevent someone from accidentally overwriting a local zarr?