### PR TITLE
Allow larger nodes in nodepool configuration; revert NDVI CDR shard size

### DIFF
--- a/deploy/aws/nodepool.yaml
+++ b/deploy/aws/nodepool.yaml
@@ -19,7 +19,7 @@ spec:
           values: ["c", "m", "r"]
         - key: "eks.amazonaws.com/instance-cpu"
           operator: Lt
-          values: ["17"]
+          values: ["33"]
         - key: "eks.amazonaws.com/instance-generation"
           operator: Gt
           values: ["6"]

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
@@ -27,8 +27,8 @@ class NoaaNdviCdrAnalysisDataset(
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="2",
-            memory="128G",
-            shared_memory="114Gi",
+            memory="230G",
+            shared_memory="190Gi",
             ephemeral_storage="30G",
             secret_names=self.storage_config.k8s_secret_names,
         )

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/template_config.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/template_config.py
@@ -198,11 +198,11 @@ class NoaaNdviCdrAnalysisTemplateConfig(TemplateConfig[NoaaNdviCdrDataVar]):
             "latitude": 100,
             "longitude": 100,
         }
-        # Sharding selected to target ~300mb compressed shards (assuming compression to ~20%)
+        # Sharding selected to target ~350mb compressed shards (assuming compression to ~20%)
         var_shards: dict[Dim, int] = {
-            "time": var_chunks["time"] * 3,
-            "latitude": var_chunks["latitude"] * 6,
-            "longitude": var_chunks["longitude"] * 6,
+            "time": var_chunks["time"] * 5,
+            "latitude": var_chunks["latitude"] * 5,
+            "longitude": var_chunks["longitude"] * 5,
         }
 
         encoding_float32_default = Encoding(

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_raw/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_raw/zarr.json
@@ -9,9 +9,9 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1095,
-        600,
-        600
+        1825,
+        500,
+        500
       ]
     }
   },

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_usable/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_usable/zarr.json
@@ -9,9 +9,9 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1095,
-        600,
-        600
+        1825,
+        500,
+        500
       ]
     }
   },

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/qa/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/qa/zarr.json
@@ -9,9 +9,9 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1095,
-        600,
-        600
+        1825,
+        500,
+        500
       ]
     }
   },

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/zarr.json
@@ -132,9 +132,9 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1095,
-              600,
-              600
+              1825,
+              500,
+              500
             ]
           }
         },
@@ -216,9 +216,9 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1095,
-              600,
-              600
+              1825,
+              500,
+              500
             ]
           }
         },
@@ -300,9 +300,9 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1095,
-              600,
-              600
+              1825,
+              500,
+              500
             ]
           }
         },


### PR DESCRIPTION
Even with[ the changes](https://github.com/dynamical-org/reformatters/pull/175) to reduce the NDVI CDR shard sizes, we were unable to get pods scheduled. This was likely due to requesting the maximum listed capacity for the node (128G memory), leaving now overhead. 

Rather than reduce the shard size further, which would be less than ideal for readers, this PR bumps up the size of the nodes we are allowed to request. This should allow us to obtain space on a `r8g.8xlarge` machine, which has 32 CPU and 256G of memory. 