### PR TITLE
Swann shared memory config: 6Gi not 6GiB

### DIFF
--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -50,7 +50,7 @@ class UarizonaSwannAnalysisDataset(
             dataset_id=self.dataset_id,
             cpu="4",
             memory="14G",
-            shared_memory="6GiB",
+            shared_memory="6Gi",
             ephemeral_storage="10G",
             secret_names=[self.storage_config.k8s_secret_name],
         )


### PR DESCRIPTION
We got the following error on deploy:
```
cronjob.batch/u-arizona-swann-analysis-validation created
cronjob.batch/noaa-gefs-forecast-35-day-operational-update configured
cronjob.batch/noaa-gefs-forecast-35-day-validation configured
cronjob.batch/noaa-gefs-analysis-operational-update configured
Error from server (BadRequest): error when creating "STDIN": CronJob in version "v1" cannot be handled as a CronJob: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
cronjob.batch/noaa-gefs-analysis-validation configured
```

I think it is because `B` is not valid character to satisfy this regex