### PR TITLE
Run tests on arm too, pin actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,19 @@
+# GitHub Actions Workflows
+
+## Security
+
+To limit our vulnerability to supply chain attacks on GitHub Actions we:
+
+- Restrict Actions to those that we've written, or those published by GitHub or another verified developer
+- [Pin versions](https://michaelheap.com/pin-your-github-actions/) to avoid unintentionally pulling in malicious code
+
+### Pinning Versions
+
+Run `npx pin-github-action .github/workflows` from the root of the repo to resolve the SHA for the given version tag of each Action.
+This will ensure that we always use the exact version we expect, rather than whatever the latest commit for that tag is.
+
+### Updating Pinned Versions
+
+Dependabot should let us know when the Actions we're using have a new version available.
+
+You can also run `npx pin-github-action .github/workflows` (from the root of the repo) to update the pinned SHAs for the given version tag of each action.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,18 +11,18 @@ jobs:
   quality:
     name: Code Quality (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    
+
     strategy:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
-            runner: ubuntu-latest-arm
-    
+            runner: ubuntu-24.04-arm
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      
+
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
@@ -44,10 +44,10 @@ jobs:
         run: uv run ruff check --output-format=github
 
       - name: Check code format
-        run: uv run ruff format --check 
+        run: uv run ruff format --check
 
       - name: Run Mypy
-        run: uv run mypy 
+        run: uv run mypy
 
       - name: Run Pytest
         run: uv run pytest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,7 +34,16 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Install Arm Build Dependencies
+        if: matrix.arch == 'arm64'
+        run: sudo apt-get install -qyy -o APT::Install-Suggests=false libgdal-dev
+
       - name: Install dependencies
+        # Needed to be able to compile dependencies on ARM64
+        env:
+          DISABLE_NUMCODECS_SSE2: 1
+          DISABLE_NUMCODECS_AVX2: 1
+          CFLAGS: "-Wno-implicit-function-declaration" 
         run: uv sync --all-extras --dev
 
       - name: Install this project

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,5 +1,8 @@
 name: Code Quality
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,20 +6,28 @@ on:
 
 jobs:
   quality:
-    name: Code Quality
-    runs-on: ubuntu-latest
+    name: Code Quality (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-latest-arm
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version-file: ".python-version"
 
@@ -30,10 +38,16 @@ jobs:
         run: "uv pip install -e ."
 
       - name: Run Ruff
-        run: uv run ruff check 
+        run: uv run ruff check --output-format=github
+
+      - name: Check code format
+        run: uv run ruff format --check 
 
       - name: Run Mypy
         run: uv run mypy 
 
       - name: Run Pytest
         run: uv run pytest
+
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fc87bb5b5a97953d987372e74478de634726b3e5 # v3

--- a/.github/workflows/deploy-operational-updates.yml
+++ b/.github/workflows/deploy-operational-updates.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 # Prevent concurrent runs since this is deploying to the K8S cluster
-concurrency: 
+concurrency:
   group: "deploy"
   cancel-in-progress: false
 
@@ -19,12 +19,12 @@ env:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: prod
-    
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      
+
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
@@ -37,7 +37,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install the project
-        run: uv sync --all-extras --dev 
+        run: uv sync --all-extras --dev
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4

--- a/.github/workflows/deploy-operational-updates.yml
+++ b/.github/workflows/deploy-operational-updates.yml
@@ -23,16 +23,16 @@ jobs:
     environment: prod
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version-file: ".python-version"
 
@@ -40,13 +40,13 @@ jobs:
         run: uv sync --all-extras --dev 
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3
         with:
           version: 'latest'
 
@@ -55,13 +55,13 @@ jobs:
           aws eks update-kubeconfig --name ${{ secrets.EKS_CLUSTER_NAME }} --region ${{ secrets.AWS_REGION }}
 
       - name: Set up Depot CLI
-        uses: depot/setup-action@v1
+        uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
         id: login-ecr
 
-      - uses: depot/build-push-action@v1
+      - uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1
         with:
           project: ${{ secrets.DEPOT_PROJECT }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
* Since we deploy arm images we should run tests on it too.
* Pins GitHub Actions to try to prevent vulnerabilities slipping in through the supply chain.
* Improves ruff linting to annotates failures on PRs.
* Checks code format as part of code quality