### PR TITLE
Replace `@pydantic_dataclass` with `_StrictBaseModel` in `ftp_to_obstore.py`

### DIFF
--- a/src/reformatters/common/ftp_to_obstore.py
+++ b/src/reformatters/common/ftp_to_obstore.py
@@ -18,28 +18,31 @@ Each `ftp_worker` keeps an `aioftp.Client` alive until there are no more `_FtpFi
 import asyncio
 from asyncio import Queue
 from collections.abc import Iterable
-from dataclasses import field
 from pathlib import PurePosixPath
 
 import aioftp
+import pydantic
 from obstore.store import ObjectStore
-from pydantic import BaseModel
 
 from reformatters.common.logging import get_logger
 
 log = get_logger(__name__)
 
 
-class _FtpFile(BaseModel):
+class _StrictBaseModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(strict=True, revalidate_instances="always")
+
+
+class _FtpFile(_StrictBaseModel):
     src_ftp_path: PurePosixPath
     dst_obstore_path: str
-    n_retries: int = field(default=0, init=False)
+    n_retries: int = pydantic.Field(default=0, init=False)
 
 
-class _ObstoreFile(BaseModel):
+class _ObstoreFile(_StrictBaseModel):
     ftp_file: _FtpFile
     data: bytes
-    n_retries: int = field(default=0, init=False)
+    n_retries: int = pydantic.Field(default=0, init=False)
 
 
 async def copy_files_from_ftp_to_obstore(

--- a/src/reformatters/common/ftp_to_obstore.py
+++ b/src/reformatters/common/ftp_to_obstore.py
@@ -23,22 +23,20 @@ from pathlib import PurePosixPath
 
 import aioftp
 from obstore.store import ObjectStore
-from pydantic.dataclasses import dataclass as pydantic_dataclass
+from pydantic import BaseModel
 
 from reformatters.common.logging import get_logger
 
 log = get_logger(__name__)
 
 
-@pydantic_dataclass
-class _FtpFile:
+class _FtpFile(BaseModel):
     src_ftp_path: PurePosixPath
     dst_obstore_path: str
     n_retries: int = field(default=0, init=False)
 
 
-@pydantic_dataclass
-class _ObstoreFile:
+class _ObstoreFile(BaseModel):
     ftp_file: _FtpFile
     data: bytes
     n_retries: int = field(default=0, init=False)
@@ -92,7 +90,7 @@ async def copy_files_from_ftp_to_obstore(
     # Put _FtpFile objects on the ftp_queue:
     ftp_queue: Queue[_FtpFile] = Queue()
     for src, dst in zip(src_ftp_paths, dst_obstore_paths, strict=True):
-        ftp_queue.put_nowait(_FtpFile(src, dst))
+        ftp_queue.put_nowait(_FtpFile(src_ftp_path=src, dst_obstore_path=dst))
 
     # Set maxsize of Queue to apply back-pressure to the FTP workers.
     obstore_queue: Queue[_ObstoreFile] = Queue(maxsize=n_obstore_workers * 2)

--- a/src/reformatters/common/ftp_to_obstore.py
+++ b/src/reformatters/common/ftp_to_obstore.py
@@ -23,21 +23,21 @@ from pathlib import PurePosixPath
 
 import aioftp
 from obstore.store import ObjectStore
-from pydantic.dataclasses import dataclass as pydatic_dataclass
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from reformatters.common.logging import get_logger
 
 log = get_logger(__name__)
 
 
-@pydatic_dataclass
+@pydantic_dataclass
 class _FtpFile:
     src_ftp_path: PurePosixPath
     dst_obstore_path: str
     n_retries: int = field(default=0, init=False)
 
 
-@pydatic_dataclass
+@pydantic_dataclass
 class _ObstoreFile:
     ftp_file: _FtpFile
     data: bytes


### PR DESCRIPTION
This PR started as a fix for a spelling mistake :slightly_smiling_face:: Replace `pydatic_dataclass` with `pydantic_dataclass` in `ftp_to_obstore.py`.

But we also took the opportunity to change from using the pydantic `@dataclass` decorator to using a `_StrictBaseModel`.