### PR TITLE
Github workflows aws secrets

### DIFF
--- a/.github/workflows/manual-create-job-from-cronjob.yml
+++ b/.github/workflows/manual-create-job-from-cronjob.yml
@@ -36,6 +36,7 @@ jobs:
   create-job:
     name: Create Job
     runs-on: ubuntu-24.04
+    environment: prod
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:

--- a/.github/workflows/manual-get-jobs.yml
+++ b/.github/workflows/manual-get-jobs.yml
@@ -11,6 +11,7 @@ jobs:
   get-jobs:
     name: Get Jobs
     runs-on: ubuntu-24.04
+    environment: prod
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:

--- a/.github/workflows/manual-get-pods.yml
+++ b/.github/workflows/manual-get-pods.yml
@@ -11,6 +11,7 @@ jobs:
   get-pods:
     name: Get Pods
     runs-on: ubuntu-24.04
+    environment: prod
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:

--- a/src/scripts/generate_manual_workflows.py
+++ b/src/scripts/generate_manual_workflows.py
@@ -16,6 +16,8 @@ from reformatters.common.logging import get_logger
 
 log = get_logger(__name__)
 
+MANUAL_K8S_GITHUB_ENVIRONMENT = "prod"
+
 
 def get_all_cronjob_names() -> list[str]:
     """Extract all CronJob names from DYNAMICAL_DATASETS."""
@@ -60,6 +62,7 @@ def generate_create_job_workflow(cronjob_names: list[str]) -> dict[str, Any]:
             "create-job": {
                 "name": "Create Job",
                 "runs-on": "ubuntu-24.04",
+                "environment": MANUAL_K8S_GITHUB_ENVIRONMENT,
                 "steps": [
                     {
                         "uses": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
@@ -134,6 +137,7 @@ def generate_get_jobs_workflow() -> dict[str, Any]:
             "get-jobs": {
                 "name": "Get Jobs",
                 "runs-on": "ubuntu-24.04",
+                "environment": MANUAL_K8S_GITHUB_ENVIRONMENT,
                 "steps": [
                     {
                         "uses": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
@@ -176,6 +180,7 @@ def generate_get_pods_workflow() -> dict[str, Any]:
             "get-pods": {
                 "name": "Get Pods",
                 "runs-on": "ubuntu-24.04",
+                "environment": MANUAL_K8S_GITHUB_ENVIRONMENT,
                 "steps": [
                     {
                         "uses": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",


### PR DESCRIPTION
Add `environment: prod` to manual GitHub workflows to enable access to AWS secrets.

The manual workflows were failing to configure AWS credentials because AWS-related secrets were not resolving. These secrets are configured within the `prod` GitHub environment, so explicitly attaching this environment to the workflow jobs allows them to access the necessary credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb1d538d-18d2-4979-8fff-459652de4ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb1d538d-18d2-4979-8fff-459652de4ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

