### PR TITLE
Use tz-naive `now` in HRRR  _update_append_dim_end

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour/region_job.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/region_job.py
@@ -199,7 +199,7 @@ class NoaaHrrrForecast48HourRegionJob(
     @classmethod
     def _update_append_dim_end(cls) -> pd.Timestamp:
         """Get the end time for operational updates."""
-        return pd.Timestamp.now(tz="UTC")
+        return pd.Timestamp.now()
 
     @classmethod
     def _update_append_dim_start(cls, existing_ds: xr.Dataset) -> pd.Timestamp:

--- a/tests/noaa/hrrr/forecast_48_hour/region_job_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour/region_job_test.py
@@ -400,3 +400,15 @@ def test_operational_update_jobs(
     for job in jobs:
         assert isinstance(job, NoaaHrrrForecast48HourRegionJob)
         assert job.data_vars == template_config.data_vars
+
+
+def test_update_append_dim_end_is_tz_naive() -> None:
+    region_job = NoaaHrrrForecast48HourRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=Mock(),
+        data_vars=Mock(),
+        append_dim=Mock(),
+        region=Mock(),
+        reformat_job_name="test",
+    )
+    assert region_job._update_append_dim_end().tzinfo is None


### PR DESCRIPTION
It's also compared with coordinates coming from xarray which must by naive. Our convention is everything is implicitly UTC following xarray.