### PR TITLE
Enforce cross dataset variable metadata consistency

### DIFF
--- a/src/reformatters/contrib/uarizona/swann/analysis/template_config.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/template_config.py
@@ -236,7 +236,7 @@ class UarizonaSwannAnalysisTemplateConfig(TemplateConfig[UarizonaSwannDataVar]):
                 name="snow_depth",
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
-                    short_name="sde",
+                    short_name="snow_depth",
                     long_name="Snow depth",
                     standard_name="surface_snow_thickness",
                     units="mm",

--- a/src/reformatters/contrib/uarizona/swann/analysis/template_config.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/template_config.py
@@ -220,7 +220,7 @@ class UarizonaSwannAnalysisTemplateConfig(TemplateConfig[UarizonaSwannDataVar]):
                 name="snow_water_equivalent",
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
-                    short_name="snow_water_equivalent",
+                    short_name="sd",
                     long_name="Snow water equivalent",
                     standard_name="lwe_thickness_of_surface_snow_amount",
                     units="mm",
@@ -236,7 +236,7 @@ class UarizonaSwannAnalysisTemplateConfig(TemplateConfig[UarizonaSwannDataVar]):
                 name="snow_depth",
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
-                    short_name="snow_depth",
+                    short_name="sde",
                     long_name="Snow depth",
                     standard_name="surface_snow_thickness",
                     units="mm",

--- a/src/reformatters/contrib/uarizona/swann/analysis/template_config.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/template_config.py
@@ -236,7 +236,7 @@ class UarizonaSwannAnalysisTemplateConfig(TemplateConfig[UarizonaSwannDataVar]):
                 name="snow_depth",
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
-                    short_name="snow_depth",
+                    short_name="sde",
                     long_name="Snow depth",
                     standard_name="surface_snow_thickness",
                     units="mm",

--- a/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/snow_depth/zarr.json
+++ b/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/snow_depth/zarr.json
@@ -66,7 +66,7 @@
   ],
   "attributes": {
     "long_name": "Snow depth",
-    "short_name": "snow_depth",
+    "short_name": "sde",
     "standard_name": "surface_snow_thickness",
     "units": "mm",
     "step_type": "instant",

--- a/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/snow_depth/zarr.json
+++ b/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/snow_depth/zarr.json
@@ -66,7 +66,7 @@
   ],
   "attributes": {
     "long_name": "Snow depth",
-    "short_name": "sde",
+    "short_name": "snow_depth",
     "standard_name": "surface_snow_thickness",
     "units": "mm",
     "step_type": "instant",

--- a/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/snow_water_equivalent/zarr.json
+++ b/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/snow_water_equivalent/zarr.json
@@ -66,7 +66,7 @@
   ],
   "attributes": {
     "long_name": "Snow water equivalent",
-    "short_name": "snow_water_equivalent",
+    "short_name": "sd",
     "standard_name": "lwe_thickness_of_surface_snow_amount",
     "units": "mm",
     "step_type": "instant",

--- a/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/zarr.json
@@ -195,7 +195,7 @@
         ],
         "attributes": {
           "long_name": "Snow depth",
-          "short_name": "snow_depth",
+          "short_name": "sde",
           "standard_name": "surface_snow_thickness",
           "units": "mm",
           "step_type": "instant",

--- a/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/zarr.json
@@ -195,7 +195,7 @@
         ],
         "attributes": {
           "long_name": "Snow depth",
-          "short_name": "snow_depth",
+          "short_name": "sde",
           "standard_name": "surface_snow_thickness",
           "units": "mm",
           "step_type": "instant",
@@ -279,7 +279,7 @@
         ],
         "attributes": {
           "long_name": "Snow water equivalent",
-          "short_name": "snow_water_equivalent",
+          "short_name": "sd",
           "standard_name": "lwe_thickness_of_surface_snow_amount",
           "units": "mm",
           "step_type": "instant",

--- a/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/contrib/uarizona/swann/analysis/templates/latest.zarr/zarr.json
@@ -195,7 +195,7 @@
         ],
         "attributes": {
           "long_name": "Snow depth",
-          "short_name": "sde",
+          "short_name": "snow_depth",
           "standard_name": "surface_snow_thickness",
           "units": "mm",
           "step_type": "instant",

--- a/src/reformatters/dwd/icon_eu/forecast/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast/region_job.py
@@ -31,9 +31,6 @@ from .template_config import DwdIconEuDataVar
 
 log = get_logger(__name__)
 
-KELVIN_TO_CELSIUS_OFFSET = 273.15
-METERS_TO_MM_FACTOR = 1000.0
-
 
 class DwdIconEuForecastSourceFileCoord(SourceFileCoord):
     """Coordinates of a single source file to process."""
@@ -150,32 +147,6 @@ class DwdIconEuForecastRegionJob(
             )
             result: ArrayFloat32 = reader.read(indexes=1, out_dtype=np.float32)
             return result
-
-    def apply_data_transformations(
-        self, data_array: xr.DataArray, data_var: DwdIconEuDataVar
-    ) -> None:
-        """
-        Apply in-place data transformations to the output data array for a given data variable.
-
-        This method is called after reading all data for a variable into the shared-memory array,
-        and before writing shards to the output store.
-
-        Parameters
-        ----------
-        data_array : xr.DataArray
-            The output data array to be transformed in-place.
-        data_var : DwdIconEuDataVar
-            The data variable metadata object, which may contain transformation parameters.
-        """
-        # Convert temperature from Kelvin to Celsius for consistency with other datasets
-        if data_var.name == "temperature_2m":
-            data_array.values -= KELVIN_TO_CELSIUS_OFFSET
-
-        # Convert snow depth from meters to millimeters for consistency with other datasets
-        if data_var.name == "snow_depth":
-            data_array.values *= METERS_TO_MM_FACTOR
-
-        super().apply_data_transformations(data_array, data_var)
 
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[DwdIconEuForecastSourceFileCoord]]

