### PR TITLE
Pluggable configuration for production dataset storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We use
 1. Install `docker` and `kubectl`. Make sure `docker` can be found at /usr/bin/docker and `kubectl` at /usr/bin/kubectl.
 1. Setup a docker image repository and export the DOCKER_REPOSITORY environment variable in your local shell. eg. `export DOCKER_REPOSITORY=us-central1-docker.pkg.dev/<project-id>/reformatters/main`
 1. Setup a kubernetes cluster and configure kubectl to point to your cluster. eg `gcloud container clusters get-credentials <cluster-name> --region <region> --project <project>`
-1. Create a kubectl secret containing your Source Coop S3 credentials `kubectl create secret generic source-coop-key --from-literal='AWS_ACCESS_KEY_ID=xxx' --from-literal='AWS_SECRET_ACCESS_KEY=xxx'` and set these environment variables in your local shell `export DYNAMICAL_SOURCE_COOP_AWS_ACCESS_KEY_ID=xxx; export DYNAMICAL_SOURCE_COOP_AWS_SECRET_ACCESS_KEY=xxx`.
+1. Create a kubectl secret containing your Source Coop S3 credentials `kubectl create secret generic source-coop-key --from-literal='AWS_ACCESS_KEY_ID=xxx' --from-literal='AWS_SECRET_ACCESS_KEY=xxx'` and set these environment variables in your local shell `export AWS_ACCESS_KEY_ID=xxx; export AWS_SECRET_ACCESS_KEY=xxx`.
 
 
 ### Development commands

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -8,13 +8,24 @@ import reformatters.noaa.gfs.forecast.cli as noaa_gfs_forecast
 import reformatters.noaa.hrrr.forecast_48_hour.cli as noaa_hrrr_forecast_48_hour
 from reformatters.common import deploy
 from reformatters.common.config import Config
+from reformatters.common.dynamical_dataset import DynamicalDatasetStorageConfig
 from reformatters.u_arizona.swann import SWANNDataset
+
 
 # Registry of all DynamicalDatasets.
 # Datasets that have not yet been ported over to the new DynamicalDataset pattern
 # are excluded here until they are refactored.
+class SourceCoopDatasetStorageConfig(DynamicalDatasetStorageConfig):
+    """Configuration for the storage of a SourceCoop dataset."""
+
+    base_path: str = "s3://us-west-2.opendata.source.coop/dynamical"
+    k8s_secret_name: str = "source-coop-key"  # noqa: S105
+
+
 DYNAMICAL_DATASETS = [
-    SWANNDataset(),
+    SWANNDataset(
+        storage_config=SourceCoopDatasetStorageConfig(),
+    ),
 ]
 
 if Config.is_sentry_enabled:

--- a/src/reformatters/common/config.py
+++ b/src/reformatters/common/config.py
@@ -1,48 +1,18 @@
 import os
-from enum import Enum
+from enum import StrEnum
 
 import pydantic
 
 
-class Env(str, Enum):
+class Env(StrEnum):
     dev = "dev"
     prod = "prod"
-
-
-class SourceCoopConfig(pydantic.BaseModel):
-    aws_access_key_id: str | None = None
-    aws_secret_access_key: str | None = None
 
 
 class DynamicalConfig(pydantic.BaseModel):
     env: Env = Env(os.getenv("DYNAMICAL_ENV", "dev"))
 
     sentry_dsn: str | None = os.getenv("DYNAMICAL_SENTRY_DSN")
-
-    source_coop: SourceCoopConfig = pydantic.Field(
-        default_factory=lambda: SourceCoopConfig(
-            aws_access_key_id=os.environ.get("DYNAMICAL_SOURCE_COOP_AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.environ.get(
-                "DYNAMICAL_SOURCE_COOP_AWS_SECRET_ACCESS_KEY"
-            ),
-        ),
-        validate_default=True,
-        json_schema_extra={
-            "description": "Source Coop credentials required in prod environment"
-        },
-    )
-
-    @pydantic.model_validator(mode="after")
-    def validate_source_coop_credentials(self) -> "DynamicalConfig":
-        if self.env == Env.prod:
-            if not (
-                self.source_coop.aws_access_key_id
-                and self.source_coop.aws_secret_access_key
-            ):
-                raise ValueError(
-                    "aws_access_key_id and aws_secret_access_key are required in prod environment"
-                )
-        return self
 
     @property
     def is_dev(self) -> bool:

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -37,7 +37,7 @@ class DynamicalDatasetStorageConfig(FrozenBaseModel):
     """Configuration for the storage of a dataset in production."""
 
     base_path: str
