### PR TITLE
SWANN: Floor Timestamp.now() for latest data validator; run crons at EOD instead of start of day

### DIFF
--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -37,7 +37,7 @@ class UarizonaSwannAnalysisDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-operational-update",
-            schedule="0 0 * * *",
+            schedule="0 22 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -49,7 +49,7 @@ class UarizonaSwannAnalysisDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
-            schedule="0 1 * * *",
+            schedule="0 23 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -49,7 +49,7 @@ class UarizonaSwannAnalysisDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
-            schedule="0 23 * * *",
+            schedule="0 17 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -37,7 +37,7 @@ class UarizonaSwannAnalysisDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-operational-update",
-            schedule="0 22 * * *",
+            schedule="30 16 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/contrib/uarizona/swann/analysis/validators.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/validators.py
@@ -15,7 +15,9 @@ def check_data_is_current(ds: xr.Dataset) -> validation.ValidationResult:
     """
     Check that the data is current within the last 48 hours.
     """
-    now = pd.Timestamp.now()
+    # All times in the dataset are set to start of day, so we need to check
+    # that there is `time` that is within 48 hours from start of day.
+    now = pd.Timestamp.now().floor("D")
     latest_init_time_ds = ds.sel(time=slice(now - pd.Timedelta(hours=48), None))
     if latest_init_time_ds.sizes["time"] == 0:
         return validation.ValidationResult(

--- a/src/reformatters/contrib/uarizona/swann/analysis/validators.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/validators.py
@@ -17,8 +17,8 @@ def check_data_is_current(ds: xr.Dataset) -> validation.ValidationResult:
     """
     # All times in the dataset are set to start of day, so we need to check
     # that there is `time` that is within 48 hours from start of day.
-    now = pd.Timestamp.now().floor("D")
-    latest_init_time_ds = ds.sel(time=slice(now - pd.Timedelta(hours=48), None))
+    today_start = pd.Timestamp.now().floor("D")
+    latest_init_time_ds = ds.sel(time=slice(today_start - pd.Timedelta(hours=48), None))
     if latest_init_time_ds.sizes["time"] == 0:
         return validation.ValidationResult(
             passed=False, message="No data found for the last 48 hours"

--- a/tests/contrib/uarizona/swann/test_validators.py
+++ b/tests/contrib/uarizona/swann/test_validators.py
@@ -64,6 +64,27 @@ def test_check_data_is_current_success(monkeypatch: MonkeyPatch) -> None:
     assert "Data found for the last 48 hours" in result.message
 
 
+def test_check_data_is_current_success_when_current_hour_is_nonzero(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Test passes when data is current."""
+    monkeypatch.setattr(
+        pd.Timestamp, "now", lambda: pd.Timestamp("2024-01-05T01:00:00")
+    )
+
+    times = pd.date_range("2024-01-01", periods=3, freq="1D")
+    data = np.ones((3, 3, 3))
+    ds = xr.Dataset(
+        {"snow_water_equivalent": (["time", "latitude", "longitude"], data)},
+        coords={"time": times, "latitude": [0, 1, 2], "longitude": [0, 1, 2]},
+    )
+
+    result = check_data_is_current(ds)
+
+    assert result.passed is True
+    assert "Data found for the last 48 hours" in result.message
+
+
 def test_check_data_is_current_failure(monkeypatch: MonkeyPatch) -> None:
     """Test passes when data is current."""
     monkeypatch.setattr(pd.Timestamp, "now", lambda: pd.Timestamp("2024-01-06"))


### PR DESCRIPTION
Our SWANN latest data validator check failed because no data was found within 48 hours from `pd.Timestamp.now()`. Because all times in this dataset are set to start of day, and the cron was configured to run at `1Z`, it looked for data since `2025-06-24T01:00` and did not count the `2025-06-24T00:00` entry.

This PR floors the `now()` value, so that we are look for data within 48 hours of start-of-day.

The cron is also adjusted to run at the end of the day rather than the start of the day.

This mean's that today's cron (which will run at 2025-06-26T23:00)  will look for entries for the 24th or 25th and fail if either are missing, which is what we want here.