--- a/src/reformatters/dwd/icon_eu/forecast/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast/region_job.py
@@ -31,6 +31,9 @@ from .template_config import DwdIconEuDataVar
 
 log = get_logger(__name__)
 
+KELVIN_TO_CELSIUS_OFFSET = 273.15
+METERS_TO_MM_FACTOR = 1000.0
+
 
 class DwdIconEuForecastSourceFileCoord(SourceFileCoord):
     """Coordinates of a single source file to process."""
@@ -148,30 +151,31 @@ class DwdIconEuForecastRegionJob(
             result: ArrayFloat32 = reader.read(indexes=1, out_dtype=np.float32)
             return result
 
-    # Implement this to apply transformations to the array (e.g. deaccumulation)
-    #
-    # def apply_data_transformations(
-    #     self, data_array: xr.DataArray, data_var: DwdIconEuDataVar
-    # ) -> None:
-    #     """
-    #     Apply in-place data transformations to the output data array for a given data variable.
+    def apply_data_transformations(
+        self, data_array: xr.DataArray, data_var: DwdIconEuDataVar
+    ) -> None:
+        """
+        Apply in-place data transformations to the output data array for a given data variable.
 
-    #     This method is called after reading all data for a variable into the shared-memory array,
-    #     and before writing shards to the output store. The default implementation applies binary
-    #     rounding to float32 arrays if `data_var.internal_attrs.keep_mantissa_bits` is set.
+        This method is called after reading all data for a variable into the shared-memory array,
+        and before writing shards to the output store.
 
-    #     Subclasses may override this method to implement additional transformations such as
-    #     deaccumulation, interpolation or other custom logic. All transformations should be
-    #     performed in-place (don't copy `data_array`, it's large).
+        Parameters
+        ----------
+        data_array : xr.DataArray
+            The output data array to be transformed in-place.
+        data_var : DwdIconEuDataVar
+            The data variable metadata object, which may contain transformation parameters.
+        """
+        # Convert temperature from Kelvin to Celsius for consistency with other datasets
+        if data_var.name == "temperature_2m":
+            data_array.values -= KELVIN_TO_CELSIUS_OFFSET
 
-    #     Parameters
-    #     ----------
-    #     data_array : xr.DataArray
-    #         The output data array to be transformed in-place.
-    #     data_var : DwdIconEuDataVar
-    #         The data variable metadata object, which may contain transformation parameters.
-    #     """
-    #     super().apply_data_transformations(data_array, data_var)
+        # Convert snow depth from meters to millimeters for consistency with other datasets
+        if data_var.name == "snow_depth":
+            data_array.values *= METERS_TO_MM_FACTOR
+
+        super().apply_data_transformations(data_array, data_var)
 
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[DwdIconEuForecastSourceFileCoord]]

