### PR TITLE
Refactor zarr data copying to use store.set instead of fsspec operations

### DIFF
--- a/src/reformatters/common/retry.py
+++ b/src/reformatters/common/retry.py
@@ -1,0 +1,15 @@
+import time
+from collections.abc import Callable
+from typing import Any
+
+
+def retry(func: Callable[[], Any], max_attempts: int = 6) -> Any:
+    """Simple retry utility that sleeps for a short time between attempts."""
+    for attempt in range(max_attempts):
+        try:
+            return func()
+        except Exception:
+            if attempt == max_attempts - 1:  # Last attempt failed
+                raise
+            time.sleep(attempt)
+            continue

--- a/tests/common/test_retry.py
+++ b/tests/common/test_retry.py
@@ -1,0 +1,23 @@
+from unittest.mock import Mock
+
+import pytest
+
+from reformatters.common.retry import retry
+
+
+def test_retry_succeeds_on_first_attempt() -> None:
+    mock_func = Mock(return_value="success")
+    result = retry(mock_func)
+    assert result == "success"
+
+
+def test_retry_succeeds_after_failures() -> None:
+    mock_func = Mock(side_effect=[ValueError("fail"), "success"])
+    result = retry(mock_func, max_attempts=3)
+    assert result == "success"
+
+
+def test_retry_fails_after_max_attempts() -> None:
+    mock_func = Mock(side_effect=ValueError("persistent failure"))
+    with pytest.raises(ValueError, match="persistent failure"):
+        retry(mock_func, max_attempts=2)


### PR DESCRIPTION
This PR refactors how we handle copying of data shards and metadata from the tmp store to another storage location. Instead of using `fsspec_apply` we can use the `set` method on our destination store. This also sets us up to be able to interface with an `icechunk` store in the same way (where fsspec operations would not work).