### PR TITLE
Common secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We use
 1. Install `docker` and `kubectl`. Make sure `docker` can be found at /usr/bin/docker and `kubectl` at /usr/bin/kubectl.
 1. Setup a docker image repository and export the DOCKER_REPOSITORY environment variable in your local shell. eg. `export DOCKER_REPOSITORY=us-central1-docker.pkg.dev/<project-id>/reformatters/main`
 1. Setup a kubernetes cluster and configure kubectl to point to your cluster. eg `gcloud container clusters get-credentials <cluster-name> --region <region> --project <project>`
-1. Create a kubectl secret containing your Source Coop S3 credentials `kubectl create secret generic source-coop-storage-options-key --from-literal=storage_options.json='{"key": "...", "secret": "..."}'`.
+1. Create a kubectl secret containing your Source Coop S3 credentials `kubectl create secret generic source-coop-storage-options-key --from-literal=contents='{"key": "...", "secret": "..."}'`.
 
 
 ### Development commands

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -255,10 +255,11 @@ class ValidationCronJob(CronJob):
 
 
 def load_secret(secret_name: str) -> dict[str, str | int | float | bool | None]:
-    """Load a secret from k8s, either from mounted file or directly from k8s API.
+    """
+    Load a secret from kubernetes, either from mounted file or directly from k8s API.
 
     Returns empty dict in non-prod environments.
-    In prod, loads from mounted secret file, or falls back to k8s API if running locally.
+    When env is prod, loads from mounted secret file, or falls back to k8s API if running locally.
     """
     if not Config.is_prod:
         return {}

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -254,7 +254,7 @@ class ValidationCronJob(CronJob):
     parallelism: int = 1
 
 
-def load_secret(secret_name: str) -> dict[str, str | int | float | bool | None]:
+def load_secret(secret_name: str) -> dict[str, Any]:
     """
     Load a secret from kubernetes, either from mounted file or directly from k8s API.
 
@@ -284,7 +284,7 @@ def load_secret(secret_name: str) -> dict[str, str | int | float | bool | None]:
 
 def _load_secret_from_k8s_api(
     secret_name: str,
-) -> dict[str, str | int | float | bool | None]:
+) -> dict[str, Any]:
     """Load secret directly from k8s API (for local development)."""
     config.load_kube_config()
     v1 = client.CoreV1Api()

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -33,9 +33,6 @@ class Job(pydantic.BaseModel):
     pod_active_deadline: timedelta = timedelta(hours=6)
 
     secret_names: Sequence[str] = pydantic.Field(default_factory=list)
-    # This is to support legacy datasets that have not yet been ported to the DynamicalDataset pattern
-    # (GEFS forecast and GEFS analysis).
-    env_var_secret_names: Sequence[str] = pydantic.Field(default_factory=list)
 
     @property
     def job_name(self) -> str:
@@ -120,10 +117,6 @@ class Job(pydantic.BaseModel):
                                         "name": "WORKERS_TOTAL",
                                         "value": f"{self.workers_total}",
                                     },
-                                ],
-                                "envFrom": [
-                                    {"secretRef": {"name": env_var_secret_name}}
-                                    for env_var_secret_name in self.env_var_secret_names
                                 ],
                                 "image": f"{self.image}",
                                 "name": "worker",

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -245,7 +245,7 @@ class ValidationCronJob(CronJob):
     parallelism: int = 1
 
 
-def load_k8s_secrets_locally(secret_name: str) -> dict[str, Any]:
+def load_secret_locally(secret_name: str) -> dict[str, Any]:
     config.load_kube_config()
     v1 = client.CoreV1Api()
     secret = v1.read_namespaced_secret(secret_name, "default")

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -256,10 +256,10 @@ class ValidationCronJob(CronJob):
 
 def load_secret(secret_name: str) -> dict[str, Any]:
     """
-    Load a secret from kubernetes, either from mounted file or directly from k8s API.
+    Load a secret from kubernetes, either from mounted file or directly from kubernetes API.
 
     Returns empty dict in non-prod environments.
-    When env is prod, loads from mounted secret file, or falls back to k8s API if running locally.
+    When env is prod, loads from mounted secret file, or falls back to kubernetes API if running locally.
     """
     if not Config.is_prod:
         return {}
@@ -274,7 +274,7 @@ def load_secret(secret_name: str) -> dict[str, Any]:
             )
         else:
             # Local case, e.g. to support backfill-kubernetes writing the zarr metadata
-            return _load_secret_from_k8s_api(secret_name)
+            return _load_secret_from_kubernetes_api(secret_name)
 
     with open(secret_file) as f:
         contents = json.load(f)
@@ -282,10 +282,10 @@ def load_secret(secret_name: str) -> dict[str, Any]:
         return contents
 
 
