### PR TITLE
Integration test to ensure that Dynamical dataset template configs always serialize correctly

### DIFF
--- a/tests/contrib/noaa/ndvi_cdr/analysis/template_config_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/template_config_test.py
@@ -1,37 +1,10 @@
-import json
 from copy import deepcopy
-from pathlib import Path
 
 import pandas as pd
-import pytest
 
 from reformatters.contrib.noaa.ndvi_cdr.analysis.template_config import (
     NoaaNdviCdrAnalysisTemplateConfig,
 )
-
-
-def test_update_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """
-    Ensure that `uv run main <dataset-id> update-template` has been run and
-    all changes to NoaaNdviCdrAnalysisTemplateConfig are reflected in the on-disk Zarr template.
-    """
-    template_config = NoaaNdviCdrAnalysisTemplateConfig()
-    with open(template_config.template_path() / "zarr.json") as f:
-        existing_template = json.load(f)
-
-    test_template_path = tmp_path / "latest.zarr"
-    monkeypatch.setattr(
-        NoaaNdviCdrAnalysisTemplateConfig,
-        "template_path",
-        lambda _self: test_template_path,
-    )
-
-    template_config.update_template()
-
-    with open(template_config.template_path() / "zarr.json") as f:
-        updated_template = json.load(f)
-
-    assert existing_template == updated_template
 
 
 def test_get_template_spatial_ref() -> None:

--- a/tests/contrib/uarizona/swann/template_config_test.py
+++ b/tests/contrib/uarizona/swann/template_config_test.py
@@ -1,33 +1,10 @@
-import json
 from copy import deepcopy
-from pathlib import Path
 
 import pandas as pd
-import pytest
 
 from reformatters.contrib.uarizona.swann.analysis.template_config import (
     UarizonaSwannAnalysisTemplateConfig,
 )
-
-
-def test_update_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    template_config = UarizonaSwannAnalysisTemplateConfig()
-    with open(template_config.template_path() / "zarr.json") as f:
-        existing_template = json.load(f)
-
-    test_template_path = tmp_path / "latest.zarr"
-    monkeypatch.setattr(
-        UarizonaSwannAnalysisTemplateConfig,
-        "template_path",
-        lambda _self: test_template_path,
-    )
-
-    template_config.update_template()
-
-    with open(template_config.template_path() / "zarr.json") as f:
-        updated_template = json.load(f)
-
-    assert existing_template == updated_template
 
 
 def test_get_template_spatial_ref() -> None:

--- a/tests/dwd/icon_eu/forecast/template_config_test.py
+++ b/tests/dwd/icon_eu/forecast/template_config_test.py
@@ -1,37 +1,11 @@
-import json
 from copy import deepcopy
-from pathlib import Path
 
 import pandas as pd
-import pytest
 from pyproj import CRS
 
 from reformatters.dwd.icon_eu.forecast.template_config import (
     DwdIconEuForecastTemplateConfig,
 )