--- a/src/reformatters/dwd/icon_eu/forecast/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast/region_job.py
@@ -148,6 +148,31 @@ class DwdIconEuForecastRegionJob(
             result: ArrayFloat32 = reader.read(indexes=1, out_dtype=np.float32)
             return result
 
+    # Implement this to apply transformations to the array (e.g. deaccumulation)
+    #
+    # def apply_data_transformations(
+    #     self, data_array: xr.DataArray, data_var: DwdIconEuDataVar
+    # ) -> None:
+    #     """
+    #     Apply in-place data transformations to the output data array for a given data variable.
+    #
+    #     This method is called after reading all data for a variable into the shared-memory array,
+    #     and before writing shards to the output store. The default implementation applies binary
+    #     rounding to float32 arrays if `data_var.internal_attrs.keep_mantissa_bits` is set.
+    #
+    #     Subclasses may override this method to implement additional transformations such as
+    #     deaccumulation, interpolation or other custom logic. All transformations should be
+    #     performed in-place (don't copy `data_array`, it's large).
+    #
+    #     Parameters
+    #     ----------
+    #     data_array : xr.DataArray
+    #         The output data array to be transformed in-place.
+    #     data_var : DwdIconEuDataVar
+    #         The data variable metadata object, which may contain transformation parameters.
+    #     """
+    #     super().apply_data_transformations(data_array, data_var)
+
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[DwdIconEuForecastSourceFileCoord]]
     ) -> xr.Dataset:

--- a/src/reformatters/dwd/icon_eu/forecast/template_config.py
+++ b/src/reformatters/dwd/icon_eu/forecast/template_config.py
@@ -454,10 +454,10 @@ class DwdIconEuForecastTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                     short_name="sde",
                     long_name="Snow depth",
                     standard_name="surface_snow_thickness",
-                    units="m",
+                    units="mm",
                     step_type="instant",
                     comment=(
-                        "Snow depth in m. It is diagnosed from RHO_SNOW and W_SNOW according to"
+                        "Snow depth in mm. It is diagnosed from RHO_SNOW and W_SNOW according to"
                         " H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m."
                     ),
                 ),
