### PR TITLE
Add timeout to sync_to_store

### DIFF
--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -131,7 +131,8 @@ def sync_to_store(store: zarr.abc.store.Store, key: str, data: bytes) -> None:
             store.set(
                 key,
                 zarr.core.buffer.default_buffer_prototype().buffer.from_bytes(data),
-            )
+            ),
+            timeout=90,  # In seconds. Timeout needs to be long enough to upload a large shard.
         ),
         max_attempts=6,
     )


### PR DESCRIPTION
We are seeing some indefinite hangs when uploading. We had this before but lost in a refactor.