-    k8s_secret_name: str
+    k8s_secret_name: str | None = None
 
 
 class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -22,6 +22,8 @@ class Job(pydantic.BaseModel):
     ttl: timedelta = timedelta(days=1)
     pod_active_deadline: timedelta = timedelta(hours=6)
 
+    secret_names: list[str] = []
+
     @property
     def job_name(self) -> str:
         # Job names should be a valid DNS name, 63 characters or less
@@ -105,24 +107,10 @@ class Job(pydantic.BaseModel):
                                         "name": "WORKERS_TOTAL",
                                         "value": f"{self.workers_total}",
                                     },
-                                    {
-                                        "name": "DYNAMICAL_SOURCE_COOP_AWS_ACCESS_KEY_ID",
-                                        "valueFrom": {
-                                            "secretKeyRef": {
-                                                "key": "AWS_ACCESS_KEY_ID",
-                                                "name": "source-coop-key",
-                                            }
-                                        },
-                                    },
-                                    {
-                                        "name": "DYNAMICAL_SOURCE_COOP_AWS_SECRET_ACCESS_KEY",
-                                        "valueFrom": {
-                                            "secretKeyRef": {
-                                                "key": "AWS_SECRET_ACCESS_KEY",
-                                                "name": "source-coop-key",
-                                            }
-                                        },
-                                    },
+                                ],
+                                "envFrom": [
+                                    {"secretRef": {"name": secret_name}}
+                                    for secret_name in self.secret_names
                                 ],
                                 "image": f"{self.image}",
                                 "name": "worker",

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -22,7 +22,7 @@ class Job(pydantic.BaseModel):
     ttl: timedelta = timedelta(days=1)
     pod_active_deadline: timedelta = timedelta(hours=6)
 
-    secret_names: list[str] = []
+    secret_names: list[str | None] = []
 
     @property
     def job_name(self) -> str:
@@ -111,6 +111,7 @@ class Job(pydantic.BaseModel):
                                 "envFrom": [
                                     {"secretRef": {"name": secret_name}}
                                     for secret_name in self.secret_names
+                                    if secret_name is not None
                                 ],
                                 "image": f"{self.image}",
                                 "name": "worker",

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -33,7 +33,9 @@ BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE = zarr.codecs.BloscCodec(
 ).to_dict()
 
 
-def get_zarr_store(dataset_id: str, version: str) -> zarr.storage.FsspecStore:
+def get_zarr_store(
+    prod_base_path: str, dataset_id: str, version: str
+) -> zarr.storage.FsspecStore:
     if not Config.is_prod:
         version = "dev"
 
@@ -58,11 +60,7 @@ def get_zarr_store(dataset_id: str, version: str) -> zarr.storage.FsspecStore:
         return store  # type: ignore[return-value]
 
     return zarr.storage.FsspecStore.from_url(
-        f"s3://us-west-2.opendata.source.coop/dynamical/{dataset_id}/v{version}.zarr",
-        storage_options={
-            "key": Config.source_coop.aws_access_key_id,
-            "secret": Config.source_coop.aws_secret_access_key,
-        },
+        f"{prod_base_path}/{dataset_id}/v{version}.zarr"
     )
 
 

--- a/src/reformatters/example/dynamical_dataset.py
+++ b/src/reformatters/example/dynamical_dataset.py
@@ -24,6 +24,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
         #     memory="30G",
         #     shared_memory="12G",
         #     ephemeral_storage="30G",
+        #     secret_names=[self.storage_config.k8s_secret_name],
         # )
         # validation_cron_job = ValidationCronJob(
         #     name=f"{self.dataset_id}-validation",
@@ -33,6 +34,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
         #     dataset_id=self.dataset_id,
         #     cpu="1.3",
         #     memory="7G",
