### PR TITLE
Add boto3 to support lsing S3 buckets anonymously

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,10 @@ dependencies = [
     "requests>=2.32.3",
     "rioxarray>=0.18.2",
     "s3fs>=2024.9.0",
-    "boto3~=1.36.0",
+    # We ran into an issue when installing boto3 1.39.x, related to https://github.com/boto/boto3/issues/4462#issuecomment-2701723847
+    # Following the comments in that thread, we have pinned boto3 to 1.36.x. This allows it to match our 
+    # currently installed version of botocore (also 1.36.x)
+    "boto3~=1.36.0", 
     "sentry-sdk>=2.20.0",
     "typer>=0.12.5",
     "xarray>=2025.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "requests>=2.32.3",
     "rioxarray>=0.18.2",
     "s3fs>=2024.9.0",
+    "boto3~=1.36.0",
     "sentry-sdk>=2.20.0",
     "typer>=0.12.5",
     "xarray>=2025.1.2",

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
@@ -1,9 +1,7 @@
 from collections.abc import Sequence
-from datetime import timedelta
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
-from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 
 from .region_job import NoaaNdviCdrAnalysisRegionJob, NoaaNdviCdrAnalysisSourceFileCoord
 from .template_config import NoaaNdviCdrAnalysisTemplateConfig, NoaaNdviCdrDataVar
@@ -18,32 +16,32 @@ class NoaaNdviCdrAnalysisDataset(
     )
     region_job_class: type[NoaaNdviCdrAnalysisRegionJob] = NoaaNdviCdrAnalysisRegionJob
 
-    def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
-        """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
-        operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
-            schedule="0 20 * * *",
-            pod_active_deadline=timedelta(minutes=30),
-            image=image_tag,
-            dataset_id=self.dataset_id,
-            cpu="2",
-            memory="230G",
-            shared_memory="190Gi",
-            ephemeral_storage="30G",
-            secret_names=self.storage_config.k8s_secret_names,
-        )
-        validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
-            schedule="30 20 * * *",
-            pod_active_deadline=timedelta(minutes=10),
-            image=image_tag,
-            dataset_id=self.dataset_id,
-            cpu="1.3",
-            memory="7G",
-            secret_names=self.storage_config.k8s_secret_names,
-        )
+    # def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+    #    """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
+    #    operational_update_cron_job = ReformatCronJob(
+    #        name=f"{self.dataset_id}-operational-update",
+    #        schedule="0 20 * * *",
+    #        pod_active_deadline=timedelta(minutes=30),
+    #        image=image_tag,
+    #        dataset_id=self.dataset_id,
+    #        cpu="2",
+    #        memory="230G",
+    #        shared_memory="190Gi",
+    #        ephemeral_storage="150G",
+    #        secret_names=self.storage_config.k8s_secret_names,
+    #    )
+    #    validation_cron_job = ValidationCronJob(
+    #        name=f"{self.dataset_id}-validation",
+    #        schedule="30 20 * * *",
+    #        pod_active_deadline=timedelta(minutes=10),
+    #        image=image_tag,
+    #        dataset_id=self.dataset_id,
+    #        cpu="1.3",
+    #        memory="7G",
+    #        secret_names=self.storage_config.k8s_secret_names,
+    #    )
 
-        return [operational_update_cron_job, validation_cron_job]
+    #    return [operational_update_cron_job, validation_cron_job]
 
     def validators(self) -> Sequence[validation.DataValidator]:
         """Return a sequence of DataValidators to run on this dataset."""

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/region_job.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/region_job.py
@@ -62,6 +62,8 @@ class NoaaNdviCdrAnalysisSourceFileCoord(SourceFileCoord):
 class NoaaNdviCdrAnalysisRegionJob(
     RegionJob[NoaaNdviCdrDataVar, NoaaNdviCdrAnalysisSourceFileCoord]
 ):
+    download_parallelism: int = 4
+
     # We observed deadlocks when using more than 2 threads to read data into shared memory.
     read_parallelism: int = 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -128,6 +128,20 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.36.23"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/54/a91d274f50bbe8fbd16ecea8bfd60249d0dc1ca50874e3a06119c6e5723a/boto3-1.36.23.tar.gz", hash = "sha256:006800604c34382873521b20890b758eea7109d699696ece932131259d0a4658", size = 111094, upload-time = "2025-02-18T20:28:16.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/b5/2217a8ebb59bbc5f28dc10d3184b1f7e238f1929d211e69298421f912411/boto3-1.36.23-py3-none-any.whl", hash = "sha256:d59642672b1f35f55f47b317693241ce53333816f47c9e72fcc8fd0e9adc6a87", size = 139179, upload-time = "2025-02-18T20:28:13.513Z" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.36.23"
 source = { registry = "https://pypi.org/simple" }
@@ -1265,6 +1279,7 @@ name = "reformatters"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "dask" },
     { name = "numba" },
     { name = "numcodecs" },
@@ -1295,6 +1310,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = "~=1.36.0" },
     { name = "dask", specifier = ">=2024.9.0" },
     { name = "numba", specifier = ">=0.61.0" },
     { name = "numcodecs", specifier = ">=0.13.1" },
@@ -1404,6 +1420,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3e/28/6754f35bfca41a706f77d556e2e681c16a3cbc747fa8656beb080cc352cf/s3fs-2025.2.0.tar.gz", hash = "sha256:d94b985f55add51c655e9ca9b4ceecb5c4b6389aecde162bdebc89f489a4e9f2", size = 76700, upload-time = "2025-02-01T18:38:52.074Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/92/3c53f932cd1ce09e6c91044eed3dfbebea549b45d24c5484aa74ac0be7e1/s3fs-2025.2.0-py3-none-any.whl", hash = "sha256:4b66b773519c1983e3071e13a42a2f2498d87da13dee40fda0622f4ed1b55664", size = 30235, upload-time = "2025-02-01T18:38:48.255Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/24/1390172471d569e281fcfd29b92f2f73774e95972c965d14b6c802ff2352/s3transfer-0.11.3.tar.gz", hash = "sha256:edae4977e3a122445660c7c114bba949f9d191bae3b34a096f18a1c8c354527a", size = 148042, upload-time = "2025-02-26T20:44:57.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/81/48c41b554a54d75d4407740abb60e3a102ae416284df04d1dbdcbe3dbf24/s3transfer-0.11.3-py3-none-any.whl", hash = "sha256:ca855bdeb885174b5ffa95b9913622459d4ad8e331fc98eb01e6d5eb6a30655d", size = 84246, upload-time = "2025-02-26T20:44:55.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We had trouble getting the `anon=True` flag to work with `fsspec` and `s3fs`. While there might be a solution, this PR adds `boto3` which works for lsing with unsigned requests. (Note that we needed to use version `~1.36.0` due a bug with later versions. See https://github.com/boto/boto3/issues/4462#issuecomment-2701723847)