### PR TITLE
Validators: Dask For Low Memory

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -47,8 +47,7 @@ def validate_dataset(
     """
     log.info(f"Validating zarr {store}")
 
-    # Open dataset
-    ds = xr.open_zarr(store, chunks=None)
+    ds = xr.open_zarr(store)
 
     # Run all validators
     failed_validations = []

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
@@ -51,7 +51,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="0.5",
-            memory="30G",
+            memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
         )
 


### PR DESCRIPTION
We needed to configure a lot of memory to run the ecmwf validators.

After profiling, we determined using Dask helps a lot. I've dropped ECMWF back down to 7 where we had it originally. Can potentially reduce other datasets as well once we observe.

Before (only partially through the primary validators due to running out of memory on my machine):
<img width="1444" height="616" alt="image" src="https://github.com/user-attachments/assets/039aa050-aef3-41a0-92da-ec358469b98f" />

After:
<img width="1422" height="762" alt="image" src="https://github.com/user-attachments/assets/72f20202-0ecc-40cc-94bc-891ca9f6dbce" />