+        #     secret_names=[self.storage_config.k8s_secret_name],
         # )
 
         # return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -330,6 +330,7 @@ def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
         memory="30G",  # fit on 32GB node
         shared_memory="12G",
         ephemeral_storage="30G",
+        secret_names=["source-coop-key"],
     )
     validation_cron_job = ValidationCronJob(
         name=f"{template.DATASET_ID}-validation",
@@ -339,6 +340,7 @@ def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
         dataset_id=template.DATASET_ID,
         cpu="1.3",  # fit on 2 vCPU node
         memory="7G",  # fit on 8GB node
+        secret_names=["source-coop-key"],
     )
 
     return [operational_update_cron_job, validation_cron_job]
@@ -389,4 +391,8 @@ def all_jobs_ordered(
 
 
 def get_store() -> zarr.storage.FsspecStore:
-    return get_zarr_store(template.DATASET_ID, template.DATASET_VERSION)
+    return get_zarr_store(
+        "s3://us-west-2.opendata.source.coop/dynamical",
+        template.DATASET_ID,
+        template.DATASET_VERSION,
+    )

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -327,6 +327,7 @@ def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
         memory="60G",  # fit on 64GB node
         shared_memory="24G",
         ephemeral_storage="150G",
+        secret_names=["source-coop-key"],
     )
     validation_cron_job = ValidationCronJob(
         name=f"{template.DATASET_ID}-validation",
@@ -336,6 +337,7 @@ def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
         dataset_id=template.DATASET_ID,
         cpu="3",  # fit on 4 vCPU node
         memory="30G",  # fit on 32GB node
+        secret_names=["source-coop-key"],
     )
 
     return [operational_update_cron_job, validation_cron_job]