@@ -472,10 +472,10 @@ class DwdIconEuForecastTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                 attrs=DataVarAttrs(
                     short_name="prmsl",
                     standard_name="air_pressure_at_mean_sea_level",
-                    long_name="Pressure reduced to mean sea level (MSL)",
+                    long_name="Pressure reduced to MSL",
                     units="Pa",
                     step_type="instant",
-                    comment="Surface pressure reduced to MSL",
+                    comment="Surface pressure reduced to mean sea level",
                 ),
                 internal_attrs=DwdIconEuInternalAttrs(
                     variable_name_in_filename="pmsl",
@@ -540,7 +540,7 @@ class DwdIconEuForecastTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                 attrs=DataVarAttrs(
                     short_name="t2m",
                     long_name="2 metre temperature",
-                    units="K",
+                    units="degree_Celsius",
                     step_type="instant",
                     comment=(
                         "Temperature at 2m above ground, averaged over all tiles of a grid point. Different agencies use different short_names for this parameter: ECMWF: 2t; NOAA & DWD: t2m."
@@ -579,11 +579,11 @@ class DwdIconEuForecastTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
                     short_name="u10",
-                    long_name="10 metre U wind component (eastward)",
+                    long_name="10 metre U wind component",
                     units="m s-1",
                     step_type="instant",
                     standard_name="eastward_wind",
-                    comment="Zonal wind at 10m above ground",
+                    comment="Zonal wind (eastward) at 10m above ground",
                 ),
                 internal_attrs=DwdIconEuInternalAttrs(
                     variable_name_in_filename="u_10m",
@@ -595,11 +595,11 @@ class DwdIconEuForecastTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
                     short_name="v10",
-                    long_name="10 metre V wind component (northward)",
+                    long_name="10 metre V wind component",
                     units="m s-1",
                     step_type="instant",
                     standard_name="northward_wind",
-                    comment="Meridional wind at 10m above ground",
+                    comment="Meridional wind (northward) at 10m above ground",
                 ),
                 internal_attrs=DwdIconEuInternalAttrs(
                     variable_name_in_filename="v_10m",

--- a/src/reformatters/dwd/icon_eu/forecast/template_config.py
+++ b/src/reformatters/dwd/icon_eu/forecast/template_config.py
@@ -454,10 +454,10 @@ class DwdIconEuForecastTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                     short_name="sde",
                     long_name="Snow depth",
                     standard_name="surface_snow_thickness",
-                    units="mm",
+                    units="m",
                     step_type="instant",
                     comment=(
-                        "Snow depth in mm. It is diagnosed from RHO_SNOW and W_SNOW according to"
+                        "Snow depth in m. It is diagnosed from RHO_SNOW and W_SNOW according to"
                         " H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m."
                     ),
                 ),

--- a/src/reformatters/dwd/icon_eu/forecast/template_config.py
+++ b/src/reformatters/dwd/icon_eu/forecast/template_config.py
@@ -556,9 +556,9 @@ class DwdIconEuForecastTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                 name="precipitation_surface",
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
-                    short_name="tp",
+                    short_name="prate",
                     standard_name="precipitation_flux",
-                    long_name="Total Precipitation",
+                    long_name="Precipitation rate",
                     units="kg m-2 s-1",
                     step_type="accum",
                     comment=(

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/precipitation_surface/zarr.json
@@ -68,8 +68,8 @@
     }
   ],
   "attributes": {
-    "long_name": "Total Precipitation",
-    "short_name": "tp",
+    "long_name": "Precipitation rate",
+    "short_name": "prate",
     "standard_name": "precipitation_flux",
     "units": "kg m-2 s-1",
     "comment": "Precipitation rate since previous forecast step. TOT_PREC = RAIN_GSP + SNOW_GSP + RAIN_CON + SNOW_CON. Units equivalent to mm/s.",

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/pressure_reduced_to_mean_sea_level/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/pressure_reduced_to_mean_sea_level/zarr.json
@@ -68,11 +68,11 @@
     }
   ],
   "attributes": {
-    "long_name": "Pressure reduced to mean sea level (MSL)",
+    "long_name": "Pressure reduced to MSL",
     "short_name": "prmsl",
     "standard_name": "air_pressure_at_mean_sea_level",
     "units": "Pa",
-    "comment": "Surface pressure reduced to MSL",
+    "comment": "Surface pressure reduced to mean sea level",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/snow_depth/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/snow_depth/zarr.json
@@ -71,8 +71,8 @@
     "long_name": "Snow depth",
     "short_name": "sde",
     "standard_name": "surface_snow_thickness",
-    "units": "mm",
-    "comment": "Snow depth in mm. It is diagnosed from RHO_SNOW and W_SNOW according to H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m.",
+    "units": "m",
+    "comment": "Snow depth in m. It is diagnosed from RHO_SNOW and W_SNOW according to H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/snow_depth/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/snow_depth/zarr.json
@@ -71,8 +71,8 @@
     "long_name": "Snow depth",
     "short_name": "sde",
     "standard_name": "surface_snow_thickness",
-    "units": "m",
-    "comment": "Snow depth in m. It is diagnosed from RHO_SNOW and W_SNOW according to H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m.",
+    "units": "mm",
+    "comment": "Snow depth in mm. It is diagnosed from RHO_SNOW and W_SNOW according to H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/temperature_2m/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/temperature_2m/zarr.json
@@ -71,7 +71,7 @@
     "long_name": "2 metre temperature",
     "short_name": "t2m",
     "standard_name": "air_temperature",
-    "units": "K",
+    "units": "degree_Celsius",
     "comment": "Temperature at 2m above ground, averaged over all tiles of a grid point. Different agencies use different short_names for this parameter: ECMWF: 2t; NOAA & DWD: t2m.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/wind_u_10m/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/wind_u_10m/zarr.json
@@ -68,11 +68,11 @@
     }
   ],
   "attributes": {
-    "long_name": "10 metre U wind component (eastward)",
+    "long_name": "10 metre U wind component",
     "short_name": "u10",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "Zonal wind at 10m above ground",
+    "comment": "Zonal wind (eastward) at 10m above ground",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/wind_v_10m/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/wind_v_10m/zarr.json
@@ -68,11 +68,11 @@
     }
   ],
   "attributes": {
-    "long_name": "10 metre V wind component (northward)",
+    "long_name": "10 metre V wind component",
     "short_name": "v10",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "Meridional wind at 10m above ground",
+    "comment": "Meridional wind (northward) at 10m above ground",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/zarr.json
@@ -1039,8 +1039,8 @@
           }
         ],
         "attributes": {
-          "long_name": "Total Precipitation",
-          "short_name": "tp",
+          "long_name": "Precipitation rate",
+          "short_name": "prate",
           "standard_name": "precipitation_flux",
           "units": "kg m-2 s-1",
           "comment": "Precipitation rate since previous forecast step. TOT_PREC = RAIN_GSP + SNOW_GSP + RAIN_CON + SNOW_CON. Units equivalent to mm/s.",

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/zarr.json
@@ -1128,11 +1128,11 @@
           }
         ],
         "attributes": {
-          "long_name": "Pressure reduced to mean sea level (MSL)",
+          "long_name": "Pressure reduced to MSL",
           "short_name": "prmsl",
           "standard_name": "air_pressure_at_mean_sea_level",
           "units": "Pa",
-          "comment": "Surface pressure reduced to MSL",
+          "comment": "Surface pressure reduced to mean sea level",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1309,8 +1309,8 @@
           "long_name": "Snow depth",
           "short_name": "sde",
           "standard_name": "surface_snow_thickness",
-          "units": "m",
-          "comment": "Snow depth in m. It is diagnosed from RHO_SNOW and W_SNOW according to H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m.",
+          "units": "mm",
+          "comment": "Snow depth in mm. It is diagnosed from RHO_SNOW and W_SNOW according to H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1713,7 +1713,7 @@
           "long_name": "2 metre temperature",
           "short_name": "t2m",
           "standard_name": "air_temperature",
-          "units": "K",
+          "units": "degree_Celsius",
           "comment": "Temperature at 2m above ground, averaged over all tiles of a grid point. Different agencies use different short_names for this parameter: ECMWF: 2t; NOAA & DWD: t2m.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
@@ -1946,11 +1946,11 @@
           }
         ],
         "attributes": {
-          "long_name": "10 metre U wind component (eastward)",
+          "long_name": "10 metre U wind component",
           "short_name": "u10",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "Zonal wind at 10m above ground",
+          "comment": "Zonal wind (eastward) at 10m above ground",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2035,11 +2035,11 @@
           }
         ],
         "attributes": {
-          "long_name": "10 metre V wind component (northward)",
+          "long_name": "10 metre V wind component",
           "short_name": "v10",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "Meridional wind at 10m above ground",
+          "comment": "Meridional wind (northward) at 10m above ground",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/zarr.json
+++ b/src/reformatters/dwd/icon_eu/forecast/templates/latest.zarr/zarr.json
@@ -1309,8 +1309,8 @@
           "long_name": "Snow depth",
           "short_name": "sde",
           "standard_name": "surface_snow_thickness",
-          "units": "mm",
-          "comment": "Snow depth in mm. It is diagnosed from RHO_SNOW and W_SNOW according to H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m.",
+          "units": "m",
+          "comment": "Snow depth in m. It is diagnosed from RHO_SNOW and W_SNOW according to H_SNOW = W_SNOW / RHO_SNOW and is limited to H_SNOW <= 40 m.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
@@ -446,9 +446,9 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                 name="precipitation_surface",
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
-                    short_name="tp",
+                    short_name="prate",
                     standard_name="precipitation_flux",
-                    long_name="Total Precipitation",
+                    long_name="Precipitation rate",
                     units="kg m-2 s-1",
                     step_type="avg",
                     comment="Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
@@ -448,7 +448,7 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                 attrs=DataVarAttrs(
                     short_name="tp",
                     standard_name="precipitation_flux",
-                    long_name="Total precipitation",
+                    long_name="Total Precipitation",
                     units="kg m-2 s-1",
                     step_type="avg",
                     comment="Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/precipitation_surface/zarr.json
@@ -71,8 +71,8 @@
     }
   ],
   "attributes": {
-    "long_name": "Total Precipitation",
-    "short_name": "tp",
+    "long_name": "Precipitation rate",
+    "short_name": "prate",
     "standard_name": "precipitation_flux",
     "units": "kg m-2 s-1",
     "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/precipitation_surface/zarr.json
@@ -71,7 +71,7 @@
     }
   ],
   "attributes": {
-    "long_name": "Total precipitation",
+    "long_name": "Total Precipitation",
     "short_name": "tp",
     "standard_name": "precipitation_flux",
     "units": "kg m-2 s-1",

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
@@ -934,7 +934,7 @@
           }
         ],
         "attributes": {
-          "long_name": "Total precipitation",
+          "long_name": "Total Precipitation",
           "short_name": "tp",
           "standard_name": "precipitation_flux",
           "units": "kg m-2 s-1",

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
@@ -934,8 +934,8 @@
           }
         ],
         "attributes": {
-          "long_name": "Total Precipitation",
-          "short_name": "tp",
+          "long_name": "Precipitation rate",
+          "short_name": "prate",
           "standard_name": "precipitation_flux",
           "units": "kg m-2 s-1",
           "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/example/template_config.py
+++ b/src/reformatters/example/template_config.py
@@ -319,9 +319,9 @@ class ExampleTemplateConfig(TemplateConfig[ExampleDataVar]):
         #         name="precipitation_surface",
         #         encoding=encoding_float32_default,
         #         attrs=DataVarAttrs(
-        #             short_name="tp",
+        #             short_name="prate",
         #             standard_name="precipitation_flux",
-        #             long_name="Total Precipitation",
+        #             long_name="Precipitation rate",
         #             units="kg m-2 s-1",
         #             comment="Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",
         #             step_type="avg",

--- a/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/precipitation_surface/zarr.json
@@ -65,8 +65,8 @@
     }
   ],
   "attributes": {
-    "long_name": "Total Precipitation",
-    "short_name": "tp",
+    "long_name": "Precipitation rate",
+    "short_name": "prate",
     "standard_name": "precipitation_flux",
     "units": "kg m-2 s-1",
     "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/zarr.json
@@ -1120,8 +1120,8 @@
           }
         ],
         "attributes": {
-          "long_name": "Total Precipitation",
-          "short_name": "tp",
+          "long_name": "Precipitation rate",
+          "short_name": "prate",
           "standard_name": "precipitation_flux",
           "units": "kg m-2 s-1",
           "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/gefs/common_gefs_template_config.py
+++ b/src/reformatters/noaa/gefs/common_gefs_template_config.py
@@ -316,9 +316,9 @@ def get_shared_data_var_configs(
             name="precipitation_surface",
             encoding=encoding_float32,
             attrs=DataVarAttrs(
-                short_name="tp",
+                short_name="prate",
                 standard_name="precipitation_flux",
-                long_name="Total Precipitation",
+                long_name="Precipitation rate",
                 units="kg m-2 s-1",
                 comment="Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",
                 step_type="avg",

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/precipitation_surface/zarr.json
@@ -71,8 +71,8 @@
     }
   ],
   "attributes": {
-    "long_name": "Total Precipitation",
-    "short_name": "tp",
+    "long_name": "Precipitation rate",
+    "short_name": "prate",
     "standard_name": "precipitation_flux",
     "units": "kg m-2 s-1",
     "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
@@ -1488,8 +1488,8 @@
           }
         ],
         "attributes": {
-          "long_name": "Total Precipitation",
-          "short_name": "tp",
+          "long_name": "Precipitation rate",
+          "short_name": "prate",
           "standard_name": "precipitation_flux",
           "units": "kg m-2 s-1",
           "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/gfs/forecast/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast/templates/latest.zarr/precipitation_surface/zarr.json
@@ -68,8 +68,8 @@
     }
   ],
   "attributes": {
-    "long_name": "Total Precipitation",
-    "short_name": "tp",
+    "long_name": "Precipitation rate",
+    "short_name": "prate",
     "standard_name": "precipitation_flux",
     "units": "kg m-2 s-1",
     "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/gfs/forecast/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast/templates/latest.zarr/zarr.json
@@ -1388,8 +1388,8 @@
           }
         ],
         "attributes": {
-          "long_name": "Total Precipitation",
-          "short_name": "tp",
+          "long_name": "Precipitation rate",
+          "short_name": "prate",
           "standard_name": "precipitation_flux",
           "units": "kg m-2 s-1",
           "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/gfs/template_config.py
+++ b/src/reformatters/noaa/gfs/template_config.py
@@ -291,9 +291,9 @@ class NoaaGfsCommonTemplateConfig(TemplateConfig[NoaaDataVar]):
                 name="precipitation_surface",
                 encoding=encoding,
                 attrs=DataVarAttrs(
-                    short_name="tp",
+                    short_name="prate",
                     standard_name="precipitation_flux",
-                    long_name="Total Precipitation",
+                    long_name="Precipitation rate",
                     units="kg m-2 s-1",
                     comment="Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",
                     step_type="avg",

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/precipitation_surface/zarr.json
@@ -65,8 +65,8 @@
     }
   ],
   "attributes": {
-    "long_name": "Total Precipitation",
-    "short_name": "tp",
+    "long_name": "Precipitation rate",
+    "short_name": "prate",
     "standard_name": "precipitation_flux",
     "units": "kg m-2 s-1",
     "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
@@ -1036,8 +1036,8 @@
           }
         ],
         "attributes": {
-          "long_name": "Total Precipitation",
-          "short_name": "tp",
+          "long_name": "Precipitation rate",
+          "short_name": "prate",
           "standard_name": "precipitation_flux",
           "units": "kg m-2 s-1",
           "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/precipitation_surface/zarr.json
@@ -68,8 +68,8 @@
     }
   ],
   "attributes": {
-    "long_name": "Total Precipitation",
-    "short_name": "tp",
+    "long_name": "Precipitation rate",
+    "short_name": "prate",
     "standard_name": "precipitation_flux",
     "units": "kg m-2 s-1",
     "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
@@ -1299,8 +1299,8 @@
           }
         ],
         "attributes": {
-          "long_name": "Total Precipitation",
-          "short_name": "tp",
+          "long_name": "Precipitation rate",
+          "short_name": "prate",
           "standard_name": "precipitation_flux",
           "units": "kg m-2 s-1",
           "comment": "Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -231,9 +231,9 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                 name="precipitation_surface",
                 encoding=encoding,
                 attrs=DataVarAttrs(
-                    short_name="tp",
+                    short_name="prate",
                     standard_name="precipitation_flux",
-                    long_name="Total Precipitation",
+                    long_name="Precipitation rate",
                     units="kg m-2 s-1",
                     comment="Average precipitation rate since the previous forecast step. Units equivalent to mm/s.",
                     step_type="avg",

--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -457,3 +457,71 @@ def test_cf_data_variable_metadata_consistency_across_datasets() -> None:
         "Data variable metadata inconsistencies found across datasets:\n\n"
         + "\n\n".join(conflicts)
     )
+
+
+def test_cf_coordinate_metadata_consistency_across_datasets() -> None:
+    """
+    Ensure that coordinates with the same name have consistent metadata
+    (long_name, standard_name, units) across all datasets.
+
+    This test helps ensure that users can trust that coordinates with the same name
+    represent the same physical quantity with consistent metadata across datasets.
+
+    Note: Coordinates do not have short_name attributes.
+    """
+    # Collect metadata for all coordinates across all datasets
+    # Structure: {coord_name: {dataset_id: {long_name, standard_name, units}}}
+    coord_metadata: dict[str, dict[str, dict[str, str | None]]] = {}
+
+    for dataset in DYNAMICAL_DATASETS:
+        template_config = dataset.template_config
+        for coord_config in template_config.coords:
+            coord_name = coord_config.name
+            if coord_name not in coord_metadata:
+                coord_metadata[coord_name] = {}
+
+            coord_metadata[coord_name][dataset.dataset_id] = {
+                "long_name": coord_config.attrs.long_name,
+                "standard_name": coord_config.attrs.standard_name,
+                "units": coord_config.attrs.units,
+            }
+
+    # Check for inconsistencies
+    conflicts: list[str] = []
+
+    for coord_name, datasets_metadata in coord_metadata.items():
+        # Skip coordinates that only appear in one dataset
+        if len(datasets_metadata) < 2:
+            continue
+
+        for attr_name in ["long_name", "standard_name", "units"]:
+            # Group datasets by their value for this attribute
+            values_to_datasets: dict[str | None, list[str]] = {}
+            for dataset_id, metadata in datasets_metadata.items():
+                value = metadata[attr_name]
+                values_to_datasets.setdefault(value, []).append(dataset_id)
+
+            # Check for conflicts (more than one unique value)
+            if len(values_to_datasets) > 1:
+                # Filter out allowed exceptions (using same exception mechanism)
+                filtered_values: dict[str | None, list[str]] = {}
+                for value, dataset_ids in values_to_datasets.items():
+                    remaining_datasets = [
+                        ds_id
+                        for ds_id in dataset_ids
+                        if (coord_name, attr_name, ds_id)
+                        not in CROSS_DATASET_CONSISTENCY_EXCEPTIONS
+                    ]
+                    if remaining_datasets:
+                        filtered_values[value] = remaining_datasets
+
+                # If after filtering we still have multiple values, it's a conflict
+                if len(filtered_values) > 1:
+                    conflicts.append(
+                        _format_conflict(coord_name, attr_name, filtered_values)
+                    )
+
+    assert not conflicts, (
+        "Coordinate metadata inconsistencies found across datasets:\n\n"
+        + "\n\n".join(conflicts)
+    )

--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -373,9 +373,7 @@ CROSS_DATASET_CONSISTENCY_EXCEPTIONS: set[tuple[str, str, str]] = {
     # U Arizona SWANN uses mm for snow variables to match source data conventions,
     # while other datasets use CF-compliant meters.
     ("snow_depth", "units", "u-arizona-swann-analysis"),
-    ("snow_depth", "short_name", "u-arizona-swann-analysis"),
     ("snow_water_equivalent", "units", "u-arizona-swann-analysis"),
-    ("snow_water_equivalent", "short_name", "u-arizona-swann-analysis"),
 }
 
 


### PR DESCRIPTION
Add a test for cross-dataset data variable metadata consistency and resolve identified discrepancies in units and names.

The new test revealed inconsistencies in `units` in WIP / contrib datasets (e.g., `temperature_2m` from Kelvin to Celsius, `snow_depth` from meters to millimeters).

The new test revealed inconsistencies in `long_name` (e.g., `wind_u_10m`, `pressure_reduced_to_mean_sea_level`, `precipitation_surface`) across various datasets which have been standardized.

`long_name` and `short_name` for precipitation_surface now reflect our transformation from an accumulated volume to a rate (flux). 

---
<a href="https://cursor.com/background-agent?bcId=bc-970350ac-65e6-4bde-9fec-881331573daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-970350ac-65e6-4bde-9fec-881331573daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

