### PR TITLE
Use `spawn` not `fork` with multiprocessing

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -1,5 +1,14 @@
+import multiprocessing
 from collections.abc import Sequence
 from typing import Any
+
+# Spawn new processes since fork isn't safe with threads
+try:
+    multiprocessing.set_start_method("spawn", force=True)
+except RuntimeError:
+    # Already set, ignore
+    pass
+
 
 import sentry_sdk
 import typer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,15 @@
+import multiprocessing
 import os
 import sys
 from pathlib import Path
+
+# Spawn new processes since fork isn't safe with threads
+try:
+    multiprocessing.set_start_method("spawn", force=True)
+except RuntimeError:
+    # Already set, ignore
+    pass
+
 
 import pytest
 


### PR DESCRIPTION
since `fork` isn't safe to use with threads.

See https://docs.python.org/3/library/os.html#os.fork

Fixes this deprecation warning, and hopefully prevents stalls in prod too.

```
tests/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset_test.py: 72
warnings
tests/contrib/uarizona/swann/dataset_integration_test.py: 120 warnings
tests/noaa/gefs/analysis/gefs_analysis_cli_integration_test.py: 12
warnings
tests/noaa/gfs/forecast/dynamical_dataset_test.py: 240 warnings
  /usr/lib/python3.12/multiprocessing/popen_fork.py:66:
  DeprecationWarning: This process (pid=347865) is multi-threaded, use
  of fork() may lead to deadlocks in the child.
      self.pid = os.fork()
```