-def _load_secret_from_k8s_api(
+def _load_secret_from_kubernetes_api(
     secret_name: str,
 ) -> dict[str, Any]:
-    """Load secret directly from k8s API (for local development)."""
+    """Load secret directly from kubernetes API (for local development)."""
     config.load_kube_config()
     v1 = client.CoreV1Api()
     secret = v1.read_namespaced_secret(secret_name, "default")

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -69,7 +69,7 @@ class StorageConfig(FrozenBaseModel):
 
     def _load_storage_options_locally(self) -> dict[str, Any]:
         assert self.k8s_secret_name is not None
-        secret_data = kubernetes.load_k8s_secrets_locally(self.k8s_secret_name)
+        secret_data = kubernetes.load_secret_locally(self.k8s_secret_name)
         storage_options_json = base64.b64decode(
             secret_data[_STORAGE_OPTIONS_KEY]
         ).decode("utf-8")

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -1,7 +1,4 @@
-import base64
 import functools
-import json
-import os
 from collections.abc import Sequence
 from enum import StrEnum
 from functools import cache
@@ -26,8 +23,6 @@ from reformatters.common.retry import retry
 log = get_logger(__name__)
 
 _LOCAL_ZARR_STORE_BASE_PATH = "data/output"
-_SECRET_MOUNT_PATH = "/secrets"  # noqa: S105 this not a real secret
-_STORAGE_OPTIONS_KEY = "storage_options.json"
 
 # This is a sentinel value to indicate that we should not try to load the storage options from a Kubernetes secret.
 # This is useful in the test and dev environments where we don't have a Kubernetes secret mounted.
@@ -48,34 +43,10 @@ class StorageConfig(FrozenBaseModel):
 
     def load_storage_options(self) -> dict[str, Any]:
         """Load the storage options from the Kubernetes secret."""
-        if not Config.is_prod or self.k8s_secret_name == _NO_SECRET_NAME:
+        if self.k8s_secret_name == _NO_SECRET_NAME:
             return {}
 
-        secret_file = Path(_SECRET_MOUNT_PATH) / f"{self.k8s_secret_name}.json"
-
-        # When we backfill, we need to write the template metadata to our cloud stoage
-        # location. To do this, we need the credentials to write to the base path, but
-        # because this happens locally, we don't have the secret mounted. In this case
-        # we will attempt to load the secrets from kubernetes locally. This assumes that
-        # we are connected to the kubernetes cluster locally. We have a guard on JOB_NAME
-        # to ensure that we don't try to do this when this is run in the cluster.
-        if not secret_file.exists() and os.getenv("JOB_NAME") is None:
-            return self._load_storage_options_locally()
-
-        with open(secret_file) as f:
-            options = json.load(f)
-            assert isinstance(options, dict)
-            return options
-
-    def _load_storage_options_locally(self) -> dict[str, Any]:
-        assert self.k8s_secret_name is not None
-        secret_data = kubernetes.load_secret_locally(self.k8s_secret_name)
-        storage_options_json = base64.b64decode(
-            secret_data[_STORAGE_OPTIONS_KEY]
-        ).decode("utf-8")
-        options = json.loads(storage_options_json)
-        assert isinstance(options, dict)
-        return options
+        return kubernetes.load_secret(self.k8s_secret_name)
 
 
 class StoreFactory(FrozenBaseModel):

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -107,13 +107,13 @@ def test_as_kubernetes_object_comprehensive() -> None:
                             {
                                 "name": "aws-creds",
                                 "mountPath": "/secrets/aws-creds.json",
-                                "subPath": "storage_options.json",
+                                "subPath": "contents",
                                 "readOnly": True,
                             },
                             {
                                 "name": "db-creds",
                                 "mountPath": "/secrets/db-creds.json",
-                                "subPath": "storage_options.json",
+                                "subPath": "contents",
                                 "readOnly": True,
                             },
                         ],

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -303,9 +303,7 @@ def test_load_secret_from_k8s_api_when_local(
 
     secret_data = {"api_key": "secret123", "count": 99}
 
-    with patch(
-        "reformatters.common.kubernetes._load_secret_from_k8s_api"
-    ) as mock_load:
+    with patch("reformatters.common.kubernetes._load_secret_from_k8s_api") as mock_load:
         mock_load.return_value = secret_data
         result = load_secret("test-secret")
 
@@ -327,9 +325,7 @@ def test_load_secret_from_k8s_api() -> None:
 
     with (
         patch("reformatters.common.kubernetes.config.load_kube_config"),
-        patch(
-            "reformatters.common.kubernetes.client.CoreV1Api", return_value=mock_v1
-        ),
+        patch("reformatters.common.kubernetes.client.CoreV1Api", return_value=mock_v1),
     ):
         result = _load_secret_from_k8s_api("db-credentials")
 

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -102,7 +102,6 @@ def test_as_kubernetes_object_comprehensive() -> None:
                                 "value": "4",
                             },
                         ],