@@ -384,4 +386,8 @@ def all_jobs_ordered(
 
 
 def get_store() -> zarr.storage.FsspecStore:
-    return get_zarr_store(template.DATASET_ID, template.DATASET_VERSION)
+    return get_zarr_store(
+        "s3://us-west-2.opendata.source.coop/dynamical",
+        template.DATASET_ID,
+        template.DATASET_VERSION,
+    )

--- a/src/reformatters/noaa/gfs/forecast/reformat.py
+++ b/src/reformatters/noaa/gfs/forecast/reformat.py
@@ -130,6 +130,7 @@ def all_jobs_ordered(
 
 def get_store() -> zarr.storage.FsspecStore:
     return get_zarr_store(
+        "s3://us-west-2.opendata.source.coop/dynamical",
         GFS_FORECAST_TEMPLATE_CONFIG.dataset_id,
         GFS_FORECAST_TEMPLATE_CONFIG.dataset_attributes.dataset_version,
     )

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/reformat.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/reformat.py
@@ -125,4 +125,8 @@ def all_jobs_ordered(
 
 
 def get_store() -> zarr.storage.FsspecStore:
-    return get_zarr_store(template.DATASET_ID, template.DATASET_VERSION)
+    return get_zarr_store(
+        "s3://us-west-2.opendata.source.coop/dynamical",
+        template.DATASET_ID,
+        template.DATASET_VERSION,
+    )

--- a/src/reformatters/u_arizona/swann/__init__.py
+++ b/src/reformatters/u_arizona/swann/__init__.py
@@ -1,7 +1,9 @@
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from datetime import timedelta
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.kubernetes import Job, ReformatCronJob, ValidationCronJob
 
 from .region_job import SWANNRegionJob, SWANNSourceFileCoord
 from .template_config import SWANNDataVar, SWANNTemplateConfig
@@ -10,6 +12,9 @@ from .validators import (
     check_latest_time_nans,
     check_random_time_within_last_year_nans,
 )
+
+_OPERATIONAL_CRON_SCHEDULE = "0 0 * * *"
+_VALIDATION_CRON_SCHEDULE = "0 0 * * *"
 
 
 class SWANNDataset(DynamicalDataset[SWANNDataVar, SWANNSourceFileCoord]):
@@ -22,3 +27,29 @@ class SWANNDataset(DynamicalDataset[SWANNDataVar, SWANNSourceFileCoord]):
             check_latest_time_nans,
             check_random_time_within_last_year_nans,
         )
+
+    def operational_kubernetes_resources(self, image_tag: str) -> Iterable[Job]:
+        operational_update_cron_job = ReformatCronJob(
+            name=f"{self.dataset_id}-operational-update",
+            schedule=_OPERATIONAL_CRON_SCHEDULE,
+            pod_active_deadline=timedelta(minutes=30),
+            image=image_tag,
+            dataset_id=self.dataset_id,
+            cpu="4",
+            memory="14G",
+            shared_memory="6GiB",
+            ephemeral_storage="10G",
+            secret_names=[self.storage_config.k8s_secret_name],
+        )
+        validation_cron_job = ValidationCronJob(
+            name=f"{self.dataset_id}-validation",
+            schedule=_VALIDATION_CRON_SCHEDULE,
+            pod_active_deadline=timedelta(minutes=10),
+            image=image_tag,
+            dataset_id=self.dataset_id,
+            cpu="1.3",
+            memory="7G",
+            secret_names=[self.storage_config.k8s_secret_name],
+        )
+
+        return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/u_arizona/swann/__init__.py
+++ b/src/reformatters/u_arizona/swann/__init__.py
@@ -1,9 +1,7 @@
-from collections.abc import Iterable, Sequence
-from datetime import timedelta
+from collections.abc import Sequence
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
-from reformatters.common.kubernetes import Job, ReformatCronJob, ValidationCronJob
 
 from .region_job import SWANNRegionJob, SWANNSourceFileCoord
 from .template_config import SWANNDataVar, SWANNTemplateConfig
@@ -28,28 +26,28 @@ class SWANNDataset(DynamicalDataset[SWANNDataVar, SWANNSourceFileCoord]):
             check_random_time_within_last_year_nans,
         )
 
-    def operational_kubernetes_resources(self, image_tag: str) -> Iterable[Job]:
-        operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
-            schedule=_OPERATIONAL_CRON_SCHEDULE,
-            pod_active_deadline=timedelta(minutes=30),
-            image=image_tag,
-            dataset_id=self.dataset_id,
-            cpu="4",
-            memory="14G",
-            shared_memory="6GiB",
-            ephemeral_storage="10G",
-            secret_names=[self.storage_config.k8s_secret_name],
-        )
-        validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
-            schedule=_VALIDATION_CRON_SCHEDULE,
-            pod_active_deadline=timedelta(minutes=10),
-            image=image_tag,
-            dataset_id=self.dataset_id,
-            cpu="1.3",
-            memory="7G",
-            secret_names=[self.storage_config.k8s_secret_name],
-        )
+    # def operational_kubernetes_resources(self, image_tag: str) -> Iterable[Job]:
+    #     operational_update_cron_job = ReformatCronJob(
+    #         name=f"{self.dataset_id}-operational-update",
+    #         schedule=_OPERATIONAL_CRON_SCHEDULE,
+    #         pod_active_deadline=timedelta(minutes=30),
+    #         image=image_tag,
+    #         dataset_id=self.dataset_id,
+    #         cpu="4",
+    #         memory="14G",
+    #         shared_memory="6GiB",
+    #         ephemeral_storage="10G",
+    #         secret_names=[self.storage_config.k8s_secret_name],
+    #     )
+    #     validation_cron_job = ValidationCronJob(
+    #         name=f"{self.dataset_id}-validation",
+    #         schedule=_VALIDATION_CRON_SCHEDULE,
+    #         pod_active_deadline=timedelta(minutes=10),
+    #         image=image_tag,
+    #         dataset_id=self.dataset_id,
+    #         cpu="1.3",
+    #         memory="7G",
+    #         secret_names=[self.storage_config.k8s_secret_name],
+    #     )
 
-        return [operational_update_cron_job, validation_cron_job]
+    #     return [operational_update_cron_job, validation_cron_job]

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -18,11 +18,19 @@ from reformatters.common.config_models import (
     DataVarAttrs,
     Encoding,
 )
