### PR TITLE
Add skip_icechunk_commit flag

### DIFF
--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -509,7 +509,12 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         if isinstance(primary_store, IcechunkStore):
             icechunk_stores.append(primary_store)
         for icechunk_store in icechunk_stores:
-            template_utils.write_metadata(self.template_ds, icechunk_store, mode="w")
+            template_utils.write_metadata(
+                self.template_ds,
+                icechunk_store,
+                mode="w",
+                skip_icechunk_commit=True,  # We will commit after all chunk data is written
+            )
 
         results: dict[str, Sequence[SOURCE_FILE_COORD]] = {}
         upload_futures: list[Any] = []

--- a/src/reformatters/common/template_utils.py
+++ b/src/reformatters/common/template_utils.py
@@ -21,6 +21,7 @@ def write_metadata(
     template_ds: xr.Dataset,
     storage: zarr.storage.StoreLike | StoreFactory,
     mode: Literal["w", "w-"] | None = None,
+    skip_icechunk_commit: bool = False,
 ) -> None:
     store: zarr.abc.store.Store | Path
     replica_stores: list[zarr.abc.store.Store]
@@ -58,11 +59,12 @@ def write_metadata(
     if isinstance(store, Path | str):
         sort_consolidated_metadata(Path(store) / "zarr.json")
 
-    commit_if_icechunk(
-        message=f"Metadata written at {pd.Timestamp.now(tz='UTC').isoformat()}",
-        primary_store=store,
-        replica_stores=replica_stores,
-    )
+    if not skip_icechunk_commit:
+        commit_if_icechunk(
+            message=f"Metadata written at {pd.Timestamp.now(tz='UTC').isoformat()}",
+            primary_store=store,
+            replica_stores=replica_stores,
+        )
 
 
 def _get_mode_from_path_store(store: Path) -> Literal["w", "w-"]:


### PR DESCRIPTION
When we update the metadata in RegionJob.process, we don't want to commit yet because this switches the store to read only. We should commit after `process` returns.