### PR TITLE
Simpler + shorter cronjob names

### DIFF
--- a/.github/workflows/deploy-operational-updates.yml
+++ b/.github/workflows/deploy-operational-updates.yml
@@ -71,4 +71,4 @@ jobs:
           file: deploy/Dockerfile
 
       - name: Deploy
-        run: uv run main deploy-operational-updates --docker-image ${{ env.IMAGE_TAG }}
+        run: uv run main deploy --docker-image ${{ env.IMAGE_TAG }}

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -14,7 +14,7 @@ import typer
 from sentry_sdk.integrations.typer import TyperIntegration
 from sentry_sdk.types import Hint, Log
 
-from reformatters.common import deploy
+from reformatters.common import deploy as deploy_module
 from reformatters.common.config import Config
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.storage import DatasetFormat, StorageConfig
@@ -156,10 +156,10 @@ for dataset in DYNAMICAL_DATASETS:
 
 
 @app.command()
-def deploy_operational_updates(
+def deploy(
     docker_image: str | None = None,
 ) -> None:
-    deploy.deploy_operational_updates(DYNAMICAL_DATASETS, docker_image)
+    deploy_module.deploy_operational_resources(DYNAMICAL_DATASETS, docker_image)
 
 
 if __name__ == "__main__":

--- a/src/reformatters/common/deploy.py
+++ b/src/reformatters/common/deploy.py
@@ -10,7 +10,7 @@ from reformatters.common.logging import get_logger
 log = get_logger(__name__)
 
 
-def deploy_operational_updates(
+def deploy_operational_resources(
     datasets: Iterable[DynamicalDataset[Any, Any]],
     docker_image: str | None = None,
 ) -> None:

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -68,7 +68,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         Implementions should look similar this:
         ```
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             schedule=_OPERATIONAL_CRON_SCHEDULE,
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -80,7 +80,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule=_VALIDATION_CRON_SCHEDULE,
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
@@ -26,7 +26,7 @@ class NasaSmapLevel336KmV9Dataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             # New data comes 1x per day, usually around 5:45 but sometimes later, more like 14:00
             # Run twice to pick up the later data too (updates only take a couple minutes)
             schedule="0 6,18 * * *",
@@ -41,7 +41,7 @@ class NasaSmapLevel336KmV9Dataset(
             secret_names=[*self.store_factory.k8s_secret_names(), "nasa-earthdata"],
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="30 6,18 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
@@ -21,7 +21,7 @@ class NoaaNdviCdrAnalysisDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 20 * * *",
             pod_active_deadline=timedelta(minutes=60),
             image=image_tag,
@@ -33,7 +33,7 @@ class NoaaNdviCdrAnalysisDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="30 21 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -36,7 +36,7 @@ class UarizonaSwannAnalysisDataset(
 
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 20 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -48,7 +48,7 @@ class UarizonaSwannAnalysisDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="30 20 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/dwd/icon_eu/forecast/dynamical_dataset.py
+++ b/src/reformatters/dwd/icon_eu/forecast/dynamical_dataset.py
@@ -17,7 +17,7 @@ class DwdIconEuForecastDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         # operational_update_cron_job = ReformatCronJob(
-        #     name=f"{self.dataset_id}-operational-update",
+        #     name=f"{self.dataset_id}-update",
         #     schedule=_OPERATIONAL_CRON_SCHEDULE,
         #     pod_active_deadline=timedelta(minutes=30),
         #     image=image_tag,
@@ -29,7 +29,7 @@ class DwdIconEuForecastDataset(
         #     secret_names=self.store_factory.k8s_secret_names(),
         # )
         # validation_cron_job = ValidationCronJob(
-        #     name=f"{self.dataset_id}-validation",
+        #     name=f"{self.dataset_id}-validate",
         #     schedule=_VALIDATION_CRON_SCHEDULE,
         #     pod_active_deadline=timedelta(minutes=10),
         #     image=image_tag,

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
@@ -44,7 +44,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="50 10 * * *",  # 3 Hours after update starts (update may take ~2 hours)
             suspend=False,
             pod_active_deadline=timedelta(minutes=10),

--- a/src/reformatters/example/dynamical_dataset.py
+++ b/src/reformatters/example/dynamical_dataset.py
@@ -21,7 +21,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         # suspend = True  # Defaults to False, remove when you're ready to run operational updates and validation
         # operational_update_cron_job = ReformatCronJob(
-        #     name=f"{self.dataset_id}-operational-update",
+        #     name=f"{self.dataset_id}-update",
         #     schedule="0 0 * * *",
         #     pod_active_deadline=timedelta(minutes=30),
         #     image=image_tag,
@@ -34,7 +34,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
         #     suspend=suspend,
         # )
         # validation_cron_job = ValidationCronJob(
-        #     name=f"{self.dataset_id}-validation",
+        #     name=f"{self.dataset_id}-validate",
         #     schedule="30 0 * * *",
         #     pod_active_deadline=timedelta(minutes=10),
         #     image=image_tag,

--- a/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
@@ -21,7 +21,7 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 0,6,12,18 * * *",  # UTC
             pod_active_deadline=timedelta(hours=1),
             image=image_tag,
@@ -33,7 +33,7 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="10 0,6,12,18 * * *",  # UTC 10 minutes after update starts
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/noaa/gefs/forecast_35_day/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/dynamical_dataset.py
@@ -23,7 +23,7 @@ class GefsForecast35DayDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 7 * * *",  # At 7:00 UTC every day.
             pod_active_deadline=timedelta(hours=3.5),
             image=image_tag,
@@ -35,7 +35,7 @@ class GefsForecast35DayDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="30 11 * * *",  # At 11:30 UTC every day.
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,

--- a/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
@@ -19,7 +19,7 @@ class NoaaGfsForecastDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             schedule="30 5,11,17,23 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -31,7 +31,7 @@ class NoaaGfsForecastDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="0 6,12,18,0 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
@@ -38,7 +38,7 @@ class NoaaHrrrForecast48HourDataset(
         # Update every 6 hours at 1h50m after the init time (when all forecast steps are available)
         # First file typically becomes available at 51 mins and last file (hour 48) at 1h51m
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             schedule="55 1,7,13,19 * * *",
             pod_active_deadline=timedelta(minutes=15),  # usually takes 3 mins
             image=image_tag,
@@ -52,7 +52,7 @@ class NoaaHrrrForecast48HourDataset(
 
         # Validation job - run 15 mins after operational update
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="10 2,8,14,20 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -98,7 +98,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
         return [
             ReformatCronJob(
-                name=f"{self.dataset_id}-operational-update",
+                name=f"{self.dataset_id}-update",
                 schedule="0 0 * * *",
                 pod_active_deadline=timedelta(minutes=30),
                 image=image_tag,
@@ -110,7 +110,7 @@ class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
                 secret_names=self.store_factory.k8s_secret_names(),
             ),
             ValidationCronJob(
-                name=f"{self.dataset_id}-validation",
+                name=f"{self.dataset_id}-validate",
                 schedule="0 0 * * *",
                 pod_active_deadline=timedelta(minutes=30),
                 image=image_tag,

--- a/tests/contrib/nasa/smap/level3_36km_v9/dynamical_dataset_test.py
+++ b/tests/contrib/nasa/smap/level3_36km_v9/dynamical_dataset_test.py
@@ -97,8 +97,8 @@ def test_operational_kubernetes_resources(
 
     assert len(cron_jobs) == 2
     update_cron_job, validation_cron_job = cron_jobs
-    assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
-    assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
+    assert update_cron_job.name == f"{dataset.dataset_id}-update"
+    assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert update_cron_job.secret_names == [
         dataset.primary_storage_config.k8s_secret_name,
         "nasa-earthdata",

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -26,7 +26,7 @@ class ExampleDataset1:
 
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[Job]:
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.dataset_id}-operational-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 0 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -37,7 +37,7 @@ class ExampleDataset1:
             ephemeral_storage="30G",
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.dataset_id}-validation",
+            name=f"{self.dataset_id}-validate",
             schedule="0 0 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
@@ -53,7 +53,7 @@ class ExampleDataset2(ExampleDataset1):
     dataset_id: str = "example-dataset-2"
 
 
-def test_deploy_operational_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_deploy_operational_resources(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_run = Mock()
     monkeypatch.setattr(subprocess, "run", mock_run)
 
@@ -69,7 +69,7 @@ def test_deploy_operational_updates(monkeypatch: pytest.MonkeyPatch) -> None:
         DYNAMICAL_DATASETS
     )  # type: ignore[assignment]
 
-    deploy.deploy_operational_updates(test_datasets, docker_image="test-image-tag")
+    deploy.deploy_operational_resources(test_datasets, docker_image="test-image-tag")
 
     assert mock_run.call_count == 1
     args, kwargs = mock_run.call_args
@@ -81,10 +81,7 @@ def test_deploy_operational_updates(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Dataset 1
     assert resources["items"][0]["kind"] == "CronJob"
-    assert (
-        resources["items"][0]["metadata"]["name"]
-        == "example-dataset-1-operational-update"
-    )
+    assert resources["items"][0]["metadata"]["name"] == "example-dataset-1-update"
     container_spec = resources["items"][0]["spec"]["jobTemplate"]["spec"]["template"][
         "spec"
     ]["containers"][0]
@@ -93,7 +90,4 @@ def test_deploy_operational_updates(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Dataset 2
     assert resources["items"][2]["kind"] == "CronJob"
-    assert (
-        resources["items"][2]["metadata"]["name"]
-        == "example-dataset-2-operational-update"
-    )
+    assert resources["items"][2]["metadata"]["name"] == "example-dataset-2-update"

--- a/tests/dwd/icon_eu/forecast/dynamical_dataset_test.py
+++ b/tests/dwd/icon_eu/forecast/dynamical_dataset_test.py
@@ -60,8 +60,8 @@
 
 #     assert len(cron_jobs) == 2
 #     update_cron_job, validation_cron_job = cron_jobs
-#     assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
-#     assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
+#     assert update_cron_job.name == f"{dataset.dataset_id}-update"
+#     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
 #     assert update_cron_job.secret_names == [
 #         dataset.primary_storage_config.k8s_secret_name
 #     ]

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset_test.py
@@ -159,7 +159,7 @@ def test_operational_kubernetes_resources(
     assert len(cron_jobs) == 2
     update_cron_job, validation_cron_job = cron_jobs
     assert update_cron_job.name == f"{dataset.dataset_id}-update"
-    assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
+    assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert update_cron_job.secret_names == [
         dataset.primary_storage_config.k8s_secret_name
     ]

--- a/tests/example/dynamical_dataset_test.py
+++ b/tests/example/dynamical_dataset_test.py
@@ -60,8 +60,8 @@
 
 #     assert len(cron_jobs) == 2
 #     update_cron_job, validation_cron_job = cron_jobs
-#     assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
-#     assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
+#     assert update_cron_job.name == f"{dataset.dataset_id}-update"
+#     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
 #     assert update_cron_job.secret_names == [
 #         dataset.primary_storage_config.k8s_secret_name
 #     ]

--- a/tests/noaa/gefs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/analysis/dynamical_dataset_test.py
@@ -23,7 +23,7 @@ def test_operational_kubernetes_resources(dataset: GefsAnalysisDataset) -> None:
     update_cron_job, validation_cron_job = cron_jobs
 
     # Check update job
-    assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
+    assert update_cron_job.name == f"{dataset.dataset_id}-update"
     assert update_cron_job.schedule == "0 0,6,12,18 * * *"  # Every 6 hours
     assert update_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert update_cron_job.cpu == "14"
@@ -32,7 +32,7 @@ def test_operational_kubernetes_resources(dataset: GefsAnalysisDataset) -> None:
     assert update_cron_job.ephemeral_storage == "35G"
 
     # Check validation job
-    assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
+    assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert (
         validation_cron_job.schedule == "10 0,6,12,18 * * *"
     )  # 10 minutes after updates

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -552,7 +552,7 @@ def test_operational_update_jobs(
                 get_template_fn=mock_get_template_fn,
                 append_dim="time",
                 all_data_vars=example_data_vars,
-                reformat_job_name="test-operational-update",
+                reformat_job_name="test-update",
             )
 
             # Verify results
@@ -567,7 +567,7 @@ def test_operational_update_jobs(
             assert call_args.kwargs["tmp_store"] == tmp_store_path
             assert call_args.kwargs["append_dim"] == "time"
             assert call_args.kwargs["all_data_vars"] == example_data_vars
-            assert call_args.kwargs["reformat_job_name"] == "test-operational-update"
+            assert call_args.kwargs["reformat_job_name"] == "test-update"
             assert call_args.kwargs["filter_start"] == existing_time.max()
 
             # Verify existing dataset was opened correctly

--- a/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
@@ -25,7 +25,7 @@ def test_operational_kubernetes_resources(dataset: GefsForecast35DayDataset) -> 
     update_cron_job, validation_cron_job = cron_jobs
 
     # Check update job
-    assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
+    assert update_cron_job.name == f"{dataset.dataset_id}-update"
     assert update_cron_job.schedule == "0 7 * * *"  # Daily at 7:00 UTC
     assert update_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert update_cron_job.cpu == "6"
@@ -34,7 +34,7 @@ def test_operational_kubernetes_resources(dataset: GefsForecast35DayDataset) -> 
     assert update_cron_job.ephemeral_storage == "150G"
 
     # Check validation job
-    assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
+    assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert validation_cron_job.schedule == "30 11 * * *"  # Daily at 11:30 UTC
     assert validation_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert validation_cron_job.cpu == "3"

--- a/tests/noaa/gefs/forecast_35_day/region_job_test.py
+++ b/tests/noaa/gefs/forecast_35_day/region_job_test.py
@@ -487,7 +487,7 @@ def test_operational_update_jobs(
                 get_template_fn=mock_get_template_fn,
                 append_dim="init_time",
                 all_data_vars=example_data_vars,
-                reformat_job_name="test-operational-update",
+                reformat_job_name="test-update",
             )
 
             # Verify results
@@ -502,7 +502,7 @@ def test_operational_update_jobs(
             assert call_args.kwargs["tmp_store"] == tmp_store_path
             assert call_args.kwargs["append_dim"] == "init_time"
             assert call_args.kwargs["all_data_vars"] == example_data_vars
-            assert call_args.kwargs["reformat_job_name"] == "test-operational-update"
+            assert call_args.kwargs["reformat_job_name"] == "test-update"
             assert call_args.kwargs["filter_start"] == existing_init_time.max()
 
             # Verify existing dataset was opened correctly

--- a/tests/noaa/gfs/forecast/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast/dynamical_dataset_test.py
@@ -206,8 +206,8 @@ def test_operational_kubernetes_resources() -> None:
 
     assert len(cron_jobs) == 2
     update_cron_job, validation_cron_job = cron_jobs
-    assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
-    assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
+    assert update_cron_job.name == f"{dataset.dataset_id}-update"
+    assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert update_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert validation_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
 

--- a/tests/noaa/hrrr/forecast_48_hour/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour/dynamical_dataset_test.py
@@ -164,10 +164,10 @@ def test_operational_kubernetes_resources(
     assert len(cron_jobs) == 2
     update_cron_job, validation_cron_job = cron_jobs
 
-    assert update_cron_job.name == f"{dataset.dataset_id}-operational-update"
+    assert update_cron_job.name == f"{dataset.dataset_id}-update"
     assert len(update_cron_job.secret_names) > 0
 
-    assert validation_cron_job.name == f"{dataset.dataset_id}-validation"
+    assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert len(validation_cron_job.secret_names) > 0
 
 


### PR DESCRIPTION
Just before this deploys i will
- delete all existing cronjobs (because new ones with the new names will be created)
- cleanup old named cron monitors in sentry