### PR TITLE
NOMADS access for recent GFS and HRRR downloads

### DIFF
--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -35,7 +35,6 @@ from reformatters.noaa.hrrr.hrrr_config_models import (
 from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
 from reformatters.noaa.noaa_utils import has_hour_0_values
 
-NOMADS_RECENT_THRESHOLD = pd.Timedelta(hours=18)
 HRRR_NOMADS_BASE_URL = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod"
 HRRR_S3_BASE_URL = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com"
 
@@ -126,7 +125,7 @@ class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
     def get_download_source(self, init_time: pd.Timestamp) -> Literal["s3", "nomads"]:
         return (
             "nomads"
-            if init_time >= pd.Timestamp.now() - NOMADS_RECENT_THRESHOLD
+            if init_time >= pd.Timestamp.now() - pd.Timedelta(hours=18)
             else "s3"
         )
 

--- a/tests/noaa/gfs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/analysis/dynamical_dataset_test.py
@@ -76,6 +76,9 @@ def test_backfill_local_and_operational_update(monkeypatch: pytest.MonkeyPatch) 
         "now",
         classmethod(lambda *args, **kwargs: pd.Timestamp("2021-05-01T06:00")),
     )
+    monkeypatch.setattr(
+        dataset.region_job_class, "get_download_source", lambda self, init_time: "s3"
+    )
     orig_get_jobs = dataset.region_job_class.get_jobs
     monkeypatch.setattr(
         dataset.region_job_class,

--- a/tests/noaa/gfs/forecast/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast/dynamical_dataset_test.py
@@ -152,6 +152,9 @@ def test_backfill_local_and_operational_update(
         "now",
         classmethod(lambda *args, **kwargs: pd.Timestamp("2021-05-01T14:00")),
     )
+    monkeypatch.setattr(
+        dataset.region_job_class, "get_download_source", lambda self, init_time: "s3"
+    )
     # Dataset updates always update all variables. For the test we hook into get_jobs to limit vars.
     orig_get_jobs = dataset.region_job_class.get_jobs
     monkeypatch.setattr(

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -291,50 +291,6 @@ def test_download_file_tries_nomads_first_for_recent_init_time(
     assert all(url.startswith("https://nomads.ncep.noaa.gov") for url in urls_called)
 
 
-def test_download_file_falls_back_to_s3_when_nomads_fails(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test that download_file falls back to S3 when NOMADS raises FileNotFoundError."""
-    template_config = NoaaGfsForecastTemplateConfig()
-    fixed_now = pd.Timestamp("2025-01-15T12:00")
-    monkeypatch.setattr(
-        pd.Timestamp, "now", classmethod(lambda *args, **kwargs: fixed_now)
-    )
-    region_job = _make_gfs_region_job(template_config, fixed_now)
-    coord = NoaaGfsForecastSourceFileCoord(
-        init_time=fixed_now - pd.Timedelta(hours=6),  # recent
-        lead_time=pd.Timedelta(hours=6),
-        data_vars=template_config.data_vars[:1],
-    )
-
-    mock_s3_path = Mock()
-
-    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
-        if "nomads" in url:
-            raise FileNotFoundError(url)
-        return mock_s3_path
-
-    mock_download = Mock(side_effect=mock_download_side_effect)
-    monkeypatch.setattr(
-        "reformatters.noaa.gfs.region_job.http_download_to_disk", mock_download
-    )
-    monkeypatch.setattr(
-        "reformatters.noaa.gfs.region_job.grib_message_byte_ranges_from_index",
-        Mock(return_value=([0], [100])),
-    )
-
-    result = region_job.download_file(coord)
-
-    assert result == mock_s3_path
-    urls_called = [call.args[0] for call in mock_download.call_args_list]
-    # NOMADS is tried first (idx fails), then S3 is used (idx + data)
-    assert urls_called[0].startswith("https://nomads.ncep.noaa.gov")
-    assert all(
-        url.startswith("https://noaa-gfs-bdp-pds.s3.amazonaws.com")
-        for url in urls_called[1:]
-    )
-
-
 @pytest.mark.slow
 def test_download_file_from_nomads_gfs() -> None:
     """Download a recent GFS init time from NOMADS and read all template variables."""

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -189,7 +189,7 @@ def test_common_region_job_operational_update_jobs(
 
 
 def test_source_file_coord_get_url_nomads() -> None:
-    """Test that get_url(nomads=True) returns a NOMADS URL with the same path as S3."""
+    """Test that get_url(source="nomads") returns a NOMADS URL with the same path as S3."""
     coord = ConcreteSourceFileCoord(
         init_time=pd.Timestamp("2025-06-15T12:00"),
         lead_time=pd.Timedelta(hours=24),
@@ -200,11 +200,11 @@ def test_source_file_coord_get_url_nomads() -> None:
         == "https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.20250615/12/atmos/gfs.t12z.pgrb2.0p25.f024"
     )
     assert (
-        coord.get_url(nomads=False)
+        coord.get_url(source="s3")
         == "https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.20250615/12/atmos/gfs.t12z.pgrb2.0p25.f024"
     )
     assert (
-        coord.get_url(nomads=True)
+        coord.get_url(source="nomads")
         == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20250615/12/atmos/gfs.t12z.pgrb2.0p25.f024"
     )
 

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -223,22 +223,31 @@ def _make_gfs_region_job(
     )
 
 
-def test_download_file_uses_s3_for_old_init_time(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test that download_file uses S3 directly for init times older than the NOMADS threshold."""
+def test_get_download_source(monkeypatch: pytest.MonkeyPatch) -> None:
     template_config = NoaaGfsForecastTemplateConfig()
     fixed_now = pd.Timestamp("2025-01-15T12:00")
     monkeypatch.setattr(
         pd.Timestamp, "now", classmethod(lambda *args, **kwargs: fixed_now)
     )
     region_job = _make_gfs_region_job(template_config, fixed_now)
+
+    assert region_job.get_download_source(fixed_now - pd.Timedelta(hours=6)) == "nomads"
+    assert region_job.get_download_source(fixed_now - pd.Timedelta(hours=24)) == "s3"
+
+
+def test_download_file_uses_source_from_get_download_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    template_config = NoaaGfsForecastTemplateConfig()
+    region_job = _make_gfs_region_job(template_config, pd.Timestamp("2025-01-15T12:00"))
     coord = NoaaGfsForecastSourceFileCoord(
-        init_time=fixed_now - pd.Timedelta(hours=24),  # old: > 18h threshold
+        init_time=pd.Timestamp("2025-01-01"),
         lead_time=pd.Timedelta(hours=6),
         data_vars=template_config.data_vars[:1],
     )
-
+    monkeypatch.setattr(
+        NoaaGfsForecastRegionJob, "get_download_source", lambda self, t: "nomads"
+    )
     mock_download = Mock(return_value=Mock())
     monkeypatch.setattr(
         "reformatters.noaa.gfs.region_job.http_download_to_disk", mock_download
@@ -250,43 +259,6 @@ def test_download_file_uses_s3_for_old_init_time(
 
     region_job.download_file(coord)
 
-    urls_called = [call.args[0] for call in mock_download.call_args_list]
-    assert all(
-        url.startswith("https://noaa-gfs-bdp-pds.s3.amazonaws.com")
-        for url in urls_called
-    )
-
-
-def test_download_file_tries_nomads_first_for_recent_init_time(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test that download_file tries NOMADS first for init times within 18h."""
-    template_config = NoaaGfsForecastTemplateConfig()
-    fixed_now = pd.Timestamp("2025-01-15T12:00")
-    monkeypatch.setattr(
-        pd.Timestamp, "now", classmethod(lambda *args, **kwargs: fixed_now)
-    )
-    region_job = _make_gfs_region_job(template_config, fixed_now)
-    coord = NoaaGfsForecastSourceFileCoord(
-        init_time=fixed_now - pd.Timedelta(hours=6),  # recent: < 18h threshold
-        lead_time=pd.Timedelta(hours=6),
-        data_vars=template_config.data_vars[:1],
-    )
-
-    mock_data_path = Mock()
-    mock_download = Mock(return_value=mock_data_path)
-    monkeypatch.setattr(
-        "reformatters.noaa.gfs.region_job.http_download_to_disk", mock_download
-    )
-    monkeypatch.setattr(
-        "reformatters.noaa.gfs.region_job.grib_message_byte_ranges_from_index",
-        Mock(return_value=([0], [100])),
-    )
-
-    result = region_job.download_file(coord)
-
-    assert result == mock_data_path
-    # NOMADS succeeds, so both idx and data calls go to NOMADS
     urls_called = [call.args[0] for call in mock_download.call_args_list]
     assert all(url.startswith("https://nomads.ncep.noaa.gov") for url in urls_called)
 

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from reformatters.common import template_utils
+from reformatters.common.pydantic import replace
 from reformatters.common.region_job import CoordinateValueOrRange
 from reformatters.common.storage import DatasetFormat, StorageConfig, StoreFactory
 from reformatters.common.types import Dim
@@ -358,7 +359,7 @@ def test_download_file_from_nomads_gfs() -> None:
             lead_time=lead_time,
             data_vars=group,
         )
-        coord.downloaded_path = region_job.download_file(coord)
+        coord = replace(coord, downloaded_path=region_job.download_file(coord))
 
         for data_var in group:
             data = region_job.read_data(coord, data_var)

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from unittest.mock import Mock
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -15,6 +16,8 @@ from reformatters.noaa.gfs.forecast.region_job import (
 )
 from reformatters.noaa.gfs.forecast.template_config import NoaaGfsForecastTemplateConfig
 from reformatters.noaa.gfs.region_job import (
+    GFS_NOMADS_BASE_URL,
+    GFS_S3_BASE_URL,
     NoaaGfsCommonRegionJob,
     NoaaGfsSourceFileCoord,
 )
@@ -184,3 +187,167 @@ def test_common_region_job_operational_update_jobs(
     for job in jobs:
         assert isinstance(job, NoaaGfsForecastRegionJob)
         assert job.data_vars == template_config.data_vars
+
+
+def test_source_file_coord_get_url_nomads() -> None:
+    """Test that get_url(nomads=True) returns a NOMADS URL with the same path as S3."""
+    coord = ConcreteSourceFileCoord(
+        init_time=pd.Timestamp("2025-06-15T12:00"),
+        lead_time=pd.Timedelta(hours=24),
+        data_vars=NoaaGfsForecastTemplateConfig().data_vars[:1],
+    )
+    s3_url = f"{GFS_S3_BASE_URL}/gfs.20250615/12/atmos/gfs.t12z.pgrb2.0p25.f024"
+    nomads_url = f"{GFS_NOMADS_BASE_URL}/gfs.20250615/12/atmos/gfs.t12z.pgrb2.0p25.f024"
+    assert coord.get_url() == s3_url
+    assert coord.get_url(nomads=False) == s3_url
+    assert coord.get_url(nomads=True) == nomads_url
+
+
+def _make_gfs_region_job(
+    template_config: NoaaGfsForecastTemplateConfig,
+    now: pd.Timestamp,
+) -> NoaaGfsForecastRegionJob:
+    return NoaaGfsForecastRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=template_config.get_template(now),
+        data_vars=template_config.data_vars[:1],
+        append_dim=template_config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+
+def test_download_file_uses_s3_for_old_init_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file uses S3 directly for init times older than the NOMADS threshold."""
+    template_config = NoaaGfsForecastTemplateConfig()
+    fixed_now = pd.Timestamp("2025-01-15T12:00")
+    monkeypatch.setattr(
+        pd.Timestamp, "now", classmethod(lambda *args, **kwargs: fixed_now)
+    )
+    region_job = _make_gfs_region_job(template_config, fixed_now)
+    coord = NoaaGfsForecastSourceFileCoord(
+        init_time=fixed_now - pd.Timedelta(hours=24),  # old: > 18h threshold
+        lead_time=pd.Timedelta(hours=6),
+        data_vars=template_config.data_vars[:1],
+    )
+
+    mock_download = Mock(return_value=Mock())
+    monkeypatch.setattr(
+        "reformatters.noaa.gfs.region_job.http_download_to_disk", mock_download
+    )
+    monkeypatch.setattr(
+        "reformatters.noaa.gfs.region_job.grib_message_byte_ranges_from_index",
+        Mock(return_value=([0], [100])),
+    )
+
+    region_job.download_file(coord)
+
+    urls_called = [call.args[0] for call in mock_download.call_args_list]
+    assert all(GFS_S3_BASE_URL in url for url in urls_called)
+    assert not any("nomads" in url for url in urls_called)
+
+
+def test_download_file_tries_nomads_first_for_recent_init_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file tries NOMADS first for init times within 18h."""
+    template_config = NoaaGfsForecastTemplateConfig()
+    fixed_now = pd.Timestamp("2025-01-15T12:00")
+    monkeypatch.setattr(
+        pd.Timestamp, "now", classmethod(lambda *args, **kwargs: fixed_now)
+    )
+    region_job = _make_gfs_region_job(template_config, fixed_now)
+    coord = NoaaGfsForecastSourceFileCoord(
+        init_time=fixed_now - pd.Timedelta(hours=6),  # recent: < 18h threshold
+        lead_time=pd.Timedelta(hours=6),
+        data_vars=template_config.data_vars[:1],
+    )
+
+    mock_data_path = Mock()
+    mock_download = Mock(return_value=mock_data_path)
+    monkeypatch.setattr(
+        "reformatters.noaa.gfs.region_job.http_download_to_disk", mock_download
+    )
+    monkeypatch.setattr(
+        "reformatters.noaa.gfs.region_job.grib_message_byte_ranges_from_index",
+        Mock(return_value=([0], [100])),
+    )
+
+    result = region_job.download_file(coord)
+
+    assert result == mock_data_path
+    first_url = mock_download.call_args_list[0].args[0]
+    assert GFS_NOMADS_BASE_URL in first_url
+
+
+def test_download_file_falls_back_to_s3_when_nomads_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file falls back to S3 when NOMADS raises FileNotFoundError."""
+    template_config = NoaaGfsForecastTemplateConfig()
+    fixed_now = pd.Timestamp("2025-01-15T12:00")
+    monkeypatch.setattr(
+        pd.Timestamp, "now", classmethod(lambda *args, **kwargs: fixed_now)
+    )
+    region_job = _make_gfs_region_job(template_config, fixed_now)
+    coord = NoaaGfsForecastSourceFileCoord(
+        init_time=fixed_now - pd.Timedelta(hours=6),  # recent
+        lead_time=pd.Timedelta(hours=6),
+        data_vars=template_config.data_vars[:1],
+    )
+
+    mock_s3_path = Mock()
+
+    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
+        if "nomads" in url:
+            raise FileNotFoundError(url)
+        return mock_s3_path
+
+    mock_download = Mock(side_effect=mock_download_side_effect)
+    monkeypatch.setattr(
+        "reformatters.noaa.gfs.region_job.http_download_to_disk", mock_download
+    )
+    monkeypatch.setattr(
+        "reformatters.noaa.gfs.region_job.grib_message_byte_ranges_from_index",
+        Mock(return_value=([0], [100])),
+    )
+
+    result = region_job.download_file(coord)
+
+    assert result == mock_s3_path
+    urls_called = [call.args[0] for call in mock_download.call_args_list]
+    assert any("nomads" in url for url in urls_called)
+    assert any(GFS_S3_BASE_URL in url for url in urls_called)
+
+
+@pytest.mark.slow
+def test_download_file_from_nomads_gfs() -> None:
+    """Download a recent GFS init time from NOMADS and read all template variables."""
+    template_config = NoaaGfsForecastTemplateConfig()
+    # 6h-old init time is within the 18h NOMADS window and typically complete
+    init_time = (pd.Timestamp.now() - pd.Timedelta(hours=6)).floor("6h")
+
+    region_job = NoaaGfsForecastRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=template_config.get_template(pd.Timestamp.now()),
+        data_vars=template_config.data_vars,
+        append_dim=template_config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+    # lead_time=6h: all vars (instant and accumulated) are present in the f006 GRIB file
+    lead_time = pd.Timedelta(hours=6)
+    for group in NoaaGfsForecastRegionJob.source_groups(template_config.data_vars):
+        coord = NoaaGfsForecastSourceFileCoord(
+            init_time=init_time,
+            lead_time=lead_time,
+            data_vars=group,
+        )
+        coord.downloaded_path = region_job.download_file(coord)
+
+        for data_var in group:
+            data = region_job.read_data(coord, data_var)
+            assert not np.all(np.isnan(data)), f"All NaN values for {data_var.name}"

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -209,6 +209,23 @@ def test_source_file_coord_get_url_nomads() -> None:
     )
 
 
+def test_source_file_coord_get_idx_url_nomads() -> None:
+    """Test that get_idx_url(source="nomads") returns the NOMADS index URL."""
+    coord = ConcreteSourceFileCoord(
+        init_time=pd.Timestamp("2025-06-15T06:00"),
+        lead_time=pd.Timedelta(hours=3),
+        data_vars=NoaaGfsForecastTemplateConfig().data_vars[:1],
+    )
+    assert (
+        coord.get_idx_url(source="nomads")
+        == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20250615/06/atmos/gfs.t06z.pgrb2.0p25.f003.idx"
+    )
+    assert (
+        coord.get_idx_url(source="s3")
+        == "https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.20250615/06/atmos/gfs.t06z.pgrb2.0p25.f003.idx"
+    )
+
+
 def _make_gfs_region_job(
     template_config: NoaaGfsForecastTemplateConfig,
     now: pd.Timestamp,

--- a/tests/noaa/hrrr/region_job_test.py
+++ b/tests/noaa/hrrr/region_job_test.py
@@ -636,7 +636,7 @@ def test_download_file_from_nomads_hrrr() -> None:
             file_type=file_type,
             data_vars=group,
         )
-        coord.downloaded_path = region_job.download_file(coord)
+        coord = replace(coord, downloaded_path=region_job.download_file(coord))
 
         for data_var in group:
             data = region_job.read_data(coord, data_var)

--- a/tests/noaa/hrrr/region_job_test.py
+++ b/tests/noaa/hrrr/region_job_test.py
@@ -427,7 +427,7 @@ def test_update_append_dim_start() -> None:
 def test_source_file_coord_get_url_nomads(
     template_config: NoaaHrrrCommonTemplateConfig,
 ) -> None:
-    """Test that get_url(nomads=True) returns a NOMADS URL with the same path as S3."""
+    """Test that get_url(source="nomads") returns a NOMADS URL with the same path as S3."""
     coord = NoaaHrrrSourceFileCoord(
         init_time=pd.Timestamp("2024-02-29T12:00"),
         lead_time=pd.Timedelta(hours=6),
@@ -440,11 +440,11 @@ def test_source_file_coord_get_url_nomads(
         == "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t12z.wrfsfcf06.grib2"
     )
     assert (
-        coord.get_url(nomads=False)
+        coord.get_url(source="s3")
         == "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t12z.wrfsfcf06.grib2"
     )
     assert (
-        coord.get_url(nomads=True)
+        coord.get_url(source="nomads")
         == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/hrrr.20240229/conus/hrrr.t12z.wrfsfcf06.grib2"
     )
 
@@ -452,7 +452,7 @@ def test_source_file_coord_get_url_nomads(
 def test_source_file_coord_get_idx_url_nomads(
     template_config: NoaaHrrrCommonTemplateConfig,
 ) -> None:
-    """Test that get_idx_url(nomads=True) returns the NOMADS index URL."""
+    """Test that get_idx_url(source="nomads") returns the NOMADS index URL."""
     coord = NoaaHrrrSourceFileCoord(
         init_time=pd.Timestamp("2024-02-29T06:00"),
         lead_time=pd.Timedelta(hours=3),
@@ -461,11 +461,11 @@ def test_source_file_coord_get_idx_url_nomads(
         data_vars=template_config.data_vars,
     )
     assert (
-        coord.get_idx_url(nomads=True)
+        coord.get_idx_url(source="nomads")
         == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/hrrr.20240229/conus/hrrr.t06z.wrfsfcf03.grib2.idx"
     )
     assert (
-        coord.get_idx_url(nomads=False)
+        coord.get_idx_url(source="s3")
         == "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t06z.wrfsfcf03.grib2.idx"
     )
 


### PR DESCRIPTION
When init_time is within 18 hours, download_file() uses NOMADS first
(nomads.ncep.noaa.gov) rather than S3 to get data ASAP and avoid any propagation issues.