### PR TITLE
Trim off the last hour for GEFS Analysis in update_template_with_results

### DIFF
--- a/src/reformatters/noaa/gefs/analysis/region_job.py
+++ b/src/reformatters/noaa/gefs/analysis/region_job.py
@@ -241,3 +241,15 @@ class GefsAnalysisRegionJob(RegionJob[GEFSDataVar, GefsAnalysisSourceFileCoord])
             filter_start=append_dim_start,
         )
         return jobs, template_ds
+
+    def update_template_with_results(
+        self, process_results: Mapping[str, Sequence[GefsAnalysisSourceFileCoord]]
+    ) -> xr.Dataset:
+        # Remove the last hour because most variables (except precip) lack hour 0 values.
+        # Precipitation extends to hour 6 of the latest forecast, but other variables do not,
+        # so we trim the final hour to keep all variables aligned.
+        return (
+            super()
+            .update_template_with_results(process_results)
+            .isel(time=slice(None, -1))
+        )

--- a/tests/noaa/gefs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/analysis/dynamical_dataset_test.py
@@ -192,15 +192,15 @@ def test_backfill_local_and_operational_update(
         dataset.store_factory.primary_store(), chunks=None, decode_timedelta=True
     )
 
-    np.testing.assert_array_equal(
-        updated_ds.time,
-        pd.date_range(
-            init_time_start,
-            init_time_end,
-            freq=dataset.template_config.append_dim_frequency,
-            inclusive="left",
-        ),
-    )
+    # We slice off the last hour because most variables (except precip) lack hour 0 values.
+    # (see GefsAnalysisRegionJob.update_template_with_results)
+    expected_times = pd.date_range(
+        init_time_start,
+        init_time_end,
+        freq=dataset.template_config.append_dim_frequency,
+        inclusive="left",
+    )[:-1]
+    np.testing.assert_array_equal(updated_ds.time, expected_times)
 
     space_subset_ds = updated_ds.sel(
         latitude=slice(10, 0),


### PR DESCRIPTION
since not all variables has a 6 hour value (only precip), which causes nans when the template extends past that.