### PR TITLE
Arm build: update apt before installing libgdal-dev

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Arm Build Dependencies
         if: matrix.arch == 'arm64'
         run: |
-          sudo apt-get update -qyy
+          sudo apt-get update -qy
           sudo apt-get install -qyy -o APT::Install-Suggests=false libgdal-dev
 
       - name: Install dependencies

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Install Arm Build Dependencies
         if: matrix.arch == 'arm64'
-        run: sudo apt-get install -qyy -o APT::Install-Suggests=false libgdal-dev
+        run: |
+          sudo apt-get update -qyy
+          sudo apt-get install -qyy -o APT::Install-Suggests=false libgdal-dev
 
       - name: Install dependencies
         # Needed to be able to compile dependencies on ARM64

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,7 +38,7 @@ jobs:
         if: matrix.arch == 'arm64'
         run: |
           sudo apt-get update -qy
-          sudo apt-get install -qyy -o APT::Install-Suggests=false libgdal-dev
+          sudo apt-get install -qy -o APT::Install-Suggests=false libgdal-dev
 
       - name: Install dependencies
         # Needed to be able to compile dependencies on ARM64


### PR DESCRIPTION
On `main` we're getting the following while building `Arm` dependencies:

```
Err:61 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 libpoppler134 arm64 24.02.0-1ubuntu9.4
  404  Not Found [IP: 91.189.91.103 80]
Err:85 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 libpoppler-dev arm64 24.02.0-1ubuntu9.4
  404  Not Found [IP: 91.189.91.103 80]
Err:86 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 libpoppler-private-dev arm64 24.02.0-1ubuntu9.4
  404  Not Found [IP: 91.189.91.103 80]
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/libpoppler134_24.02.0-1ubuntu9.4_arm64.deb  404  Not Found [IP: 91.189.91.103 80]
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/libpoppler-dev_24.02.0-1ubuntu9.4_arm64.deb  404  Not Found [IP: 91.189.91.103 80]
Fetched 65.6 MB in 6s (10.6 MB/s)
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/libpoppler-private-dev_24.02.0-1ubuntu9.4_arm64.deb  404  Not Found [IP: 91.189.91.103 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

the `ubuntu9.4`  for `libpoppler` appears to have been pulled, but a 9.5 version exists: https://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/libpoppler134_24.02.0-1ubuntu9.5_arm64.deb