### PR TITLE
Load k8s secrets from mounted volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We use
 1. Install `docker` and `kubectl`. Make sure `docker` can be found at /usr/bin/docker and `kubectl` at /usr/bin/kubectl.
 1. Setup a docker image repository and export the DOCKER_REPOSITORY environment variable in your local shell. eg. `export DOCKER_REPOSITORY=us-central1-docker.pkg.dev/<project-id>/reformatters/main`
 1. Setup a kubernetes cluster and configure kubectl to point to your cluster. eg `gcloud container clusters get-credentials <cluster-name> --region <region> --project <project>`
-1. Create a kubectl secret containing your Source Coop S3 credentials `kubectl create secret generic source-coop-key --from-literal='AWS_ACCESS_KEY_ID=xxx' --from-literal='AWS_SECRET_ACCESS_KEY=xxx'` and set these environment variables in your local shell `export AWS_ACCESS_KEY_ID=xxx; export AWS_SECRET_ACCESS_KEY=xxx`.
+1. Create a kubectl secret containing your Source Coop S3 credentials `kubectl create secret generic source-coop-storage-options-key --from-literal=storage_options.json='{"key": "...", "secret": "..."}'`.
 
 
 ### Development commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "typer>=0.12.5",
     "xarray>=2025.1.2",
     "zarr>=3.0.4",
+    "kubernetes>=33.1.0",
 ]
 
 [build-system]

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -38,7 +38,7 @@ class UpstreamGriddedZarrsDatasetStorageConfig(StorageConfig):
     # The R2 endpoint URL is stored within our k8s secret and will be set
     # when it's imported into the env.
     base_path: str = "s3://upstream-gridded-zarrs"
-    k8s_secret_name: str = "upstream-gridded-zarrs-key"  # noqa: S105
+    k8s_secret_name: str = "upstream-gridded-zarrs-storage-options-key"  # noqa: S105
     format: DatasetFormat = DatasetFormat.ZARR3
 
 

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -27,7 +27,7 @@ class SourceCoopDatasetStorageConfig(StorageConfig):
     """Configuration for the storage of a SourceCoop dataset."""
 
     base_path: str = "s3://us-west-2.opendata.source.coop/dynamical"
-    k8s_secret_names: Sequence[str] = ["source-coop-key"]
+    k8s_secret_name: str = "source-coop-key"  # noqa: S105
     format: DatasetFormat = DatasetFormat.ZARR3
 
 
@@ -38,7 +38,7 @@ class UpstreamGriddedZarrsDatasetStorageConfig(StorageConfig):
     # The R2 endpoint URL is stored within our k8s secret and will be set
     # when it's imported into the env.
     base_path: str = "s3://upstream-gridded-zarrs"
-    k8s_secret_names: Sequence[str] = ["upstream-gridded-zarrs-key"]
+    k8s_secret_name: str = "upstream-gridded-zarrs-key"  # noqa: S105
     format: DatasetFormat = DatasetFormat.ZARR3
 
 

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -27,7 +27,7 @@ class SourceCoopDatasetStorageConfig(StorageConfig):
     """Configuration for the storage of a SourceCoop dataset."""
 
     base_path: str = "s3://us-west-2.opendata.source.coop/dynamical"
-    k8s_secret_name: str = "source-coop-key"  # noqa: S105
+    k8s_secret_name: str = "source-coop-storage-options-key"  # noqa: S105
     format: DatasetFormat = DatasetFormat.ZARR3
 
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -71,7 +71,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             memory="30G",
             shared_memory="12G",
             ephemeral_storage="30G",
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
@@ -81,7 +81,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             dataset_id=self.dataset_id,
             cpu="1.3",
             memory="7G",
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
 
         return [operational_update_cron_job, validation_cron_job]
@@ -233,7 +233,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                     "pod_active_deadline",
                 }
             ),
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
         subprocess.run(
             ["/usr/bin/kubectl", "apply", "-f", "-"],

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -26,13 +26,10 @@ from reformatters.common.kubernetes import (
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.region_job import RegionJob, SourceFileCoord
-from reformatters.common.storage import StorageConfig, StoreFactory
+from reformatters.common.storage import StorageConfig, StoreFactory, get_local_tmp_store
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import DatetimeLike
-from reformatters.common.zarr import (
-    copy_zarr_metadata,
-    get_local_tmp_store,
-)
+from reformatters.common.zarr import copy_zarr_metadata
 
 DATA_VAR = TypeVar("DATA_VAR", bound=DataVar[Any])
 SOURCE_FILE_COORD = TypeVar("SOURCE_FILE_COORD", bound=SourceFileCoord)

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -24,6 +24,8 @@ class Job(pydantic.BaseModel):
     pod_active_deadline: timedelta = timedelta(hours=6)
 
     secret_names: Sequence[str] = pydantic.Field(default_factory=list)
+    # This is to support legacy datasets that have not yet been ported to the DynamicalDataset pattern
+    # (GEFS forecast and GEFS analysis).
     env_var_secret_names: Sequence[str] = pydantic.Field(default_factory=list)
 
     @property

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -126,6 +126,15 @@ class Job(pydantic.BaseModel):
                                         "mountPath": "/dev/shm",  # noqa: S108 yes we're using a known, shared path
                                         "name": "shared-memory-dir",
                                     },
+                                    *[
+                                        {
+                                            "name": secret_name,
+                                            "mountPath": f"/secrets/{secret_name}.json",
+                                            "subPath": "storage_options.json",
+                                            "readOnly": True,
+                                        }
+                                        for secret_name in self.secret_names
+                                    ],
                                 ],
                             }
                         ],
@@ -163,6 +172,13 @@ class Job(pydantic.BaseModel):
                                     "sizeLimit": self.shared_memory,
                                 },
                             },
+                            *[
+                                {
+                                    "name": secret_name,
+                                    "secret": {"secretName": secret_name},
+                                }
+                                for secret_name in self.secret_names
+                            ],
                         ],
                     }
                 },

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -22,7 +22,8 @@ class Job(pydantic.BaseModel):
     ttl: timedelta = timedelta(days=1)
     pod_active_deadline: timedelta = timedelta(hours=6)
 
-    secret_names: Sequence[str] = []
+    secret_names: Sequence[str] = pydantic.Field(default_factory=list)
+    env_var_secret_names: Sequence[str] = pydantic.Field(default_factory=list)
 
     @property
     def job_name(self) -> str:
@@ -109,8 +110,8 @@ class Job(pydantic.BaseModel):
                                     },
                                 ],
                                 "envFrom": [
-                                    {"secretRef": {"name": secret_name}}
-                                    for secret_name in self.secret_names
+                                    {"secretRef": {"name": env_var_secret_name}}
+                                    for env_var_secret_name in self.env_var_secret_names
                                 ],
                                 "image": f"{self.image}",
                                 "name": "worker",

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from typing import Annotated, Any
 
 import pydantic
+from kubernetes import client, config  # type: ignore[import-untyped]
 
 
 class Job(pydantic.BaseModel):
@@ -222,3 +223,11 @@ class ValidationCronJob(CronJob):
     command: Sequence[str] = ["validate"]
     workers_total: int = 1
     parallelism: int = 1
