### PR TITLE
Contrib NDVI: Bump NaN threshold for validator to 95%

### DIFF
--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/validators.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/validators.py
@@ -41,8 +41,8 @@ def check_latest_ndvi_usable_nan_percentage(
     # 95% of the data is NaN
     # We have seen NaN percentages as low as ~93.5%, which means that ~6.5% of the data
     # can be expected to plausibly have a value. We have seen this percentage go over our original threshold of 94% in the past,
-    # so 95% is set so that we are alerted if roughly 25% of this subset of plausibly non-NaN data is NaN.
-    threshold = 0.95
+    # so 96% is set so that we are alerted if roughly 40% of this subset of plausibly non-NaN data is NaN.
+    threshold = 0.96
     ndvi_usable = ds.isel(time=-1).ndvi_usable
 
     if (percentage_nan := ndvi_usable.isnull().sum() / ndvi_usable.size) >= threshold:

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/validators.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/validators.py
@@ -37,7 +37,12 @@ def check_latest_ndvi_usable_nan_percentage(
     # NaNed out. For `ndvi_usable`, we will generally read this this data using a rolling
     # 16 day max, so individual days with high nan percentages, due to e.g., cloud cover, will
     # be smoothed out.
-    threshold = 0.94  # 94% of the data is NaN
+    #
+    # 95% of the data is NaN
+    # We have seen NaN percentages as low as ~93.5%, which means that ~6.5% of the data
+    # can be expected to plausibly have a value. We have seen this percentage go over our original threshold of 94% in the past,
+    # so 95% is set so that we are alerted if roughly 25% of this subset of plausibly non-NaN data is NaN.
+    threshold = 0.95
     ndvi_usable = ds.isel(time=-1).ndvi_usable
 
     if (percentage_nan := ndvi_usable.isnull().sum() / ndvi_usable.size) >= threshold:

--- a/tests/contrib/noaa/ndvi_cdr/analysis/validators_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/validators_test.py
@@ -71,8 +71,8 @@ def test_check_data_is_current_success_with_nonzero_time(
 @pytest.mark.parametrize(
     "nan_count,expected_pass",
     [
-        (94, True),  # 94% NaN, should fail
-        (95, True),  # 95% NaN, should fail
+        (94, True),  # 94% NaN, should pass
+        (95, True),  # 95% NaN, should pass
         (96, False),  # 96% NaN, should fail
     ],
 )

--- a/tests/contrib/noaa/ndvi_cdr/analysis/validators_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/validators_test.py
@@ -71,15 +71,15 @@ def test_check_data_is_current_success_with_nonzero_time(
 @pytest.mark.parametrize(
     "nan_count,expected_pass",
     [
-        (93, True),  # 93% NaN, should pass
-        (94, False),  # 94% NaN, should fail
-        (95, False),  # 95% NaN, should fail
+        (94, True),  # 94% NaN, should fail
+        (95, True),  # 95% NaN, should fail
+        (96, False),  # 96% NaN, should fail
     ],
 )
 def test_check_latest_ndvi_usable_nan_percentage_threshold(
     nan_count: int, expected_pass: bool
 ) -> None:
-    """Test validator at, below, and above the 94% NaN threshold."""
+    """Test validator at, below, and above the 96% NaN threshold."""
     times = pd.date_range("2024-01-01", periods=2, freq="1D")
     shape = (2, 10, 10)  # 100 values per time step
     ndvi_usable = np.ones(shape)

--- a/tests/contrib/noaa/ndvi_cdr/analysis/validators_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/validators_test.py
@@ -71,9 +71,9 @@ def test_check_data_is_current_success_with_nonzero_time(
 @pytest.mark.parametrize(
     "nan_count,expected_pass",
     [
-        (94, True),  # 94% NaN, should pass
         (95, True),  # 95% NaN, should pass
         (96, False),  # 96% NaN, should fail
+        (97, False),  # 97% NaN, should fail
     ],
 )
 def test_check_latest_ndvi_usable_nan_percentage_threshold(


### PR DESCRIPTION
From a previous spot check of recent data, we saw some days had a nan percentage as low as ~93.5. Recently we've had a number of days where the percentage was a bit higher than 94%. Since this seems to be a somewhat regular occurrence, and there is also little we can do to mitigate it, we are raising the threshold for validation failure. 95% is selected since it would mean that close to 25% of the normally non-nan data happens to be NaN.

```
In [47]: ds.isel(time=-1).ndvi_usable.shape
Out[47]: (3600, 7200)

In [48]: 3600*7200
Out[48]: 25920000

In [49]: total_values = 3600*7200

In [51]: (total_values - (total_values * 0.95)) / (total_values - (total_values * 0.935))
Out[51]: 0.7692307692307693
```