### PR TITLE
Nodepool: use generation >= 8 aws nodes

### DIFF
--- a/deploy/aws/nodepool.yaml
+++ b/deploy/aws/nodepool.yaml
@@ -22,7 +22,7 @@ spec:
           values: ["17"]
         - key: "eks.amazonaws.com/instance-generation"
           operator: Gt
-          values: ["6"]
+          values: ["7"]
         - key: "topology.kubernetes.io/zone"
           operator: In
           values: ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]


### PR DESCRIPTION
They are faster and a better value for our workloads than gen 7