### PR TITLE
Validation: memory improvements

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -107,6 +107,9 @@ def check_forecast_recent_nans(
 
     problem_vars = []
     for var_name, sample_da in sample_ds.data_vars.items():
+        # Create a deep copy to avoid sharing memory with the original dataset
+        # We observed that this helps avoid memory leaks as we iterate and check
+        # nulls across variables.
         da = sample_da.copy(deep=True)
         nan_percentage = da.isnull().mean().compute() * 100
         if nan_percentage > max_nan_percentage:
@@ -249,6 +252,7 @@ def compare_replica_and_primary(
             if dim_name != append_dim
         }
 
+        # We create deep copies here to avoid sharing memory with the original dataset
         replica_ds_last_chunk = (
             replica_ds[var]
             .isel({append_dim: last_chunk, **non_append_dim_slices})

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -106,7 +106,8 @@ def check_forecast_recent_nans(
     )
 
     problem_vars = []
-    for var_name, da in sample_ds.data_vars.items():
+    for var_name, sample_da in sample_ds.data_vars.items():
+        da = sample_da.copy(deep=True)
         nan_percentage = da.isnull().mean().compute() * 100
         if nan_percentage > max_nan_percentage:
             problem_vars.append((var_name, nan_percentage))
@@ -248,11 +249,15 @@ def compare_replica_and_primary(
             if dim_name != append_dim
         }
 
-        replica_ds_last_chunk = replica_ds[var].isel(
-            {append_dim: last_chunk, **non_append_dim_slices}
+        replica_ds_last_chunk = (
+            replica_ds[var]
+            .isel({append_dim: last_chunk, **non_append_dim_slices})
+            .copy(deep=True)
         )
-        primary_ds_last_chunk = primary_ds[var].isel(
-            {append_dim: last_chunk, **non_append_dim_slices}
+        primary_ds_last_chunk = (
+            primary_ds[var]
+            .isel({append_dim: last_chunk, **non_append_dim_slices})
+            .copy(deep=True)
         )
 
         try:


### PR DESCRIPTION
Implement some manual memory cleanup to avoid memory leaks and reduce the amount of data checked in the replica vs primary validator.

The primary types of tweaks here are to:

* Avoid leaving a `ds` or `da` object around that we don't need
    * Open the validating dataset for each invoked validator
    * Create [deep copies](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.copy.html) of dataset/dataarray objects to avoid anything persisting in memory  between iterations
 * Explicit ds/da `close`  and `del` calls to expedite memory release
 * Reduce the amount of data we need to load when necessary
   * We've updated the replica vs primary comparison check to only look at random slices of data within the last `append_dim` chunk.   