### PR TITLE
StoreFactory refactor 

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -9,10 +9,8 @@ import reformatters.noaa.gefs.analysis.cli as noaa_gefs_analysis
 import reformatters.noaa.gefs.forecast_35_day.cli as noaa_gefs_forecast_35_day
 from reformatters.common import deploy
 from reformatters.common.config import Config
-from reformatters.common.dynamical_dataset import (
-    DynamicalDataset,
-    DynamicalDatasetStorageConfig,
-)
+from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.contrib.noaa.ndvi_cdr.analysis import (
     NoaaNdviCdrAnalysisDataset,
 )
@@ -24,14 +22,15 @@ from reformatters.noaa.hrrr.forecast_48_hour.dynamical_dataset import (
 )
 
 
-class SourceCoopDatasetStorageConfig(DynamicalDatasetStorageConfig):
+class SourceCoopDatasetStorageConfig(StorageConfig):
     """Configuration for the storage of a SourceCoop dataset."""
 
     base_path: str = "s3://us-west-2.opendata.source.coop/dynamical"
     k8s_secret_names: Sequence[str] = ["source-coop-key"]
+    format: DatasetFormat = DatasetFormat.ZARR3
 
 
-class UpstreamGriddedZarrsDatasetStorageConfig(DynamicalDatasetStorageConfig):
+class UpstreamGriddedZarrsDatasetStorageConfig(StorageConfig):
     """Configuration for storage in the Upstream gridded zarrs bucket."""
 
     # This bucket is actually an R2 bucket.
@@ -39,6 +38,7 @@ class UpstreamGriddedZarrsDatasetStorageConfig(DynamicalDatasetStorageConfig):
     # when it's imported into the env.
     base_path: str = "s3://upstream-gridded-zarrs"
     k8s_secret_names: Sequence[str] = ["upstream-gridded-zarrs-key"]
