### PR TITLE
Don't fail entire shard on assertion errors when downloading and reading specific files

### DIFF
--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -616,8 +616,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 path = self.download_file(coord)
                 return replace(coord, downloaded_path=path)
             except Exception as e:
-                if isinstance(e, AssertionError):
-                    raise
                 updated_coord = replace(coord, status=SourceFileStatus.DownloadFailed)
 
                 # For recent files, we expect some files to not exist yet, just log the path
@@ -677,9 +675,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                     updated_coords[index] = replace(
                         coord, status=SourceFileStatus.Succeeded
                     )
-                except Exception as e:
-                    if isinstance(e, AssertionError):
-                        raise
+                except Exception:
                     log.exception(f"Read failed {coord.downloaded_path}")
                     updated_coords[index] = replace(
                         coord, status=SourceFileStatus.ReadFailed


### PR DESCRIPTION
Instead, leave nan in the array. These errors happen with things like malformed files and we don't want to loose out on data from other files in the same shard when an individual file is malformed.

I recently added this in as an extra layer of "caution", but in practice would cause unnecessary missing data. We check for missing values both offline in report_nulls and in operational update validators (e.g. check recent nans)