-                        "envFrom": [],
                         "image": "weather-app:v1.0",
                         "name": "worker",
                         "resources": {

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -286,7 +286,7 @@ def test_load_secret_raises_when_file_missing_in_job(
     monkeypatch.setenv("JOB_NAME", "test-job")
 
     with pytest.raises(
-        FileNotFoundError, match="Secret file .* not found in production job"
+        FileNotFoundError, match=r"Secret file .* not found in production job"
     ):
         load_secret("missing-secret")
 

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -1,9 +1,18 @@
+import base64
+import json
 from datetime import timedelta
+from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from reformatters.common.kubernetes import Job
+from reformatters.common.config import Config, Env
+from reformatters.common.kubernetes import (
+    Job,
+    _load_secret_from_k8s_api,
+    load_secret,
+)
 
 
 def test_as_kubernetes_object_comprehensive() -> None:
@@ -234,3 +243,95 @@ def test_max_failed_indexes_calculation(
 
     k8s_obj = job.as_kubernetes_object()
     assert k8s_obj["spec"]["maxFailedIndexes"] == expected_max_failed_indexes
+
+
+def test_load_secret_returns_empty_dict_in_non_prod(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that load_secret returns empty dict when not in prod environment."""
+    monkeypatch.setattr(Config, "env", Env.dev)
+    result = load_secret("test-secret")
+    assert result == {}
+
+    monkeypatch.setattr(Config, "env", Env.test)
+    result = load_secret("test-secret")
+    assert result == {}
+
+
+def test_load_secret_from_mounted_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that load_secret loads from mounted file in prod when file exists."""
+    monkeypatch.setattr(Config, "env", Env.prod)
+    monkeypatch.setattr(
+        "reformatters.common.kubernetes._SECRET_MOUNT_PATH", str(tmp_path)
+    )
+
+    secret_data = {"key1": "value1", "key2": 42, "key3": True}
+    secret_file = tmp_path / "test-secret.json"
+    secret_file.write_text(json.dumps(secret_data))
+
+    result = load_secret("test-secret")
+    assert result == secret_data
+
+
+def test_load_secret_raises_when_file_missing_in_job(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that load_secret raises FileNotFoundError when file missing and JOB_NAME is set."""
+    monkeypatch.setattr(Config, "env", Env.prod)
+    monkeypatch.setattr(
+        "reformatters.common.kubernetes._SECRET_MOUNT_PATH", str(tmp_path)
+    )
+    monkeypatch.setenv("JOB_NAME", "test-job")
+
+    with pytest.raises(
+        FileNotFoundError, match="Secret file .* not found in production job"
+    ):
+        load_secret("missing-secret")
+
+
+def test_load_secret_from_k8s_api_when_local(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that load_secret falls back to k8s API when running locally (no JOB_NAME)."""
+    monkeypatch.setattr(Config, "env", Env.prod)
+    monkeypatch.setattr(
+        "reformatters.common.kubernetes._SECRET_MOUNT_PATH", str(tmp_path)
+    )
+    monkeypatch.delenv("JOB_NAME", raising=False)
+
+    secret_data = {"api_key": "secret123", "count": 99}
+
+    with patch(
+        "reformatters.common.kubernetes._load_secret_from_k8s_api"
+    ) as mock_load:
+        mock_load.return_value = secret_data
+        result = load_secret("test-secret")
+
+    assert result == secret_data
+    mock_load.assert_called_once_with("test-secret")
+
+
+def test_load_secret_from_k8s_api() -> None:
+    """Test _load_secret_from_k8s_api loads and decodes secret from k8s API."""
+    secret_data = {"username": "admin", "password": "secret", "port": 5432}
+    secret_json = json.dumps(secret_data)
+    encoded_secret = base64.b64encode(secret_json.encode("utf-8")).decode("utf-8")
+
+    mock_secret = Mock()
+    mock_secret.data = {"contents": encoded_secret}
+
+    mock_v1 = MagicMock()
+    mock_v1.read_namespaced_secret.return_value = mock_secret
+
+    with (
+        patch("reformatters.common.kubernetes.config.load_kube_config"),
+        patch(
+            "reformatters.common.kubernetes.client.CoreV1Api", return_value=mock_v1
+        ),
+    ):
+        result = _load_secret_from_k8s_api("db-credentials")
+
+    assert result == secret_data
+    mock_v1.read_namespaced_secret.assert_called_once_with("db-credentials", "default")


### PR DESCRIPTION
Generalize the secret mounting, decoding, k8s-api-fetching-when-running-locally pattern we use for storage_options.json to be general k8s utils for us so we can use the same pattern to load secrets for other things (e.g. credentials to access some data).

Note: this change requires we edit our existing secrets before merging to have their key be `contents` not `storage_options.json`.  (More general name, and doesn't have dots in it so easier to use with jsonpath=...)