### PR TITLE
Add 2m dew point temperature to ECMWF IFS ENS

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
@@ -527,4 +527,22 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                     keep_mantissa_bits=11,
                 ),
             ),
+            EcmwfDataVar(
+                name="dew_point_temperature_2m",
+                encoding=encoding_float32_default,
+                attrs=DataVarAttrs(
+                    short_name="2d",
+                    long_name="2 metre dewpoint temperature",
+                    units="C",
+                    step_type="instant",
+                    standard_name="dew_point_temperature",
+                ),
+                internal_attrs=EcmwfInternalAttrs(
+                    grib_comment="Dew point temperature [C]",
+                    grib_description='2[m] HTGL="Specified height level above ground"',
+                    grib_element="DPT",
+                    grib_index_param="2d",
+                    keep_mantissa_bits=default_keep_mantissa_bits,
+                ),
+            ),
         ]

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/dew_point_temperature_2m/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/dew_point_temperature_2m/zarr.json
@@ -1,0 +1,92 @@
+{
+  "shape": [
+    1,
+    85,
+    51,
+    721,
+    1440
+  ],
+  "data_type": "float32",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [
+        1,
+        85,
+        51,
+        320,
+        320
+      ]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": "NaN",
+  "codecs": [
+    {
+      "name": "sharding_indexed",
+      "configuration": {
+        "chunk_shape": [
+          1,
+          85,
+          51,
+          32,
+          32
+        ],
+        "codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "blosc",
+            "configuration": {
+              "typesize": 4,
+              "cname": "zstd",
+              "clevel": 3,
+              "shuffle": "shuffle",
+              "blocksize": 0
+            }
+          }
+        ],
+        "index_codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "crc32c"
+          }
+        ],
+        "index_location": "end"
+      }
+    }
+  ],
+  "attributes": {
+    "long_name": "2 metre dewpoint temperature",
+    "short_name": "2d",
+    "standard_name": "dew_point_temperature",
+    "units": "C",
+    "step_type": "instant",
+    "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
+    "_FillValue": "AAAAAAAA+H8="
+  },
+  "dimension_names": [
+    "init_time",
+    "lead_time",
+    "ensemble_member",
+    "latitude",
+    "longitude"
+  ],
+  "zarr_format": 3,
+  "node_type": "array",
+  "storage_transformers": []
+}

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
@@ -108,6 +108,98 @@
         "node_type": "array",
         "storage_transformers": []
       },
+      "dew_point_temperature_2m": {
+        "shape": [
+          1,
+          85,
+          51,
+          721,
+          1440
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              1,
+              85,
+              51,
+              320,
+              320
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+            "name": "sharding_indexed",
+            "configuration": {
+              "chunk_shape": [
+                1,
+                85,
+                51,
+                32,
+                32
+              ],
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "blosc",
+                  "configuration": {
+                    "typesize": 4,
+                    "cname": "zstd",
+                    "clevel": 3,
+                    "shuffle": "shuffle",
+                    "blocksize": 0
+                  }
+                }
+              ],
+              "index_codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "crc32c"
+                }
+              ],
+              "index_location": "end"
+            }
+          }
+        ],
+        "attributes": {
+          "long_name": "2 metre dewpoint temperature",
+          "short_name": "2d",
+          "standard_name": "dew_point_temperature",
+          "units": "C",
+          "step_type": "instant",
+          "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
+          "_FillValue": "AAAAAAAA+H8="
+        },
+        "dimension_names": [
+          "init_time",
+          "lead_time",
+          "ensemble_member",
+          "latitude",
+          "longitude"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
       "downward_long_wave_radiation_flux_surface": {
         "shape": [
           1,

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job_test.py
@@ -48,7 +48,7 @@ def test_region_job_source_groups() -> None:
         template_config.data_vars
     )
     assert len(groups) == 2
-    assert len(groups[0]) == 10
+    assert len(groups[0]) == 11
 
     # categorical_precipitation_type_surface is grouped separately
     # since it is the only one with a date_available value


### PR DESCRIPTION
- I temporarily added this variable to the integration tests and they produced reasonable values but im not keeping it in to avoid slowing down the integration test
- This will cause a new, empty variable to be added to the dataset after it deploys and the next update runs. I'll then run a backfill for this variable specifically. While we could backfill and then make the new variable visible to readers only after that was complete when writing only to a standard zarr, Icechunk's validation is more strict (you can't write to vars that don't exist in the store) and we haven't yet implemented Icechunk's cooperative concurrent writes to do the backfill before exposing the new variable to readers. We won't document this new variable until it's backfilled and validated and the backfill period will only take a couple hours, so im expecting limited/no impact of this temporary period with an incomplete variable.