### PR TITLE
Set GFS forecast pod active deadline back down to 30 mins

### DIFF
--- a/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
@@ -21,7 +21,7 @@ class NoaaGfsForecastDataset(
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-operational-update",
             schedule="30 5,11,17,23 * * *",
-            pod_active_deadline=timedelta(minutes=120),
+            pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="3.5",


### PR DESCRIPTION
Now that the update has caught up and only has to process 1 or 2 forecasts per run