### PR TITLE
Check all AppendDims when ignoring 404s from recent files

### DIFF
--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -196,6 +196,11 @@ def test_source_file_coord_out_loc_default_impl() -> None:
     assert coord.out_loc() == {"time": pd.Timestamp("2025-01-01T00")}
 
 
+def test_source_file_coord_append_dim_coord() -> None:
+    coord = ExampleSourceFileCoords(time=pd.Timestamp("2025-01-01T00"))
+    assert coord.append_dim_coord == pd.Timestamp("2025-01-01T00")
+
+
 def test_get_jobs_grouping_no_filters(template_ds: xr.Dataset) -> None:
     data_vars = [ExampleDataVar(name=name) for name in template_ds.data_vars.keys()]
     tmp_store = get_local_tmp_store()

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -315,6 +315,17 @@ def test_source_file_coord_out(
     }
 
 
+def test_source_file_coord_append_dim_coord(
+    example_data_vars: list[GEFSDataVar],
+) -> None:
+    coord = GefsAnalysisSourceFileCoord(
+        init_time=pd.Timestamp("2021-01-01T00:00"),  # Use current archive period
+        lead_time=pd.Timedelta("6h"),
+        data_vars=example_data_vars[:1],
+    )
+    assert coord.append_dim_coord == pd.Timestamp("2021-01-01T06:00")
+
+
 def test_download_file(
     template_ds: xr.Dataset,
     example_data_vars: list[GEFSDataVar],


### PR DESCRIPTION
Fixes https://dynamical.sentry.io/issues/6894613970/

The append dim on a `GefsAnalysisSourceFileCoord` is `time`, it's not present as a field on the class. This change correctly checks that a source file coord is recent, silencing errors about missing files that haven't been created yet for noaa-gefs-analysis.