### PR TITLE
Trim last HRRR analysis step

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/region_job.py
+++ b/src/reformatters/noaa/hrrr/analysis/region_job.py
@@ -59,3 +59,16 @@ class NoaaHrrrAnalysisRegionJob(NoaaHrrrRegionJob):
             )
             for init_time in init_times
         ]
+
+    def update_template_with_results(
+        self, process_results: Mapping[str, Sequence[NoaaHrrrSourceFileCoord]]
+    ) -> xr.Dataset:
+        # Remove the last hour. We pull accumulated variables (precipitation) from the 1 hour lead time,
+        # but use the 0 hour lead time for other variables. This results in one additional
+        # hour of data for accumulated variables. Trim it off so we aren't left with nans for
+        # most variables in the final step.
+        return (
+            super()
+            .update_template_with_results(process_results)
+            .isel(time=slice(None, -1))
+        )

--- a/tests/noaa/hrrr/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/analysis/dynamical_dataset_test.py
@@ -66,7 +66,8 @@ def test_backfill_local_and_operational_update(monkeypatch: pytest.MonkeyPatch) 
     assert_allclose(point_ds["precipitation_surface"].values, [np.nan, 0.0])
 
     dataset = make_dataset()
-    append_dim_end = pd.Timestamp("2018-09-16T03:00")
+    # Set append_dim_end to T04:00. update_template_with_results trims the last hour so we expect 3 hours.
+    append_dim_end = pd.Timestamp("2018-09-16T04:00")
     monkeypatch.setattr(
         dataset.region_job_class,
         "_update_append_dim_end",
@@ -87,15 +88,9 @@ def test_backfill_local_and_operational_update(monkeypatch: pytest.MonkeyPatch) 
         dataset.store_factory.primary_store(), chunks=None, decode_timedelta=True
     )
 
-    expected_times = pd.date_range(
-        time_start,
-        append_dim_end,
-        freq=dataset.template_config.append_dim_frequency,
-        inclusive="left",
-    )
-    assert_array_equal(
-        expected_times,
-        pd.DatetimeIndex(["2018-09-16T00:00", "2018-09-16T01:00", "2018-09-16T02:00"]),
+    # Expected times after trimming the last hour
+    expected_times = pd.DatetimeIndex(
+        ["2018-09-16T00:00", "2018-09-16T01:00", "2018-09-16T02:00"]
     )
     assert_array_equal(updated_ds["time"], expected_times)
 


### PR DESCRIPTION
Because accumulated variables (precip) are pulled from the 1h forecast, we have one additional step of their data. Trim the last step so we don't have nans in the final step for most (non accumulated) variables.