-from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.dynamical_dataset import (
+    DynamicalDataset,
+    DynamicalDatasetStorageConfig,
+)
 from reformatters.common.kubernetes import Job, ReformatCronJob
 from reformatters.common.region_job import RegionJob, SourceFileCoord
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
+
+
+class ExampleDatasetStorageConfig(DynamicalDatasetStorageConfig):
+    base_path: str = "s3://some-bucket/path"
+    k8s_secret_name: str = "k8s-secret-name"  # noqa: S105
 
 
 class ExampleDataVar(DataVar[BaseInternalAttrs]):
@@ -76,6 +84,7 @@ class ExampleConfig(TemplateConfig[ExampleDataVar]):
 class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
     template_config: ExampleConfig = ExampleConfig()
     region_job_class: type[ExampleRegionJob] = ExampleRegionJob
+    storage_config: ExampleDatasetStorageConfig = ExampleDatasetStorageConfig()
 
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[Job]:
         return [

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -107,7 +107,7 @@ def template_ds() -> xr.Dataset:
     "ignore:This process .* is multi-threaded, use of fork.* may lead to deadlocks in the child"
 )
 def test_region_job(template_ds: xr.Dataset) -> None:
-    store = get_zarr_store("test-dataset-A", "test-version")
+    store = get_zarr_store("fake-prod-path", "test-dataset-A", "test-version")
     tmp_store = get_local_tmp_store()
 
     # Write zarr metadata for this RegionJob to write into
@@ -138,7 +138,7 @@ def test_region_job(template_ds: xr.Dataset) -> None:
 
 
 def test_update_template_with_results(template_ds: xr.Dataset) -> None:
