### PR TITLE
Ensure that kubernetes_job.job_name computes the same name every time it is called

### DIFF
--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -5,6 +5,7 @@ import random
 import string
 from collections.abc import Sequence
 from datetime import timedelta
+from functools import cached_property
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -37,7 +38,7 @@ class Job(pydantic.BaseModel):
 
     secret_names: Sequence[str] = pydantic.Field(default_factory=list)
 
-    @property
+    @cached_property
     def job_name(self) -> str:
         # Job names should be a valid DNS name, 63 characters or less
         name = f"{self.dataset_id[:21]}-{'-'.join(self.command)}"

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -178,6 +178,7 @@ def test_kubernetes_job_name() -> None:
 
     k8s_obj: dict[str, Any] = job.as_kubernetes_object()
     assert job.job_name == k8s_obj["metadata"]["name"]
+    assert job.job_name == job.job_name  # quick explicit check that result is cached
 
 
 def test_as_kubernetes_object_with_custom_values() -> None:

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -163,6 +163,23 @@ def test_as_kubernetes_object_comprehensive() -> None:
     assert k8s_obj["spec"] == expected_spec
 
 
+def test_kubernetes_job_name() -> None:
+    """Test ensure that the job name is consistent across invocations"""
+    job = Job(
+        command=["backfill-kubernetes", "2025-01-01T00:00:00", "1", "1"],
+        image="weather-app:v1.0",
+        dataset_id="weather_data",
+        cpu="500m",
+        memory="1Gi",
+        workers_total=4,
+        parallelism=2,
+        secret_names=["aws-creds", "db-creds"],
+    )
+
+    k8s_obj: dict[str, Any] = job.as_kubernetes_object()
+    assert job.job_name == k8s_obj["metadata"]["name"]
+
+
 def test_as_kubernetes_object_with_custom_values() -> None:
     """Test as_kubernetes_object with custom resource values."""
     job = Job(


### PR DESCRIPTION
As a `property`, `job_name` has been returning a different name each time it is invoked, because we randomly generate a suffix for each name. For each instantiated k8s job object, the name should be consistent across invocations.

The bug's impact thus far as has been minimal: we call `job_name` in only two places  currently: setting the `metadata` name in the k8s yaml, and when logging the job name. The current problematic behavior is that we log the incorrect job name when we do:

```
        log.info(f"Submitted kubernetes job {kubernetes_job.job_name}")
```

This fix caches the result, so the name is consistent.

