### PR TITLE
Default to 0 when parsing ICON-EU TransferSummary values

### DIFF
--- a/src/reformatters/dwd/parse_rclone_log.py
+++ b/src/reformatters/dwd/parse_rclone_log.py
@@ -47,13 +47,13 @@ class TransferSummary(NamedTuple):
             raise ValueError("No stats in log_entries!")
 
         return TransferSummary(
-            total_transfers=stats["totalTransfers"],
-            total_bytes=stats["totalBytes"],
-            total_checks=stats["totalChecks"],
-            errors=stats["errors"],
-            elapsed_time=stats["elapsedTime"],
-            transfer_time=stats["transferTime"],
-            listed=stats["listed"],
+            total_transfers=stats.get("totalTransfers", 0),
+            total_bytes=stats.get("totalBytes", 0),
+            total_checks=stats.get("totalChecks", 0),
+            errors=stats.get("errors", 0),
+            elapsed_time=stats.get("elapsedTime", 0),
+            transfer_time=stats.get("transferTime", 0),
+            listed=stats.get("listed", 0),
         )
 
     def __add__(self, other: object) -> "TransferSummary":


### PR DESCRIPTION
#258 

Got some logs/stats that look like this:

```
[

{
level: "info",
msg: "There was nothing to transfer",
source: "sync/sync.go:939",
time: "2026-01-27T17:47:13.563327+00:00"
},

{
level: "info",
msg: "\nTransferred:   \t          0 B / 0 B, -, 0 B/s, ETA -\nChecks:                93 / 93, 100%\nElapsed time:         7.0s\n\n",
source: "accounting/stats.go:482",

stats: {
bytes: 0,
checks: 93,
deletedDirs: 0,
deletes: 0,
elapsedTime: 7.091163686,
errors: 0,
eta: None,
fatalError: False,
renames: 0,
retryError: False
},
time: "2026-01-27T17:47:13.56342+00:00"
}
]
```
Same as above with nicer formatting:

<img width="805" height="519" alt="image" src="https://github.com/user-attachments/assets/22d6b7d0-d74a-4b49-948d-bf2999a6c89f" />