-    store = get_zarr_store("test-dataset-C", "test-version")
+    store = get_zarr_store("fake-prod-path", "test-dataset-C", "test-version")
     tmp_store = get_local_tmp_store()
 
     job = ExampleRegionJob(
@@ -181,7 +181,7 @@ def test_source_file_coord_out_loc_default_impl() -> None:
 
 def test_get_jobs_grouping_no_filters(template_ds: xr.Dataset) -> None:
     data_vars = [ExampleDataVar(name=name) for name in template_ds.data_vars.keys()]
-    store = get_zarr_store("test-dataset-B", "test-version")
+    store = get_zarr_store("fake-prod-path", "test-dataset-B", "test-version")
     tmp_store = get_local_tmp_store()
     jobs = ExampleRegionJob.get_jobs(
         kind="backfill",
@@ -219,7 +219,7 @@ def test_get_jobs_grouping_no_filters(template_ds: xr.Dataset) -> None:
 
 def test_get_jobs_grouping_filters(template_ds: xr.Dataset) -> None:
     data_vars = [ExampleDataVar(name=name) for name in template_ds.data_vars.keys()]
-    store = get_zarr_store("test-dataset-B", "test-version")
+    store = get_zarr_store("fake-prod-path", "test-dataset-B", "test-version")
     tmp_store = get_local_tmp_store()
     jobs = ExampleRegionJob.get_jobs(
         kind="backfill",
@@ -264,7 +264,7 @@ def test_get_jobs_grouping_filters_and_worker_index(
     template_ds: xr.Dataset,
 ) -> None:
     data_vars = [ExampleDataVar(name=name) for name in template_ds.data_vars.keys()]
-    store = get_zarr_store("test-dataset-B", "test-version")
+    store = get_zarr_store("fake-prod-path", "test-dataset-B", "test-version")
     tmp_store = get_local_tmp_store()
     jobs = ExampleRegionJob.get_jobs(
         kind="backfill",

--- a/tests/common/test_update_progress_tracker.py
+++ b/tests/common/test_update_progress_tracker.py
@@ -15,7 +15,7 @@ def test_update_progress_tracker_close_with_local_store(
 ) -> None:
     """Test UpdateProgressTracker loads existing progress with LocalStore (sync filesystem)"""
     monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
-    store = get_zarr_store("test", "dev")
+    store = get_zarr_store("fake-prod-path", "test", "dev")
     assert not store.fs.async_impl
 
     # Create an existing progress file
@@ -40,7 +40,7 @@ def test_update_progress_tracker_close_with_async_store(
 ) -> None:
     """Test UpdateProgressTracker loads existing progress with FsspecStore (async filesystem)"""
     monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
-    store = get_zarr_store("test", "dev")
+    store = get_zarr_store("fake-prod-path", "test", "dev")
     store = zarr.storage.FsspecStore.from_url(store.path)
     assert store.fs.async_impl
 

--- a/tests/common/test_zarr.py
+++ b/tests/common/test_zarr.py
@@ -9,19 +9,16 @@ from reformatters.common.zarr import get_mode, get_zarr_store
 
 def test_get_zarr_store_dev(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(Config, "env", Env.dev)
-    store = get_zarr_store("test-dataset", "1.0.0")
+    store = get_zarr_store("fake-prod-path", "test-dataset", "1.0.0")
     assert isinstance(store, zarr.storage.LocalStore)
     assert store.path == str(Path("data/output/test-dataset/vdev.zarr").absolute())
 
 
 def test_get_zarr_store_prod(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(Config, "env", Env.prod)
-    store = get_zarr_store("test-dataset", "1.0.0")
+    store = get_zarr_store("s3://fake-prod-path", "test-dataset", "1.0.0")
     assert isinstance(store, zarr.storage.FsspecStore)
-    assert (
-        store.path
-        == "us-west-2.opendata.source.coop/dynamical/test-dataset/v1.0.0.zarr"
-    )
+    assert store.path == "fake-prod-path/test-dataset/v1.0.0.zarr"
 
 
 def test_get_mode() -> None:

--- a/tests/u_arizona/swann/dataset_integration_test.py
+++ b/tests/u_arizona/swann/dataset_integration_test.py
@@ -16,7 +16,6 @@ pytestmark = pytest.mark.slow
 
 noop_storage_config = DynamicalDatasetStorageConfig(
     base_path="noop",
-    k8s_secret_name="noop",  # noqa: S106
 )
 
 

--- a/tests/u_arizona/swann/dataset_integration_test.py
+++ b/tests/u_arizona/swann/dataset_integration_test.py
@@ -7,10 +7,17 @@ import xarray as xr
 from _pytest.monkeypatch import MonkeyPatch
 
 from reformatters.common import zarr as common_zarr_module
+from reformatters.common.dynamical_dataset import DynamicalDatasetStorageConfig
 from reformatters.u_arizona.swann import SWANNDataset
 from reformatters.u_arizona.swann.region_job import SWANNRegionJob, SWANNSourceFileCoord
 
 pytestmark = pytest.mark.slow
+
+
+noop_storage_config = DynamicalDatasetStorageConfig(
+    base_path="noop",
+    k8s_secret_name="noop",  # noqa: S106
+)
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +26,7 @@ def set_test_final_store(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
 
 
 def test_reformat_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-    dataset = SWANNDataset()
+    dataset = SWANNDataset(storage_config=noop_storage_config)
     # Dataset starts at 1981-10-01
     dataset.reformat_local(append_dim_end=pd.Timestamp("1981-10-02"))
     ds = xr.open_zarr(dataset._final_store(), chunks=None)
@@ -32,7 +39,7 @@ def test_reformat_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
 
 
 def test_reformat_operational_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-    dataset = SWANNDataset()
+    dataset = SWANNDataset(storage_config=noop_storage_config)
     # Dataset starts at 1981-10-01
     dataset.reformat_local(append_dim_end=pd.Timestamp("1981-10-02"))
     ds = xr.open_zarr(dataset._final_store(), chunks=None)
@@ -65,7 +72,7 @@ def test_reformat_operational_update(monkeypatch: MonkeyPatch, tmp_path: Path) -
 def test_reformat_operational_update_template_trimming(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:
-    dataset = SWANNDataset()
+    dataset = SWANNDataset(storage_config=noop_storage_config)
     # Dataset starts at 1981-10-01
     dataset.reformat_local(append_dim_end=pd.Timestamp("1981-10-02"))
     ds = xr.open_zarr(dataset._final_store(), chunks=None)


### PR DESCRIPTION
 This allows us to splat environment variables from a K8S secret per Job,
and override the base zarr storage path per dataset.
    
This will let us write SWANN data to a separate bucket from other
datasets.
    
Paired with @aldenks & @mosegontar