+
+
+def load_k8s_secrets_locally(secret_name: str) -> dict[str, Any]:
+    config.load_kube_config()
+    v1 = client.CoreV1Api()
+    secret = v1.read_namespaced_secret(secret_name, "default")
+    assert isinstance(secret.data, dict)
+    return secret.data

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -147,7 +147,9 @@ class Job(pydantic.BaseModel):
                             "fsGroup": 999,  # this is the `app` group our app runs under
                         },
                         "terminationGracePeriodSeconds": 5,
-                        "activeDeadlineSeconds": self.pod_active_deadline.total_seconds(),
+                        "activeDeadlineSeconds": int(
+                            self.pod_active_deadline.total_seconds()
+                        ),
                         "volumes": [
                             {
                                 "ephemeral": {

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -482,7 +482,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         progress_tracker = UpdateProgressTracker(
             self.reformat_job_name,
             self.region.start,
-            self.primary_store_factory.store_path,
+            self.primary_store_factory,
         )
         data_vars_to_process: Sequence[DATA_VAR] = progress_tracker.get_unprocessed(
             self.data_vars

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -43,7 +43,7 @@ class StorageConfig(FrozenBaseModel):
         # because this happens locally, we don't have the secret mounted. In this case
         # we will attempt to load the secrets from kubernetes locally. This assumes that
         # we are connected to the kubernetes cluster locally. We have a guard on JOB_NAME
-        # to ensure that we don't try to do this this is run within the kubernetes cluster.
+        # to ensure that we don't try to do this when this is run in the cluster.
         if not secret_file.exists() and os.getenv("JOB_NAME") is None:
             return self._load_storage_options_locally()
 

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from enum import StrEnum
 from functools import cache
 from pathlib import Path
@@ -7,7 +6,7 @@ from uuid import uuid4
 
 import fsspec  # type: ignore
 import zarr
-from pydantic import Field, computed_field
+from pydantic import computed_field
 
 from reformatters.common.config import Config, Env
 from reformatters.common.pydantic import FrozenBaseModel
@@ -23,7 +22,7 @@ class StorageConfig(FrozenBaseModel):
     """Configuration for the storage of a dataset in production."""
 
     base_path: str
-    k8s_secret_names: Sequence[str] = Field(default_factory=tuple)
+    k8s_secret_name: str = ""
     format: DatasetFormat
 
 

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -28,12 +28,12 @@ class StorageConfig(FrozenBaseModel):
     """Configuration for the storage of a dataset in production."""
 
     base_path: str
-    k8s_secret_name: str = ""
+    k8s_secret_name: str | None = None
     format: DatasetFormat
 
     def load_storage_options(self) -> dict[str, Any]:
         """Load the storage options from the Kubernetes secret."""
-        if not Config.is_prod or self.k8s_secret_name == "":
+        if not Config.is_prod or self.k8s_secret_name is None:
             return {}
 
         secret_file = Path(_SECRET_MOUNT_PATH) / f"{self.k8s_secret_name}.json"
@@ -53,6 +53,7 @@ class StorageConfig(FrozenBaseModel):
             return options
 
     def _load_storage_options_locally(self) -> dict[str, Any]:
+        assert self.k8s_secret_name is not None
         secret_data = kubernetes.load_k8s_secrets_locally(self.k8s_secret_name)
         storage_options_json = base64.b64decode(
             secret_data[_STORAGE_OPTIONS_KEY]

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -87,7 +87,8 @@ class StoreFactory(FrozenBaseModel):
         The filesystem type depends on the store_path (e.g., LocalFileSystem
         for file://, S3FileSystem for s3://, etc.).
         """
-        fs, relative_path = fsspec.core.url_to_fs(self.store_path)
+        storage_options = self.storage_config.load_storage_options()
+        fs, relative_path = fsspec.core.url_to_fs(self.store_path, **storage_options)
         assert isinstance(fs, fsspec.spec.AbstractFileSystem)
         return fs, relative_path
 

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -1,14 +1,17 @@
 from collections.abc import Sequence
 from enum import StrEnum
+from functools import cache
 from pathlib import Path
 from typing import Literal, assert_never
+from uuid import uuid4
 
 import zarr
 from pydantic import Field, computed_field
 
 from reformatters.common.config import Config, Env
 from reformatters.common.pydantic import FrozenBaseModel
-from reformatters.common.zarr import _LOCAL_ZARR_STORE_BASE_PATH
+
+_LOCAL_ZARR_STORE_BASE_PATH = "data/output"
 
 
 class DatasetFormat(StrEnum):
@@ -62,3 +65,8 @@ class StoreFactory(FrozenBaseModel):
 
     def mode(self) -> Literal["w", "w-"]:
         return "w" if self.version == "dev" else "w-"
+
+
+@cache
+def get_local_tmp_store() -> Path:
+    return Path(f"data/tmp/{uuid4()}-tmp.zarr").absolute()

--- a/src/reformatters/common/update_progress_tracker.py
+++ b/src/reformatters/common/update_progress_tracker.py
@@ -8,6 +8,7 @@ import fsspec  # type: ignore
 from reformatters.common.config_models import BaseInternalAttrs, DataVar
 from reformatters.common.logging import get_logger
 from reformatters.common.retry import retry
+from reformatters.common.storage import StoreFactory
 
 log = get_logger(__name__)
 
@@ -24,14 +25,15 @@ class UpdateProgressTracker:
         self,
         reformat_job_name: str,
         time_i_slice_start: int,
-        store_path: str,
+        store_factory: StoreFactory,
     ):
         self.reformat_job_name = reformat_job_name
         self.time_i_slice_start = time_i_slice_start
         self.queue: queue.Queue[str] = queue.Queue()
 
-        self.fs, self.update_progress_dir = fsspec.core.url_to_fs(
-            store_path.replace(".zarr", "_update_progress")
+        self.fs, relative_store_path = store_factory.fsspec_filesystem()
+        self.update_progress_dir = relative_store_path.replace(
+            ".zarr", "_update_progress"
         )
 
         if isinstance(self.fs, fsspec.implementations.local.LocalFileSystem):

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -1,14 +1,9 @@
 from collections.abc import Callable
-from functools import cache
 from pathlib import Path
-from typing import Literal
-from uuid import uuid4
 
 import xarray as xr
 import zarr
-from fsspec.implementations.local import LocalFileSystem  # type: ignore
 
-from reformatters.common.config import Config
 from reformatters.common.logging import get_logger
 from reformatters.common.retry import retry
 
@@ -37,60 +32,6 @@ BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE = zarr.codecs.BloscCodec(
     clevel=3,
     shuffle="shuffle",
 ).to_dict()
-
-
-def get_zarr_store(
-    prod_base_path: str, dataset_id: str, version: str
-) -> zarr.storage.FsspecStore:
-    if not Config.is_prod:
-        version = "dev" if Config.is_dev else version
-
-        # This should work, but it gives FileNotFoundError when it should be creating a new zarr.
-        # return zarr.storage.FsspecStore.from_url(
-        #     "file://data/output/noaa/gefs/forecast/dev.zarr"
-        # )
-        # Instead make a zarr LocalStore and attach an fsspec filesystem to it.
-        # Technically that filesystem should be an AsyncFileSystem to match
-        # zarr.storage.FsspecStore but AsyncFileSystem does not support _put.
-        local_path = Path(
-            f"{_LOCAL_ZARR_STORE_BASE_PATH}/{dataset_id}/v{version}.zarr"
-        ).absolute()
-
-        store = zarr.storage.LocalStore(local_path)
-
-        fs = LocalFileSystem(auto_mkdir=True)
-        store.fs = fs  # type: ignore[attr-defined]
-        store.path = str(local_path)  # type: ignore[attr-defined]
-
-        # We are duck typing this LocalStore as a FsspecStore
-        return store  # type: ignore[return-value]
-
-    return zarr.storage.FsspecStore.from_url(
-        f"{prod_base_path}/{dataset_id}/v{version}.zarr"
-    )
-
-
-@cache
-def get_local_tmp_store() -> Path:
-    return Path(f"data/tmp/{uuid4()}-tmp.zarr").absolute()
-
-
-def get_mode(
-    store: zarr.abc.store.Store | Path,
-) -> Literal["w-", "w"]:
-    if isinstance(store, zarr.storage.FsspecStore):
-        path_str = store.path
-    elif isinstance(store, zarr.storage.LocalStore):
-        path_str = store.root.name
-    elif isinstance(store, Path):
-        path_str = store.name
-    else:
-        raise ValueError(f"Unexpected store type: {type(store)}")
-
-    if path_str.endswith(("dev.zarr", "-tmp.zarr")):
-        return "w"  # Allow overwritting dev store
-
-    return "w-"  # Safe default - don't overwrite
 
 
 def copy_data_var(

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
@@ -30,7 +30,7 @@ class NoaaNdviCdrAnalysisDataset(
             memory="100G",
             shared_memory="76Gi",
             ephemeral_storage="150G",
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
@@ -40,7 +40,7 @@ class NoaaNdviCdrAnalysisDataset(
             dataset_id=self.dataset_id,
             cpu="1.3",
             memory="7G",
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -45,7 +45,7 @@ class UarizonaSwannAnalysisDataset(
             memory="14G",
             shared_memory="6Gi",
             ephemeral_storage="10G",
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
@@ -55,7 +55,7 @@ class UarizonaSwannAnalysisDataset(
             dataset_id=self.dataset_id,
             cpu="1.3",
             memory="7G",
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/dwd/icon_eu/forecast/dynamical_dataset.py
+++ b/src/reformatters/dwd/icon_eu/forecast/dynamical_dataset.py
@@ -26,7 +26,7 @@ class DwdIconEuForecastDataset(
         #     memory="30G",
         #     shared_memory="12G",
         #     ephemeral_storage="30G",
-        #     secret_names=self.storage_config.k8s_secret_names,
+        #     secret_names=[self.storage_config.k8s_secret_name],
         # )
         # validation_cron_job = ValidationCronJob(
         #     name=f"{self.dataset_id}-validation",
@@ -36,7 +36,7 @@ class DwdIconEuForecastDataset(
         #     dataset_id=self.dataset_id,
         #     cpu="1.3",
         #     memory="7G",
-        #     secret_names=self.storage_config.k8s_secret_names,
+        #     secret_names=[self.storage_config.k8s_secret_name],
         # )
 
         # return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/example/dynamical_dataset.py
+++ b/src/reformatters/example/dynamical_dataset.py
@@ -24,7 +24,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
         #     memory="30G",
         #     shared_memory="12G",
         #     ephemeral_storage="30G",
-        #     secret_names=self.storage_config.k8s_secret_names,
+        #     secret_names=[self.storage_config.k8s_secret_name],
         # )
         # validation_cron_job = ValidationCronJob(
         #     name=f"{self.dataset_id}-validation",
@@ -34,7 +34,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
         #     dataset_id=self.dataset_id,
         #     cpu="1.3",
         #     memory="7G",
-        #     secret_names=self.storage_config.k8s_secret_names,
+        #     secret_names=[self.storage_config.k8s_secret_name],
         # )
 
         # return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -331,7 +331,7 @@ def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
         memory="30G",  # fit on 32GB node
         shared_memory="12G",
         ephemeral_storage="35G",
-        secret_names=["source-coop-key"],
+        env_var_secret_names=["source-coop-key"],
     )
     validation_cron_job = ValidationCronJob(
         name=f"{template.DATASET_ID}-validation",
@@ -341,7 +341,7 @@ def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
         dataset_id=template.DATASET_ID,
         cpu="1.3",  # fit on 2 vCPU node
         memory="7G",  # fit on 8GB node
-        secret_names=["source-coop-key"],
+        env_var_secret_names=["source-coop-key"],
     )
 
     return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -41,7 +41,9 @@ from reformatters.noaa.gefs.analysis.reformat_internals import (
 )
 from reformatters.noaa.gefs.gefs_config_models import GEFSDataVar
 from reformatters.noaa.gefs.gefs_utils import get_mode, get_zarr_store
-from reformatters.noaa.gefs.legacy_progress_tracker import UpdateProgressTracker
+from reformatters.noaa.gefs.legacy_progress_tracker import (
+    LegacyUpdateProgressTracker as UpdateProgressTracker,
+)
 
 # 1 makes logic simpler when accessing GEFSv12 reforecast which has a file per variable
 _VARIABLES_PER_BACKFILL_JOB = 1

--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -29,7 +29,6 @@ from reformatters.common.kubernetes import (
 from reformatters.common.logging import get_logger
 from reformatters.common.reformat_utils import ChunkFilters
 from reformatters.common.types import DatetimeLike
-from reformatters.common.update_progress_tracker import UpdateProgressTracker
 from reformatters.common.zarr import (
     copy_data_var,
     copy_zarr_metadata,
@@ -43,6 +42,7 @@ from reformatters.noaa.gefs.analysis.reformat_internals import (
     reformat_time_i_slices,
 )
 from reformatters.noaa.gefs.gefs_config_models import GEFSDataVar
+from reformatters.noaa.gefs.legacy_progress_tracker import UpdateProgressTracker
 
 # 1 makes logic simpler when accessing GEFSv12 reforecast which has a file per variable
 _VARIABLES_PER_BACKFILL_JOB = 1

--- a/src/reformatters/noaa/gefs/analysis/reformat.py
+++ b/src/reformatters/noaa/gefs/analysis/reformat.py
@@ -28,13 +28,11 @@ from reformatters.common.kubernetes import (
 )
 from reformatters.common.logging import get_logger
 from reformatters.common.reformat_utils import ChunkFilters
+from reformatters.common.storage import get_local_tmp_store
 from reformatters.common.types import DatetimeLike
 from reformatters.common.zarr import (
     copy_data_var,
     copy_zarr_metadata,
-    get_local_tmp_store,
-    get_mode,
-    get_zarr_store,
 )
 from reformatters.noaa.gefs.analysis import template
 from reformatters.noaa.gefs.analysis.reformat_internals import (
@@ -42,6 +40,7 @@ from reformatters.noaa.gefs.analysis.reformat_internals import (
     reformat_time_i_slices,
 )
 from reformatters.noaa.gefs.gefs_config_models import GEFSDataVar
+from reformatters.noaa.gefs.gefs_utils import get_mode, get_zarr_store
 from reformatters.noaa.gefs.legacy_progress_tracker import UpdateProgressTracker
 
 # 1 makes logic simpler when accessing GEFSv12 reforecast which has a file per variable

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -23,19 +23,18 @@ from reformatters.common.iterating import (
 from reformatters.common.kubernetes import Job, ReformatCronJob, ValidationCronJob
 from reformatters.common.logging import get_logger
 from reformatters.common.reformat_utils import ChunkFilters
+from reformatters.common.storage import get_local_tmp_store
 from reformatters.common.types import Array1D, DatetimeLike
 from reformatters.common.zarr import (
     copy_data_var,
     copy_zarr_metadata,
-    get_local_tmp_store,
-    get_mode,
-    get_zarr_store,
 )
 from reformatters.noaa.gefs.forecast_35_day import template
 from reformatters.noaa.gefs.forecast_35_day.reformat_internals import (
     group_data_vars_by_gefs_file_type,
     reformat_init_time_i_slices,
 )
+from reformatters.noaa.gefs.gefs_utils import get_mode, get_zarr_store
 from reformatters.noaa.gefs.legacy_progress_tracker import UpdateProgressTracker
 
 _VARIABLES_PER_BACKFILL_JOB = 3

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -24,7 +24,6 @@ from reformatters.common.kubernetes import Job, ReformatCronJob, ValidationCronJ
 from reformatters.common.logging import get_logger
 from reformatters.common.reformat_utils import ChunkFilters
 from reformatters.common.types import Array1D, DatetimeLike
-from reformatters.common.update_progress_tracker import UpdateProgressTracker
 from reformatters.common.zarr import (
     copy_data_var,
     copy_zarr_metadata,
@@ -37,6 +36,7 @@ from reformatters.noaa.gefs.forecast_35_day.reformat_internals import (
     group_data_vars_by_gefs_file_type,
     reformat_init_time_i_slices,
 )
+from reformatters.noaa.gefs.legacy_progress_tracker import UpdateProgressTracker
 
 _VARIABLES_PER_BACKFILL_JOB = 3
 _OPERATIONAL_CRON_SCHEDULE = "0 7 * * *"  # At 7:00 UTC every day.

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -35,7 +35,9 @@ from reformatters.noaa.gefs.forecast_35_day.reformat_internals import (
     reformat_init_time_i_slices,
 )
 from reformatters.noaa.gefs.gefs_utils import get_mode, get_zarr_store
-from reformatters.noaa.gefs.legacy_progress_tracker import UpdateProgressTracker
+from reformatters.noaa.gefs.legacy_progress_tracker import (
+    LegacyUpdateProgressTracker as UpdateProgressTracker,
+)
 
 _VARIABLES_PER_BACKFILL_JOB = 3
 _OPERATIONAL_CRON_SCHEDULE = "0 7 * * *"  # At 7:00 UTC every day.

--- a/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/reformat.py
@@ -328,7 +328,7 @@ def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
         memory="60G",  # fit on 64GB node
         shared_memory="24G",
         ephemeral_storage="150G",
-        secret_names=["source-coop-key"],
+        env_var_secret_names=["source-coop-key"],
     )
     validation_cron_job = ValidationCronJob(
         name=f"{template.DATASET_ID}-validation",
@@ -338,7 +338,7 @@ def operational_kubernetes_resources(image_tag: str) -> Iterable[Job]:
         dataset_id=template.DATASET_ID,
         cpu="3",  # fit on 4 vCPU node
         memory="30G",  # fit on 32GB node
-        secret_names=["source-coop-key"],
+        env_var_secret_names=["source-coop-key"],
     )
 
     return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/gefs/gefs_utils.py
+++ b/src/reformatters/noaa/gefs/gefs_utils.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from typing import Literal
+
+import zarr
+from fsspec.implementations.local import LocalFileSystem  # type: ignore
+
+from reformatters.common import storage
+from reformatters.common.config import Config
+
+
+def get_zarr_store(
+    prod_base_path: str, dataset_id: str, version: str
+) -> zarr.storage.FsspecStore:
+    if not Config.is_prod:
+        version = "dev" if Config.is_dev else version
+
+        # This should work, but it gives FileNotFoundError when it should be creating a new zarr.
+        # return zarr.storage.FsspecStore.from_url(
+        #     "file://data/output/noaa/gefs/forecast/dev.zarr"
+        # )
+        # Instead make a zarr LocalStore and attach an fsspec filesystem to it.
+        # Technically that filesystem should be an AsyncFileSystem to match
+        # zarr.storage.FsspecStore but AsyncFileSystem does not support _put.
+        local_path = Path(
+            f"{storage._LOCAL_ZARR_STORE_BASE_PATH}/{dataset_id}/v{version}.zarr"
+        ).absolute()
+
+        store = zarr.storage.LocalStore(local_path)
+
+        fs = LocalFileSystem(auto_mkdir=True)
+        store.fs = fs  # type: ignore[attr-defined]
+        store.path = str(local_path)  # type: ignore[attr-defined]
+
+        # We are duck typing this LocalStore as a FsspecStore
+        return store  # type: ignore[return-value]
+
+    return zarr.storage.FsspecStore.from_url(
+        f"{prod_base_path}/{dataset_id}/v{version}.zarr"
+    )
+
+
+def get_mode(
+    store: zarr.abc.store.Store | Path,
+) -> Literal["w-", "w"]:
+    if isinstance(store, zarr.storage.FsspecStore):
+        path_str = store.path
+    elif isinstance(store, zarr.storage.LocalStore):
+        path_str = store.root.name
+    elif isinstance(store, Path):
+        path_str = store.name
+    else:
+        raise ValueError(f"Unexpected store type: {type(store)}")
+
+    if path_str.endswith(("dev.zarr", "-tmp.zarr")):
+        return "w"  # Allow overwritting dev store
+
+    return "w-"  # Safe default - don't overwrite

--- a/src/reformatters/noaa/gefs/legacy_progress_tracker.py
+++ b/src/reformatters/noaa/gefs/legacy_progress_tracker.py
@@ -1,0 +1,110 @@
+"""Legacy implementation for GEFS datasets that have not yet been ported to the DynamicalDataset pattern."""
+
+import json
+import queue
+import threading
+from collections.abc import Sequence
+
+import fsspec  # type: ignore
+
+from reformatters.common.config_models import BaseInternalAttrs, DataVar
+from reformatters.common.logging import get_logger
+from reformatters.common.retry import retry
+
+log = get_logger(__name__)
+
+PROCESSED_VARIABLES_KEY = "processed_variables"
+
+
+class UpdateProgressTracker:
+    """
+    Tracks which variables have been processed within a time slice of a job.
+    Allows for skipping already processed variables in case the process is interrupted.
+    """
+
+    def __init__(
+        self,
+        reformat_job_name: str,
+        time_i_slice_start: int,
+        store_path: str,
+    ):
+        self.reformat_job_name = reformat_job_name
+        self.time_i_slice_start = time_i_slice_start
+        self.queue: queue.Queue[str] = queue.Queue()
+
+        self.fs, self.update_progress_dir = fsspec.core.url_to_fs(
+            store_path.replace(".zarr", "_update_progress")
+        )
+
+        if isinstance(self.fs, fsspec.implementations.local.LocalFileSystem):
+            self.fs.makedirs(self.update_progress_dir, exist_ok=True)
+
+        try:
+            file_content = retry(
+                lambda: self.fs.read_text(self._get_path(), encoding="utf-8"),
+                max_attempts=1,
+            )
+            self.processed_variables: set[str] = set(
+                json.loads(file_content)[PROCESSED_VARIABLES_KEY]
+            )
+            log.info(
+                f"Loaded {len(self.processed_variables)} processed variables: {self.processed_variables}"
+            )
+        except FileNotFoundError:
+            self.processed_variables = set()
+
+        self.thread = threading.Thread(target=self._process_queue, daemon=True)
+        self.thread.start()
+
+    def record_completion(self, var: str) -> None:
+        self.queue.put(var)
+
+    def get_unprocessed_str(self, all_vars: Sequence[str]) -> list[str]:
+        # Method used by pre-RegionJob reformatters.
+        unprocessed = [v for v in all_vars if v not in self.processed_variables]
+        # Edge case: if all variables have been processed, but the job failed on writing metadata,
+        # reprocess (any) one variable to ensure metadata is written.
+        if len(unprocessed) == 0:
+            return [all_vars[0]]
+        return unprocessed
+
+    def get_unprocessed[T: BaseInternalAttrs](
+        self, all_vars: Sequence[DataVar[T]]
+    ) -> list[DataVar[T]]:
+        # Edge case: if all variables have been processed, but the job failed on writing metadata,
+        # reprocess (any) one variable to ensure metadata is written.
+        unprocessed = [v for v in all_vars if v.name not in self.processed_variables]
+        if len(unprocessed) == 0:
+            return [all_vars[0]]
+        return unprocessed
+
+    def close(self) -> None:
+        try:
+            retry(lambda: self.fs.rm(self._get_path()), max_attempts=1)
+        except Exception as e:
+            log.warning(f"Could not delete progress file: {e}")
+
+    def _get_path(self) -> str:
+        return f"{self.update_progress_dir}/_internal_update_progress_{self.reformat_job_name}_{self.time_i_slice_start}.json"
+
+    def _process_queue(self) -> None:
+        """Run as a background thread to process variables from the queue and record progress."""
+        while True:
+            try:
+                var = self.queue.get()
+                self.processed_variables.add(var)
+
+                def _write_content() -> None:
+                    content = json.dumps(
+                        {PROCESSED_VARIABLES_KEY: list(self.processed_variables)}
+                    )
+                    self.fs.pipe(self._get_path(), content.encode("utf-8"))
+
+                retry(
+                    _write_content,
+                    max_attempts=3,
+                )
+
+                self.queue.task_done()
+            except Exception as e:
+                log.warning(f"Could not record progress for variable {e}")

--- a/src/reformatters/noaa/gefs/legacy_progress_tracker.py
+++ b/src/reformatters/noaa/gefs/legacy_progress_tracker.py
@@ -16,8 +16,12 @@ log = get_logger(__name__)
 PROCESSED_VARIABLES_KEY = "processed_variables"
 
 
-class UpdateProgressTracker:
+class LegacyUpdateProgressTracker:
     """
+    Used only for legacy datasets that have not yet been ported to the DynamicalDataset pattern
+    (GEFS forecast and GEFS analysis). This version does not take a StoreFactory as an argument
+    and instead just takes a store path.
+
     Tracks which variables have been processed within a time slice of a job.
     Allows for skipping already processed variables in case the process is interrupted.
     """

--- a/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
@@ -28,7 +28,7 @@ class NoaaGfsForecastDataset(
             memory="7G",
             shared_memory="1.5G",
             ephemeral_storage="20G",
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validation",
@@ -38,7 +38,7 @@ class NoaaGfsForecastDataset(
             dataset_id=self.dataset_id,
             cpu="1.3",
             memory="7G",
-            secret_names=self.storage_config.k8s_secret_names,
+            secret_names=[self.storage_config.k8s_secret_name],
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
@@ -58,7 +58,7 @@ class NoaaHrrrForecast48HourDataset(DynamicalDataset[HRRRDataVar, HRRRSourceFile
         #     memory="24G",  # Large memory for GRIB processing and zarr chunks
         #     shared_memory="8Gi",  # Shared memory for parallel processing
         #     ephemeral_storage="50G",  # HRRR files can be large
-        #     secret_names=self.storage_config.k8s_secret_names,
+        #     secret_names=[self.storage_config.k8s_secret_name],
         # )
 
         # # Validation job - run 1 hour after operational update
@@ -70,7 +70,7 @@ class NoaaHrrrForecast48HourDataset(DynamicalDataset[HRRRDataVar, HRRRSourceFile
         #     dataset_id=self.dataset_id,
         #     cpu="2",
         #     memory="8G",
-        #     secret_names=self.storage_config.k8s_secret_names,
+        #     secret_names=[self.storage_config.k8s_secret_name],
         # )
 
         # return [operational_update_cron_job, validation_cron_job]

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -1,5 +1,5 @@
 import subprocess
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import ClassVar
@@ -28,14 +28,14 @@ from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
 
 NOOP_STORAGE_CONFIG = StorageConfig(
     base_path="noop",
-    k8s_secret_names=["noop-secret"],
+    k8s_secret_name="noop-secret",  # noqa: S106
     format=DatasetFormat.ZARR3,
 )
 
 
 class ExampleDatasetStorageConfig(StorageConfig):
     base_path: str = "s3://some-bucket/path"
-    k8s_secret_names: Sequence[str] = ["k8s-secret-name"]
+    k8s_secret_name: str = "k8s-secret-name"  # noqa: S105
     format: DatasetFormat = DatasetFormat.ZARR3
 
 
@@ -104,7 +104,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
                 memory="1G",
                 shared_memory="1G",
                 ephemeral_storage="1G",
-                secret_names=self.storage_config.k8s_secret_names,
+                secret_names=[self.storage_config.k8s_secret_name],
             ),
             ValidationCronJob(
                 name=f"{self.dataset_id}-validation",
@@ -116,7 +116,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
                 memory="1G",
                 shared_memory="1G",
                 ephemeral_storage="1G",
-                secret_names=self.storage_config.k8s_secret_names,
+                secret_names=[self.storage_config.k8s_secret_name],
             ),
         ]
 

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -20,9 +20,13 @@ from reformatters.common.region_job import (
     SourceFileCoord,
     SourceFileStatus,
 )
-from reformatters.common.storage import DatasetFormat, StorageConfig, StoreFactory
+from reformatters.common.storage import (
+    DatasetFormat,
+    StorageConfig,
+    StoreFactory,
+    get_local_tmp_store,
+)
 from reformatters.common.types import ArrayFloat32, Timestamp
-from reformatters.common.zarr import get_local_tmp_store
 
 
 class ExampleDataVar(DataVar[BaseInternalAttrs]):

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -93,10 +93,7 @@ def test_as_kubernetes_object_comprehensive() -> None:
                                 "value": "4",
                             },
                         ],
-                        "envFrom": [
-                            {"secretRef": {"name": "aws-creds"}},
-                            {"secretRef": {"name": "db-creds"}},
-                        ],
+                        "envFrom": [],
                         "image": "weather-app:v1.0",
                         "name": "worker",
                         "resources": {

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -1,0 +1,120 @@
+from datetime import timedelta
+from typing import Any
+
+from reformatters.common.kubernetes import Job
+
+
+def test_as_kubernetes_object_basic_structure() -> None:
+    """Test that as_kubernetes_object returns the expected basic structure."""
+    job = Job(
+        command=["update"],
+        image="my-image:latest",
+        dataset_id="test_dataset",
+        cpu="1000m",
+        memory="2Gi",
+        workers_total=4,
+        parallelism=2,
+    )
+
+    k8s_obj: dict[str, Any] = job.as_kubernetes_object()
+
+    # Test top-level structure
+    assert k8s_obj["apiVersion"] == "batch/v1"
+    assert k8s_obj["kind"] == "Job"
+
+    # Test metadata
+    assert "name" in k8s_obj["metadata"]
+    assert k8s_obj["metadata"]["name"].startswith("test-dataset-update-")
+
+    # Test spec structure
+    spec: dict[str, Any] = k8s_obj["spec"]
+    assert spec["completions"] == 4
+    assert spec["parallelism"] == 2
+    assert spec["completionMode"] == "Indexed"
+    assert spec["backoffLimitPerIndex"] == 5
+
+
+def test_as_kubernetes_object_container_config() -> None:
+    """Test that the container configuration is correct."""
+    job = Job(
+        command=["backfill-kubernetes", "2025-01-01T00:00:00", "1", "1"],
+        image="weather-app:v1.0",
+        dataset_id="weather_data",
+        cpu="500m",
+        memory="1Gi",
+        workers_total=1,
+        parallelism=1,
+        secret_names=["aws-creds", "db-creds"],
+    )
+
+    k8s_obj: dict[str, Any] = job.as_kubernetes_object()
+    container: dict[str, Any] = k8s_obj["spec"]["template"]["spec"]["containers"][0]
+
+    # Test command
+    expected_command: list[str] = [
+        "python",
+        "src/reformatters/__main__.py",
+        "weather_data",
+        "backfill-kubernetes",
+        "2025-01-01T00:00:00",
+        "1",
+        "1",
+    ]
+    assert container["command"] == expected_command
+
+    # Test image
+    assert container["image"] == "weather-app:v1.0"
+
+    # Test resources
+    assert container["resources"]["requests"]["cpu"] == "500m"
+    assert container["resources"]["requests"]["memory"] == "1Gi"
+
+    # Test environment variables
+    env_vars: dict[str, dict[str, Any]] = {env["name"]: env for env in container["env"]}
+    assert env_vars["DYNAMICAL_ENV"]["value"] == "prod"
+    assert env_vars["WORKERS_TOTAL"]["value"] == "1"
+
+    # Test secret references
+    assert len(container["envFrom"]) == 2
+    secret_names: set[str] = {ref["secretRef"]["name"] for ref in container["envFrom"]}
+    assert secret_names == {"aws-creds", "db-creds"}
+
+
+def test_as_kubernetes_object_with_custom_values() -> None:
+    """Test as_kubernetes_object with custom resource values."""
+    job = Job(
+        command=["validate"],
+        image="validator:latest",
+        dataset_id="custom_dataset",
+        cpu="2000m",
+        memory="4Gi",
+        shared_memory="512Mi",
+        ephemeral_storage="50G",
+        workers_total=8,
+        parallelism=4,
+        ttl=timedelta(hours=2),
+        pod_active_deadline=timedelta(hours=3),
+    )
+
+    k8s_obj: dict[str, Any] = job.as_kubernetes_object()
+
+    # Test custom TTL
+    assert k8s_obj["spec"]["ttlSecondsAfterFinished"] == 7200  # 2 hours
+
+    # Test pod active deadline
+    pod_spec: dict[str, Any] = k8s_obj["spec"]["template"]["spec"]
+    assert pod_spec["activeDeadlineSeconds"] == 10800  # 3 hours
+
+    # Test shared memory volume
+    volumes: dict[str, dict[str, Any]] = {
+        vol["name"]: vol for vol in pod_spec["volumes"]
+    }
+    shared_mem_vol: dict[str, Any] = volumes["shared-memory-dir"]
+    assert shared_mem_vol["emptyDir"]["sizeLimit"] == "512Mi"
+
+    # Test ephemeral storage
+    ephemeral_vol: dict[str, Any] = volumes["ephemeral-vol"]
+    storage_request: str = ephemeral_vol["ephemeral"]["volumeClaimTemplate"]["spec"][
+        "resources"
+    ]["requests"]["storage"]
+    assert storage_request == "50G"

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -4,16 +4,17 @@ from typing import Any
 from reformatters.common.kubernetes import Job
 
 
-def test_as_kubernetes_object_basic_structure() -> None:
-    """Test that as_kubernetes_object returns the expected basic structure."""
+def test_as_kubernetes_object_comprehensive() -> None:
+    """Test that as_kubernetes_object returns the expected structure and configuration."""
     job = Job(
-        command=["update"],
-        image="my-image:latest",
-        dataset_id="test_dataset",
-        cpu="1000m",
-        memory="2Gi",
+        command=["backfill-kubernetes", "2025-01-01T00:00:00", "1", "1"],
+        image="weather-app:v1.0",
+        dataset_id="weather_data",
+        cpu="500m",
+        memory="1Gi",
         workers_total=4,
         parallelism=2,
+        secret_names=["aws-creds", "db-creds"],
     )
 
     k8s_obj: dict[str, Any] = job.as_kubernetes_object()
@@ -24,33 +25,20 @@ def test_as_kubernetes_object_basic_structure() -> None:
 
     # Test metadata
     assert "name" in k8s_obj["metadata"]
-    assert k8s_obj["metadata"]["name"].startswith("test-dataset-update-")
+    assert k8s_obj["metadata"]["name"].startswith("weather-data-backfill-kubernetes-")
 
-    # Test spec structure
+    # Test job spec structure
     spec: dict[str, Any] = k8s_obj["spec"]
     assert spec["completions"] == 4
     assert spec["parallelism"] == 2
     assert spec["completionMode"] == "Indexed"
     assert spec["backoffLimitPerIndex"] == 5
 
+    # Test pod spec structure
+    pod_spec: dict[str, Any] = spec["template"]["spec"]
+    container: dict[str, Any] = pod_spec["containers"][0]
 
-def test_as_kubernetes_object_container_config() -> None:
-    """Test that the container configuration is correct."""
-    job = Job(
-        command=["backfill-kubernetes", "2025-01-01T00:00:00", "1", "1"],
-        image="weather-app:v1.0",
-        dataset_id="weather_data",
-        cpu="500m",
-        memory="1Gi",
-        workers_total=1,
-        parallelism=1,
-        secret_names=["aws-creds", "db-creds"],
-    )
-
-    k8s_obj: dict[str, Any] = job.as_kubernetes_object()
-    container: dict[str, Any] = k8s_obj["spec"]["template"]["spec"]["containers"][0]
-
-    # Test command
+    # Test container configuration
     expected_command: list[str] = [
         "python",
         "src/reformatters/__main__.py",
@@ -61,8 +49,6 @@ def test_as_kubernetes_object_container_config() -> None:
         "1",
     ]
     assert container["command"] == expected_command
-
-    # Test image
     assert container["image"] == "weather-app:v1.0"
 
     # Test resources
@@ -72,12 +58,50 @@ def test_as_kubernetes_object_container_config() -> None:
     # Test environment variables
     env_vars: dict[str, dict[str, Any]] = {env["name"]: env for env in container["env"]}
     assert env_vars["DYNAMICAL_ENV"]["value"] == "prod"
-    assert env_vars["WORKERS_TOTAL"]["value"] == "1"
+    assert env_vars["WORKERS_TOTAL"]["value"] == "4"
 
     # Test secret references
     assert len(container["envFrom"]) == 2
     secret_names: set[str] = {ref["secretRef"]["name"] for ref in container["envFrom"]}
     assert secret_names == {"aws-creds", "db-creds"}
+
+    # Test volume mounts
+    volume_mounts: dict[str, Any] = {
+        mount["name"]: mount for mount in container["volumeMounts"]
+    }
+    assert volume_mounts["ephemeral-vol"]["mountPath"] == "/app/data"
+    assert volume_mounts["shared-memory-dir"]["mountPath"] == "/dev/shm"  # noqa: S108 yes we're using a known, shared path
+    assert volume_mounts["aws-creds"]["mountPath"] == "/secrets/aws-creds.json"
+    assert volume_mounts["db-creds"]["mountPath"] == "/secrets/db-creds.json"
+
+    # Test volumes
+    volumes: dict[str, dict[str, Any]] = {
+        vol["name"]: vol for vol in pod_spec["volumes"]
+    }
+
+    # Test ephemeral volume
+    ephemeral_vol: dict[str, Any] = volumes["ephemeral-vol"]
+    assert "ephemeral" in ephemeral_vol
+    assert ephemeral_vol["ephemeral"]["volumeClaimTemplate"]["spec"]["accessModes"] == [
+        "ReadWriteOnce"
+    ]
+    assert (
+        ephemeral_vol["ephemeral"]["volumeClaimTemplate"]["spec"]["resources"][
+            "requests"
+        ]["storage"]
+        == "10G"
+    )  # default value
+
+    # Test shared memory volume
+    shared_mem_vol: dict[str, Any] = volumes["shared-memory-dir"]
+    assert shared_mem_vol["emptyDir"]["medium"] == "Memory"
+    assert shared_mem_vol["emptyDir"]["sizeLimit"] == "1k"  # default value
+
+    # Test secret volumes
+    assert "aws-creds" in volumes
+    assert volumes["aws-creds"]["secret"]["secretName"] == "aws-creds"
+    assert "db-creds" in volumes
+    assert volumes["db-creds"]["secret"]["secretName"] == "db-creds"
 
 
 def test_as_kubernetes_object_with_custom_values() -> None:

--- a/tests/common/test_update_progress_tracker.py
+++ b/tests/common/test_update_progress_tracker.py
@@ -55,7 +55,7 @@ def test_update_progress_tracker_initialization_with_existing_progress(
     """Test UpdateProgressTracker correctly loads existing processed variables"""
     print(store_factory.store_path)
 
-    tracker = UpdateProgressTracker("test-job", 0, store_factory.store_path)
+    tracker = UpdateProgressTracker("test-job", 0, store_factory)
 
     # Create existing progress file
     progress_file = (
@@ -68,7 +68,7 @@ def test_update_progress_tracker_initialization_with_existing_progress(
     )
 
     # Create new tracker - should load existing progress
-    new_tracker = UpdateProgressTracker("test-job", 0, store_factory.store_path)
+    new_tracker = UpdateProgressTracker("test-job", 0, store_factory)
     assert new_tracker.processed_variables == set(existing_vars)
     new_tracker.close()
 
@@ -89,7 +89,7 @@ def test_get_unprocessed_with_datavar_objects_parametrized(
     store_factory: StoreFactory,
 ) -> None:
     """Test get_unprocessed with DataVar objects - normal case and edge case"""
-    tracker = UpdateProgressTracker("test-job", 0, store_factory.store_path)
+    tracker = UpdateProgressTracker("test-job", 0, store_factory)
 
     # Set processed variables
     tracker.processed_variables = processed_vars
@@ -112,7 +112,7 @@ def test_record_completion_adds_to_processed_variables(
     store_factory: StoreFactory,
 ) -> None:
     """Test record_completion adds variables to processed set"""
-    tracker = UpdateProgressTracker("test-job", 0, store_factory.store_path)
+    tracker = UpdateProgressTracker("test-job", 0, store_factory)
 
     initial_count = len(tracker.processed_variables)
     tracker.record_completion("new_var")
@@ -125,7 +125,7 @@ def test_record_completion_adds_to_processed_variables(
 
 
 def test_close_deletes_progress_file(store_factory: StoreFactory) -> None:
-    tracker = UpdateProgressTracker("test-job", 0, store_factory.store_path)
+    tracker = UpdateProgressTracker("test-job", 0, store_factory)
     assert not tracker.fs.exists(tracker._get_path())
 
     tracker.fs.write_text(
@@ -141,7 +141,7 @@ def test_process_queue_multiple_items_written_separately(
     store_factory: StoreFactory,
 ) -> None:
     """Test that multiple items on the queue are processed and written with separate content"""
-    tracker = UpdateProgressTracker("test-job", 0, store_factory.store_path)
+    tracker = UpdateProgressTracker("test-job", 0, store_factory)
 
     # Record two variables to the queue
     tracker.record_completion("var1")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ sys.path.append(str(Path(__file__).parent.parent))
 os.environ["DYNAMICAL_ENV"] = "test"
 
 from reformatters.common import storage
-from reformatters.common import zarr as common_zarr_module
 
 
 @pytest.fixture(autouse=True)
@@ -24,5 +23,4 @@ def set_local_zarr_store_base_path(
         is not None
     ):
         return
-    monkeypatch.setattr(common_zarr_module, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
     monkeypatch.setattr(storage, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)

--- a/tests/dwd/icon_eu/forecast/dynamical_dataset_test.py
+++ b/tests/dwd/icon_eu/forecast/dynamical_dataset_test.py
@@ -52,8 +52,8 @@
 #     update_cron_job, validation_cron_job = cron_jobs
 #     assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
 #     assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
-#     assert update_cron_job.secret_names == dataset.storage_config.k8s_secret_names
-#     assert validation_cron_job.secret_names == dataset.storage_config.k8s_secret_names
+#     assert update_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
+#     assert validation_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
 
 
 # def test_validators(dataset: DwdIconEuForecastDataset) -> None:

--- a/tests/example/dynamical_dataset_test.py
+++ b/tests/example/dynamical_dataset_test.py
@@ -52,8 +52,8 @@
 #     update_cron_job, validation_cron_job = cron_jobs
 #     assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
 #     assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
-#     assert update_cron_job.secret_names == dataset.storage_config.k8s_secret_names
-#     assert validation_cron_job.secret_names == dataset.storage_config.k8s_secret_names
+#     assert update_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
+#     assert validation_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
 
 
 # def test_validators(dataset: ExampleDataset) -> None:

--- a/tests/noaa/gefs/test_gefs_utils.py
+++ b/tests/noaa/gefs/test_gefs_utils.py
@@ -5,7 +5,7 @@ import zarr
 from pytest import MonkeyPatch
 
 from reformatters.common.config import Config, Env
-from reformatters.common.zarr import get_mode, get_zarr_store
+from reformatters.noaa.gefs.gefs_utils import get_mode, get_zarr_store
 
 
 @pytest.mark.skip_set_local_zarr_store_base_path

--- a/tests/noaa/gfs/forecast/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast/dynamical_dataset_test.py
@@ -156,8 +156,8 @@ def test_operational_kubernetes_resources() -> None:
     update_cron_job, validation_cron_job = cron_jobs
     assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
     assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
-    assert update_cron_job.secret_names == dataset.storage_config.k8s_secret_names
-    assert validation_cron_job.secret_names == dataset.storage_config.k8s_secret_names
+    assert update_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
+    assert validation_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
 
 
 def test_validators() -> None:

--- a/tests/noaa/hrrr/forecast_48_hour/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour/dynamical_dataset_test.py
@@ -66,7 +66,7 @@ def test_operational_kubernetes_resources(
     # # Check update job
     # assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
     # assert update_cron_job.schedule == "30 0,6,12,18 * * *"  # Every 6 hours at :30
-    # assert update_cron_job.secret_names == dataset.storage_config.k8s_secret_names
+    # assert update_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
     # assert "6" in update_cron_job.cpu  # Should be CPU intensive
     # assert (
     #     "24G" in update_cron_job.memory
@@ -75,7 +75,7 @@ def test_operational_kubernetes_resources(
     # # Check validation job
     # assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
     # assert validation_cron_job.schedule == "30 1,7,13,19 * * *"  # 1 hour after updates
-    # assert validation_cron_job.secret_names == dataset.storage_config.k8s_secret_names
+    # assert validation_cron_job.secret_names == [dataset.storage_config.k8s_secret_name]
 
 
 def test_validators(dataset: NoaaHrrrForecast48HourDataset) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -142,6 +142,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -391,6 +400,15 @@ wheels = [
 ]
 
 [[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -470,6 +488,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/79/68612ed99700e6413de42895aa725463e821a6b3be75c87fcce1b4af4c70/fsspec-2025.2.0.tar.gz", hash = "sha256:1c24b16eaa0a1798afa0337aa0db9b256718ab2a89c425371f5628d22c3b6afd", size = 292283, upload-time = "2025-02-01T18:30:26.893Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/94/758680531a00d06e471ef649e4ec2ed6bf185356a7f9fbfbb7368a40bd49/fsspec-2025.2.0-py3-none-any.whl", hash = "sha256:9de2ad9ce1f85e1931858535bc882543171d197001a0a5eb2ddc04f1781ab95b", size = 184484, upload-time = "2025-02-01T18:30:19.802Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.40.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
 ]
 
 [[package]]
@@ -557,6 +589,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/05/f9/27e94c1b3eb29e6933b6986ffc5fa1177d2cd1f0c8efc5f02c91c9ac61de/kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:151dffc4865e5fe6dafce5480fab84f950d14566c480c08a53c663a0020504b6", size = 2390661, upload-time = "2024-12-24T18:30:34.939Z" },
     { url = "https://files.pythonhosted.org/packages/d9/d4/3c9735faa36ac591a4afcc2980d2691000506050b7a7e80bcfe44048daa7/kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:577facaa411c10421314598b50413aa1ebcf5126f704f1e5d72d7e4e9f020d90", size = 2546710, upload-time = "2024-12-24T18:30:37.281Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fa/be89a49c640930180657482a74970cdcf6f7072c8d2471e1babe17a222dc/kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:be4816dc51c8a471749d664161b434912eee82f2ea66bd7628bd14583a833e85", size = 2349213, upload-time = "2024-12-24T18:30:40.019Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "33.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "google-auth" },
+    { name = "oauthlib" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/52/19ebe8004c243fdfa78268a96727c71e08f00ff6fe69a301d0b7fcbce3c2/kubernetes-33.1.0.tar.gz", hash = "sha256:f64d829843a54c251061a8e7a14523b521f2dc5c896cf6d65ccf348648a88993", size = 1036779, upload-time = "2025-06-09T21:57:58.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/43/d9bebfc3db7dea6ec80df5cb2aad8d274dd18ec2edd6c4f21f32c237cbbb/kubernetes-33.1.0-py2.py3-none-any.whl", hash = "sha256:544de42b24b64287f7e0aa9513c93cb503f7f40eea39b20f66810011a86eabc5", size = 1941335, upload-time = "2025-06-09T21:57:56.327Z" },
 ]
 
 [[package]]
@@ -812,6 +866,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "obstore"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1024,6 +1087,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/02/5ac83217d522394b6a2e81a2e888167e7ca629ef6569a3f09852d6dcb01a/propcache-0.2.1-cp313-cp313-win32.whl", hash = "sha256:ddfab44e4489bd79bda09d84c430677fc7f0a4939a73d2bba3073036f487a0a6", size = 39472, upload-time = "2024-12-01T18:28:48.983Z" },
     { url = "https://files.pythonhosted.org/packages/f4/33/d6f5420252a36034bc8a3a01171bc55b4bff5df50d1c63d9caa50693662f/propcache-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:556fc6c10989f19a179e4321e5d678db8eb2924131e64652a51fe83e4c3db0e1", size = 43363, upload-time = "2024-12-01T18:28:50.025Z" },
     { url = "https://files.pythonhosted.org/packages/41/b6/c5319caea262f4821995dca2107483b94a3345d4607ad797c76cb9c36bcc/propcache-0.2.1-py3-none-any.whl", hash = "sha256:52277518d6aae65536e9cea52d4e7fd2f7a66f4aa2d30ed3f2fcea620ace3c54", size = 11818, upload-time = "2024-12-01T18:29:14.716Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1267,6 +1351,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },
+    { name = "kubernetes" },
     { name = "numba" },
     { name = "numcodecs" },
     { name = "numpy" },
@@ -1297,6 +1382,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dask", specifier = ">=2024.9.0" },
+    { name = "kubernetes", specifier = ">=33.1.0" },
     { name = "numba", specifier = ">=0.61.0" },
     { name = "numcodecs", specifier = ">=0.13.1" },
     { name = "numpy", specifier = ">=2.1.1" },
@@ -1340,6 +1426,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1366,6 +1465,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0d/29/6a97e32d53190ce892e4d849615d3fc4b5eaa802b7ae9fe5ed39998f0b8c/rioxarray-0.18.2.tar.gz", hash = "sha256:9237b9f3c26957823dc76f3c972c0f16c2ab178c930e81a4629716b425818ab6", size = 54485, upload-time = "2025-01-17T17:14:05.286Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/b0/2c74f302512fbd24d68fbba0ec6b650b33ef83e398daeb0a2bb1a4cd641c/rioxarray-0.18.2-py3-none-any.whl", hash = "sha256:f351c15fc682081ac2cd2c8db367ef0a7ed5acdea29b9e43a6d7bc2ebc5ec6e5", size = 61943, upload-time = "2025-01-17T17:14:03.966Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
@@ -1522,6 +1633,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/88/dacc875dd54a8acadb4bcbfd4e3e86df8be75527116c91d8f9784f5e9cab/virtualenv-20.29.2.tar.gz", hash = "sha256:fdaabebf6d03b5ba83ae0a02cfe96f48a716f4fae556461d180825866f75b728", size = 4320272, upload-time = "2025-02-10T19:03:53.117Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/fa/849483d56773ae29740ae70043ad88e068f98a6401aa819b5d6bee604683/virtualenv-20.29.2-py3-none-any.whl", hash = "sha256:febddfc3d1ea571bdb1dc0f98d7b45d24def7428214d4fb73cc486c9568cce6a", size = 4301478, upload-time = "2025-02-10T19:03:48.221Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR refactors how storage options secrets (credentials needed to interface with cloud storage buckets) are loaded. Rather than relying on setting environment variables, we store a json object with the credentials in a mounted volume when a pod deploys. It is assumed that the credentials within the json are stored within a `storage_options.json` key.