### PR TITLE
Add autouse fixture to automatically set zarr path to a tmp file in a test env

### DIFF
--- a/src/reformatters/common/config.py
+++ b/src/reformatters/common/config.py
@@ -7,6 +7,7 @@ import pydantic
 class Env(str, Enum):
     dev = "dev"
     prod = "prod"
+    test = "test"
 
 
 class SourceCoopConfig(pydantic.BaseModel):
@@ -43,6 +44,10 @@ class DynamicalConfig(pydantic.BaseModel):
                     "aws_access_key_id and aws_secret_access_key are required in prod environment"
                 )
         return self
+
+    @property
+    def is_test(self) -> bool:
+        return self.env == Env.test
 
     @property
     def is_dev(self) -> bool:

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -35,7 +35,7 @@ BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE = zarr.codecs.BloscCodec(
 
 def get_zarr_store(dataset_id: str, version: str) -> zarr.storage.FsspecStore:
     if not Config.is_prod:
-        version = "dev"
+        version = "dev" if Config.is_dev else version
 
         # This should work, but it gives FileNotFoundError when it should be creating a new zarr.
         # return zarr.storage.FsspecStore.from_url(

--- a/tests/common/test_update_progress_tracker.py
+++ b/tests/common/test_update_progress_tracker.py
@@ -2,20 +2,14 @@ import json
 from pathlib import Path
 
 import zarr
-from pytest import MonkeyPatch
 
-from reformatters.common import zarr as common_zarr_module
 from reformatters.common.update_progress_tracker import UpdateProgressTracker
 from reformatters.common.zarr import get_zarr_store
 
 
-def test_update_progress_tracker_close_with_local_store(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+def test_update_progress_tracker_close_with_local_store(tmp_path: Path) -> None:
     """Test UpdateProgressTracker loads existing progress with LocalStore (sync filesystem)"""
-    monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
-    store = get_zarr_store("test", "dev")
+    store = get_zarr_store("test", "test-version")
     assert not store.fs.async_impl
 
     # Create an existing progress file
@@ -34,13 +28,9 @@ def test_update_progress_tracker_close_with_local_store(
     assert not progress_file.exists()
 
 
-def test_update_progress_tracker_close_with_async_store(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+def test_update_progress_tracker_close_with_async_store(tmp_path: Path) -> None:
     """Test UpdateProgressTracker loads existing progress with FsspecStore (async filesystem)"""
-    monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
-    store = get_zarr_store("test", "dev")
+    store = get_zarr_store("test", "test-version")
     store = zarr.storage.FsspecStore.from_url(store.path)
     assert store.fs.async_impl
 

--- a/tests/common/test_zarr.py
+++ b/tests/common/test_zarr.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import zarr
 from pytest import MonkeyPatch
 
@@ -7,6 +8,7 @@ from reformatters.common.config import Config, Env
 from reformatters.common.zarr import get_mode, get_zarr_store
 
 
+@pytest.mark.skip_set_test_final_store
 def test_get_zarr_store_dev(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(Config, "env", Env.dev)
     store = get_zarr_store("test-dataset", "1.0.0")

--- a/tests/common/test_zarr.py
+++ b/tests/common/test_zarr.py
@@ -8,7 +8,7 @@ from reformatters.common.config import Config, Env
 from reformatters.common.zarr import get_mode, get_zarr_store
 
 
-@pytest.mark.skip_set_test_final_store
+@pytest.mark.skip_set_local_zarr_store_base_path
 def test_get_zarr_store_dev(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(Config, "env", Env.dev)
     store = get_zarr_store("test-dataset", "1.0.0")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+from pathlib import Path
+
+import pytest
+
+# This needs to run before any application imports to ensure that
+# Config.env is set to test.
+os.environ["DYNAMICAL_ENV"] = "test"
+
+from reformatters.common import zarr as common_zarr_module
+
+
+@pytest.fixture(autouse=True)
+def set_test_final_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    if request.node.get_closest_marker("skip_set_test_final_store") is not None:
+        return
+    monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,12 @@ from reformatters.common import zarr as common_zarr_module
 
 
 @pytest.fixture(autouse=True)
-def set_test_final_store(
+def set_local_zarr_store_base_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
 ) -> None:
-    if request.node.get_closest_marker("skip_set_test_final_store") is not None:
+    if (
+        request.node.get_closest_marker("skip_set_local_zarr_store_base_path")
+        is not None
+    ):
         return
     monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)

--- a/tests/noaa/gefs/analysis/gefs_analysis_cli_integration_test.py
+++ b/tests/noaa/gefs/analysis/gefs_analysis_cli_integration_test.py
@@ -9,7 +9,6 @@ import pytest
 import xarray as xr
 from pytest import MonkeyPatch
 
-from reformatters.common import zarr
 from reformatters.noaa.gefs.analysis import (
     cli,
     reformat,
@@ -41,10 +40,7 @@ def test_update_template(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     )
 
 
-def test_reformat_local_reforecast_period(
-    monkeypatch: MonkeyPatch, tmp_path: Path
-) -> None:
-    monkeypatch.setattr(zarr, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
+def test_reformat_local_reforecast_period() -> None:
     time_start = template_config.TIME_START
     time_end = time_start + pd.Timedelta(days=1)
 
@@ -77,7 +73,7 @@ def test_reformat_local_reforecast_period(
 
 
 def test_reformat_local_reforecast_to_pre_v12_transition_period(
-    monkeypatch: MonkeyPatch, tmp_path: Path
+    monkeypatch: MonkeyPatch,
 ) -> None:
     time_start = pd.Timestamp("2019-12-31T00:00")
     # Add 3 more hours to exclusive end point so we end on a 00Z hour
@@ -87,8 +83,6 @@ def test_reformat_local_reforecast_to_pre_v12_transition_period(
     # Update the template so this test starts processing at time_start
     monkeypatch.setattr(template_config, "TIME_START", time_start)
     cli.update_template()
-
-    monkeypatch.setattr(zarr, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
 
     # 1. Backfill archive
     cli.reformat_local(time_end=time_end.isoformat())
@@ -129,7 +123,7 @@ def test_reformat_local_reforecast_to_pre_v12_transition_period(
 
 
 def test_reformat_local_pre_v12_to_v12_transition_period_and_operational_update(
-    monkeypatch: MonkeyPatch, tmp_path: Path
+    monkeypatch: MonkeyPatch,
 ) -> None:
     time_start = pd.Timestamp("2020-09-22T00:00")
     time_end = pd.Timestamp("2020-09-24T00:00")
@@ -137,8 +131,6 @@ def test_reformat_local_pre_v12_to_v12_transition_period_and_operational_update(
     # Update the template so this test starts processing at time_start
     monkeypatch.setattr(template_config, "TIME_START", time_start)
     cli.update_template()
-
-    monkeypatch.setattr(zarr, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
 
     # 1. Backfill archive
     cli.reformat_local(time_end=time_end.isoformat())

--- a/tests/noaa/gefs/forecast_35_day/gefs_forecast_35_day_cli_integration_test.py
+++ b/tests/noaa/gefs/forecast_35_day/gefs_forecast_35_day_cli_integration_test.py
@@ -6,7 +6,6 @@ import pytest
 import xarray as xr
 from pytest import MonkeyPatch
 
-from reformatters.common import zarr
 from reformatters.noaa.gefs.forecast_35_day import (
     cli,
     reformat,
@@ -34,10 +33,7 @@ def test_update_template(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     )
 
 
-def test_reformat_local_and_operational_update(
-    monkeypatch: MonkeyPatch, tmp_path: Path
-) -> None:
-    monkeypatch.setattr(zarr, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
+def test_reformat_local_and_operational_update(monkeypatch: MonkeyPatch) -> None:
     init_time_start = template_config.INIT_TIME_START
     init_time_end = init_time_start + timedelta(days=1)
 

--- a/tests/noaa/gfs/forecast/gfs_forecast_cli_integration_test.py
+++ b/tests/noaa/gfs/forecast/gfs_forecast_cli_integration_test.py
@@ -6,7 +6,6 @@ import pytest
 import xarray as xr
 from pytest import MonkeyPatch
 
-from reformatters.common import zarr
 from reformatters.noaa.gfs.forecast import (
     cli,
     reformat,
@@ -37,8 +36,7 @@ def test_update_template(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     )
 
 
-def test_reformat_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(zarr, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
+def test_reformat_local() -> None:
     init_time_start = GFS_FORECAST_TEMPLATE_CONFIG.append_dim_start
     init_time_end = init_time_start + timedelta(days=1)
 

--- a/tests/u_arizona/swann/dataset_integration_test.py
+++ b/tests/u_arizona/swann/dataset_integration_test.py
@@ -6,16 +6,10 @@ import pytest
 import xarray as xr
 from _pytest.monkeypatch import MonkeyPatch
 
-from reformatters.common import zarr as common_zarr_module
 from reformatters.u_arizona.swann import SWANNDataset
 from reformatters.u_arizona.swann.region_job import SWANNRegionJob, SWANNSourceFileCoord
 
 pytestmark = pytest.mark.slow
-
-
-@pytest.fixture(autouse=True)
-def set_test_final_store(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
 
 
 def test_reformat_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
This PR:
- Adds a `test` env as possible environment in `config.py`
- Automatically configures tests to run in the `test` env
- Automatically monkeypatches `_LOCAL_ZARR_STORE_BASE_PATH` to the pytest `tmp_path` for the running test
- Removes manual monkeypatching of this constant in individual tests
