### PR TITLE
ECMWF ENS: new hail categorical precip type in comment + adjust ECMWF catagorical precipitation type comment assert to allow new categories to be added

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -188,9 +188,16 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
             grib_comment = reader.tags(rasterio_band_index)["GRIB_COMMENT"]
             grib_description = reader.descriptions[rasterio_band_index - 1]
 
-            assert grib_comment == data_var.internal_attrs.grib_comment, (
-                f"{grib_comment=} != {data_var.internal_attrs.grib_comment=}"
-            )
+            if data_var.name == "categorical_precipitation_type_surface":
+                # ECMWF occasionally adds new values in the reserved range.
+                # Check the first 6 categories that shouldn't change.
+                assert (
+                    grib_comment[:100] == data_var.internal_attrs.grib_comment[:100]
+                ), f"{grib_comment=} != {data_var.internal_attrs.grib_comment=}"
+            else:
+                assert grib_comment == data_var.internal_attrs.grib_comment, (
+                    f"{grib_comment=} != {data_var.internal_attrs.grib_comment=}"
+                )
             assert grib_description == data_var.internal_attrs.grib_description, (
                 f"{grib_description=} != {data_var.internal_attrs.grib_description}"
             )

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
@@ -475,11 +475,11 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                     short_name="ptype",
                     long_name="Precipitation type",
                     units="1",
-                    comment="0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
+                    comment="0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13=Hail (less than 5 mm); 14=Hail (greater than or equal to 5 mm); 15-191=Reserved; 192-254=Reserved for local use; 255=Missing",
                     step_type="instant",
                 ),
                 internal_attrs=EcmwfInternalAttrs(
-                    grib_comment="Precipitation type [0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing]",
+                    grib_comment="Precipitation type [0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13=Hail (less than 5 mm); 14=Hail (greater than or equal to 5 mm); 15-191=Reserved; 192-254=Reserved for local use; 255=Missing]",
                     grib_description='0[-] SFC="Ground or water surface"',
                     grib_element="PTYPE",
                     grib_index_param="ptype",

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/categorical_precipitation_type_surface/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/categorical_precipitation_type_surface/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "Precipitation type",
     "short_name": "ptype",
     "units": "1",
-    "comment": "0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
+    "comment": "0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13=Hail (less than 5 mm); 14=Hail (greater than or equal to 5 mm); 15-191=Reserved; 192-254=Reserved for local use; 255=Missing",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/templates/latest.zarr/zarr.json
@@ -93,7 +93,7 @@
           "long_name": "Precipitation type",
           "short_name": "ptype",
           "units": "1",
-          "comment": "0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
+          "comment": "0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13=Hail (less than 5 mm); 14=Hail (greater than or equal to 5 mm); 15-191=Reserved; 192-254=Reserved for local use; 255=Missing",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="


### PR DESCRIPTION
And add new hail sub-types `13=Hail (less than 5 mm); 14=Hail (greater than or equal to 5 mm);`