### PR TITLE
Make StorageConfig.k8s_secret_names a Sequence

### DIFF
--- a/docs/dataset_integration_guide.md
+++ b/docs/dataset_integration_guide.md
@@ -36,9 +36,10 @@ from reformatters.provider.model.variant import ProviderModelVariantDataset
 
 DYNAMICAL_DATASETS = [
     ...,
-    ProviderModelVariantDataset(),
+    ProviderModelVariantDataset(storage_config=SourceCoopDatasetStorageConfig()),
 ]
 ```
+If you plan to write this dataset to a location not maintained by dynamical.org, you can instantiate and pass your own StorageConfig, contact feedback@dynamical.org for support.
 
 ### 3. Implement `TemplateConfig` subclass
 
@@ -94,7 +95,7 @@ uv run pytest tests/$DATASET_PATH/dynamical_dataset_test.py
 
 ### 6. Deployment
 
-The details here depend on the computing resources and the Zarr storage location you'll be using. Get in touch with the dynamical.org team for support at this point if you haven't already.
+The details here depend on the computing resources and the Zarr storage location you'll be using. Get in touch with feedback@dynamical.org for support at this point if you haven't already.
 
 Complete the steps in README.md > Deploying to the cloud > Setup.
 

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -23,7 +23,7 @@ class SourceCoopDatasetStorageConfig(DynamicalDatasetStorageConfig):
     """Configuration for the storage of a SourceCoop dataset."""
 
     base_path: str = "s3://us-west-2.opendata.source.coop/dynamical"
-    k8s_secret_name: str = "source-coop-key"  # noqa: S105
+    k8s_secret_names: Sequence[str] = ["source-coop-key"]
 
 
 # Registry of all DynamicalDatasets.
@@ -36,7 +36,7 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
             # The R2 endpoint URL is stored within our k8s secret and will be set
             # when it's imported into the env.
             base_path="s3://upstream-gridded-zarrs",
-            k8s_secret_name="upstream-gridded-zarrs-key",  # noqa: S106
+            k8s_secret_names=["upstream-gridded-zarrs-key"],
         )
     ),
     NoaaGfsForecastDataset(storage_config=SourceCoopDatasetStorageConfig()),

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -46,7 +46,7 @@ class DynamicalDatasetStorageConfig(FrozenBaseModel):
     """Configuration for the storage of a dataset in production."""
 
     base_path: str
-    k8s_secret_name: str | None = None
+    k8s_secret_names: Sequence[str] = []
 
 
 class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
@@ -74,7 +74,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             memory="30G",
             shared_memory="12G",
             ephemeral_storage="30G",
-            secret_names=[self.storage_config.k8s_secret_name],
+            secret_names=self.storage_config.k8s_secret_names,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
@@ -84,7 +84,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             dataset_id=self.dataset_id,
             cpu="1.3",
             memory="7G",
-            secret_names=[self.storage_config.k8s_secret_name],
+            secret_names=self.storage_config.k8s_secret_names,
         )
 
         return [operational_update_cron_job, validation_cron_job]
@@ -228,7 +228,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                     "pod_active_deadline",
                 }
             ),
-            secret_names=[self.storage_config.k8s_secret_name],
+            secret_names=self.storage_config.k8s_secret_names,
         )
         subprocess.run(  # noqa: S603
             ["/usr/bin/kubectl", "apply", "-f", "-"],

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -22,7 +22,7 @@ class Job(pydantic.BaseModel):
     ttl: timedelta = timedelta(days=1)
     pod_active_deadline: timedelta = timedelta(hours=6)
 
-    secret_names: list[str | None] = []
+    secret_names: Sequence[str] = []
 
     @property
     def job_name(self) -> str:
@@ -111,7 +111,6 @@ class Job(pydantic.BaseModel):
                                 "envFrom": [
                                     {"secretRef": {"name": secret_name}}
                                     for secret_name in self.secret_names
-                                    if secret_name is not None
                                 ],
                                 "image": f"{self.image}",
                                 "name": "worker",

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -45,7 +45,7 @@ class UarizonaSwannAnalysisDataset(
             memory="14G",
             shared_memory="6Gi",
             ephemeral_storage="10G",
-            secret_names=[self.storage_config.k8s_secret_name],
+            secret_names=self.storage_config.k8s_secret_names,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
@@ -55,7 +55,7 @@ class UarizonaSwannAnalysisDataset(
             dataset_id=self.dataset_id,
             cpu="1.3",
             memory="7G",
-            secret_names=[self.storage_config.k8s_secret_name],
+            secret_names=self.storage_config.k8s_secret_names,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/example/dynamical_dataset.py
+++ b/src/reformatters/example/dynamical_dataset.py
@@ -24,7 +24,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
         #     memory="30G",
         #     shared_memory="12G",
         #     ephemeral_storage="30G",
-        #     secret_names=[self.storage_config.k8s_secret_name],
+        #     secret_names=self.storage_config.k8s_secret_names,
         # )
         # validation_cron_job = ValidationCronJob(
         #     name=f"{self.dataset_id}-validation",
@@ -34,7 +34,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
         #     dataset_id=self.dataset_id,
         #     cpu="1.3",
         #     memory="7G",
-        #     secret_names=[self.storage_config.k8s_secret_name],
+        #     secret_names=self.storage_config.k8s_secret_names,
         # )
 
         # return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
@@ -28,7 +28,7 @@ class NoaaGfsForecastDataset(
             memory="7G",
             shared_memory="1.5G",
             ephemeral_storage="20G",
-            secret_names=[self.storage_config.k8s_secret_name],
+            secret_names=self.storage_config.k8s_secret_names,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
@@ -38,7 +38,7 @@ class NoaaGfsForecastDataset(
             dataset_id=self.dataset_id,
             cpu="1.3",
             memory="7G",
-            secret_names=[self.storage_config.k8s_secret_name],
+            secret_names=self.storage_config.k8s_secret_names,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -1,5 +1,5 @@
 import subprocess
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import ClassVar
@@ -30,13 +30,13 @@ from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
 
 NOOP_STORAGE_CONFIG = DynamicalDatasetStorageConfig(
     base_path="noop",
-    k8s_secret_name="noop-secret",  # noqa: S106
+    k8s_secret_names=["noop-secret"],
 )
 
 
 class ExampleDatasetStorageConfig(DynamicalDatasetStorageConfig):
     base_path: str = "s3://some-bucket/path"
-    k8s_secret_name: str = "k8s-secret-name"  # noqa: S105
+    k8s_secret_names: Sequence[str] = ["k8s-secret-name"]
 
 
 class ExampleDataVar(DataVar[BaseInternalAttrs]):
@@ -104,7 +104,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
                 memory="1G",
                 shared_memory="1G",
                 ephemeral_storage="1G",
-                secret_names=[self.storage_config.k8s_secret_name],
+                secret_names=self.storage_config.k8s_secret_names,
             ),
             ValidationCronJob(
                 name=f"{self.dataset_id}-validation",
@@ -116,7 +116,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
                 memory="1G",
                 shared_memory="1G",
                 ephemeral_storage="1G",
-                secret_names=[self.storage_config.k8s_secret_name],
+                secret_names=self.storage_config.k8s_secret_names,
             ),
         ]
 

--- a/tests/example/dynamical_dataset_test.py
+++ b/tests/example/dynamical_dataset_test.py
@@ -52,8 +52,8 @@
 #     update_cron_job, validation_cron_job = cron_jobs
 #     assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
 #     assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
-#     assert update_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
-#     assert validation_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
+#     assert update_cron_job.secret_names == dataset.storage_config.k8s_secret_names
+#     assert validation_cron_job.secret_names == dataset.storage_config.k8s_secret_names
 
 
 # def test_validators(dataset: ExampleDataset) -> None:

--- a/tests/noaa/gfs/forecast/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast/dynamical_dataset_test.py
@@ -159,8 +159,8 @@ def test_operational_kubernetes_resources(
     update_cron_job, validation_cron_job = cron_jobs
     assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
     assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
-    assert update_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
-    assert validation_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
+    assert update_cron_job.secret_names == dataset.storage_config.k8s_secret_names
+    assert validation_cron_job.secret_names == dataset.storage_config.k8s_secret_names
 
 
 def test_validators(dataset: NoaaGfsForecastDataset) -> None:


### PR DESCRIPTION
To support omitting kubernetes secrets if you don't need em. E.g. Anyone who just wants to run locally and write to disk, or is running this on a super computer who writes to networked storage, probably doesn't need a secret.