### PR TITLE
Use pytest-xdist to run tests in parallel on all cores

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -46,7 +46,7 @@ jobs:
           DISABLE_NUMCODECS_SSE2: 1
           DISABLE_NUMCODECS_AVX2: 1
           CFLAGS: "-Wno-implicit-function-declaration" 
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras --dev --locked
 
       - name: Install this project
         run: "uv pip install -e ."

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ We use
 * Lint: `uv run ruff check`
 * Type check: `uv run mypy`
 * Format: `uv run ruff format`
-* Test: `uv run pytest`
+* Tests: 
+   * Run tests in parallel on all available cores: `uv run pytest`
+   * Run tests serially: `uv run pytest -n 0`
 
 ## Deploying to the cloud
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dev = [
     "pre-commit==4.3.0",
     "pyqt6>=6.7.1",
     "pytest~=8.4",
+    "pytest-sugar~=1.0",
+    "pytest-xdist~=3.8",
     # NOTE: keep this in sync with .pre-commit-config.yaml
     "ruff==0.13.1",
     "types-requests~=2.32",
@@ -86,3 +88,12 @@ warn_required_dynamic_aliases = true
 
 [project.package-data]
 reformatters = ["py.typed"]
+
+[tool.pytest.ini_options]
+pythonpath = "src/reformatters"
+testpaths = ["tests/"]
+addopts = "-n auto --dist loadfile"
+markers = [
+    "slow: slow running tests.",
+    "skip_set_local_zarr_store_base_path: opt out of automatically writing zarrs to a tmp directory during tests",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-pythonpath = src/reformatters
-testpaths = tests/
-markers =
-    slow: slow running tests.
-    skip_set_local_zarr_store_base_path: opt out of automatically writing zarrs to a tmp directory during tests

--- a/uv.lock
+++ b/uv.lock
@@ -397,6 +397,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1409,6 +1418,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-sugar"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1513,6 +1548,8 @@ dev = [
     { name = "pre-commit" },
     { name = "pyqt6" },
     { name = "pytest" },
+    { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-requests" },
 ]
@@ -1546,6 +1583,8 @@ dev = [
     { name = "pre-commit", specifier = "==4.3.0" },
     { name = "pyqt6", specifier = ">=6.7.1" },
     { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest-sugar", specifier = "~=1.0" },
+    { name = "pytest-xdist", specifier = "~=3.8" },
     { name = "ruff", specifier = "==0.13.1" },
     { name = "types-requests", specifier = "~=2.32" },
 ]
@@ -1688,6 +1727,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/6c/3d75c196ac07ac8749600b60b03f4f6094d54e132c4d94ebac6ee0e0add0/termcolor-3.1.0.tar.gz", hash = "sha256:6a6dd7fbee581909eeec6a756cff1d7f7c376063b14e4a298dc4980309e55970", size = 14324, upload-time = "2025-04-30T11:37:53.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl", hash = "sha256:591dd26b5c2ce03b9e43f391264626557873ce1d379019786f99b0c2bee140aa", size = 7684, upload-time = "2025-04-30T11:37:52.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This saves about 90 seconds when running all tests, though it's slower when only running a few tests (due to the fixed overhead of spawning worker processes). To run tests serially use `uv run pytest -n 0`.