### PR TITLE
Add shared memory estimate to chunk_shard_size tool

### DIFF
--- a/docs/chunk_shard_layout_tool.md
+++ b/docs/chunk_shard_layout_tool.md
@@ -152,6 +152,7 @@ The tool outputs a comprehensive ASCII table with:
 1. **Spatial Slice**: Chunks/data needed to read full spatial domain for single time
 2. **Shard Touch**: Total shard data opened for spatial slice
 3. **Full Time Series**: Shards/data needed for complete time series at single location
+4. **Shared Memory Estimate**: Uncompressed memory needed for a single slice along the append dimension (init_time for forecast mode, time for analysis mode)
 
 ### Spatial Scores
 - **Evenness**: Score from 0 to 1 (1.0 = perfectly even division across the domain)
@@ -233,6 +234,9 @@ uv run python src/scripts/chunk_shard_size.py \
 │ 3. FULL TIME SERIES (all time, single spatial pixel)                        │
 │    Shards to read:              26                                          │
 │    Compressed data:          57.38 MB                                       │
+│                                                                              │
+│ 4. SHARED MEMORY ESTIMATE (slice along time)                                │
+│    Uncompressed data:        12.66 GB                                       │
 └──────────────────────────────────────────────────────────────────────────────┘
 
 ┌──────────────────────────────────────────────────────────────────────────────┐
@@ -268,6 +272,7 @@ uv run python src/scripts/chunk_shard_size.py \
 - ✓ OK on shard: 324 MB is within the 100-600 MB range
 - Spatial slice costs ~1.16 GB and touches 8 shards
 - Full time series for one pixel requires 26 shards
+- Shared memory estimate: 12.66 GB of uncompressed data needed for a single slice along the time dimension
 - The template config code block can be copied directly into your `template_config.py`
 
 ---

--- a/src/scripts/chunk_shard_size.py
+++ b/src/scripts/chunk_shard_size.py
@@ -696,9 +696,7 @@ def print_diagnostic_table(
 
     # Calculate shared memory estimate
     append_dim = "init_time" if mode == "forecast" else "time"
-    shared_memory_gb = calculate_shared_memory_estimate(
-        config, append_dim
-    )
+    shared_memory_gb = calculate_shared_memory_estimate(config, append_dim)
 
     # Calculate chunks per shard
     chunks_per_shard = 1
@@ -890,11 +888,7 @@ def print_diagnostic_table(
         + " " * (78 - len(f"│ 4. SHARED MEMORY ESTIMATE (slice along {append_dim})"))
         + "│"
     )
-    print(
-        f"│    Uncompressed data:   {shared_memory_gb:>10.2f} GB"
-        + " " * 39
-        + "│"
-    )
+    print(f"│    Uncompressed data:   {shared_memory_gb:>10.2f} GB" + " " * 39 + "│")
 
     print("└" + "─" * 78 + "┘")
 

--- a/src/scripts/chunk_shard_size.py
+++ b/src/scripts/chunk_shard_size.py
@@ -507,7 +507,7 @@ def calculate_shared_memory_estimate(
 
     The shared memory needed is equal to the sum of all shards touched by a single
     slice along the AppendDim (in uncompressed bytes). This is calculated as:
-    (number of shards along all dims except append_dim) × (uncompressed shard size)
+    (number of shards along all dims except append_dim) x (uncompressed shard size)
 
     Args:
         config: Layout configuration
@@ -532,7 +532,7 @@ def calculate_shared_memory_estimate(
     shard_storage = calculate_storage(shard_elements)
     uncompressed_shard_gb = shard_storage.raw_bytes / (1024 * 1024 * 1024)
 
-    # Total shared memory needed = shards touched × uncompressed shard size
+    # Total shared memory needed = shards touched x uncompressed shard size
     shared_memory_gb = shards_touched * uncompressed_shard_gb
 
     return shared_memory_gb


### PR DESCRIPTION
Adds a new section to the diagnostic output that estimates the shared
memory required for processing a single slice along the append dimension.

The shared memory estimate calculates the total uncompressed data that
needs to be held in memory when processing one slice along the append
dimension (init_time for forecast mode, time for analysis mode).

Calculation:
- Count shards touched along all dimensions except append_dim
- Multiply by uncompressed shard size
- Display result in GB

Example: For a dataset with 4 shards along longitude, 2 along latitude,
2 along lead_time, and 1 along ensemble_member, with init_time as the
append dimension, the estimate is:
  4 × 2 × 2 × 1 = 16 shards touched
  If uncompressed shard size is 2GB, shared memory = 16 × 2GB = 32GB

The estimate appears in the ACCESS PATTERN COSTS section of the
diagnostic output and helps users plan memory requirements for their
zarr processing workflows.