### PR TITLE
Revert "Validators: Dask For Low Memory"

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -47,7 +47,8 @@ def validate_dataset(
     """
     log.info(f"Validating zarr {store}")
 
-    ds = xr.open_zarr(store)
+    # Open dataset
+    ds = xr.open_zarr(store, chunks=None)
 
     # Run all validators
     failed_validations = []

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
@@ -51,7 +51,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="0.5",
-            memory="7G",
+            memory="30G",
             secret_names=self.store_factory.k8s_secret_names(),
         )
 


### PR DESCRIPTION
Reverts dynamical-org/reformatters#309

Reverting because this causes validation to be > 10 min which is the limit set for most of our datasets. We can revisit next weel.