### PR TITLE
NOAA HRRR read_data fix: don't transpose result

### DIFF
--- a/src/reformatters/noaa/hrrr/read_data.py
+++ b/src/reformatters/noaa/hrrr/read_data.py
@@ -118,7 +118,7 @@ def read_hrrr_data(
 
             # HRRR data comes in as (y, x) but we need to transpose to (x, y)
             # to match our x, y dimension order in the template
-            return result.T
+            return result
 
     except Exception as e:
         raise ValueError(f"Failed to read data from {file_path}: {e}") from e


### PR DESCRIPTION
We encountered the following error when running a backfill:

```
could not broadcast input array from shape (1799,1059) into shape (1059,1799)
```

Removing the transpose call fixed.