### PR TITLE
RegionJob: Only log exception if data is older than 48 hours

### DIFF
--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -598,11 +598,11 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 append_dim_coord = getattr(coord, self.append_dim, pd.Timestamp.min)
                 if isinstance(append_dim_coord, slice):
                     append_dim_coord = append_dim_coord.start
-                day_ago = pd.Timestamp.now() - pd.Timedelta(hours=24)
+                two_days_ago = pd.Timestamp.now() - pd.Timedelta(hours=48)
                 if (
                     isinstance(e, FileNotFoundError)
                     and isinstance(append_dim_coord, np.datetime64 | pd.Timestamp)
-                    and append_dim_coord > day_ago
+                    and append_dim_coord > two_days_ago
                 ):
                     log.info(" ".join(str(e).split("\n")[:2]))
                 else:


### PR DESCRIPTION
This PR relaxes that criteria for logging an exception when we receive a 404 for a source file. 

The motivation for this is that depending on when we run a particular dataset job and when the source file gets updated by the provider, we may be just outside of our 24 hour window and get noisy alerts. We think 48 hours should still work to alert us when a source is too far out of date.