### PR TITLE
Reenable swann operational resources for deployment and stagger validation cron to run an hour later

### DIFF
--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -1,7 +1,9 @@
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from datetime import timedelta
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 
 from .region_job import (
     UarizonaSwannAnalysisRegionJob,
@@ -15,7 +17,7 @@ from .validators import (
 )
 
 _OPERATIONAL_CRON_SCHEDULE = "0 0 * * *"
-_VALIDATION_CRON_SCHEDULE = "0 0 * * *"
+_VALIDATION_CRON_SCHEDULE = "0 1 * * *"
 
 
 class UarizonaSwannAnalysisDataset(
@@ -35,28 +37,28 @@ class UarizonaSwannAnalysisDataset(
             check_random_time_within_last_year_nans,
         )
 
-    # def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
-    #    operational_update_cron_job = ReformatCronJob(
-    #        name=f"{self.dataset_id}-operational-update",
-    #        schedule=_OPERATIONAL_CRON_SCHEDULE,
-    #        pod_active_deadline=timedelta(minutes=30),
-    #        image=image_tag,
-    #        dataset_id=self.dataset_id,
-    #        cpu="4",
-    #        memory="14G",
-    #        shared_memory="6Gi",
-    #        ephemeral_storage="10G",
-    #        secret_names=[self.storage_config.k8s_secret_name],
-    #    )
-    #    validation_cron_job = ValidationCronJob(
-    #        name=f"{self.dataset_id}-validation",
-    #        schedule=_VALIDATION_CRON_SCHEDULE,
-    #        pod_active_deadline=timedelta(minutes=10),
-    #        image=image_tag,
-    #        dataset_id=self.dataset_id,
-    #        cpu="1.3",
-    #        memory="7G",
-    #        secret_names=[self.storage_config.k8s_secret_name],
-    #    )
+    def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
+        operational_update_cron_job = ReformatCronJob(
+            name=f"{self.dataset_id}-operational-update",
+            schedule=_OPERATIONAL_CRON_SCHEDULE,
+            pod_active_deadline=timedelta(minutes=30),
+            image=image_tag,
+            dataset_id=self.dataset_id,
+            cpu="4",
+            memory="14G",
+            shared_memory="6Gi",
+            ephemeral_storage="10G",
+            secret_names=[self.storage_config.k8s_secret_name],
+        )
+        validation_cron_job = ValidationCronJob(
+            name=f"{self.dataset_id}-validation",
+            schedule=_VALIDATION_CRON_SCHEDULE,
+            pod_active_deadline=timedelta(minutes=10),
+            image=image_tag,
+            dataset_id=self.dataset_id,
+            cpu="1.3",
+            memory="7G",
+            secret_names=[self.storage_config.k8s_secret_name],
+        )
 
-    #    return [operational_update_cron_job, validation_cron_job]
+        return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -16,9 +16,6 @@ from .validators import (
     check_random_time_within_last_year_nans,
 )
 
-_OPERATIONAL_CRON_SCHEDULE = "0 0 * * *"
-_VALIDATION_CRON_SCHEDULE = "0 1 * * *"
-
 
 class UarizonaSwannAnalysisDataset(
     DynamicalDataset[UarizonaSwannDataVar, UarizonaSwannAnalysisSourceFileCoord]
@@ -40,7 +37,7 @@ class UarizonaSwannAnalysisDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-operational-update",
-            schedule=_OPERATIONAL_CRON_SCHEDULE,
+            schedule="0 0 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -52,7 +49,7 @@ class UarizonaSwannAnalysisDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
-            schedule=_VALIDATION_CRON_SCHEDULE,
+            schedule="0 1 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,


### PR DESCRIPTION
Now that https://github.com/dynamical-org/reformatters/pull/156/ has deployed with a fix to ensure k8s secrets are getting passed through to the job, we can reenable this cron.

This PR also pushes back validation to run an hour after the primary worker job runs.