### PR TITLE
Comment out operational k8s resources for SWANN temporarily

### DIFF
--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -1,13 +1,7 @@
-from collections.abc import Iterable, Sequence
-from datetime import timedelta
+from collections.abc import Sequence
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
-from reformatters.common.kubernetes import (
-    Job,
-    ReformatCronJob,
-    ValidationCronJob,
-)
 
 from .region_job import (
     UarizonaSwannAnalysisRegionJob,
@@ -41,28 +35,28 @@ class UarizonaSwannAnalysisDataset(
             check_random_time_within_last_year_nans,
         )
 
-    def operational_kubernetes_resources(self, image_tag: str) -> Iterable[Job]:
-        operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
-            schedule=_OPERATIONAL_CRON_SCHEDULE,
-            pod_active_deadline=timedelta(minutes=30),
-            image=image_tag,
-            dataset_id=self.dataset_id,
-            cpu="4",
-            memory="14G",
-            shared_memory="6Gi",
-            ephemeral_storage="10G",
-            secret_names=[self.storage_config.k8s_secret_name],
-        )
-        validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
-            schedule=_VALIDATION_CRON_SCHEDULE,
-            pod_active_deadline=timedelta(minutes=10),
-            image=image_tag,
-            dataset_id=self.dataset_id,
-            cpu="1.3",
-            memory="7G",
-            secret_names=[self.storage_config.k8s_secret_name],
-        )
+    # def operational_kubernetes_resources(self, image_tag: str) -> Iterable[Job]:
+    #    operational_update_cron_job = ReformatCronJob(
+    #        name=f"{self.dataset_id}-operational-update",
+    #        schedule=_OPERATIONAL_CRON_SCHEDULE,
+    #        pod_active_deadline=timedelta(minutes=30),
+    #        image=image_tag,
+    #        dataset_id=self.dataset_id,
+    #        cpu="4",
+    #        memory="14G",
+    #        shared_memory="6Gi",
+    #        ephemeral_storage="10G",
+    #        secret_names=[self.storage_config.k8s_secret_name],
+    #    )
+    #    validation_cron_job = ValidationCronJob(
+    #        name=f"{self.dataset_id}-validation",
+    #        schedule=_VALIDATION_CRON_SCHEDULE,
+    #        pod_active_deadline=timedelta(minutes=10),
+    #        image=image_tag,
+    #        dataset_id=self.dataset_id,
+    #        cpu="1.3",
+    #        memory="7G",
+    #        secret_names=[self.storage_config.k8s_secret_name],
+    #    )
 
-        return [operational_update_cron_job, validation_cron_job]
+    #    return [operational_update_cron_job, validation_cron_job]


### PR DESCRIPTION
Temporarily comment this out until fixes in https://github.com/dynamical-org/reformatters/pull/156 deploy.

This is to avoid SWANN failures over the weekend.