### PR TITLE
Push SWANN crons back a bit

### DIFF
--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -37,7 +37,7 @@ class UarizonaSwannAnalysisDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-operational-update",
-            schedule="30 16 * * *",
+            schedule="0 20 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -49,7 +49,7 @@ class UarizonaSwannAnalysisDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
-            schedule="0 17 * * *",
+            schedule="30 20 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,


### PR DESCRIPTION
We realized today that we cannot rely on the `Last-Modified` header to determine data availability. The actual files appear for download a few hours later than the updated timestamp. 

I noticed the files available around 19:40z so this sets the cron to run at 20z and validation at 20:30z.