### PR TITLE
Replace Final with ClassVar for class variable annotation

### DIFF
--- a/src/reformatters/dwd/icon_eu/forecast/dynamical_dataset.py
+++ b/src/reformatters/dwd/icon_eu/forecast/dynamical_dataset.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from datetime import timedelta
 from pathlib import PurePosixPath
-from typing import Annotated, Final
+from typing import Annotated, ClassVar
 
 import typer
 
@@ -23,7 +23,7 @@ class DwdIconEuForecastDataset(
     # `dynamical_grib_archive_rclone_root` must be in the format that `rclone` expects:
     # `:s3:<bucket>/<path>`. Note that there is no double slash after `:s3:`. The leading colon
     # tells `rclone` to create an on the fly rclone backend and use the env variables we set.
-    dynamical_grib_archive_rclone_root: Final[str] = (
+    dynamical_grib_archive_rclone_root: ClassVar[str] = (
         ":s3:us-west-2.opendata.source.coop/dynamical/dwd-icon-grib/icon-eu/regular-lat-lon/"
     )
 


### PR DESCRIPTION
## Summary
Updated the type annotation for the `dynamical_grib_archive_rclone_root` class variable from `Final` to `ClassVar` to better reflect its intended use as a class variable rather than a constant.

## Changes
- Changed `dynamical_grib_archive_rclone_root` type annotation from `Final[str]` to `ClassVar[str]` in `DwdIconEuForecastDataset`

## Details
`ClassVar` is the more semantically correct annotation for class-level variables that are shared across all instances, while `Final` is intended for constants that should not be reassigned. This change improves code clarity and aligns with Python typing best practices for distinguishing between class variables and immutable constants.

https://claude.ai/code/session_017KqajeDUaevofebc9MxyXQ