### PR TITLE
Sentry cron monitoring for DynamicalDatasets

### DIFF
--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 from collections.abc import Iterable, Sequence
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, Generic, Literal, TypeVar
@@ -11,7 +12,6 @@ import sentry_sdk
 import typer
 import xarray as xr
 import zarr
-from contextlib import contextmanager
 from pydantic import computed_field
 
 from reformatters.common import docker, template_utils, validation
@@ -349,7 +349,9 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                     "schedule": {"type": "crontab", "value": cron_job.schedule},
                     "timezone": "UTC",
                     "checkin_margin": 10,
-                    "max_runtime": int(cron_job.pod_active_deadline.total_seconds() / 60),
+                    "max_runtime": int(
+                        cron_job.pod_active_deadline.total_seconds() / 60
+                    ),
                     "failure_issue_threshold": 1,
                     "recovery_threshold": 1,
                 },

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -15,6 +15,7 @@ import zarr
 from pydantic import computed_field
 
 from reformatters.common import docker, template_utils, validation
+from reformatters.common.config import Config
 from reformatters.common.config_models import DataVar
 from reformatters.common.iterating import digest, item
 from reformatters.common.kubernetes import (
@@ -338,6 +339,11 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         cron_type: type[CronJob],
         reformat_job_name: str,
     ) -> Iterator[None]:
+        # Don't require operational_kubernetes_resources to be defined unless sentry reporting is enabled
+        if not Config.is_sentry_enabled:
+            yield
+            return
+
         cron_jobs = self.operational_kubernetes_resources("placeholder-image-tag")
         cron_job = item(c for c in cron_jobs if isinstance(c, cron_type))
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -1,10 +1,10 @@
 import json
 import subprocess
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Any, Generic, Literal, TypeVar, Iterator
+from typing import Annotated, Any, Generic, Literal, TypeVar
 
 import numpy as np
 import pandas as pd

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Any, Generic, Literal, TypeVar
+from typing import Annotated, Any, Generic, Literal, TypeVar, Iterator
 
 import numpy as np
 import pandas as pd
@@ -336,7 +336,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         self,
         cron_type: type[CronJob],
         reformat_job_name: str,
-    ):
+    ) -> Iterator[None]:
         cron_jobs = self.operational_kubernetes_resources("placeholder-image-tag")
         cron_job = item(c for c in cron_jobs if isinstance(c, cron_type))
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -125,7 +125,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         reformat_job_name: Annotated[str, typer.Argument(envvar="JOB_NAME")],
     ) -> None:
         """Update an existing dataset with the latest data."""
-        with self._sentry_check_in(ReformatCronJob, reformat_job_name):
+        with self._sentry_monitor(ReformatCronJob, reformat_job_name):
             final_store = self._final_store()
             tmp_store = self._tmp_store()
 
@@ -300,7 +300,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         reformat_job_name: Annotated[str, typer.Argument(envvar="JOB_NAME")],
     ) -> None:
         """Validate the dataset, raising an exception if it is invalid."""
-        with self._sentry_check_in(ValidationCronJob, reformat_job_name):
+        with self._sentry_monitor(ValidationCronJob, reformat_job_name):
             store = self._final_store()
             validation.validate_zarr(store, validators=self.validators())
             logger.info(f"Done validating {store}")
@@ -332,7 +332,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         return self.template_config.get_template(pd.Timestamp(append_dim_end))
 
     @contextmanager
