### PR TITLE
Implement overwrite_existing flag and add env guards

### DIFF
--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -458,6 +458,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         return self.template_config.get_template(pd.Timestamp(append_dim_end))
 
     def _can_run_in_kubernetes(self) -> bool:
+        # This is a method to support testing without changing the Config.env
         return Config.is_prod
 
     @contextmanager

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -226,6 +226,9 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         if overwrite_existing:
             log.info("Writing to existing stores, skipping metadata write.")
+            assert self.store_factory.all_stores_exist(), (
+                "Not all stores exist, cannot run with overwrite_existing=True"
+            )
         else:
             template_utils.write_metadata(template_ds, self.store_factory)
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -225,7 +225,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         template_ds = self._get_template(append_dim_end)
 
         if overwrite_existing:
-            log.info("Writing to existing store")
+            log.info("Writing to existing stores, skipping metadata write.")
         else:
             template_utils.write_metadata(template_ds, self.store_factory)
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -225,10 +225,10 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         template_ds = self._get_template(append_dim_end)
 
         if overwrite_existing:
-            log.info("Writing to existing stores, skipping metadata write.")
             assert self.store_factory.all_stores_exist(), (
                 "Not all stores exist, cannot run with overwrite_existing=True"
             )
+            log.info("Writing to existing stores, skipping metadata write.")
         else:
             template_utils.write_metadata(template_ds, self.store_factory)
 

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -164,7 +164,7 @@ class StoreFactory(FrozenBaseModel):
         """Check if all stores exist."""
         for store in [self.primary_store(), *self.replica_stores()]:
             try:
-                xr.open_zarr(store)
+                xr.open_zarr(store, decode_timedelta=True)
             except Exception:
                 log.error(f"Store {store} does not exist")
                 return False

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -12,14 +12,18 @@ from uuid import uuid4
 
 import fsspec  # type: ignore[import-untyped]
 import icechunk
+import xarray as xr
 import zarr
 from icechunk.store import IcechunkStore
 from pydantic import Field, computed_field, field_validator
 
 from reformatters.common import kubernetes
 from reformatters.common.config import Config, Env
+from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.retry import retry
+
+log = get_logger(__name__)
 
 _LOCAL_ZARR_STORE_BASE_PATH = "data/output"
 _SECRET_MOUNT_PATH = "/secrets"  # noqa: S105 this not a real secret
@@ -155,6 +159,16 @@ class StoreFactory(FrozenBaseModel):
         assert isinstance(fs, fsspec.spec.AbstractFileSystem)
 
         return fs, relative_path
+
+    def all_stores_exist(self) -> bool:
+        """Check if all stores exist."""
+        for store in [self.primary_store(), *self.replica_stores()]:
+            try:
+                xr.open_zarr(store)
+            except Exception:
+                log.error(f"Store {store} does not exist")
+                return False
+        return True
 
 
 @cache

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -278,7 +278,7 @@ def test_backfill_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
 
 
 def test_backfill_kubernetes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    # Generally this monkeypatching _can_run_in_kuberneretes is dangerous.
+    # Generally monkeypatching _can_run_in_kuberneretes is dangerous.
     # However, we need to test the internals of backfill_kubernetes so we override this here.
     monkeypatch.setattr(
         DynamicalDataset, "_can_run_in_kubernetes", Mock(return_value=True)
@@ -458,7 +458,7 @@ def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_backfill_kubernetes_overwrite_existing_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Generally this monkeypatching _can_run_in_kuberneretes is dangerous.
+    # Generally monkeypatching _can_run_in_kuberneretes is dangerous.
     # However, we need to test the internals of backfill_kubernetes so we override this here.
     monkeypatch.setattr(
         DynamicalDataset, "_can_run_in_kubernetes", Mock(return_value=True)

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -575,3 +575,19 @@ def test_backfill_kubernetes_overwrite_existing_flag_fails_in_wrong_environment(
             max_parallelism=1,
             overwrite_existing=True,
         )
+
+
+def test_backfill_local_fails_in_wrong_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Config, "env", Mock(return_value="not-dev-or-test"))
+
+    dataset = ExampleDataset(
+        template_config=ExampleConfig(),
+        region_job_class=ExampleRegionJob,
+    )
+    with pytest.raises(
+        AssertionError,
+        match="backfill_local is only supported in dev or test environments",
+    ):
+        dataset.backfill_local(append_dim_end=pd.Timestamp("2000-01-02"))


### PR DESCRIPTION
This PR

* Adds an `overwrite_existing` flag that can be passed to `backfill_kubernetes`
* Adds env guards for `backfill_local` and `backfill_kubernetes`.
   * The guard for backfill kubernetes is wrapped in a new private method that can be directly monkeypatched without dangerous monkeypatching the actual env (which controls what stores we load etc).