### PR TITLE
Disable parallel pytest-xdist when a single test file is passed 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ reformatters = ["py.typed"]
 [tool.pytest.ini_options]
 pythonpath = "src/reformatters"
 testpaths = ["tests/"]
-addopts = "-n auto --dist loadfile"
+addopts = "-n auto --dist loadfile"  # see pytest_xdist_auto_num_workers in conftest.py
 markers = [
     "slow: slow running tests.",
     "skip_set_local_zarr_store_base_path: opt out of automatically writing zarrs to a tmp directory during tests",

--- a/src/reformatters/common/retry.py
+++ b/src/reformatters/common/retry.py
@@ -1,11 +1,10 @@
 import time
 from collections.abc import Callable
-from typing import Any
 
 import numpy as np
 
 
-def retry(func: Callable[[], Any], max_attempts: int = 6) -> Any:
+def retry[T](func: Callable[[], T], max_attempts: int = 6) -> T:
     """Simple retry utility that sleeps for a short time between attempts."""
     for attempt in range(max_attempts):
         try:
@@ -15,3 +14,5 @@ def retry(func: Callable[[], Any], max_attempts: int = 6) -> Any:
                 raise
             time.sleep(attempt * np.random.uniform(0.8, 1.2) + 0.1)
             continue
+
+    raise AssertionError("Unreachable")

--- a/src/reformatters/common/retry.py
+++ b/src/reformatters/common/retry.py
@@ -6,13 +6,13 @@ import numpy as np
 
 def retry[T](func: Callable[[], T], max_attempts: int = 6) -> T:
     """Simple retry utility that sleeps for a short time between attempts."""
+    last_exception = None
     for attempt in range(max_attempts):
         try:
             return func()
-        except Exception:
-            if attempt == max_attempts - 1:  # Last attempt failed
-                raise
-            time.sleep(attempt * np.random.uniform(0.8, 1.2) + 0.1)
-            continue
+        except Exception as e:
+            last_exception = e
+            if attempt < max_attempts - 1:  # sleep unless we're out of attempts
+                time.sleep(attempt * np.random.uniform(0.8, 1.2) + 0.1)
 
-    raise AssertionError("Unreachable")
+    raise last_exception if last_exception else AssertionError("unreachable")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,23 @@ os.environ["DYNAMICAL_ENV"] = "test"
 from reformatters.common import storage
 
 
+def pytest_xdist_auto_num_workers(config: pytest.Config) -> int | None:
+    """
+    Determine the number of parallel test workers.
+
+    Disables xdist when a single test file is specified,
+    otherwise uses all available CPUs.
+    """
+    file_or_dir = config.option.file_or_dir
+    if (
+        file_or_dir
+        and len(file_or_dir) == 1
+        and file_or_dir[0].split("::")[0].endswith(".py")
+    ):
+        return 0
+    return None  # use default behavior (all CPUs)
+
+
 @pytest.fixture(autouse=True)
 def set_local_zarr_store_base_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,11 +31,7 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int | None:
     otherwise uses all available CPUs.
     """
     file_or_dir = config.option.file_or_dir
-    if (
-        file_or_dir
-        and len(file_or_dir) == 1
-        and file_or_dir[0].split("::")[0].endswith(".py")
-    ):
+    if len(file_or_dir) == 1 and file_or_dir[0].split("::")[0].endswith(".py"):
         return 0
     return None  # use default behavior (all CPUs)
 


### PR DESCRIPTION
This avoids the parallel worker startup overhead when iterating on quick tests, but keeps it when there's multiple files and parallelism is likely worthwhile.

Unrelated but also add type parameter to retry function so wrapped function's return type is not lost.
