### PR TITLE
Migrate from mypy to ty for type checking

### DIFF
--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-import zarr
+import zarr.core.sync
+import zarr.storage
 
 from reformatters.common import validation
 


### PR DESCRIPTION
Replace mypy with Astral's ty type checker throughout the project:

- Replace mypy dependency with ty in pyproject.toml
- Update ty configuration in pyproject.toml
- Update pre-commit hook to use ty
- Update GitHub Actions workflow to use ty
- Update documentation (README.md, AGENTS.md/CLAUDE.md)
- Update .vscode/extensions.json to remove mypy extension
- Update .gitignore and .dockerignore for ty cache

Remove unnecessary type: ignore comments that ty no longer needs:
- ty has better type stubs for numba, numcodecs, fsspec, rasterio, yaml, kubernetes
- ty handles pydantic's @computed_field properly

Add explicit submodule imports for zarr.abc, zarr.storage, sentry_sdk.crons,
numcodecs.abc to satisfy ty's stricter submodule attribute checking.

Add targeted ty: ignore comments for:
- numba's prange (not-iterable - prange is only iterable at runtime in @njit)
- Complex type narrowing that ty can't verify through control flow
- xarray's ds[[list]] returning DataArray instead of Dataset (stub limitation)

Configure ty rules to treat some checks as warnings instead of errors:
- invalid-method-override: Subclass return type covariance is valid Python
- no-matching-overload: xarray stubs are incomplete
- possibly-missing-attribute: For submodule access patterns

ty finds issues mypy missed due to better type stubs, while still being fast.

https://claude.ai/code/session_01RTS6T1SJHLNr4u6vinbqVg