+    format: DatasetFormat = DatasetFormat.ZARR3
 
 
 # Registry of all DynamicalDatasets.

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -27,6 +27,7 @@ from reformatters.common.kubernetes import (
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.region_job import RegionJob, SourceFileCoord
+from reformatters.common.storage import StorageConfig
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import DatetimeLike
 from reformatters.common.zarr import (
@@ -42,20 +43,13 @@ SOURCE_FILE_COORD = TypeVar("SOURCE_FILE_COORD", bound=SourceFileCoord)
 logger = get_logger(__name__)
 
 
-class DynamicalDatasetStorageConfig(FrozenBaseModel):
-    """Configuration for the storage of a dataset in production."""
-
-    base_path: str
-    k8s_secret_names: Sequence[str] = []
-
-
 class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     """Top level class managing a dataset configuration and processing."""
 
     template_config: TemplateConfig[DATA_VAR]
     region_job_class: type[RegionJob[DATA_VAR, SOURCE_FILE_COORD]]
 
-    storage_config: DynamicalDatasetStorageConfig
+    storage_config: StorageConfig
 
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
         """

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -11,7 +11,6 @@ import pandas as pd
 import sentry_sdk
 import typer
 import xarray as xr
-import zarr
 from pydantic import computed_field
 
 from reformatters.common import docker, template_utils, validation
@@ -27,14 +26,12 @@ from reformatters.common.kubernetes import (
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.region_job import RegionJob, SourceFileCoord
-from reformatters.common.storage import StorageConfig
+from reformatters.common.storage import StorageConfig, StoreFactory
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import DatetimeLike
 from reformatters.common.zarr import (
     copy_zarr_metadata,
     get_local_tmp_store,
-    get_mode,
-    get_zarr_store,
 )
 
 DATA_VAR = TypeVar("DATA_VAR", bound=DataVar[Any])
@@ -50,6 +47,15 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     region_job_class: type[RegionJob[DATA_VAR, SOURCE_FILE_COORD]]
 
     storage_config: StorageConfig
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def primary_store_factory(self) -> StoreFactory:
+        return StoreFactory(
+            storage_config=self.storage_config,
+            dataset_id=self.dataset_id,
+            template_config_version=self.template_config.version,
+        )
 
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
         """
@@ -121,27 +127,30 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     ) -> None:
         """Update an existing dataset with the latest data."""
         with self._monitor(ReformatCronJob, reformat_job_name):
-            final_store = self._final_store()
             tmp_store = self._tmp_store()
 
             jobs, template_ds = self.region_job_class.operational_update_jobs(
-                final_store=final_store,
+                primary_store_factory=self.primary_store_factory,
                 tmp_store=tmp_store,
                 get_template_fn=self._get_template,
                 append_dim=self.template_config.append_dim,
                 all_data_vars=self.template_config.data_vars,
                 reformat_job_name=reformat_job_name,
             )
-            template_utils.write_metadata(template_ds, tmp_store, get_mode(tmp_store))
+            first_write_mode: Literal["w", "w-"] = "w" if Config.is_test else "w-"
+            template_utils.write_metadata(template_ds, tmp_store, first_write_mode)
+
             for job in jobs:
                 process_results = job.process()
                 updated_template = job.update_template_with_results(process_results)
-                template_utils.write_metadata(
-                    updated_template, tmp_store, get_mode(tmp_store)
-                )
-                copy_zarr_metadata(updated_template, tmp_store, final_store)
+                # overwrite the tmp store metadata with updated template
+                template_utils.write_metadata(updated_template, tmp_store, "w")
+                primary_store = self.primary_store_factory.store()
+                copy_zarr_metadata(updated_template, tmp_store, primary_store)
 
-        logger.info(f"Operational update complete. Wrote to store: {final_store}")
+        logger.info(
+            f"Operational update complete. Wrote to store: {self.primary_store_factory.store()}"
+        )
 
     def backfill_kubernetes(
         self,
@@ -158,15 +167,17 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         image_tag = docker_image or docker.build_and_push_image()
 
         template_ds = self._get_template(append_dim_end)
-        final_store = self._final_store()
-        logger.info(f"Writing zarr metadata to {final_store}")
+        primary_store = self.primary_store_factory.store()
+        logger.info(f"Writing zarr metadata to {primary_store}")
 
-        template_utils.write_metadata(template_ds, final_store, get_mode(final_store))
+        template_utils.write_metadata(
+            template_ds, primary_store, self.primary_store_factory.mode()
+        )
 
         num_jobs = len(
             self.region_job_class.get_jobs(
                 kind="backfill",
-                final_store=final_store,
+                primary_store_factory=self.primary_store_factory,
                 tmp_store=self._tmp_store(),
                 template_ds=template_ds,
                 append_dim=self.template_config.append_dim,
@@ -253,9 +264,13 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     ) -> None:
         """Run dataset reformatting locally in this process."""
         template_ds = self._get_template(append_dim_end)
-        final_store = self._final_store()
+        primary_store = self.primary_store_factory.store()
 
-        template_utils.write_metadata(template_ds, final_store, get_mode(final_store))
+        template_utils.write_metadata(
+            template_ds,
+            primary_store,
+            self.primary_store_factory.mode(),
+        )
 
         self.process_backfill_region_jobs(
             append_dim_end,
@@ -267,7 +282,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             filter_contains=filter_contains,
             filter_variable_names=filter_variable_names,
         )
-        logger.info(f"Done writing to {final_store}")
+        logger.info(f"Done writing to {primary_store}")
 
     def process_backfill_region_jobs(
         self,
@@ -285,7 +300,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         region_jobs = self.region_job_class.get_jobs(
             kind="backfill",
-            final_store=self._final_store(),
+            primary_store_factory=self.primary_store_factory,
             tmp_store=self._tmp_store(),
             template_ds=self._get_template(append_dim_end),
             append_dim=self.template_config.append_dim,
@@ -314,7 +329,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     ) -> None:
         """Validate the dataset, raising an exception if it is invalid."""
         with self._monitor(ValidationCronJob, reformat_job_name):
-            store = self._final_store()
+            store = self.primary_store_factory.store()
             validation.validate_dataset(store, validators=self.validators())
 
         logger.info(f"Done validating {store}")
@@ -332,13 +347,6 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         # Avoid method name conflict with pydantic's validate while keeping cli commands consistent
         app.command("validate")(self.validate_dataset)
         return app
-
-    def _final_store(self) -> zarr.abc.store.Store:
-        return get_zarr_store(
-            self.storage_config.base_path,
-            self.template_config.dataset_id,
-            self.template_config.version,
-        )
 
     def _tmp_store(self) -> Path:
         return get_local_tmp_store()

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -15,7 +15,6 @@ import numpy as np
 import pandas as pd
 import pydantic
 import xarray as xr
-import zarr
 from pydantic import AfterValidator, Field, computed_field
 
 from reformatters.common import template_utils
@@ -28,6 +27,7 @@ from reformatters.common.reformat_utils import (
     create_data_array_and_template,
 )
 from reformatters.common.shared_memory_utils import make_shared_buffer, write_shards
+from reformatters.common.storage import StoreFactory
 from reformatters.common.types import (
     AppendDim,
     ArrayND,
@@ -36,7 +36,7 @@ from reformatters.common.types import (
     Timestamp,
 )
 from reformatters.common.update_progress_tracker import UpdateProgressTracker
-from reformatters.common.zarr import copy_data_var, get_mode
+from reformatters.common.zarr import copy_data_var
 
 log = get_logger(__name__)
 
@@ -101,7 +101,7 @@ def region_slice(s: slice) -> slice:
 
 
 class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
-    final_store: zarr.abc.store.Store
+    primary_store_factory: StoreFactory
     tmp_store: Path
     template_ds: xr.Dataset
     data_vars: Sequence[DATA_VAR]
@@ -228,7 +228,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         Subclasses should implement this method to apply dataset-specific adjustments
         based on the processing results. Examples include:
         - Trimming dataset along append_dim to only include successfully processed data
-        - Loading existing coordinate values from final_store and updating them based on results
+        - Loading existing coordinate values from the primary store and updating them based on results
         - Updating metadata based on what was actually processed vs what was planned
 
         The default implementation here trims along append_dim to end at the most recent
@@ -266,7 +266,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     @classmethod
     def operational_update_jobs(
         cls,
-        final_store: zarr.abc.store.Store,
+        primary_store_factory: StoreFactory,
         tmp_store: Path,
         get_template_fn: Callable[[DatetimeLike], xr.Dataset],
         append_dim: AppendDim,
@@ -284,16 +284,16 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         The exact logic is dataset-specific, but it generally follows this pattern:
         1. Figure out the range of time to process: append_dim_start (inclusive) and append_dim_end (exclusive)
-            a. Read existing data from final_store to determine what's already processed
+            a. Read existing data from the primary store to determine what's already processed
             b. Optionally identify recent incomplete/non-final data for reprocessing
         2. Call get_template_fn(append_dim_end) to get the template_ds
         3. Create RegionJob instances by calling cls.get_jobs(..., filter_start=append_dim_start)
 
         Parameters
         ----------
-        final_store : zarr.abc.store.Store
-            The destination Zarr store to read existing data from and write updates to.
-        tmp_store : zarr.abc.store.Store | Path
+        primary_store_factory : StoreFactory
+            The factory to get the primary store to read existing data from and write updates to.
+        tmp_store : Path
             The temporary Zarr store to write into while processing.
         get_template_fn : Callable[[DatetimeLike], xr.Dataset]
             Function to get the template_ds for the operational update.
@@ -331,7 +331,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     def get_jobs(
         cls,
         kind: Literal["backfill", "operational-update"],
-        final_store: zarr.abc.store.Store,
+        primary_store_factory: StoreFactory,
         tmp_store: Path,
         template_ds: xr.Dataset,
         append_dim: AppendDim,
@@ -357,9 +357,9 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         Parameters
         ----------
-        final_store : zarr.abc.store.Store
-            The destination Zarr store to write into.
-        tmp_store : zarr.abc.store.Store | Path
+        primary_store_factory : StoreFactory
+            The factory to get the primary store to read existing data from and write updates to.
+        tmp_store : Path
             The temporary Zarr store to write into while processing.
         template_ds : xr.Dataset
             Dataset template defining structure and metadata.
@@ -442,7 +442,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         all_jobs = [
             cls(
-                final_store=final_store,
+                primary_store_factory=primary_store_factory,
                 tmp_store=tmp_store,
                 template_ds=template_ds,
                 data_vars=data_var_group,
@@ -468,7 +468,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 i.   Read data from source files into the shared array
                 ii.  Apply any required data transformations (e.g., rounding, deaccumulation)
                 iii. Write output shards to the tmp_store
-                iv.  Upload chunk data from tmp_store to final_store
+                iv.  Upload chunk data from tmp_store to the primary store
 
         Returns
         -------
@@ -477,8 +477,10 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         """
         processing_region_ds, output_region_ds = self._get_region_datasets()
 
+        primary_store = self.primary_store_factory.store()
+
         progress_tracker = UpdateProgressTracker(
-            self.final_store, self.reformat_job_name, self.region.start
+            primary_store, self.reformat_job_name, self.region.start
         )
         data_vars_to_process: Sequence[DATA_VAR] = progress_tracker.get_unprocessed(
             self.data_vars
@@ -489,9 +491,8 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 data_var_groups, self.max_vars_per_download_group
             )
 
-        template_utils.write_metadata(
-            self.template_ds, self.tmp_store, get_mode(self.tmp_store)
-        )
+        # Hardcode w since many region jobs may write metadata to the same tmp store
+        template_utils.write_metadata(self.template_ds, self.tmp_store, "w")
 
         results: dict[str, Sequence[SOURCE_FILE_COORD]] = {}
         upload_futures: list[Any] = []
@@ -555,7 +556,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                             self.template_ds,
                             self.append_dim,
                             self.tmp_store,
-                            self.final_store,
+                            primary_store,
                             partial(progress_tracker.record_completion, data_var.name),
                         )
                     )

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -491,7 +491,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 data_var_groups, self.max_vars_per_download_group
             )
 
-        # Hardcode w since many region jobs may write metadata to the same tmp store
         template_utils.write_metadata(self.template_ds, self.tmp_store)
 
         results: dict[str, Sequence[SOURCE_FILE_COORD]] = {}

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -492,7 +492,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             )
 
         # Hardcode w since many region jobs may write metadata to the same tmp store
-        template_utils.write_metadata(self.template_ds, self.tmp_store, "w")
+        template_utils.write_metadata(self.template_ds, self.tmp_store)
 
         results: dict[str, Sequence[SOURCE_FILE_COORD]] = {}
         upload_futures: list[Any] = []

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -27,7 +27,7 @@ class StorageConfig(FrozenBaseModel):
 class StoreFactory(FrozenBaseModel):
     storage_config: StorageConfig
     dataset_id: str
-    _template_config_version: str
+    template_config_version: str
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -36,7 +36,7 @@ class StoreFactory(FrozenBaseModel):
             case Env.dev:
                 return "dev"
             case Env.prod | Env.test:
-                return self._template_config_version
+                return self.template_config_version
             case _ as unreachable:
                 assert_never(unreachable)
 

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -1,0 +1,69 @@
+from collections.abc import Sequence
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal, assert_never
+
+import fsspec  # type: ignore[import-untyped]
+import zarr
+from pydantic import Field, computed_field
+
+from reformatters.common.config import Config, Env
+from reformatters.common.pydantic import FrozenBaseModel
+from reformatters.common.zarr import _LOCAL_ZARR_STORE_BASE_PATH
+
+
+class DatasetFormat(StrEnum):
+    ZARR3 = "zarr3"
+
+
+class StorageConfig(FrozenBaseModel):
+    """Configuration for the storage of a dataset in production."""
+
+    base_path: str
+    k8s_secret_names: Sequence[str] = Field(default_factory=tuple)
+    format: DatasetFormat
+
+
+class StoreFactory(FrozenBaseModel):
+    storage_config: StorageConfig
+    dataset_id: str
+    _template_config_version: str
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def version(self) -> str:
+        match Config.env:
+            case Env.dev:
+                return "dev"
+            case Env.prod | Env.test:
+                return self._template_config_version
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    def store(self) -> zarr.abc.store.Store:
+        if not Config.is_prod:
+            # This should work, but it gives FileNotFoundError when it should be creating a new zarr.
+            # return zarr.storage.FsspecStore.from_url(
+            #     "file://data/output/noaa/gefs/forecast/dev.zarr"
+            # )
+            # Instead make a zarr LocalStore and attach an fsspec filesystem to it.
+            # Technically that filesystem should be an AsyncFileSystem to match
+            # zarr.storage.FsspecStore but AsyncFileSystem does not support _put.
+            local_path = Path(
+                f"{_LOCAL_ZARR_STORE_BASE_PATH}/{self.dataset_id}/v{self.version}.zarr"
+            ).absolute()
+
+            store = zarr.storage.LocalStore(local_path)
+
+            fs = fsspec.implementations.local.LocalFileSystem(auto_mkdir=True)
+            store.fs = fs  # type: ignore[attr-defined]
+            store.path = str(local_path)  # type: ignore[attr-defined]
+            # We are duck typing this LocalStore as a FsspecStore
+            return store
+
+        return zarr.storage.FsspecStore.from_url(
+            f"{self.storage_config.base_path}/{self.dataset_id}/v{self.version}.zarr"
+        )
+
+    def mode(self) -> Literal["w", "w-"]:
+        return "w" if self.version == "dev" else "w-"

--- a/src/reformatters/common/template_config.py
+++ b/src/reformatters/common/template_config.py
@@ -152,7 +152,7 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
                 ds.coords[coord_config.name], coord_config
             )
 
-        template_utils.write_metadata(ds, self.template_path(), mode="w")
+        template_utils.write_metadata(ds, self.template_path())
 
     def append_dim_coordinate_chunk_size(self) -> int:
         """

--- a/src/reformatters/contrib/uarizona/swann/analysis/region_job.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/region_job.py
@@ -5,7 +5,6 @@ from typing import ClassVar
 import numpy as np
 import pandas as pd
 import xarray as xr
-import zarr
 from pydantic import Field
 from rasterio import rasterio  # type: ignore
 
@@ -15,6 +14,7 @@ from reformatters.common.region_job import (
     RegionJob,
     SourceFileCoord,
 )
+from reformatters.common.storage import StoreFactory
 from reformatters.common.types import (
     AppendDim,
     Array2D,
@@ -85,7 +85,7 @@ class UarizonaSwannAnalysisRegionJob(
     @classmethod
     def operational_update_jobs(
         cls,
-        final_store: zarr.abc.store.Store,
+        primary_store_factory: StoreFactory,
         tmp_store: Path,
         get_template_fn: Callable[[DatetimeLike], xr.Dataset],
         append_dim: AppendDim,
@@ -95,14 +95,14 @@ class UarizonaSwannAnalysisRegionJob(
         Sequence[RegionJob[UarizonaSwannDataVar, UarizonaSwannAnalysisSourceFileCoord]],
         xr.Dataset,
     ]:
-        existing_ds = xr.open_zarr(final_store)
+        existing_ds = xr.open_zarr(primary_store_factory.store())
         append_dim_start = cls._update_append_dim_start(existing_ds)
         append_dim_end = cls._update_append_dim_end()
         template_ds = get_template_fn(append_dim_end)
 
         jobs = cls.get_jobs(
             kind="operational-update",
-            final_store=final_store,
+            primary_store_factory=primary_store_factory,
             tmp_store=tmp_store,
             template_ds=template_ds,
             append_dim=append_dim,

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -148,10 +148,10 @@ def reformat_chunks(
     },
 )
 def reformat_operational_update(job_name: str) -> None:
-    final_store = get_store()
+    primary_store = get_store()
     tmp_store = get_local_tmp_store()
     # Get the dataset, check what data is already present
-    ds = xr.open_zarr(final_store, decode_timedelta=True)
+    ds = xr.open_zarr(primary_store, decode_timedelta=True)
     for coord in ds.coords.values():
         coord.load()
     last_existing_init_time = ds.init_time.max()
@@ -221,7 +221,7 @@ def reformat_operational_update(job_name: str) -> None:
         )
 
         progress_tracker = UpdateProgressTracker(
-            final_store, job_name, init_time_i_slice.start
+            primary_store, job_name, init_time_i_slice.start
         )
         vars_to_process = progress_tracker.get_unprocessed_str(
             list(template_ds.data_vars.keys())
@@ -244,7 +244,7 @@ def reformat_operational_update(job_name: str) -> None:
                     template_ds,
                     template.APPEND_DIMENSION,
                     tmp_store,
-                    final_store,
+                    primary_store,
                     partial(progress_tracker.record_completion, data_var.name),
                 )
             )
@@ -268,7 +268,7 @@ def reformat_operational_update(job_name: str) -> None:
             get_mode(tmp_store),
         )
         # Write the metadata last, the data must be written first
-        copy_zarr_metadata(truncated_template_ds, tmp_store, final_store)
+        copy_zarr_metadata(truncated_template_ds, tmp_store, primary_store)
 
 
 def _get_operational_update_init_time_end() -> pd.Timestamp:

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -195,7 +195,6 @@ def test_backfill_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
         "get_template",
         lambda self, end: xr.Dataset(attrs={"cool": "weather"}),
     )
-    monkeypatch.setattr(ExampleDataset, "_final_store", lambda _self: tmp_path)
     process_backfill_region_jobs_mock = Mock()
     monkeypatch.setattr(
         ExampleDataset,
@@ -210,7 +209,9 @@ def test_backfill_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
 
     dataset.backfill_local(pd.Timestamp("2000-01-02"))
 
-    assert xr.open_zarr(tmp_path).attrs["cool"] == "weather"
+    assert (
+        xr.open_zarr(dataset.primary_store_factory.store()).attrs["cool"] == "weather"
+    )
     process_backfill_region_jobs_mock.assert_called_once_with(
         pd.Timestamp("2000-01-02"),
         worker_index=0,
@@ -236,13 +237,15 @@ def test_backfill_kubernetes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
 
     # Mock template retrieval and metadata writing
     monkeypatch.setattr(ExampleConfig, "get_template", lambda self, end: xr.Dataset())
-    monkeypatch.setattr(ExampleDataset, "_final_store", lambda self: tmp_path)
     monkeypatch.setattr(template_utils, "write_metadata", lambda *args, **kwargs: None)
 
     dataset = ExampleDataset(
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,
     )
+    primary_store_factory = Mock()
+    monkeypatch.setattr(ExampleDataset, "primary_store_factory", primary_store_factory)
+    monkeypatch.setattr(primary_store_factory, "store", lambda: tmp_path)
 
     dataset.backfill_kubernetes(
         append_dim_end=datetime(2025, 1, 1),
@@ -273,14 +276,11 @@ def test_backfill_kubernetes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     assert '"my-docker-image"' in input_str
 
 
-def test_validate_dataset_calls_validators_and_uses_final_store(
+def test_validate_dataset_calls_validators_and_uses_primary_store(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     mock_validators = [Mock(), Mock()]
     monkeypatch.setattr(ExampleDataset, "validators", lambda self: mock_validators)
-
-    mock_store = Mock()
-    monkeypatch.setattr(ExampleDataset, "_final_store", lambda self: mock_store)
 
     mock_validate = Mock()
     monkeypatch.setattr(validation, "validate_dataset", mock_validate)
@@ -289,12 +289,16 @@ def test_validate_dataset_calls_validators_and_uses_final_store(
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,
     )
+    primary_store_factory = Mock()
+    mock_store = Mock()
+    monkeypatch.setattr(ExampleDataset, "primary_store_factory", primary_store_factory)
+    monkeypatch.setattr(primary_store_factory, "store", lambda: mock_store)
 
     dataset.validate_dataset("example-job-name")
 
     # Ensure validate_dataset was called with correct arguments
     # this implies
-    # - self._final_store() was called and returned our mock_store
+    # - self.primary_store_factory.store() was called and returned our mock_store
     # - self.validators() was called and returned our mock_validators
     mock_validate.assert_called_once_with(mock_store, validators=mock_validators)
 

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -19,24 +19,24 @@ from reformatters.common.config_models import (
     DataVarAttrs,
     Encoding,
 )
-from reformatters.common.dynamical_dataset import (
-    DynamicalDataset,
-    DynamicalDatasetStorageConfig,
-)
+from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 from reformatters.common.region_job import RegionJob, SourceFileCoord
+from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
 
-NOOP_STORAGE_CONFIG = DynamicalDatasetStorageConfig(
+NOOP_STORAGE_CONFIG = StorageConfig(
     base_path="noop",
     k8s_secret_names=["noop-secret"],
+    format=DatasetFormat.ZARR3,
 )
 
 
-class ExampleDatasetStorageConfig(DynamicalDatasetStorageConfig):
+class ExampleDatasetStorageConfig(StorageConfig):
     base_path: str = "s3://some-bucket/path"
     k8s_secret_names: Sequence[str] = ["k8s-secret-name"]
+    format: DatasetFormat = DatasetFormat.ZARR3
 
 
 class ExampleDataVar(DataVar[BaseInternalAttrs]):

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -123,7 +123,7 @@ def test_region_job(template_ds: xr.Dataset, store_factory: StoreFactory) -> Non
     tmp_store = get_local_tmp_store()
 
     # Write zarr metadata for this RegionJob to write into
-    template_utils.write_metadata(template_ds, store_factory.store(), mode="w")
+    template_utils.write_metadata(template_ds, store_factory)
 
     job = ExampleRegionJob(
         primary_store_factory=store_factory,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 # Config.env is set to test.
 os.environ["DYNAMICAL_ENV"] = "test"
 
+from reformatters.common import storage
 from reformatters.common import zarr as common_zarr_module
 
 
@@ -24,3 +25,4 @@ def set_local_zarr_store_base_path(
     ):
         return
     monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
+    monkeypatch.setattr(storage, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)

--- a/tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 from _pytest.monkeypatch import MonkeyPatch
 
-from reformatters.common.dynamical_dataset import DynamicalDatasetStorageConfig
+from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.contrib.noaa.ndvi_cdr.analysis.dynamical_dataset import (
     NoaaNdviCdrAnalysisDataset,
 )
@@ -14,8 +14,9 @@ from reformatters.contrib.noaa.ndvi_cdr.analysis.dynamical_dataset import (
 pytestmark = pytest.mark.slow
 
 
-noop_storage_config = DynamicalDatasetStorageConfig(
+noop_storage_config = StorageConfig(
     base_path="noop",
+    format=DatasetFormat.ZARR3,
 )
 
 

--- a/tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py
@@ -24,7 +24,7 @@ def test_backfill_local_and_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> 
     dataset = NoaaNdviCdrAnalysisDataset(storage_config=noop_storage_config)
     # Dataset starts at 1981-06-24, test with a couple days after start
     dataset.backfill_local(append_dim_end=pd.Timestamp("1981-06-25"))
-    ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
 
     assert ds.time.max() == pd.Timestamp("1981-06-24")
 
@@ -60,9 +60,9 @@ def test_backfill_local_and_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> 
 
     # Mock pd.Timestamp.now() to control the update end date
     monkeypatch.setattr("pandas.Timestamp.now", lambda: pd.Timestamp("1981-06-26"))
-
+    dataset = NoaaNdviCdrAnalysisDataset(storage_config=noop_storage_config)
     dataset.update("test-update")
-    updated_ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    updated_ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
     np.testing.assert_array_equal(
         updated_ds.time, pd.date_range("1981-06-24", "1981-06-25")
     )

--- a/tests/contrib/noaa/ndvi_cdr/analysis/region_job_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/region_job_test.py
@@ -8,7 +8,6 @@ import pytest
 import xarray as xr
 
 from reformatters.common.types import ArrayFloat32, ArrayInt16
-from reformatters.common.zarr import get_zarr_store
 from reformatters.contrib.noaa.ndvi_cdr.analysis.region_job import (
     NoaaNdviCdrAnalysisRegionJob,
     NoaaNdviCdrAnalysisSourceFileCoord,
@@ -86,7 +85,7 @@ def test_region_job_generate_source_file_coords(
     )
 
     region_job = NoaaNdviCdrAnalysisRegionJob.model_construct(
-        final_store=get_zarr_store("fake-prod-path", "test-dataset", "test-version"),
+        primary_store_factory=Mock(),
         tmp_store=Mock(),
         template_ds=template_ds,
         data_vars=template_config.data_vars,
@@ -160,7 +159,7 @@ def test_region_job_generate_source_file_coords_file_not_found(
     )
 
     region_job = NoaaNdviCdrAnalysisRegionJob.model_construct(
-        final_store=get_zarr_store("fake-prod-path", "test-dataset", "test-version"),
+        primary_store_factory=Mock(),
         tmp_store=Mock(),
         template_ds=template_ds,
         data_vars=template_config.data_vars,
@@ -192,7 +191,7 @@ def test_read_usable_ndvi_avhrr_era(monkeypatch: pytest.MonkeyPatch) -> None:
     template_config = NoaaNdviCdrAnalysisTemplateConfig()
 
     region_job = NoaaNdviCdrAnalysisRegionJob.model_construct(
-        final_store=get_zarr_store("fake-prod-path", "test-dataset", "test-version"),
+        primary_store_factory=Mock(),
         tmp_store=Mock(),
         template_ds=Mock(),
         data_vars=template_config.data_vars,
@@ -256,7 +255,7 @@ def test_read_usable_ndvi_viirs_era(monkeypatch: pytest.MonkeyPatch) -> None:
     template_config = NoaaNdviCdrAnalysisTemplateConfig()
 
     region_job = NoaaNdviCdrAnalysisRegionJob.model_construct(
-        final_store=get_zarr_store("fake-prod-path", "test-dataset", "test-version"),
+        primary_store_factory=Mock(),
         tmp_store=Mock(),
         template_ds=Mock(),
         data_vars=template_config.data_vars,
@@ -356,7 +355,7 @@ def test_generate_source_file_coords_uses_ncei_for_recent_year(
     )
 
     region_job = NoaaNdviCdrAnalysisRegionJob.model_construct(
-        final_store=get_zarr_store("prod-path", "test-dataset", "test-version"),
+        primary_store_factory=Mock(),
         tmp_store=Mock(),
         template_ds=template_ds,
         data_vars=template_config.data_vars,
@@ -412,7 +411,7 @@ def test_list_source_files_routing_by_year(
     template_config = NoaaNdviCdrAnalysisTemplateConfig()
 
     region_job = NoaaNdviCdrAnalysisRegionJob.model_construct(
-        final_store=get_zarr_store("prod-path", "test-dataset", "test-version"),
+        primary_store_factory=Mock(),
         tmp_store=Mock(),
         template_ds=Mock(),
         data_vars=template_config.data_vars,

--- a/tests/contrib/uarizona/swann/dataset_integration_test.py
+++ b/tests/contrib/uarizona/swann/dataset_integration_test.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 from _pytest.monkeypatch import MonkeyPatch
 
-from reformatters.common.dynamical_dataset import DynamicalDatasetStorageConfig
+from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.contrib.uarizona.swann.analysis import UarizonaSwannAnalysisDataset
 from reformatters.contrib.uarizona.swann.analysis.region_job import (
     UarizonaSwannAnalysisRegionJob,
@@ -16,8 +16,9 @@ from reformatters.contrib.uarizona.swann.analysis.region_job import (
 pytestmark = pytest.mark.slow
 
 
-noop_storage_config = DynamicalDatasetStorageConfig(
+noop_storage_config = StorageConfig(
     base_path="noop",
+    format=DatasetFormat.ZARR3,
 )
 
 

--- a/tests/contrib/uarizona/swann/dataset_integration_test.py
+++ b/tests/contrib/uarizona/swann/dataset_integration_test.py
@@ -26,7 +26,7 @@ def test_backfill_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     dataset = UarizonaSwannAnalysisDataset(storage_config=noop_storage_config)
     # Dataset starts at 1981-10-01
     dataset.backfill_local(append_dim_end=pd.Timestamp("1981-10-02"))
-    ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
     assert ds.snow_depth.mean() == 0.23608214
     assert ds.snow_water_equivalent.mean() == 0.0433126
 
@@ -39,7 +39,7 @@ def test_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     dataset = UarizonaSwannAnalysisDataset(storage_config=noop_storage_config)
     # Dataset starts at 1981-10-01
     dataset.backfill_local(append_dim_end=pd.Timestamp("1981-10-02"))
-    ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
     assert ds.time.max() == pd.Timestamp("1981-10-01")
 
     monkeypatch.setattr(
@@ -55,7 +55,7 @@ def test_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     )
 
     dataset.update("test-update")
-    updated_ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    updated_ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
     np.testing.assert_array_equal(
         updated_ds.time, pd.date_range("1981-10-01", "1981-10-03")
     )
@@ -70,7 +70,7 @@ def test_update_template_trimming(monkeypatch: MonkeyPatch, tmp_path: Path) -> N
     dataset = UarizonaSwannAnalysisDataset(storage_config=noop_storage_config)
     # Dataset starts at 1981-10-01
     dataset.backfill_local(append_dim_end=pd.Timestamp("1981-10-02"))
-    ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
     assert ds.time.max() == pd.Timestamp("1981-10-01")
 
     monkeypatch.setattr(
@@ -99,7 +99,7 @@ def test_update_template_trimming(monkeypatch: MonkeyPatch, tmp_path: Path) -> N
     monkeypatch.setattr(dataset.region_job_class, "download_file", mock_download_file)
 
     dataset.update("test-update")
-    updated_ds = xr.open_zarr(dataset._final_store(), chunks=None)
+    updated_ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
 
     # The dataset should only extend to 1981-10-02 because 1981-10-03 failed to download
     np.testing.assert_array_equal(

--- a/tests/example/dynamical_dataset_test.py
+++ b/tests/example/dynamical_dataset_test.py
@@ -14,7 +14,7 @@
 
 #     # Local backfill reformat
 #     dataset.backfill_local(append_dim_end=pd.Timestamp("2000-01-02"))
-#     ds = xr.open_zarr(dataset._final_store(), chunks=None)
+#     ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
 #     assert ds.time.max() == pd.Timestamp("2000-01-01")
 
 #     # Operational update
@@ -32,7 +32,7 @@
 #     dataset.update("test-update")
 
 #     # Check resulting dataset
-#     updated_ds = xr.open_zarr(dataset._final_store(), chunks=None)
+#     updated_ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)
 
 #     np.testing.assert_array_equal(
 #         updated_ds.time, pd.date_range("1981-10-01", "1981-10-03")

--- a/tests/example/region_job_test.py
+++ b/tests/example/region_job_test.py
@@ -18,7 +18,7 @@
 #     template_ds = template_config.get_template(pd.Timestamp("2000-01-23"))
 
 #     region_job = ExampleRegionJob(
-#         final_store=Mock(),
+#         primary_store_factory=Mock(),
 #         tmp_store=Mock(),
 #         template_ds=template_ds,
 #         data_vars=[Mock(), Mock()],

--- a/tests/noaa/gfs/forecast/region_job_test.py
+++ b/tests/noaa/gfs/forecast/region_job_test.py
@@ -3,14 +3,26 @@ from unittest.mock import Mock
 
 import pandas as pd
 import pytest
-import zarr
 
 from reformatters.common import template_utils
+from reformatters.common.storage import DatasetFormat, StorageConfig, StoreFactory
 from reformatters.noaa.gfs.forecast.region_job import (
     NoaaGfsForecastRegionJob,
     NoaaGfsForecastSourceFileCoord,
 )
 from reformatters.noaa.gfs.forecast.template_config import NoaaGfsForecastTemplateConfig
+
+
+@pytest.fixture
+def store_factory() -> StoreFactory:
+    return StoreFactory(
+        storage_config=StorageConfig(
+            base_path="fake-prod-path",
+            format=DatasetFormat.ZARR3,
+        ),
+        dataset_id="test-dataset-A",
+        template_config_version="test-version",
+    )
 
 
 def test_source_file_coord_get_url() -> None:
@@ -29,7 +41,7 @@ def test_region_job_generete_source_file_coords() -> None:
 
     # use `model_construct` to skip pydantic validation so we can pass mock stores
     region_job = NoaaGfsForecastRegionJob.model_construct(
-        final_store=Mock(),
+        primary_store_factory=Mock(),
         tmp_store=Mock(),
         template_ds=template_ds,
         data_vars=template_config.data_vars[:3],
@@ -68,7 +80,7 @@ def test_region_job_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Create a region job with mock stores
     region_job = NoaaGfsForecastRegionJob.model_construct(
-        final_store=Mock(),
+        primary_store_factory=Mock(),
         tmp_store=Mock(),
         template_ds=template_config.get_template(pd.Timestamp("2025-01-01")),
         data_vars=template_config.data_vars[:2],
@@ -134,6 +146,14 @@ def test_operational_update_jobs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     template_config = NoaaGfsForecastTemplateConfig()
+    primary_store_factory = StoreFactory(
+        storage_config=StorageConfig(
+            base_path="fake-prod-path",
+            format=DatasetFormat.ZARR3,
+        ),
+        dataset_id="test-dataset-A",
+        template_config_version="test-version",
+    )
 
     # Set the append_dim_end for the update
     monkeypatch.setattr(
@@ -144,11 +164,10 @@ def test_operational_update_jobs(
     existing_ds = template_config.get_template(
         pd.Timestamp("2025-01-01T06:01")  # 06 will be max existing init time
     )
-    final_store = zarr.storage.LocalStore(tmp_path / "existing_ds.zarr")
-    template_utils.write_metadata(existing_ds, final_store, mode="w-")
+    template_utils.write_metadata(existing_ds, primary_store_factory.store(), mode="w-")
 
     jobs, template_ds = NoaaGfsForecastRegionJob.operational_update_jobs(
-        final_store=final_store,
+        primary_store_factory=primary_store_factory,
         tmp_store=tmp_path / "tmp_ds.zarr",
         get_template_fn=template_config.get_template,
         append_dim=template_config.append_dim,

--- a/tests/noaa/gfs/forecast/region_job_test.py
+++ b/tests/noaa/gfs/forecast/region_job_test.py
@@ -164,7 +164,7 @@ def test_operational_update_jobs(
     existing_ds = template_config.get_template(
         pd.Timestamp("2025-01-01T06:01")  # 06 will be max existing init time
     )
-    template_utils.write_metadata(existing_ds, primary_store_factory.store(), mode="w-")
+    template_utils.write_metadata(existing_ds, primary_store_factory)
 
     jobs, template_ds = NoaaGfsForecastRegionJob.operational_update_jobs(
         primary_store_factory=primary_store_factory,


### PR DESCRIPTION
This PR introduces a `StoreFactory` abstraction that establishes a new pattern for accessing the `final_store` (the target final destination store for the dataset).  The motivation is to provide downstream modules (e.g., `RegionJob`) the means to re-instantiate the store, in order to support stores such as `icechunk` stores, which require instantiating a new store for every commit.

Notes the term `final store` has been replaced with `primary store` in preparation for support for replica stores.
