### PR TITLE
SMAP: allow up to 97% nans in a quadrant of the earth

### DIFF
--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
@@ -66,7 +66,7 @@ class NasaSmapLevel336KmV9Dataset(
                 validation.check_analysis_recent_nans,
                 max_expected_delay=max_expected_delay,
                 # Oceans and about half of land (due to swaths) are expected to be NaNs
-                max_nan_percentage=90,
+                max_nan_percentage=97,
                 spatial_sampling="quarter",
             ),
         )


### PR DESCRIPTION
In practice this is what we find on a single day because of oceans and swath coverage