### PR TITLE
rclone s3 path style force `false`

### DIFF
--- a/src/reformatters/dwd/archive_gribs/copy_files_from_dwd.py
+++ b/src/reformatters/dwd/archive_gribs/copy_files_from_dwd.py
@@ -100,7 +100,7 @@ def copy_files_from_dwd_https(
                 "RCLONE_S3_ACCESS_KEY_ID": "key",
                 "RCLONE_S3_SECRET_ACCESS_KEY": "secret",
                 "RCLONE_S3_REGION": "us-west-2",
-                "RCLONE_S3_FORCE_PATH_STYLE": "true",  # needed if bucket name has period or underscore
+                "RCLONE_S3_FORCE_PATH_STYLE": "false",
             }
     """
     # Check inputs:

--- a/src/reformatters/dwd/icon_eu/forecast/dynamical_dataset.py
+++ b/src/reformatters/dwd/icon_eu/forecast/dynamical_dataset.py
@@ -107,7 +107,7 @@ class DwdIconEuForecastDataset(
                 "RCLONE_S3_ACCESS_KEY_ID": secret["key"],
                 "RCLONE_S3_SECRET_ACCESS_KEY": secret["secret"],
                 "RCLONE_S3_REGION": "us-west-2",
-                "RCLONE_S3_FORCE_PATH_STYLE": "true",  # needed if bucket name has period or underscore (e.g. us-west-2.opendata.source.coop)
+                "RCLONE_S3_FORCE_PATH_STYLE": "false",
             }
         else:
             s3_credentials_env_vars_for_rclone = None


### PR DESCRIPTION
Invert #423, maybe i misunderstood the default behavior? We are getting logs like this

`2026-02-06T02:16:34Z INFO:reformatters.dwd.archive_gribs.rclone_copyurl:stderr: '2026/02/06 02:16:34 ERROR : 2026-02-05T00/p/icon-eu_europe_regular-lat-lon_model-level_2026020500_020_55_P.grib2.bz2: failed to copy URL "https://opendata.dwd.de/weather/nwp/icon-eu/grib/00/p/icon-eu_europe_regular-lat-lon_model-level_2026020500_020_55_P.grib2.bz2": failed to prepare upload: operation error S3: CreateBucket, https response error StatusCode: 400, RequestID: 3X6BYTW1FT316N02, HostID: krlJvAX370Dpbj0aIF48yYH6nv5vgtZr4ltfG6Ewt+maFD3UWtlfXmiSHpYFXOXVbjIO1Ou2tQY=, api error IllegalLocationConstraintException: The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.`