### PR TITLE
Initialize arrays with nan, Set HRRR fill_value=0.0 on data vars to reflect how data was written

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -239,6 +239,17 @@ def check_for_expected_shards(
         # that expected_shard_indexes should be a proper subset of actual_var_shard_indexes.
         missing_shard_indexes = expected_shard_indexes - actual_var_shard_indexes
         if len(missing_shard_indexes) > 0:
+            # HRRR categorical variables have enough 0s that some shards are not written
+            # We will remove this skip when fill_value is updated to nan / write_empty_chunks is true
+            if (
+                ds.attrs["dataset_id"] == "noaa-hrrr-forecast-48-hour"
+                and "categorical" in var
+            ):
+                log.info(
+                    f"Expecting to find fewer than the maximum shards for categorical hrrr variable ({var}) due to fill value 0 and write empty chunks false"
+                )
+                continue
+
             problem_vars.append(var)
             var_missing_shard_indexes[var] = sorted(missing_shard_indexes)
 

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/template_config.py
@@ -339,7 +339,7 @@ class NoaaHrrrForecast48HourTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
 
         encoding_float32_default = Encoding(
             dtype="float32",
-            fill_value=np.nan,
+            fill_value=0.0,
             chunks=tuple(var_chunks[d] for d in self.dims),
             shards=tuple(var_shards[d] for d in self.dims),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/categorical_freezing_rain_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/categorical_freezing_rain_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/categorical_ice_pellets_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/categorical_ice_pellets_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/categorical_rain_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/categorical_rain_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/categorical_snow_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/categorical_snow_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/composite_reflectivity/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/composite_reflectivity/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/downward_long_wave_radiation_flux_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/downward_long_wave_radiation_flux_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/downward_short_wave_radiation_flux_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/downward_short_wave_radiation_flux_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/precipitable_water_atmosphere/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/precipitable_water_atmosphere/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/precipitation_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/pressure_reduced_to_mean_sea_level/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/pressure_reduced_to_mean_sea_level/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/pressure_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/pressure_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/relative_humidity_2m/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/relative_humidity_2m/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/temperature_2m/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/temperature_2m/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/total_cloud_cover_atmosphere/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/total_cloud_cover_atmosphere/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/wind_u_10m/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/wind_u_10m/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/wind_u_80m/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/wind_u_80m/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/wind_v_10m/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/wind_v_10m/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/wind_v_80m/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/wind_v_80m/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": 0.0,
   "codecs": [
     {
       "name": "sharding_indexed",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
@@ -42,7 +42,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -129,7 +129,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -216,7 +216,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -303,7 +303,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -390,7 +390,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -477,7 +477,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -564,7 +564,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -704,7 +704,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1062,7 +1062,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1149,7 +1149,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1236,7 +1236,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1324,7 +1324,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1411,7 +1411,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1498,7 +1498,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1643,7 +1643,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1731,7 +1731,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1874,7 +1874,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1962,7 +1962,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -2050,7 +2050,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -2138,7 +2138,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": 0.0,
         "codecs": [
           {
             "name": "sharding_indexed",

--- a/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
@@ -155,13 +155,32 @@ def test_backfill_local_and_operational_update(
                 [
                     "precipitation_surface",
                     "maximum_temperature_2m",
-                    "downward_short_wave_radiation_flux_surface",
+                    "categorical_freezing_rain_surface",
                 ]
             ]
             .sel(lead_time=slice("1h", None))
             .isnull()
             .mean()
             == 0
+        )
+        .all()
+        .to_array()
+        .all()
+    )
+    assert (
+        (
+            space_subset_ds[
+                [
+                    "precipitation_surface",
+                    "maximum_temperature_2m",
+                    "categorical_freezing_rain_surface",
+                ]
+            ]
+            # All null at lead time 0
+            .isel(lead_time=0)
+            .isnull()
+            .mean()
+            == 1
         )
         .all()
         .to_array()
@@ -179,7 +198,6 @@ def test_backfill_local_and_operational_update(
     assert point_ds["temperature_2m"] == 23.25
     assert point_ds["precipitation_surface"] == 1.2040138e-05
     assert point_ds["maximum_temperature_2m"] == 23.875
-    assert point_ds["downward_short_wave_radiation_flux_surface"] == 0.0
 
     # Operational update
     # Advance the init_time_end to the next day to ensure we get the next day's data
@@ -233,13 +251,32 @@ def test_backfill_local_and_operational_update(
                 [
                     "precipitation_surface",
                     "maximum_temperature_2m",
-                    "downward_short_wave_radiation_flux_surface",
+                    "categorical_freezing_rain_surface",
                 ]
             ]
             .sel(lead_time=slice("1h", None))
             .isnull()
             .mean()
             == 0
+        )
+        .all()
+        .to_array()
+        .all()
+    )
+    assert (
+        (
+            space_subset_ds[
+                [
+                    "precipitation_surface",
+                    "maximum_temperature_2m",
+                    "categorical_freezing_rain_surface",
+                ]
+            ]
+            # All null at lead time 0
+            .isel(lead_time=0)
+            .isnull()
+            .mean()
+            == 1
         )
         .all()
         .to_array()
@@ -257,4 +294,3 @@ def test_backfill_local_and_operational_update(
     assert point_ds["temperature_2m"] == 23.25
     assert point_ds["precipitation_surface"] == 1.2040138e-05
     assert point_ds["maximum_temperature_2m"] == 23.875
-    assert point_ds["downward_short_wave_radiation_flux_surface"] == 0.0

--- a/tests/noaa/gfs/forecast/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast/dynamical_dataset_test.py
@@ -90,6 +90,26 @@ def test_backfill_local_and_operational_update(
             .to_array()
             .all()
         )
+        assert (
+            (
+                space_subset_ds[
+                    [
+                        "precipitation_surface",
+                        "maximum_temperature_2m",
+                        "minimum_temperature_2m",
+                        "categorical_freezing_rain_surface",
+                    ]
+                ]
+                # All null at lead time 0
+                .isel(lead_time=0)
+                .isnull()
+                .mean()
+                == 1
+            )
+            .all()
+            .to_array()
+            .all()
+        )
 
         point_ds = original_ds.sel(
             latitude=0,


### PR DESCRIPTION
With the default write_empty_chunks=False and an issue w/ xarray/zarr not round tripping nan fill value when read and rewritten, the effective fill value was 0. This meant chunks w/ all 0s (e.g. some chunks of some categorical variables) were not written. Until they are rewritten, keep fill_value=0 so they read properly as 0 not nan.

Also temporarily skip shard count check specifically for these variables in hrrr because we don't expect the full set of shards to exist.