-
-
-def test_update_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Ensure that `uv run main <dataset-id> update-template` has been run and
-    all changes to DwdIconEuForecastTemplateConfig are reflected in the on-disk
-    Zarr template."""
-    template_config = DwdIconEuForecastTemplateConfig()
-    with open(template_config.template_path() / "zarr.json") as f:
-        existing_template = json.load(f)
-
-    test_template_path = tmp_path / "latest.zarr"
-    monkeypatch.setattr(
-        DwdIconEuForecastTemplateConfig,
-        "template_path",
-        lambda _self: test_template_path,
-    )
-
-    template_config.update_template()
-
-    with open(template_config.template_path() / "zarr.json") as f:
-        updated_template = json.load(f)
-
-    assert existing_template == updated_template
 
 
 def test_get_template_spatial_ref() -> None:

--- a/tests/example/template_config_test.py
+++ b/tests/example/template_config_test.py
@@ -7,31 +7,6 @@
 
 # from reformatters.example.template_config import ExampleTemplateConfig
 
-
-# def test_update_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-#     """
-#     Ensure that `uv run main <dataset-id> update-template` has been run and
-#     all changes to ExampleTemplateConfig are reflected in the on-disk Zarr template.
-#     """
-#     template_config = ExampleTemplateConfig()
-#     with open(template_config.template_path() / "zarr.json") as f:
-#         existing_template = json.load(f)
-
-#     test_template_path = tmp_path / "latest.zarr"
-#     monkeypatch.setattr(
-#         ExampleTemplateConfig,
-#         "template_path",
-#         lambda _self: test_template_path,
-#     )
-
-#     template_config.update_template()
-
-#     with open(template_config.template_path() / "zarr.json") as f:
-#         updated_template = json.load(f)
-
-#     assert existing_template == updated_template
-
-
 # def test_get_template_spatial_ref() -> None:
 #     """Ensure the spatial reference system in the template matched our expectation."""
 #     template_config = ExampleTemplateConfig()

--- a/tests/noaa/gfs/forecast/template_config_test.py
+++ b/tests/noaa/gfs/forecast/template_config_test.py
@@ -1,39 +1,12 @@
-import json
 import re
 from copy import deepcopy
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pytest
 import xarray as xr
 
 from reformatters.common.template_config import SPATIAL_REF_COORDS
 from reformatters.noaa.gfs.forecast.template_config import NoaaGfsForecastTemplateConfig
-
-
-def test_update_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """
-    Ensure that `uv run main <dataset-id> update-template` has been run and
-    all changes to NoaaGfsForecastTemplateConfig are reflected in the on-disk Zarr template.
-    """
-    template_config = NoaaGfsForecastTemplateConfig()
-    with open(template_config.template_path() / "zarr.json") as f:
-        existing_template = json.load(f)
-
-    test_template_path = tmp_path / "latest.zarr"
-    monkeypatch.setattr(
-        NoaaGfsForecastTemplateConfig,
-        "template_path",
-        lambda _self: test_template_path,
-    )
-
-    template_config.update_template()
-
-    with open(template_config.template_path() / "zarr.json") as f:
-        updated_template = json.load(f)
-
-    assert existing_template == updated_template
 
 
 def test_get_template_spatial_ref() -> None:

--- a/tests/noaa/hrrr/forecast_48_hour/template_config_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour/template_config_test.py
@@ -1,9 +1,5 @@
-import json
-from pathlib import Path
-
 import numpy as np
 import pandas as pd
-import pytest
 import xarray as xr
 
 from reformatters.common.download import http_download_to_disk
@@ -14,30 +10,6 @@ from reformatters.noaa.hrrr.forecast_48_hour.template_config import (
     NoaaHrrrForecast48HourTemplateConfig,
 )
 from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
-
-
-def test_update_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """
-    Ensure that `uv run main <dataset-id> update-template` has been run and
-    all changes to NoaaHrrrForecast48HourTemplateConfig are reflected in the on-disk Zarr template.
-    """
-    template_config = NoaaHrrrForecast48HourTemplateConfig()
-    with open(template_config.template_path() / "zarr.json") as f:
-        existing_template = json.load(f)
-
-    test_template_path = tmp_path / "latest.zarr"
-    monkeypatch.setattr(
-        NoaaHrrrForecast48HourTemplateConfig,
-        "template_path",
-        lambda _self: test_template_path,
-    )
-
-    template_config.update_template()
-
-    with open(template_config.template_path() / "zarr.json") as f:
-        updated_template = json.load(f)
-
-    assert existing_template == updated_template
 
 
 def test_spatial_coordinates() -> None:


### PR DESCRIPTION
This PR adds a a test that serializes all datasets listed in DYNAMICAL_DATASETS and ensures that the resulting template matches the official, committed `latest.zarr` template for that dataset. 

As part of this, individual dataset tests doing the same work are removed.