### PR TITLE
Only upload one data variable at a time

### DIFF
--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -509,7 +509,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         with (
             make_shared_buffer(processing_region_ds) as shared_buffer,
             ThreadPoolExecutor(max_workers=1) as download_executor,
-            ThreadPoolExecutor(max_workers=2) as upload_executor,
+            ThreadPoolExecutor(max_workers=1) as upload_executor,
         ):
             log.info(f"Starting {self!r}")
 


### PR DESCRIPTION
Multiple in parallel seem to be causing issues with icechunk's more rigid index validation on store.set

Uploads are still done on another thread so their time is hidden by the compression of the next variable.