### PR TITLE
Append newline char when writing __init__.py

### DIFF
--- a/src/reformatters/example/new_dataset.py
+++ b/src/reformatters/example/new_dataset.py
@@ -74,7 +74,7 @@ def initialize_new_integration(
 
     dataset_class_name = example_to_actual_mappings["ExampleDataset"]
     (src_path / "__init__.py").write_text(
-        f"from .dynamical_dataset import {dataset_class_name} as {dataset_class_name}"
+        f"from .dynamical_dataset import {dataset_class_name} as {dataset_class_name}\n"
     )
 
     print(f"Created new dataset integration at {src_path} and {test_path}")


### PR DESCRIPTION
This PR just appends `\n` to the text written to `src/reformatters/{provider}/{model}/{variant}/__init__.py` so `ruff` doesn't complain immediately after running `uv run main initialize-new-integration <provider> <model> <variant>`.

Fixes the "ruff: Failed" issue shown below:

<img width="1063" height="585" alt="image" src="https://github.com/user-attachments/assets/0e019a37-a222-4cdd-a033-5ac7e4521291" />
