### PR TITLE
NDVI CDR: Reduce shard time size to reduce shared memory buffer size

### DIFF
--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
@@ -27,8 +27,8 @@ class NoaaNdviCdrAnalysisDataset(
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="2",
-            memory="250G",
-            shared_memory="190Gi",
+            memory="128G",
+            shared_memory="114Gi",
             ephemeral_storage="30G",
             secret_names=self.storage_config.k8s_secret_names,
         )

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/template_config.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/template_config.py
@@ -198,11 +198,11 @@ class NoaaNdviCdrAnalysisTemplateConfig(TemplateConfig[NoaaNdviCdrDataVar]):
             "latitude": 100,
             "longitude": 100,
         }
-        # Sharding selected to target ~350mb compressed shards (assuming compression to ~20%)
+        # Sharding selected to target ~300mb compressed shards (assuming compression to ~20%)
         var_shards: dict[Dim, int] = {
-            "time": var_chunks["time"] * 5,
-            "latitude": var_chunks["latitude"] * 5,
-            "longitude": var_chunks["longitude"] * 5,
+            "time": var_chunks["time"] * 3,
+            "latitude": var_chunks["latitude"] * 6,
+            "longitude": var_chunks["longitude"] * 6,
         }
 
         encoding_float32_default = Encoding(

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_raw/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_raw/zarr.json
@@ -9,9 +9,9 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1825,
-        500,
-        500
+        1095,
+        600,
+        600
       ]
     }
   },

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_usable/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_usable/zarr.json
@@ -9,9 +9,9 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1825,
-        500,
-        500
+        1095,
+        600,
+        600
       ]
     }
   },

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/qa/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/qa/zarr.json
@@ -9,9 +9,9 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1825,
-        500,
-        500
+        1095,
+        600,
+        600
       ]
     }
   },

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/zarr.json
@@ -132,9 +132,9 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1825,
-              500,
-              500
+              1095,
+              600,
+              600
             ]
           }
         },
@@ -216,9 +216,9 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1825,
-              500,
-              500
+              1095,
+              600,
+              600
             ]
           }
         },
@@ -300,9 +300,9 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1825,
-              500,
-              500
+              1095,
+              600,
+              600
             ]
           }
         },


### PR DESCRIPTION
The NDVI CDR jobs were failing to run because we were requesting nodes with more more memory than `nodepool.yaml` constrainted us to:

```
  Warning  FailedScheduling  99s (x3 over 11m)  karpenter          Failed to schedule pod, no instance type has enough resources, requirements=eks.amazonaws.com/compute-type In [auto], eks.amazonaws.com/instance-category In [c m r], eks.amazonaws.com/instance-cpu Exists <17, eks.amazonaws.com/instance-generation Exists >6, eks.amazonaws.com/nodeclass In [default-spot], karpenter.sh/capacity-type In [spot], karpenter.sh/nodepool In [general-spot], kubernetes.io/arch In [amd64 arm64], topology.kubernetes.io/zone In [us-west-2a us-west-2b us-west-2c us-west-2d], resources={"cpu":"3356m","memory":"244847185Ki","pods":"8"}
```

I've reduced the size of the `time` component of our shards, which is what determines the size of our shared memory buffer. Now the buffer will require ~113G of memory. This lets us target a smaller node that has under 17 CPU. 