### PR TITLE
Allow up to 98% of SMAP values to be nan in validator

### DIFF
--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
@@ -65,7 +65,8 @@ class NasaSmapLevel336KmV9Dataset(
                 validation.check_analysis_recent_nans,
                 max_expected_delay=max_expected_delay,
                 # Oceans and about half of land (due to swaths) are expected to be NaNs
-                max_nan_percentage=97,
+                # This value sounds very loose but has been tuned based on real values
+                max_nan_percentage=98,
                 spatial_sampling="quarter",
             ),
         )


### PR DESCRIPTION
After accounting for oceans (2/3rds always nan),
satellite swaths (about 50% per day),
and clouds, esp at overrepresented high latitudes, we see ocasional days with > 97% nans in practice

<img width="851" height="61" alt="image" src="https://github.com/user-attachments/assets/c0f53126-f143-48f3-8527-f03099b8e804" />
