### PR TITLE
NDVI CDR integration test source file fix

### DIFF
--- a/tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py
@@ -24,6 +24,12 @@ noop_storage_config = StorageConfig(
 
 
 def test_backfill_local_and_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        NoaaNdviCdrAnalysisRegionJob,
+        "_use_ncei_to_download",
+        lambda self, file_time: False,
+    )
+
     dataset = NoaaNdviCdrAnalysisDataset(storage_config=noop_storage_config)
     # Dataset starts at 1981-06-24, test with a couple days after start
     dataset.backfill_local(append_dim_end=pd.Timestamp("1981-06-25"))
@@ -63,11 +69,6 @@ def test_backfill_local_and_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> 
 
     # Mock pd.Timestamp.now() to control the update end date
     monkeypatch.setattr("pandas.Timestamp.now", lambda: pd.Timestamp("1981-06-26"))
-    monkeypatch.setattr(
-        NoaaNdviCdrAnalysisRegionJob,
-        "_use_ncei_to_download",
-        lambda self, file_time: False,
-    )
     dataset = NoaaNdviCdrAnalysisDataset(storage_config=noop_storage_config)
     dataset.update("test-update")
     updated_ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)

--- a/tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py
@@ -10,6 +10,9 @@ from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.contrib.noaa.ndvi_cdr.analysis.dynamical_dataset import (
     NoaaNdviCdrAnalysisDataset,
 )
+from reformatters.contrib.noaa.ndvi_cdr.analysis.region_job import (
+    NoaaNdviCdrAnalysisRegionJob,
+)
 
 pytestmark = pytest.mark.slow
 
@@ -60,6 +63,11 @@ def test_backfill_local_and_update(monkeypatch: MonkeyPatch, tmp_path: Path) -> 
 
     # Mock pd.Timestamp.now() to control the update end date
     monkeypatch.setattr("pandas.Timestamp.now", lambda: pd.Timestamp("1981-06-26"))
+    monkeypatch.setattr(
+        NoaaNdviCdrAnalysisRegionJob,
+        "_use_ncei_to_download",
+        lambda self, file_time: False,
+    )
     dataset = NoaaNdviCdrAnalysisDataset(storage_config=noop_storage_config)
     dataset.update("test-update")
     updated_ds = xr.open_zarr(dataset.primary_store_factory.store(), chunks=None)


### PR DESCRIPTION
This PR fixes a bug where we were downloading data from NCEI for 1980s data. The bug was due to the fact that we monkeypatch `Timestamp.now` to an older date. This PR ensures that the integration test always uses S3.