### PR TITLE
Make  RegionJob._read_data_into_array thread safe

### DIFF
--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -667,21 +667,34 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         Reads data from source files into `out`.
         Returns a list of coords with the final status.
         """
-
-        def _read_and_write_one(coord: SOURCE_FILE_COORD) -> SOURCE_FILE_COORD:
-            try:
-                out.loc[coord.out_loc()] = self.read_data(coord, data_var)
-                return replace(coord, status=SourceFileStatus.Succeeded)
-            except Exception:
-                log.exception(f"Read failed {coord.downloaded_path}")
-                return replace(coord, status=SourceFileStatus.ReadFailed)
-
         # Skip coords where the download failed
         read_coords = (
             c for c in source_file_coords if c.status == SourceFileStatus.Processing
         )
+
+        def _read_and_write_one(coord: SOURCE_FILE_COORD) -> ArrayND[np.generic]:
+            return self.read_data(coord, data_var)
+
+        futures = {}
         with ThreadPoolExecutor(max_workers=self.read_parallelism) as executor:
-            return list(executor.map(_read_and_write_one, read_coords))
+            for coord in read_coords:
+                future = executor.submit(_read_and_write_one, coord)
+                futures[future] = coord
+
+        updated_coords = []
+        for future in concurrent.futures.as_completed(futures):
+            coord = futures[future]
+            try:
+                data = future.result()
+                out.loc[coord.out_loc()] = data
+                updated_coords.append(replace(coord, status=SourceFileStatus.Succeeded))
+            except Exception:
+                log.exception(f"Read failed {coord.downloaded_path}")
+                updated_coords.append(
+                    replace(coord, status=SourceFileStatus.ReadFailed)
+                )
+
+        return updated_coords
 
     def _write_shards(
         self,


### PR DESCRIPTION
The call to `out.loc[coord.out_loc()]` in `_read_data_into_array` was throwing intermittent errors during a GFS backfill:

```
2025-09-08T19:47:09Z ERROR:reformatters.common.region_job:Read failed data/download/noaa-gfs-forecast/gfs.20240708/12/atmos/gfs.t12z.pgrb2.0p25.f001-6e99e8a3
Traceback (most recent call last):
  File "index.pyx", line 609, in pandas._libs.index.DatetimeEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 2606, in pandas._libs.hashtable.Int64HashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 2630, in pandas._libs.hashtable.Int64HashTable.get_item
KeyError: 1720440000000000000

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3805, in get_loc
    return self._engine.get_loc(casted_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "index.pyx", line 577, in pandas._libs.index.DatetimeEngine.get_loc
  File "index.pyx", line 611, in pandas._libs.index.DatetimeEngine.get_loc
KeyError: Timestamp('2024-07-08 12:00:00')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/lib/python3.12/site-packages/reformatters/common/region_job.py", line 673, in _read_and_write_one
    out.loc[coord.out_loc()] = self.read_data(coord, data_var)
    ~~~~~^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.12/site-packages/xarray/core/dataarray.py", line 270, in __setitem__
    dim_indexers = map_index_queries(self.data_array, key).dim_indexers
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.12/site-packages/xarray/core/indexing.py", line 195, in map_index_queries
    results.append(index.sel(labels, **options))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.12/site-packages/xarray/core/indexes.py", line 791, in sel
    raise KeyError(
KeyError: "not all values found in index 'init_time'. Try setting the `method` keyword argument (example: method='nearest')."
```

Accessing `loc` on a DataArray is not thread safe. See this similar issue with a similar error: https://github.com/pandas-dev/pandas/issues/28439.

This PR leaves the the data reads on the threadpool, but moves the assignments to `out` to the main thread.