### PR TITLE
Revert GFS forecast v0.2.6 back to v0.2.1

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -79,7 +79,7 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
     ),
     NoaaGfsForecastDataset(
         primary_storage_config=SourceCoopDatasetStorageConfig(),
-        replica_storage_configs=[NoaaGfsAwsOpenDataDatasetStorageConfig()],
+        # replica_storage_configs=[NoaaGfsAwsOpenDataDatasetStorageConfig()],
     ),
     DwdIconEuForecastDataset(primary_storage_config=SourceCoopDatasetStorageConfig()),
     NoaaHrrrForecast48HourDataset(

--- a/src/reformatters/noaa/gfs/forecast/template_config.py
+++ b/src/reformatters/noaa/gfs/forecast/template_config.py
@@ -37,7 +37,7 @@ class NoaaGfsForecastTemplateConfig(TemplateConfig[NoaaDataVar]):
     def dataset_attributes(self) -> DatasetAttributes:
         return DatasetAttributes(
             dataset_id="noaa-gfs-forecast",
-            dataset_version="0.2.6",
+            dataset_version="0.2.1",
             name="NOAA GFS forecast",
             description="Weather forecasts from the Global Forecast System (GFS) operated by NOAA NWS NCEP.",
             attribution="NOAA NWS NCEP GFS data processed by dynamical.org from NOAA Open Data Dissemination archives.",

--- a/src/reformatters/noaa/gfs/forecast/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast/templates/latest.zarr/zarr.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "dataset_id": "noaa-gfs-forecast",
-    "dataset_version": "0.2.6",
+    "dataset_version": "0.2.1",
     "name": "NOAA GFS forecast",
     "description": "Weather forecasts from the Global Forecast System (GFS) operated by NOAA NWS NCEP.",
     "attribution": "NOAA NWS NCEP GFS data processed by dynamical.org from NOAA Open Data Dissemination archives.",


### PR DESCRIPTION
While we figure out icechunk store.set chunk index validation errors