### PR TITLE
NDVI: Refactor to ls and download with obstore and operationalize

### DIFF
--- a/deploy/aws/nodepool.yaml
+++ b/deploy/aws/nodepool.yaml
@@ -19,7 +19,7 @@ spec:
           values: ["c", "m", "r"]
         - key: "eks.amazonaws.com/instance-cpu"
           operator: Lt
-          values: ["33"]
+          values: ["17"]
         - key: "eks.amazonaws.com/instance-generation"
           operator: Gt
           values: ["6"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,6 @@ dependencies = [
     "requests>=2.32.3",
     "rioxarray>=0.18.2",
     "s3fs>=2024.9.0",
-    # We ran into an issue when installing boto3 1.39.x, related to https://github.com/boto/boto3/issues/4462#issuecomment-2701723847
-    # Following the comments in that thread, we have pinned boto3 to 1.36.x. This allows it to match our 
-    # currently installed version of botocore (also 1.36.x)
-    "boto3~=1.36.0", 
     "sentry-sdk>=2.20.0",
     "typer>=0.12.5",
     "xarray>=2025.1.2",

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import functools
 import os
@@ -5,15 +7,19 @@ import uuid
 from collections.abc import Sequence
 from datetime import timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import obstore
+
+if TYPE_CHECKING:
+    from obstore.store import ObjectStore
 
 DOWNLOAD_DIR = Path("data/download/")
 
 
 def download_to_disk(
-    store: obstore.store.ObjectStore,
+    store: ObjectStore,
     path: str,
     local_path: Path,
     *,

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -13,7 +13,7 @@ DOWNLOAD_DIR = Path("data/download/")
 
 
 def download_to_disk(
-    store: obstore.store.HTTPStore | obstore.store.S3Store,
+    store: obstore.store.ObjectStore,
     path: str,
     local_path: Path,
     *,

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -13,7 +13,7 @@ DOWNLOAD_DIR = Path("data/download/")
 
 
 def download_to_disk(
-    store: obstore.store.HTTPStore,
+    store: obstore.store.HTTPStore | obstore.store.S3Store,
     path: str,
     local_path: Path,
     *,
@@ -86,12 +86,7 @@ def http_download_to_disk(
     parsed_url = urlparse(url)
     base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
     store = http_store(base_url)
-    base_local = DOWNLOAD_DIR / dataset_id / parsed_url.path.removeprefix("/")
-    local_path = (
-        base_local.with_name(base_local.name + local_path_suffix)
-        if local_path_suffix
-        else base_local
-    )
+    local_path = get_local_path(dataset_id, parsed_url.path, local_path_suffix)
     download_to_disk(
         store,
         parsed_url.path,
@@ -100,3 +95,12 @@ def http_download_to_disk(
         byte_ranges=byte_ranges,
     )
     return local_path
+
+
+def get_local_path(dataset_id: str, path: str, local_path_suffix: str = "") -> Path:
+    base_local = DOWNLOAD_DIR / dataset_id / path.removeprefix("/")
+    return (
+        base_local.with_name(base_local.name + local_path_suffix)
+        if local_path_suffix
+        else base_local
+    )

--- a/src/reformatters/common/fsspec.py
+++ b/src/reformatters/common/fsspec.py
@@ -31,7 +31,7 @@ def fsspec_apply(
         try:
             if fs.async_impl:
                 return zarr.core.sync.sync(
-                    getattr(fs, f"_{method}")(*args, **kwargs), timeout=120
+                    getattr(fs, f"_{method}")(*args, **kwargs), timeout=500
                 )
             else:
                 return getattr(fs, method)(*args, **kwargs)

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
@@ -1,7 +1,9 @@
 from collections.abc import Sequence
+from datetime import timedelta
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 
 from .region_job import NoaaNdviCdrAnalysisRegionJob, NoaaNdviCdrAnalysisSourceFileCoord
 from .template_config import NoaaNdviCdrAnalysisTemplateConfig, NoaaNdviCdrDataVar
@@ -16,32 +18,32 @@ class NoaaNdviCdrAnalysisDataset(
     )
     region_job_class: type[NoaaNdviCdrAnalysisRegionJob] = NoaaNdviCdrAnalysisRegionJob
 
-    # def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
-    #    """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
-    #    operational_update_cron_job = ReformatCronJob(
-    #        name=f"{self.dataset_id}-operational-update",
-    #        schedule="0 20 * * *",
-    #        pod_active_deadline=timedelta(minutes=30),
-    #        image=image_tag,
-    #        dataset_id=self.dataset_id,
-    #        cpu="2",
-    #        memory="230G",
-    #        shared_memory="190Gi",
-    #        ephemeral_storage="150G",
-    #        secret_names=self.storage_config.k8s_secret_names,
-    #    )
-    #    validation_cron_job = ValidationCronJob(
-    #        name=f"{self.dataset_id}-validation",
-    #        schedule="30 20 * * *",
-    #        pod_active_deadline=timedelta(minutes=10),
-    #        image=image_tag,
-    #        dataset_id=self.dataset_id,
-    #        cpu="1.3",
-    #        memory="7G",
-    #        secret_names=self.storage_config.k8s_secret_names,
-    #    )
+    def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+        """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
+        operational_update_cron_job = ReformatCronJob(
+            name=f"{self.dataset_id}-operational-update",
+            schedule="0 20 * * *",
+            pod_active_deadline=timedelta(minutes=60),
+            image=image_tag,
+            dataset_id=self.dataset_id,
+            cpu="2",
+            memory="230G",
+            shared_memory="190Gi",
+            ephemeral_storage="150G",
+            secret_names=self.storage_config.k8s_secret_names,
+        )
+        validation_cron_job = ValidationCronJob(
+            name=f"{self.dataset_id}-validation",
+            schedule="30 20 * * *",
+            pod_active_deadline=timedelta(minutes=10),
+            image=image_tag,
+            dataset_id=self.dataset_id,
+            cpu="1.3",
+            memory="7G",
+            secret_names=self.storage_config.k8s_secret_names,
+        )
 
-    #    return [operational_update_cron_job, validation_cron_job]
+        return [operational_update_cron_job, validation_cron_job]
 
     def validators(self) -> Sequence[validation.DataValidator]:
         """Return a sequence of DataValidators to run on this dataset."""

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/dynamical_dataset.py
@@ -27,14 +27,14 @@ class NoaaNdviCdrAnalysisDataset(
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="2",
-            memory="230G",
-            shared_memory="190Gi",
+            memory="100G",
+            shared_memory="76Gi",
             ephemeral_storage="150G",
             secret_names=self.storage_config.k8s_secret_names,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
-            schedule="30 20 * * *",
+            schedule="30 21 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/region_job.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/region_job.py
@@ -124,7 +124,7 @@ class NoaaNdviCdrAnalysisRegionJob(
         local_path = get_local_path(self.dataset_id, object_key)
 
         download_to_disk(store, object_key, local_path, overwrite_existing=True)
-        log.info(f"Downloaded {object_key} to {local_path}")
+        log.debug(f"Downloaded {object_key} to {local_path}")
 
         return local_path
 

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/template_config.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/template_config.py
@@ -198,9 +198,11 @@ class NoaaNdviCdrAnalysisTemplateConfig(TemplateConfig[NoaaNdviCdrDataVar]):
             "latitude": 100,
             "longitude": 100,
         }
-        # Sharding selected to target ~350mb compressed shards (assuming compression to ~20%)
+        # Sharding selected to target ~140mb compressed shards (assuming compression to ~20%)
+        # Note: We previously targeted larger shards (time * 5), but had trouble getting jobs to
+        # on the larger nodes before they got evicted.
         var_shards: dict[Dim, int] = {
-            "time": var_chunks["time"] * 5,
+            "time": var_chunks["time"] * 2,
             "latitude": var_chunks["latitude"] * 5,
             "longitude": var_chunks["longitude"] * 5,
         }

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_raw/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_raw/zarr.json
@@ -9,7 +9,7 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1825,
+        730,
         500,
         500
       ]

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_usable/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/ndvi_usable/zarr.json
@@ -9,7 +9,7 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1825,
+        730,
         500,
         500
       ]

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/qa/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/qa/zarr.json
@@ -9,7 +9,7 @@
     "name": "regular",
     "configuration": {
       "chunk_shape": [
-        1825,
+        730,
         500,
         500
       ]

--- a/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/ndvi_cdr/analysis/templates/latest.zarr/zarr.json
@@ -132,7 +132,7 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1825,
+              730,
               500,
               500
             ]
@@ -216,7 +216,7 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1825,
+              730,
               500,
               500
             ]
@@ -300,7 +300,7 @@
           "name": "regular",
           "configuration": {
             "chunk_shape": [
-              1825,
+              730,
               500,
               500
             ]

--- a/uv.lock
+++ b/uv.lock
@@ -128,20 +128,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3"
-version = "1.36.23"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/54/a91d274f50bbe8fbd16ecea8bfd60249d0dc1ca50874e3a06119c6e5723a/boto3-1.36.23.tar.gz", hash = "sha256:006800604c34382873521b20890b758eea7109d699696ece932131259d0a4658", size = 111094, upload-time = "2025-02-18T20:28:16.076Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/b5/2217a8ebb59bbc5f28dc10d3184b1f7e238f1929d211e69298421f912411/boto3-1.36.23-py3-none-any.whl", hash = "sha256:d59642672b1f35f55f47b317693241ce53333816f47c9e72fcc8fd0e9adc6a87", size = 139179, upload-time = "2025-02-18T20:28:13.513Z" },
-]
-
-[[package]]
 name = "botocore"
 version = "1.36.23"
 source = { registry = "https://pypi.org/simple" }
@@ -1279,7 +1265,6 @@ name = "reformatters"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "boto3" },
     { name = "dask" },
     { name = "numba" },
     { name = "numcodecs" },
@@ -1310,7 +1295,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = "~=1.36.0" },
     { name = "dask", specifier = ">=2024.9.0" },
     { name = "numba", specifier = ">=0.61.0" },
     { name = "numcodecs", specifier = ">=0.13.1" },
@@ -1420,18 +1404,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3e/28/6754f35bfca41a706f77d556e2e681c16a3cbc747fa8656beb080cc352cf/s3fs-2025.2.0.tar.gz", hash = "sha256:d94b985f55add51c655e9ca9b4ceecb5c4b6389aecde162bdebc89f489a4e9f2", size = 76700, upload-time = "2025-02-01T18:38:52.074Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/92/3c53f932cd1ce09e6c91044eed3dfbebea549b45d24c5484aa74ac0be7e1/s3fs-2025.2.0-py3-none-any.whl", hash = "sha256:4b66b773519c1983e3071e13a42a2f2498d87da13dee40fda0622f4ed1b55664", size = 30235, upload-time = "2025-02-01T18:38:48.255Z" },
-]
-
-[[package]]
-name = "s3transfer"
-version = "0.11.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/24/1390172471d569e281fcfd29b92f2f73774e95972c965d14b6c802ff2352/s3transfer-0.11.3.tar.gz", hash = "sha256:edae4977e3a122445660c7c114bba949f9d191bae3b34a096f18a1c8c354527a", size = 148042, upload-time = "2025-02-26T20:44:57.459Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/81/48c41b554a54d75d4407740abb60e3a102ae416284df04d1dbdcbe3dbf24/s3transfer-0.11.3-py3-none-any.whl", hash = "sha256:ca855bdeb885174b5ffa95b9913622459d4ad8e331fc98eb01e6d5eb6a30655d", size = 84246, upload-time = "2025-02-26T20:44:55.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR:

- Refactors listing and downloading available source files to use `obstore`
- Reduces our shard size to get us on smaller nodes -- we think this reduces our chance of eviction.
- Removes the `boto3` dependency (no longer needed with `obstore`)
- Tweaks the operational resources definitions.