### PR TITLE
GFS Forecast: increment version to 0.2.7

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -79,7 +79,7 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
     ),
     NoaaGfsForecastDataset(
         primary_storage_config=SourceCoopDatasetStorageConfig(),
-        # replica_storage_configs=[NoaaGfsAwsOpenDataDatasetStorageConfig()],
+        replica_storage_configs=[NoaaGfsAwsOpenDataDatasetStorageConfig()],
     ),
     DwdIconEuForecastDataset(primary_storage_config=SourceCoopDatasetStorageConfig()),
     NoaaHrrrForecast48HourDataset(

--- a/src/reformatters/noaa/gfs/forecast/template_config.py
+++ b/src/reformatters/noaa/gfs/forecast/template_config.py
@@ -37,7 +37,7 @@ class NoaaGfsForecastTemplateConfig(TemplateConfig[NoaaDataVar]):
     def dataset_attributes(self) -> DatasetAttributes:
         return DatasetAttributes(
             dataset_id="noaa-gfs-forecast",
-            dataset_version="0.2.1",
+            dataset_version="0.2.7",
             name="NOAA GFS forecast",
             description="Weather forecasts from the Global Forecast System (GFS) operated by NOAA NWS NCEP.",
             attribution="NOAA NWS NCEP GFS data processed by dynamical.org from NOAA Open Data Dissemination archives.",

--- a/src/reformatters/noaa/gfs/forecast/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast/templates/latest.zarr/zarr.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "dataset_id": "noaa-gfs-forecast",
-    "dataset_version": "0.2.1",
+    "dataset_version": "0.2.7",
     "name": "NOAA GFS forecast",
     "description": "Weather forecasts from the Global Forecast System (GFS) operated by NOAA NWS NCEP.",
     "attribution": "NOAA NWS NCEP GFS data processed by dynamical.org from NOAA Open Data Dissemination archives.",


### PR DESCRIPTION
We've implemented a number of bug fixes over the last week or so. We believe some of these bug fixes (e.g., https://github.com/dynamical-org/reformatters/pull/233)  should resolve issues that caused our previous backfill of `noaa-gfs-forecast` 0.2.6 to have NaNs where the currently published latest version (0.2.1) has values. 

A 0.2.7 backfill is currently running. If it's successful, we can merge this PR, run a catch up operational update job and then point our proxy to this new version, which has an Icechunk replica.