### PR TITLE
ECMWF IFS: Update temp units to Celsius

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
@@ -342,7 +342,7 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                 attrs=DataVarAttrs(
                     short_name="t2m",
                     long_name="2 metre temperature",
-                    units="K",
+                    units="C",
                     step_type="instant",
                     standard_name="air_temperature",
                 ),

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/temperature_2m/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/temperature_2m/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "2 metre temperature",
     "short_name": "t2m",
     "standard_name": "air_temperature",
-    "units": "K",
+    "units": "C",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
@@ -1061,7 +1061,7 @@
           "long_name": "2 metre temperature",
           "short_name": "t2m",
           "standard_name": "air_temperature",
-          "units": "K",
+          "units": "C",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="


### PR DESCRIPTION
This one's an oops that passed through our checks/review so far! 

It's definitely in Celsius -- the source dataset notes it's in C, and I only noticed it when looking at one of the plots creating the quickstart notebook that it's wrong right now (note all the values in the plot are definitely in C range, not K)!

<img width="1063" height="707" alt="image" src="https://github.com/user-attachments/assets/121286e3-f38c-4156-9486-06dee81bc406" />

