### PR TITLE
ECMWF IFS ENS: tiniest units reformatting

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
@@ -360,7 +360,7 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                 attrs=DataVarAttrs(
                     short_name="u10",
                     long_name="10 metre U wind component",
-                    units="m s**-1",
+                    units="m/s",
                     step_type="instant",
                     standard_name="eastward_wind",
                 ),
@@ -378,7 +378,7 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                 attrs=DataVarAttrs(
                     short_name="v10",
                     long_name="10 metre V wind component",
-                    units="m s**-1",
+                    units="m/s",
                     step_type="instant",
                     standard_name="northward_wind",
                 ),
@@ -457,7 +457,7 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                 attrs=DataVarAttrs(
                     short_name="ptype",
                     long_name="Categorical precipitation type at surface",
-                    units="[0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
+                    units="0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
                     step_type="instant",
                 ),
                 internal_attrs=EcmwfInternalAttrs(

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/categorical_precipitation_type_surface/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/categorical_precipitation_type_surface/zarr.json
@@ -73,7 +73,7 @@
   "attributes": {
     "long_name": "Categorical precipitation type at surface",
     "short_name": "ptype",
-    "units": "[0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
+    "units": "0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/wind_u_10m/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/wind_u_10m/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "10 metre U wind component",
     "short_name": "u10",
     "standard_name": "eastward_wind",
-    "units": "m s**-1",
+    "units": "m/s",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/wind_v_10m/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/wind_v_10m/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "10 metre V wind component",
     "short_name": "v10",
     "standard_name": "northward_wind",
-    "units": "m s**-1",
+    "units": "m/s",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
@@ -92,7 +92,7 @@
         "attributes": {
           "long_name": "Categorical precipitation type at surface",
           "short_name": "ptype",
-          "units": "[0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
+          "units": "0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1301,7 +1301,7 @@
           "long_name": "10 metre U wind component",
           "short_name": "u10",
           "standard_name": "eastward_wind",
-          "units": "m s**-1",
+          "units": "m/s",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1485,7 +1485,7 @@
           "long_name": "10 metre V wind component",
           "short_name": "v10",
           "standard_name": "northward_wind",
-          "units": "m s**-1",
+          "units": "m/s",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="


### PR DESCRIPTION
changes:
* makes all windspeed units consistent as `m/s` (rather than some at `m/s` and others at `m s**-1`)
* removes an extraneous bracket from precip type categorical units description