### PR TITLE
Basic fallback to NOMADS implementation for GEFS datasets

### DIFF
--- a/src/reformatters/noaa/gefs/forecast_35_day/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/region_job.py
@@ -9,10 +9,7 @@ import zarr
 
 from reformatters.common.binary_rounding import round_float32_inplace
 from reformatters.common.deaccumulation import deaccumulate_to_rates_inplace
-from reformatters.common.download import (
-    http_download_to_disk,
-)
-from reformatters.common.iterating import digest, item
+from reformatters.common.iterating import item
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import RegionJob
 from reformatters.common.types import AppendDim, ArrayND, DatetimeLike
@@ -22,7 +19,7 @@ from reformatters.noaa.gefs.gefs_config_models import (
     GEFSFileType,
 )
 from reformatters.noaa.gefs.read_data import read_data
-from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
+from reformatters.noaa.gefs.utils import gefs_download_file
 from reformatters.noaa.noaa_utils import has_hour_0_values
 
 log = get_logger(__name__)
@@ -90,21 +87,7 @@ class GefsForecast35DayRegionJob(
 
     def download_file(self, coord: GefsForecast35DaySourceFileCoord) -> Path:
         """Download the source file for the given coordinate."""
-        # Download grib index file
-        idx_url = f"{coord.get_url()}.idx"
-        idx_local_path = http_download_to_disk(idx_url, self.dataset_id)
-
-        # Download the grib messages for the data vars in the coord using byte ranges
-        starts, ends = grib_message_byte_ranges_from_index(
-            idx_local_path, coord.data_vars, coord.init_time, coord.lead_time
-        )
-        vars_suffix = digest(f"{s}-{e}" for s, e in zip(starts, ends, strict=True))
-        return http_download_to_disk(
-            coord.get_url(),
-            self.dataset_id,
-            byte_ranges=(starts, ends),
-            local_path_suffix=f"-{vars_suffix}",
-        )
+        return gefs_download_file(self.dataset_id, coord)
 
     def read_data(
         self, coord: GefsForecast35DaySourceFileCoord, data_var: GEFSDataVar

--- a/src/reformatters/noaa/gefs/utils.py
+++ b/src/reformatters/noaa/gefs/utils.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pandas as pd
+
+from reformatters.common.download import http_download_to_disk
+from reformatters.common.iterating import digest
+from reformatters.common.retry import retry
+from reformatters.noaa.gefs.gefs_config_models import GefsSourceFileCoord
+from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
+
+
+def _download_file_from_gefs_source(
+    dataset_id: str,
+    coord: GefsSourceFileCoord,
+    index_url: str,
+    source_url: str,
+) -> Path:
+    # Download grib index file
+    idx_local_path = http_download_to_disk(index_url, dataset_id)
+
+    # Download the grib messages for the data vars in the coord using byte ranges
+    starts, ends = grib_message_byte_ranges_from_index(
+        idx_local_path, coord.data_vars, coord.init_time, coord.lead_time
+    )
+    vars_suffix = digest(f"{s}-{e}" for s, e in zip(starts, ends, strict=True))
+    return http_download_to_disk(
+        source_url,
+        dataset_id,
+        byte_ranges=(starts, ends),
+        local_path_suffix=f"-{vars_suffix}",
+    )
+
+
+def gefs_download_file(
+    dataset_id: str,
+    coord: GefsSourceFileCoord,
+) -> Path:
+    """Download file from GEFS source with retry and fallback to alternative source."""
+    try:
+
+        def download_fn() -> Path:
+            return _download_file_from_gefs_source(
+                dataset_id, coord, coord.get_index_url(), coord.get_url()
+            )
+
+        return retry(download_fn)
+    except FileNotFoundError:
+        # if init time is within the last 4 days, try to download from the fallback source
+        if coord.init_time >= pd.Timestamp.now() - pd.Timedelta(days=4):
+
+            def fallback_fn() -> Path:
+                return _download_file_from_gefs_source(
+                    dataset_id,
+                    coord,
+                    coord.get_index_url(fallback=True),
+                    coord.get_fallback_url(),
+                )
+
+            return retry(fallback_fn, max_attempts=2)
+        else:
+            raise

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -12,7 +12,6 @@ import xarray as xr
 from reformatters.common.config_models import DataVarAttrs, Encoding
 from reformatters.common.pydantic import replace
 from reformatters.common.region_job import SourceFileStatus
-from reformatters.common.retry import retry
 from reformatters.common.storage import (
     DatasetFormat,
     StorageConfig,
@@ -658,12 +657,6 @@ def test_download_file_fallback(
         mock_download,
     )
 
-    original_retry = retry
-    monkeypatch.setattr(
-        "reformatters.noaa.gefs.utils.retry",
-        lambda func, max_attempts=1: original_retry(func, max_attempts=max_attempts),
-    )
-
     mock_grib_message_byte_ranges_from_index = Mock(
         return_value=([123456, 234567], [234566, 345678])
     )
@@ -712,12 +705,6 @@ def test_download_file_no_fallback_for_old_data(
         data_vars=data_vars,
     )
 
-    original_retry = retry
-    monkeypatch.setattr(
-        "reformatters.noaa.gefs.utils.retry",
-        lambda func, max_attempts=1: original_retry(func, max_attempts=max_attempts),
-    )
-
     def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
         raise FileNotFoundError(f"Not found: {url}")
 
@@ -732,7 +719,6 @@ def test_download_file_no_fallback_for_old_data(
         job.download_file(coord)
 
     # Should have only tried primary source
-    # The retry logic will try the primary source multiple times before giving up
     for call in mock_download.call_args_list:
         url = call[0][0]
         # All calls should be to primary source (AWS S3), not fallback (NOMADS)

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -2,6 +2,7 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
+from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
@@ -735,4 +736,4 @@ def test_download_file_no_fallback_for_old_data(
     for call in mock_download.call_args_list:
         url = call[0][0]
         # All calls should be to primary source (AWS S3), not fallback (NOMADS)
-        assert "noaa-gefs-retrospective.s3.amazonaws.com" in url
+        assert urlparse(url).netloc == "noaa-gefs-retrospective.s3.amazonaws.com"

--- a/tests/noaa/gefs/forecast_35_day/region_job_test.py
+++ b/tests/noaa/gefs/forecast_35_day/region_job_test.py
@@ -2,6 +2,7 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
+from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
@@ -472,7 +473,7 @@ def test_download_file_no_fallback_for_old_data(
     for call in mock_download.call_args_list:
         url = call[0][0]
         # All calls should be to primary source (AWS S3), not fallback (NOMADS)
-        assert "noaa-gefs-pds.s3.amazonaws.com" in url
+        assert urlparse(url).netloc == "noaa-gefs-pds.s3.amazonaws.com"
 
 
 @patch("reformatters.noaa.gefs.forecast_35_day.region_job.read_data")

--- a/tests/noaa/gefs/forecast_35_day/region_job_test.py
+++ b/tests/noaa/gefs/forecast_35_day/region_job_test.py
@@ -10,6 +10,7 @@ import xarray as xr
 
 from reformatters.common.config_models import DataVarAttrs, Encoding
 from reformatters.common.pydantic import replace
+from reformatters.common.retry import retry
 from reformatters.common.storage import (
     DatasetFormat,
     StorageConfig,
@@ -220,6 +221,28 @@ def test_source_file_coord_url_generation(example_data_vars: list[GEFSDataVar]) 
     assert "pgrb2s.0p25.f003" in url
 
 
+def test_source_file_coord_fallback_url(example_data_vars: list[GEFSDataVar]) -> None:
+    """Test fallback URL generation for source file coordinates."""
+    coord = GefsEnsembleSourceFileCoord(
+        init_time=pd.Timestamp("2021-01-01T00:00"),  # Use current archive period
+        lead_time=pd.Timedelta("3h"),
+        ensemble_member=1,
+        data_vars=example_data_vars[:1],
+    )
+
+    primary_url = coord.get_url()
+    fallback_url = coord.get_fallback_url()
+
+    assert (
+        primary_url
+        == "https://noaa-gefs-pds.s3.amazonaws.com/gefs.20210101/00/atmos/pgrb2sp25/gep01.t00z.pgrb2s.0p25.f003"
+    )
+    assert (
+        fallback_url
+        == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gens/prod/gefs.20210101/00/atmos/pgrb2sp25/gep01.t00z.pgrb2s.0p25.f003"
+    )
+
+
 def test_source_file_coord_out_loc_forecast(
     example_data_vars: list[GEFSDataVar],
 ) -> None:
@@ -280,7 +303,7 @@ def test_download_file(
 
     mock_download.side_effect = mock_download_side_effect
     monkeypatch.setattr(
-        "reformatters.noaa.gefs.forecast_35_day.region_job.http_download_to_disk",
+        "reformatters.noaa.gefs.utils.http_download_to_disk",
         mock_download,
     )
 
@@ -289,7 +312,7 @@ def test_download_file(
         return_value=([123456, 234567], [234566, 345678])
     )
     monkeypatch.setattr(
-        "reformatters.noaa.gefs.forecast_35_day.region_job.grib_message_byte_ranges_from_index",
+        "reformatters.noaa.gefs.utils.grib_message_byte_ranges_from_index",
         mock_grib_message_byte_ranges_from_index,
     )
 
@@ -312,6 +335,144 @@ def test_download_file(
     assert second_call[0][1] == "noaa-gefs-forecast-35-day"
     assert second_call[1]["byte_ranges"] == ([123456, 234567], [234566, 345678])
     assert "local_path_suffix" in second_call[1]
+
+
+def test_download_file_fallback(
+    template_ds: xr.Dataset,
+    example_data_vars: list[GEFSDataVar],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test download_file falls back to alternative source when primary fails for recent data."""
+    tmp_store = get_local_tmp_store()
+    data_vars = example_data_vars[:1]
+
+    job = GefsForecast35DayRegionJob(
+        tmp_store=tmp_store,
+        template_ds=template_ds,
+        data_vars=data_vars,
+        append_dim="init_time",
+        region=slice(0, 1),
+        reformat_job_name="test-job",
+    )
+
+    # Use a recent init_time (within 4 days) to trigger fallback behavior
+    recent_init_time = pd.Timestamp.now() - pd.Timedelta(days=1)
+    coord = GefsForecast35DaySourceFileCoord(
+        init_time=recent_init_time,
+        lead_time=pd.Timedelta("3h"),
+        ensemble_member=1,
+        data_vars=data_vars,
+    )
+
+    mock_index_path = Mock()
+    mock_index_path.read_text.return_value = "ignored"
+    mock_data_path = Mock()
+
+    primary_index_url = coord.get_index_url()
+    fallback_url = coord.get_fallback_url()
+    fallback_index_url = coord.get_index_url(fallback=True)
+
+    call_count = 0
+
+    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
+        nonlocal call_count
+        call_count += 1
+        # Primary source fails with FileNotFoundError
+        if url == primary_index_url:
+            raise FileNotFoundError(f"Primary index not found: {url}")
+        # Fallback source succeeds
+        if url == fallback_index_url:
+            return mock_index_path
+        if url == fallback_url:
+            return mock_data_path
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    mock_download = Mock(side_effect=mock_download_side_effect)
+    monkeypatch.setattr(
+        "reformatters.noaa.gefs.utils.http_download_to_disk",
+        mock_download,
+    )
+
+    original_retry = retry
+    monkeypatch.setattr(
+        "reformatters.noaa.gefs.utils.retry",
+        lambda func, max_attempts=1: original_retry(func, max_attempts=max_attempts),
+    )
+
+    mock_grib_message_byte_ranges_from_index = Mock(
+        return_value=([123456, 234567], [234566, 345678])
+    )
+    monkeypatch.setattr(
+        "reformatters.noaa.gefs.utils.grib_message_byte_ranges_from_index",
+        mock_grib_message_byte_ranges_from_index,
+    )
+
+    result = job.download_file(coord)
+
+    assert result == mock_data_path
+
+    # Should have called: primary index (failed) + fallback index + fallback data
+    assert call_count == 3
+
+    # Verify fallback URLs were used
+    calls = mock_download.call_args_list
+    assert calls[0][0][0] == primary_index_url  # First tried primary
+    assert calls[1][0][0] == fallback_index_url  # Then fallback index
+    assert calls[2][0][0] == fallback_url  # Then fallback data
+
+
+def test_download_file_no_fallback_for_old_data(
+    template_ds: xr.Dataset,
+    example_data_vars: list[GEFSDataVar],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test download_file does not fallback for old data (>4 days)."""
+    tmp_store = get_local_tmp_store()
+    data_vars = example_data_vars[:1]
+
+    job = GefsForecast35DayRegionJob(
+        tmp_store=tmp_store,
+        template_ds=template_ds,
+        data_vars=data_vars,
+        append_dim="init_time",
+        region=slice(0, 1),
+        reformat_job_name="test-job",
+    )
+
+    # Use an old init_time (>4 days ago) - should NOT trigger fallback
+    old_init_time = pd.Timestamp("2025-01-01T00:00")
+    coord = GefsForecast35DaySourceFileCoord(
+        init_time=old_init_time,
+        lead_time=pd.Timedelta("3h"),
+        ensemble_member=1,
+        data_vars=data_vars,
+    )
+
+    original_retry = retry
+    monkeypatch.setattr(
+        "reformatters.noaa.gefs.utils.retry",
+        lambda func, max_attempts=1: original_retry(func, max_attempts=max_attempts),
+    )
+
+    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
+        raise FileNotFoundError(f"Not found: {url}")
+
+    mock_download = Mock(side_effect=mock_download_side_effect)
+    monkeypatch.setattr(
+        "reformatters.noaa.gefs.utils.http_download_to_disk",
+        mock_download,
+    )
+
+    # Should raise FileNotFoundError without attempting fallback
+    with pytest.raises(FileNotFoundError):
+        job.download_file(coord)
+
+    # Should have only tried primary source
+    # The retry logic will try the primary source multiple times before giving up
+    for call in mock_download.call_args_list:
+        url = call[0][0]
+        # All calls should be to primary source (AWS S3), not fallback (NOMADS)
+        assert "noaa-gefs-pds.s3.amazonaws.com" in url
 
 
 @patch("reformatters.noaa.gefs.forecast_35_day.region_job.read_data")


### PR DESCRIPTION
This PR implements a fallback method for GEFS datasets to fetch data from NOMADS if recent data isn't found in S3. We've recently run into a case where S3 is a bit behind NOMADS.