### PR TITLE
Add runtime check that asserts are enabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ then deterministically selects its subset. No coordinator or job queue is needed
 * Test: `uv run pytest`
 * Fast/unit tests: `uv run pytest -m "not slow"`
 * Single test: `uv run pytest tests/test_file.py::test_function_name`
-* Always run before commiting: `uv run ruff format && uv run ruff check --fix && uv run ty check`. Always run every one of these checks, you must not skip them.
+* Important: always run all of these checks before committing, do not skip them: `uv run ruff format && uv run ruff check --fix && uv run ty check`.
 * Use `uv run ...` to run python commands in the environment, e.g. `uv run python -c "..."`, `uv run src/scripts/foo.py`. Do not call `python3` when working in this repo.
 
 ## Code Style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ then deterministically selects its subset. No coordinator or job queue is needed
 * Test: `uv run pytest`
 * Fast/unit tests: `uv run pytest -m "not slow"`
 * Single test: `uv run pytest tests/test_file.py::test_function_name`
-* Always run before commiting: `uv run ruff format && uv run ruff check --fix && uv run ty check`.
+* Always run before commiting: `uv run ruff format && uv run ruff check --fix && uv run ty check`. Always run every one of these checks, you must not skip them.
 * Use `uv run ...` to run python commands in the environment, e.g. `uv run python -c "..."`, `uv run src/scripts/foo.py`. Do not call `python3` when working in this repo.
 
 ## Code Style

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -192,5 +192,8 @@ def deploy(
     deploy_module.deploy_operational_resources(DYNAMICAL_DATASETS, docker_image)
 
 
+if not __debug__:
+    raise RuntimeError("This project relies on assert statements. Do not run with python -O.")
+
 if __name__ == "__main__":
     app()

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -193,7 +193,9 @@ def deploy(
 
 
 if not __debug__:
-    raise RuntimeError("This project relies on assert statements. Do not run with python -O.")
+    raise RuntimeError(
+        "This project relies on assert statements. Do not run with python -O."
+    )
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
This project relies on assert statements for correctness. Raise an
error at module load time if Python is run with -O (optimizations),
which strips assert statements.

https://claude.ai/code/session_01VUbUu2NEtUnNq6WcZH8qGW