### PR TITLE
Reduce char length of ecmwf operational update job name

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
@@ -29,7 +29,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
 
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             # ECMWF uploads the first file at 07:40 UTC and the last one by ~07:45 UTC.
             # (Ensemble stats get uploaded 15-20 mins later, but we don't process those.)
             schedule="50 7 * * *",

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset_test.py
@@ -158,7 +158,7 @@ def test_operational_kubernetes_resources(
 
     assert len(cron_jobs) == 2
     update_cron_job, validation_cron_job = cron_jobs
-    assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
+    assert update_cron_job.name == f"{dataset.dataset_id}-update"
     assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
     assert update_cron_job.secret_names == [
         dataset.primary_storage_config.k8s_secret_name


### PR DESCRIPTION
The length of this job name is too long! We were getting the following errors during deploys.

`The CronJob "ecmwf-ifs-ens-forecast-15-day-0-25-degree-operational-update" is invalid: metadata.name: Invalid value: "ecmwf-ifs-ens-forecast-15-day-0-25-degree-operational-update": must be no more than 52 characters`

The new name (`ecmwf-ifs-ens-forecast-15-day-0-25-degree-update`) should slide right in under the limit.

We may want to do this for all operational update jobs in the future, but this unblocks deploys without messing with our operational resources for now.