-    def _sentry_check_in(
+    def _sentry_monitor(
         self,
         cron_type: type[CronJob],
         reformat_job_name: str,

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -22,7 +22,7 @@ from reformatters.common.dynamical_dataset import (
     DynamicalDataset,
     DynamicalDatasetStorageConfig,
 )
-from reformatters.common.kubernetes import CronJob, ReformatCronJob
+from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 from reformatters.common.region_job import RegionJob, SourceFileCoord
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
@@ -104,7 +104,19 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
                 shared_memory="1G",
                 ephemeral_storage="1G",
                 secret_names=[self.storage_config.k8s_secret_name],
-            )
+            ),
+            ValidationCronJob(
+                name=f"{self.dataset_id}-validation",
+                schedule="0 0 * * *",
+                pod_active_deadline=timedelta(minutes=30),
+                image=image_tag,
+                dataset_id=self.dataset_id,
+                cpu="1",
+                memory="1G",
+                shared_memory="1G",
+                ephemeral_storage="1G",
+                secret_names=[self.storage_config.k8s_secret_name],
+            ),
         ]
 
 

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -12,6 +12,7 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common import template_utils, validation
+from reformatters.common.config import Config
 from reformatters.common.config_models import (
     BaseInternalAttrs,
     DataVar,
@@ -26,7 +27,6 @@ from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationC
 from reformatters.common.region_job import RegionJob, SourceFileCoord
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
-from reformatters.common.config import Config
 
 NOOP_STORAGE_CONFIG = DynamicalDatasetStorageConfig(
     base_path="noop",
@@ -328,9 +328,11 @@ def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,
     )
+
     # make operational_kubernetes_resources raise if called
     def fail_resources(image_tag: str):
         raise RuntimeError("operational_kubernetes_resources should not be called")
+
     monkeypatch.setattr(dataset, "operational_kubernetes_resources", fail_resources)
     # this should not raise
     with dataset._monitor(ReformatCronJob, "job"):

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -287,6 +287,7 @@ def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> N
 
     # Mock capture_checkin to record statuses
     calls: list[str] = []
+
     def fake_capture_checkin(*, status, **kwargs):
         calls.append(status)
 

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -333,7 +333,9 @@ def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
     def fail_resources(image_tag: str) -> None:
         raise RuntimeError("operational_kubernetes_resources should not be called")
 
-    monkeypatch.setattr(ExampleDataset, "operational_kubernetes_resources", fail_resources)
+    monkeypatch.setattr(
+        ExampleDataset, "operational_kubernetes_resources", fail_resources
+    )
 
     # this should not raise
     with dataset._monitor(ReformatCronJob, "job"):

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -311,7 +311,7 @@ def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> N
     assert statuses == ["in_progress", "ok"]
 
     # Error case: should record "in_progress" then "error"
-    calls.clear()
+    mock_capture.reset_mock()
     with pytest.raises(ValueError):
         with dataset._monitor(ReformatCronJob, "job-name"):
             raise ValueError("failure")

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -303,6 +303,7 @@ def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> N
     # Mock capture_checkin to record statuses
     calls: list[str] = []
 
+    # use a Mock() object to capture and verify calls AI!
     def fake_capture_checkin(*, status: str, **kwargs: Any) -> None:
         calls.append(status)
 
@@ -322,6 +323,8 @@ def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Test that it's ok to not define operational_kubernetes_resources if sentry reporting is disabled
+
     # disable sentry reporting
     monkeypatch.setattr(Config, "is_sentry_enabled", False)
     dataset = ExampleDataset(
@@ -334,6 +337,7 @@ def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
         raise RuntimeError("operational_kubernetes_resources should not be called")
 
     monkeypatch.setattr(dataset, "operational_kubernetes_resources", fail_resources)
+
     # this should not raise
     with dataset._monitor(ReformatCronJob, "job"):
         pass

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -333,7 +333,7 @@ def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
     def fail_resources(image_tag: str) -> None:
         raise RuntimeError("operational_kubernetes_resources should not be called")
 
-    monkeypatch.setattr(dataset, "operational_kubernetes_resources", fail_resources)
+    monkeypatch.setattr(ExampleDataset, "operational_kubernetes_resources", fail_resources)
 
     # this should not raise
     with dataset._monitor(ReformatCronJob, "job"):

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -292,9 +292,8 @@ def test_validate_zarr_calls_validators_and_uses_final_store(
 def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None:
     import sentry_sdk
 
-    monkeypatch.setattr(type(Config), "is_sentry_enabled", True, raising=False)
+    monkeypatch.setattr(type(Config), "is_sentry_enabled", True)
 
-    # Prepare dataset instance
     dataset = ExampleDataset(
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,
@@ -323,7 +322,7 @@ def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
     # Test that it's ok to not define operational_kubernetes_resources if sentry reporting is disabled
 
     # disable sentry reporting
-    monkeypatch.setattr(type(Config), "is_sentry_enabled", False, raising=False)
+    monkeypatch.setattr(type(Config), "is_sentry_enabled", False)
     dataset = ExampleDataset(
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -291,6 +291,8 @@ def test_validate_zarr_calls_validators_and_uses_final_store(
 def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None:
     import sentry_sdk
 
+    # monkeypatch Config.is_sentry_enabled to True so we can test the sentry reporting AI!
+
     # Prepare dataset instance
     dataset = ExampleDataset(
         template_config=ExampleConfig(),
@@ -303,6 +305,7 @@ def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> N
     def fake_capture_checkin(*, status: str, **kwargs: Any) -> None:
         calls.append(status)
 
+    # Use a real Mock() to capture and verify calls AI!
     monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", fake_capture_checkin)
 
     # Success case: should record "in_progress" then "ok"
@@ -316,3 +319,6 @@ def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> N
         with dataset._monitor(ReformatCronJob, "job-name"):
             raise ValueError("failure")
     assert calls == ["in_progress", "error"]
+
+
+# Add another test here to check that operation_kubernetes_resources is not required if sentry reporting is disabled AI!

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -292,7 +292,7 @@ def test_validate_zarr_calls_validators_and_uses_final_store(
 def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None:
     import sentry_sdk
 
-    monkeypatch.setattr(Config, "is_sentry_enabled", True)
+    monkeypatch.setattr(type(Config), "is_sentry_enabled", True, raising=False)
 
     # Prepare dataset instance
     dataset = ExampleDataset(
@@ -323,7 +323,7 @@ def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
     # Test that it's ok to not define operational_kubernetes_resources if sentry reporting is disabled
 
     # disable sentry reporting
-    monkeypatch.setattr(Config, "is_sentry_enabled", False)
+    monkeypatch.setattr(type(Config), "is_sentry_enabled", False, raising=False)
     dataset = ExampleDataset(
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -2,7 +2,7 @@ import subprocess
 from collections.abc import Iterable
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import ClassVar
 from unittest.mock import Mock
 
 import numpy as np

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -330,7 +330,7 @@ def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     # make operational_kubernetes_resources raise if called
-    def fail_resources(image_tag: str):
+    def fail_resources(image_tag: str) -> None:
         raise RuntimeError("operational_kubernetes_resources should not be called")
 
     monkeypatch.setattr(dataset, "operational_kubernetes_resources", fail_resources)

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -2,7 +2,7 @@ import subprocess
 from collections.abc import Iterable
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 from unittest.mock import Mock
 
 import numpy as np
@@ -288,7 +288,7 @@ def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> N
     # Mock capture_checkin to record statuses
     calls: list[str] = []
 
-    def fake_capture_checkin(*, status, **kwargs):
+    def fake_capture_checkin(*, status: str, **kwargs: Any) -> None:
         calls.append(status)
 
     monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", fake_capture_checkin)

--- a/tests/noaa/gfs/forecast/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast/dynamical_dataset_test.py
@@ -119,7 +119,7 @@ def test_reformat_local_and_operational_update(
         ),
     )
 
-    dataset.reformat_operational_update(job_name="test-op")
+    dataset.reformat_operational_update("test-update-job-name")
 
     updated_ds = xr.open_zarr(
         dataset._final_store(), decode_timedelta=True, chunks=None


### PR DESCRIPTION
Nice thing about this is it takes all the configuration it needs (monitor slug, check in id aka reformat job name, schedule, timeout) from the already defined operational_kubernetes_resources so there's no extra effort for dataset implementers but it is configured with the unique schedule and run time for each dataset.

TODOs
 - [x] tests
 - [x] confirm it's ok with reformat job name as the check in id or do we need to hash it to make it look like a UUID? 