### PR TITLE
Add default validator: check for expected shards

### DIFF
--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -338,7 +338,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             primary_store = self.store_factory.primary_store()
             primary_store_validators = list(self.validators())
             primary_store_validators.append(
-                partial(validation.check_shard_count, primary_store)
+                partial(validation.check_for_expected_shards, primary_store)
             )
 
             validation.validate_dataset(
@@ -350,7 +350,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             for replica_store in self.store_factory.replica_stores():
                 replica_store_validators = list(self.validators())
                 replica_store_validators.append(
-                    partial(validation.check_shard_count, replica_store)
+                    partial(validation.check_for_expected_shards, replica_store)
                 )
                 replica_store_validators.append(
                     partial(

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -335,13 +335,24 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     ) -> None:
         """Validate the dataset, raising an exception if it is invalid."""
         with self._monitor(ValidationCronJob, reformat_job_name):
-            store = self.store_factory.primary_store()
-            validation.validate_dataset(store, validators=self.validators())
-            log.info(f"Done validating {store}")
+            primary_store = self.store_factory.primary_store()
+            primary_store_validators = list(self.validators())
+            primary_store_validators.append(
+                partial(validation.check_shard_count, primary_store)
+            )
+
+            validation.validate_dataset(
+                primary_store,
+                validators=primary_store_validators,
+            )
+            log.info(f"Done validating {primary_store}")
 
             for replica_store in self.store_factory.replica_stores():
-                validators = list(self.validators())
-                validators.append(
+                replica_store_validators = list(self.validators())
+                replica_store_validators.append(
+                    partial(validation.check_shard_count, replica_store)
+                )
+                replica_store_validators.append(
                     partial(
                         validation.compare_replica_and_primary,
                         self.template_config.append_dim,
@@ -349,7 +360,10 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                     )
                 )
 
-                validation.validate_dataset(replica_store, validators=validators)
+                validation.validate_dataset(
+                    replica_store,
+                    validators=replica_store_validators,
+                )
                 log.info(f"Done validating {replica_store}")
 
     def get_cli(

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -228,7 +228,7 @@ def check_for_expected_shards(
         )
 
         # During operational updates we trim down the dataset to only include
-        # data that was fully processed. This means there may be some extrashards present
+        # data that was fully processed. This means there may be some extra shards present
         # in the store, but the metadata has been trimmed such that they are not exposed.
         # As such, we don't expect these two sets to necessarily be equal, but we do expect
         # that expected_shard_indexes should be a proper subset of actual_var_shard_indexes.

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -205,7 +205,9 @@ def compare_replica_and_primary(
     )
 
 
-def check_shard_count(store: zarr.abc.store.Store, ds: xr.Dataset) -> ValidationResult:
+def check_for_expected_shards(
+    store: zarr.abc.store.Store, ds: xr.Dataset
+) -> ValidationResult:
     """Check that the number of shards is the same as the number of chunks."""
     log.info(f"Checking shard count for {store}")
 

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -208,8 +208,8 @@ def compare_replica_and_primary(
 def check_for_expected_shards(
     store: zarr.abc.store.Store, ds: xr.Dataset
 ) -> ValidationResult:
-    """Check that the number of shards is the same as the number of chunks."""
-    log.info(f"Checking shard count for {store}")
+    """Check that the expected shards are present in the store."""
+    log.info(f"Checking for expected shards in {store}")
 
     shard_counts_per_dim = [
         len(iterating.dimension_slices(ds, str(dim), "shards"))

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -371,8 +371,8 @@ def test_validate_dataset_calls_validators(
 
     # Check the first call (primary store)
     positional_args, keyword_args = mock_validate.call_args_list[0]
-    assert positional_args == (mock_store,)  # positional args
-    primary_store_validators = keyword_args["validators"]  # keyword args
+    assert positional_args == (mock_store,)
+    primary_store_validators = keyword_args["validators"]
 
     assert primary_store_validators[:-1] == configured_validators
     assert isinstance(primary_store_validators[-1], partial)
@@ -381,8 +381,8 @@ def test_validate_dataset_calls_validators(
 
     # Check the second call (replica store)
     positional_args, keyword_args = mock_validate.call_args_list[1]
-    assert positional_args == (mock_replica_store,)  # positional args
-    replica_validators = keyword_args["validators"]  # keyword args
+    assert positional_args == (mock_replica_store,)
+    replica_validators = keyword_args["validators"]
 
     # Verify replica validators = base validators + compare_replica_and_primary partial
     assert len(replica_validators) == len(configured_validators) + 2

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -376,7 +376,7 @@ def test_validate_dataset_calls_validators(
 
     assert primary_store_validators[:-1] == configured_validators
     assert isinstance(primary_store_validators[-1], partial)
-    assert primary_store_validators[-1].func == validation.check_shard_count
+    assert primary_store_validators[-1].func == validation.check_for_expected_shards
     assert primary_store_validators[-1].args == (mock_store,)
 
     # Check the second call (replica store)
@@ -388,7 +388,7 @@ def test_validate_dataset_calls_validators(
     assert len(replica_validators) == len(configured_validators) + 2
     assert replica_validators[:-2] == configured_validators
 
-    assert replica_validators[-2].func == validation.check_shard_count
+    assert replica_validators[-2].func == validation.check_for_expected_shards
     assert replica_validators[-2].args == (mock_replica_store,)
 
     assert replica_validators[-1].func == validation.compare_replica_and_primary


### PR DESCRIPTION
This PR adds a default validator to be run on all stores checking that all expected shards (based on dataset dimension sizes and encoding) actually exist in the store. The intention here is to catch a case where some region job were to fail to write a shard.