### PR TITLE
Add NOMADS fallback support for NOAA data downloads

### DIFF
--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -65,6 +65,7 @@ def http_store(base_url: str) -> obstore.store.HTTPStore:
     return obstore.store.HTTPStore.from_url(
         base_url,
         client_options={
+            "user_agent": "dynamical.org reformatters",
             "connect_timeout": "4 seconds",
             "timeout": "120 seconds",
         },

--- a/src/reformatters/common/retry.py
+++ b/src/reformatters/common/retry.py
@@ -4,13 +4,17 @@ from collections.abc import Callable
 import numpy as np
 
 
-def retry[T](func: Callable[[], T], max_attempts: int = 6) -> T:
+def retry[T](
+    func: Callable[[], T],
+    max_attempts: int = 6,
+    retryable_exceptions: tuple[type[Exception], ...] = (Exception,),
+) -> T:
     """Simple retry utility that sleeps for a short time between attempts."""
     last_exception = None
     for attempt in range(max_attempts):
         try:
             return func()
-        except Exception as e:  # noqa: BLE001
+        except retryable_exceptions as e:
             last_exception = e
             if attempt < max_attempts - 1:  # sleep unless we're out of attempts
                 rng = np.random.default_rng()

--- a/src/reformatters/noaa/gfs/region_job.py
+++ b/src/reformatters/noaa/gfs/region_job.py
@@ -1,11 +1,14 @@
+import threading
 import warnings
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
+from typing import Literal, assert_never
 
 import numpy as np
 import pandas as pd
 import rasterio
 import xarray as xr
+from obstore.exceptions import GenericError
 from zarr.abc.store import Store
 
 from reformatters.common.binary_rounding import round_float32_inplace
@@ -20,6 +23,7 @@ from reformatters.common.region_job import (
     RegionJob,
     SourceFileCoord,
 )
+from reformatters.common.retry import retry
 from reformatters.common.time_utils import whole_hours
 from reformatters.common.types import (
     AppendDim,
@@ -35,6 +39,12 @@ from reformatters.noaa.noaa_utils import has_hour_0_values
 
 log = get_logger(__name__)
 
+type DownloadSource = Literal["s3", "nomads"]
+
+NOMADS_RECENCY_THRESHOLD = pd.Timedelta(hours=18)
+# Limit concurrent NOMADS requests to avoid overloading their servers
+_nomads_semaphore = threading.Semaphore(4)
+
 
 class NoaaGfsSourceFileCoord(SourceFileCoord):
     """Coordinates of a single source file to process."""
@@ -43,12 +53,23 @@ class NoaaGfsSourceFileCoord(SourceFileCoord):
     lead_time: Timedelta
     data_vars: Sequence[NoaaDataVar]
 
-    def get_url(self) -> str:
+    def get_url(self, source: DownloadSource = "s3") -> str:
         init_date_str = self.init_time.strftime("%Y%m%d")
         init_hour_str = self.init_time.strftime("%H")
         lead_hours = whole_hours(self.lead_time)
-        base_path = f"gfs.{init_date_str}/{init_hour_str}/atmos/gfs.t{init_hour_str}z.pgrb2.0p25.f{lead_hours:03d}"
-        return f"https://noaa-gfs-bdp-pds.s3.amazonaws.com/{base_path}"
+        path = f"gfs.{init_date_str}/{init_hour_str}/atmos/gfs.t{init_hour_str}z.pgrb2.0p25.f{lead_hours:03d}"
+        match source:
+            case "nomads":
+                base = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod"
+            case "s3":
+                base = "https://noaa-gfs-bdp-pds.s3.amazonaws.com"
+            case _ as unreachable:
+                assert_never(unreachable)
+
+        return f"{base}/{path}"
+
+    def get_idx_url(self, source: DownloadSource = "s3") -> str:
+        return f"{self.get_url(source=source)}.idx"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValueOrRange]:
         raise NotImplementedError("Subclasses must implement out_loc()")
@@ -65,23 +86,45 @@ class NoaaGfsCommonRegionJob(RegionJob[NoaaDataVar, NoaaGfsSourceFileCoord]):
         """Return groups of variables that can be downloaded from the same source file."""
         return group_by(data_vars, has_hour_0_values)
 
-    def download_file(self, coord: NoaaGfsSourceFileCoord) -> Path:
-        """Download the file for the given coordinate and return the local path."""
-        # Download grib index file
-        idx_url = f"{coord.get_url()}.idx"
-        idx_local_path = http_download_to_disk(idx_url, self.dataset_id)
+    def get_download_source(self, init_time: pd.Timestamp) -> DownloadSource:
+        if init_time >= (pd.Timestamp.now() - NOMADS_RECENCY_THRESHOLD):
+            return "nomads"
+        else:
+            return "s3"
 
-        # Download the grib messages for the data vars in the coord using byte ranges
+    def _download_from_source(
+        self, coord: NoaaGfsSourceFileCoord, source: DownloadSource
+    ) -> Path:
+        idx_local_path = http_download_to_disk(
+            coord.get_idx_url(source=source), self.dataset_id
+        )
         starts, ends = grib_message_byte_ranges_from_index(
             idx_local_path, coord.data_vars, coord.init_time, coord.lead_time
         )
         vars_suffix = digest(f"{s}-{e}" for s, e in zip(starts, ends, strict=True))
         return http_download_to_disk(
-            coord.get_url(),
+            coord.get_url(source=source),
             self.dataset_id,
             byte_ranges=(starts, ends),
             local_path_suffix=f"-{vars_suffix}",
         )
+
+    def download_file(self, coord: NoaaGfsSourceFileCoord) -> Path:
+        source = self.get_download_source(coord.init_time)
+        if source == "nomads":
+            try:
+                return retry(
+                    lambda: self._nomads_download(coord),
+                    max_attempts=4,
+                    retryable_exceptions=(GenericError,),
+                )
+            except (FileNotFoundError, GenericError) as e:
+                log.info(f"NOMADS download failed ({e}), falling back to S3")
+        return self._download_from_source(coord, source="s3")
+
+    def _nomads_download(self, coord: NoaaGfsSourceFileCoord) -> Path:
+        with _nomads_semaphore:
+            return self._download_from_source(coord, source="nomads")
 
     def read_data(
         self,

--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -42,7 +42,6 @@ log = get_logger(__name__)
 
 type DownloadSource = Literal["s3", "nomads"]
 
-NOMADS_RECENCY_THRESHOLD = pd.Timedelta(hours=18)
 # Limit concurrent NOMADS requests to avoid overloading their servers
 _nomads_semaphore = threading.Semaphore(4)
 
@@ -130,8 +129,8 @@ class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
         )
         return jobs, template_ds
 
-    def get_download_source(self, init_time: pd.Timestamp) -> DownloadSource:
-        if init_time >= (pd.Timestamp.now() - NOMADS_RECENCY_THRESHOLD):
+    def _get_download_source(self, init_time: pd.Timestamp) -> DownloadSource:
+        if init_time >= (pd.Timestamp.now() - pd.Timedelta(hours=18)):
             return "nomads"
         else:
             return "s3"
@@ -157,21 +156,15 @@ class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
 
     def download_file(self, coord: NoaaHrrrSourceFileCoord) -> Path:
         """Download a subset of variables from a HRRR file and return the local path."""
-        source = self.get_download_source(coord.init_time)
+        source = self._get_download_source(coord.init_time)
         if source == "nomads":
-            try:
-                return retry(
-                    lambda: self._nomads_download(coord),
-                    max_attempts=4,
-                    retryable_exceptions=(GenericError,),
-                )
-            except (FileNotFoundError, GenericError) as e:
-                log.info(f"NOMADS download failed ({e}), falling back to S3")
-        return self._download_from_source(coord, source="s3")
 
-    def _nomads_download(self, coord: NoaaHrrrSourceFileCoord) -> Path:
-        with _nomads_semaphore:
-            return self._download_from_source(coord, source="nomads")
+            def attempt() -> Path:
+                with _nomads_semaphore:
+                    return self._download_from_source(coord, source="nomads")
+
+            return retry(attempt, max_attempts=4, retryable_exceptions=(GenericError,))
+        return self._download_from_source(coord, source=source)
 
     def read_data(
         self,

--- a/tests/common/test_retry.py
+++ b/tests/common/test_retry.py
@@ -21,3 +21,17 @@ def test_retry_fails_after_max_attempts() -> None:
     mock_func = Mock(side_effect=ValueError("persistent failure"))
     with pytest.raises(ValueError, match="persistent failure"):
         retry(mock_func, max_attempts=2)
+
+
+def test_retryable_exceptions_retries_matching() -> None:
+    mock_func = Mock(side_effect=[ValueError("transient"), "success"])
+    result = retry(mock_func, max_attempts=3, retryable_exceptions=(ValueError,))
+    assert result == "success"
+    assert mock_func.call_count == 2
+
+
+def test_retryable_exceptions_propagates_non_matching() -> None:
+    mock_func = Mock(side_effect=TypeError("not retryable"))
+    with pytest.raises(TypeError, match="not retryable"):
+        retry(mock_func, max_attempts=3, retryable_exceptions=(ValueError,))
+    assert mock_func.call_count == 1

--- a/tests/noaa/gfs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/analysis/dynamical_dataset_test.py
@@ -77,7 +77,7 @@ def test_backfill_local_and_operational_update(monkeypatch: pytest.MonkeyPatch) 
         classmethod(lambda *args, **kwargs: pd.Timestamp("2021-05-01T06:00")),
     )
     monkeypatch.setattr(
-        dataset.region_job_class, "get_download_source", lambda self, init_time: "s3"
+        dataset.region_job_class, "_get_download_source", lambda self, init_time: "s3"
     )
     orig_get_jobs = dataset.region_job_class.get_jobs
     monkeypatch.setattr(

--- a/tests/noaa/gfs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/analysis/dynamical_dataset_test.py
@@ -76,6 +76,9 @@ def test_backfill_local_and_operational_update(monkeypatch: pytest.MonkeyPatch) 
         "now",
         classmethod(lambda *args, **kwargs: pd.Timestamp("2021-05-01T06:00")),
     )
+    monkeypatch.setattr(
+        dataset.region_job_class, "get_download_source", lambda self, init_time: "s3"
+    )
     orig_get_jobs = dataset.region_job_class.get_jobs
     monkeypatch.setattr(
         dataset.region_job_class,

--- a/tests/noaa/gfs/forecast/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast/dynamical_dataset_test.py
@@ -153,7 +153,7 @@ def test_backfill_local_and_operational_update(
         classmethod(lambda *args, **kwargs: pd.Timestamp("2021-05-01T14:00")),
     )
     monkeypatch.setattr(
-        dataset.region_job_class, "get_download_source", lambda self, init_time: "s3"
+        dataset.region_job_class, "_get_download_source", lambda self, init_time: "s3"
     )
     # Dataset updates always update all variables. For the test we hook into get_jobs to limit vars.
     orig_get_jobs = dataset.region_job_class.get_jobs

--- a/tests/noaa/gfs/forecast/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast/dynamical_dataset_test.py
@@ -152,6 +152,9 @@ def test_backfill_local_and_operational_update(
         "now",
         classmethod(lambda *args, **kwargs: pd.Timestamp("2021-05-01T14:00")),
     )
+    monkeypatch.setattr(
+        dataset.region_job_class, "get_download_source", lambda self, init_time: "s3"
+    )
     # Dataset updates always update all variables. For the test we hook into get_jobs to limit vars.
     orig_get_jobs = dataset.region_job_class.get_jobs
     monkeypatch.setattr(

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -2,10 +2,13 @@ from collections.abc import Mapping
 from pathlib import Path
 from unittest.mock import Mock
 
+import numpy as np
 import pandas as pd
 import pytest
+from obstore.exceptions import GenericError
 
 from reformatters.common import template_utils
+from reformatters.common.pydantic import replace
 from reformatters.common.region_job import CoordinateValueOrRange
 from reformatters.common.storage import DatasetFormat, StorageConfig, StoreFactory
 from reformatters.common.types import Dim
@@ -184,3 +187,235 @@ def test_common_region_job_operational_update_jobs(
     for job in jobs:
         assert isinstance(job, NoaaGfsForecastRegionJob)
         assert job.data_vars == template_config.data_vars
+
+
+def test_source_file_coord_get_url_nomads() -> None:
+    """Test that get_url(source="nomads") returns a NOMADS URL with the same path as S3."""
+    coord = ConcreteSourceFileCoord(
+        init_time=pd.Timestamp("2025-06-15T12:00"),
+        lead_time=pd.Timedelta(hours=24),
+        data_vars=NoaaGfsForecastTemplateConfig().data_vars[:1],
+    )
+    assert (
+        coord.get_url()
+        == "https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.20250615/12/atmos/gfs.t12z.pgrb2.0p25.f024"
+    )
+    assert (
+        coord.get_url(source="s3")
+        == "https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.20250615/12/atmos/gfs.t12z.pgrb2.0p25.f024"
+    )
+    assert (
+        coord.get_url(source="nomads")
+        == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20250615/12/atmos/gfs.t12z.pgrb2.0p25.f024"
+    )
+
+
+def test_source_file_coord_get_idx_url_nomads() -> None:
+    """Test that get_idx_url(source="nomads") returns the NOMADS index URL."""
+    coord = ConcreteSourceFileCoord(
+        init_time=pd.Timestamp("2025-06-15T06:00"),
+        lead_time=pd.Timedelta(hours=3),
+        data_vars=NoaaGfsForecastTemplateConfig().data_vars[:1],
+    )
+    assert (
+        coord.get_idx_url(source="nomads")
+        == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20250615/06/atmos/gfs.t06z.pgrb2.0p25.f003.idx"
+    )
+    assert (
+        coord.get_idx_url(source="s3")
+        == "https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.20250615/06/atmos/gfs.t06z.pgrb2.0p25.f003.idx"
+    )
+
+
+def _make_gfs_region_job(
+    template_config: NoaaGfsForecastTemplateConfig,
+    now: pd.Timestamp,
+) -> NoaaGfsForecastRegionJob:
+    return NoaaGfsForecastRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=template_config.get_template(now),
+        data_vars=template_config.data_vars[:1],
+        append_dim=template_config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+
+def test_get_download_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    template_config = NoaaGfsForecastTemplateConfig()
+    fixed_now = pd.Timestamp("2025-01-15T12:00")
+    monkeypatch.setattr(
+        pd.Timestamp, "now", classmethod(lambda *args, **kwargs: fixed_now)
+    )
+    region_job = _make_gfs_region_job(template_config, fixed_now)
+
+    assert region_job.get_download_source(fixed_now - pd.Timedelta(hours=6)) == "nomads"
+    assert region_job.get_download_source(fixed_now - pd.Timedelta(hours=24)) == "s3"
+
+
+def test_download_file_uses_nomads_for_recent_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    template_config = NoaaGfsForecastTemplateConfig()
+    region_job = _make_gfs_region_job(template_config, pd.Timestamp("2025-01-15T12:00"))
+    coord = NoaaGfsForecastSourceFileCoord(
+        init_time=pd.Timestamp("2025-01-01"),
+        lead_time=pd.Timedelta(hours=6),
+        data_vars=template_config.data_vars[:1],
+    )
+    monkeypatch.setattr(
+        NoaaGfsForecastRegionJob, "get_download_source", lambda self, t: "nomads"
+    )
+    mock_download = Mock(return_value=Mock())
+    monkeypatch.setattr(
+        "reformatters.noaa.gfs.region_job.http_download_to_disk", mock_download
+    )
+    monkeypatch.setattr(
+        "reformatters.noaa.gfs.region_job.grib_message_byte_ranges_from_index",
+        Mock(return_value=([0], [100])),
+    )
+
+    region_job.download_file(coord)
+
+    urls_called = [call.args[0] for call in mock_download.call_args_list]
+    assert all(url.startswith("https://nomads.ncep.noaa.gov") for url in urls_called)
+
+
+def test_download_file_falls_back_to_s3_on_generic_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file falls back to S3 when NOMADS raises GenericError (bare redirect)."""
+    template_config = NoaaGfsForecastTemplateConfig()
+    region_job = _make_gfs_region_job(template_config, pd.Timestamp("2025-01-15T12:00"))
+    coord = NoaaGfsForecastSourceFileCoord(
+        init_time=pd.Timestamp("2025-01-01"),
+        lead_time=pd.Timedelta(hours=6),
+        data_vars=template_config.data_vars[:1],
+    )
+    monkeypatch.setattr(
+        NoaaGfsForecastRegionJob, "get_download_source", lambda self, t: "nomads"
+    )
+    # Disable retry sleep for fast tests
+    monkeypatch.setattr("reformatters.common.retry.time.sleep", lambda _: None)
+
+    s3_result = Mock()
+    nomads_call_count = 0
+
+    def mock_download_from_source(
+        self: NoaaGfsCommonRegionJob,
+        coord: NoaaGfsForecastSourceFileCoord,
+        source: str,
+    ) -> Path:
+        nonlocal nomads_call_count
+        if source == "nomads":
+            nomads_call_count += 1
+            raise GenericError("Received redirect without LOCATION")
+        return s3_result
+
+    monkeypatch.setattr(
+        NoaaGfsCommonRegionJob, "_download_from_source", mock_download_from_source
+    )
+
+    result = region_job.download_file(coord)
+
+    assert result == s3_result
+    # Should have retried NOMADS 4 times before falling back
+    assert nomads_call_count == 4
+
+
+def test_download_file_falls_back_to_s3_on_file_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file falls back to S3 when NOMADS raises FileNotFoundError."""
+    template_config = NoaaGfsForecastTemplateConfig()
+    region_job = _make_gfs_region_job(template_config, pd.Timestamp("2025-01-15T12:00"))
+    coord = NoaaGfsForecastSourceFileCoord(
+        init_time=pd.Timestamp("2025-01-01"),
+        lead_time=pd.Timedelta(hours=6),
+        data_vars=template_config.data_vars[:1],
+    )
+    monkeypatch.setattr(
+        NoaaGfsForecastRegionJob, "get_download_source", lambda self, t: "nomads"
+    )
+
+    s3_result = Mock()
+
+    def mock_download_from_source(
+        self: NoaaGfsCommonRegionJob,
+        coord: NoaaGfsForecastSourceFileCoord,
+        source: str,
+    ) -> Path:
+        if source == "nomads":
+            raise FileNotFoundError("Not found on NOMADS")
+        return s3_result
+
+    monkeypatch.setattr(
+        NoaaGfsCommonRegionJob, "_download_from_source", mock_download_from_source
+    )
+
+    result = region_job.download_file(coord)
+    assert result == s3_result
+
+
+def test_download_file_skips_nomads_for_old_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file goes directly to S3 for old data."""
+    template_config = NoaaGfsForecastTemplateConfig()
+    region_job = _make_gfs_region_job(template_config, pd.Timestamp("2025-01-15T12:00"))
+    coord = NoaaGfsForecastSourceFileCoord(
+        init_time=pd.Timestamp("2025-01-01"),
+        lead_time=pd.Timedelta(hours=6),
+        data_vars=template_config.data_vars[:1],
+    )
+    monkeypatch.setattr(
+        NoaaGfsForecastRegionJob, "get_download_source", lambda self, t: "s3"
+    )
+
+    s3_result = Mock()
+
+    def mock_download_from_source(
+        self: NoaaGfsCommonRegionJob,
+        coord: NoaaGfsForecastSourceFileCoord,
+        source: str,
+    ) -> Path:
+        assert source == "s3"
+        return s3_result
+
+    monkeypatch.setattr(
+        NoaaGfsCommonRegionJob, "_download_from_source", mock_download_from_source
+    )
+
+    result = region_job.download_file(coord)
+    assert result == s3_result
+
+
+@pytest.mark.slow
+def test_download_file_from_nomads_gfs() -> None:
+    """Download a recent GFS init time from NOMADS and read all template variables."""
+    template_config = NoaaGfsForecastTemplateConfig()
+    # 6h-old init time is within the 18h NOMADS window and typically complete
+    init_time = (pd.Timestamp.now() - pd.Timedelta(hours=6)).floor("6h")
+
+    region_job = NoaaGfsForecastRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=template_config.get_template(pd.Timestamp.now()),
+        data_vars=template_config.data_vars,
+        append_dim=template_config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+    # lead_time=6h: all vars (instant and accumulated) are present in the f006 GRIB file
+    lead_time = pd.Timedelta(hours=6)
+    for group in NoaaGfsForecastRegionJob.source_groups(template_config.data_vars):
+        coord = NoaaGfsForecastSourceFileCoord(
+            init_time=init_time,
+            lead_time=lead_time,
+            data_vars=group,
+        )
+        coord = replace(coord, downloaded_path=region_job.download_file(coord))
+
+        for data_var in group:
+            data = region_job.read_data(coord, data_var)
+            assert np.all(np.isfinite(data)), f"Non-finite values for {data_var.name}"

--- a/tests/noaa/hrrr/region_job_test.py
+++ b/tests/noaa/hrrr/region_job_test.py
@@ -5,8 +5,13 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from obstore.exceptions import GenericError
 
 from reformatters.common.pydantic import replace
+from reformatters.noaa.hrrr.forecast_48_hour.region_job import (
+    NoaaHrrrForecast48HourRegionJob,
+    NoaaHrrrForecast48HourSourceFileCoord,
+)
 from reformatters.noaa.hrrr.forecast_48_hour.template_config import (
     NoaaHrrrForecast48HourTemplateConfig,
 )
@@ -418,3 +423,256 @@ def test_update_append_dim_start() -> None:
     result = NoaaHrrrRegionJob._update_append_dim_start(time_coord)
 
     assert result == pd.Timestamp("2024-01-01 09:00:00")
+
+
+def test_source_file_coord_get_url_nomads(
+    template_config: NoaaHrrrCommonTemplateConfig,
+) -> None:
+    """Test that get_url(source="nomads") returns a NOMADS URL with the same path as S3."""
+    coord = NoaaHrrrSourceFileCoord(
+        init_time=pd.Timestamp("2024-02-29T12:00"),
+        lead_time=pd.Timedelta(hours=6),
+        domain="conus",
+        file_type="sfc",
+        data_vars=template_config.data_vars,
+    )
+    assert (
+        coord.get_url()
+        == "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t12z.wrfsfcf06.grib2"
+    )
+    assert (
+        coord.get_url(source="s3")
+        == "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t12z.wrfsfcf06.grib2"
+    )
+    assert (
+        coord.get_url(source="nomads")
+        == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/hrrr.20240229/conus/hrrr.t12z.wrfsfcf06.grib2"
+    )
+
+
+def test_source_file_coord_get_idx_url_nomads(
+    template_config: NoaaHrrrCommonTemplateConfig,
+) -> None:
+    """Test that get_idx_url(source="nomads") returns the NOMADS index URL."""
+    coord = NoaaHrrrSourceFileCoord(
+        init_time=pd.Timestamp("2024-02-29T06:00"),
+        lead_time=pd.Timedelta(hours=3),
+        domain="conus",
+        file_type="sfc",
+        data_vars=template_config.data_vars,
+    )
+    assert (
+        coord.get_idx_url(source="nomads")
+        == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/hrrr.20240229/conus/hrrr.t06z.wrfsfcf03.grib2.idx"
+    )
+    assert (
+        coord.get_idx_url(source="s3")
+        == "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t06z.wrfsfcf03.grib2.idx"
+    )
+
+
+def _make_hrrr_region_job(
+    template_config: NoaaHrrrCommonTemplateConfig,
+) -> NoaaHrrrRegionJob:
+    return NoaaHrrrRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=Mock(),
+        data_vars=template_config.data_vars[:1],
+        append_dim=template_config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+
+def test_get_download_source(
+    template_config: NoaaHrrrCommonTemplateConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_now = pd.Timestamp("2025-01-15T12:00")
+    monkeypatch.setattr(
+        pd.Timestamp, "now", classmethod(lambda *args, **kwargs: fixed_now)
+    )
+    region_job = _make_hrrr_region_job(template_config)
+
+    assert region_job.get_download_source(fixed_now - pd.Timedelta(hours=6)) == "nomads"
+    assert region_job.get_download_source(fixed_now - pd.Timedelta(hours=24)) == "s3"
+
+
+def test_download_file_uses_nomads_for_recent_data(
+    template_config: NoaaHrrrCommonTemplateConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    region_job = _make_hrrr_region_job(template_config)
+    monkeypatch.setattr(NoaaHrrrRegionJob, "dataset_id", "test-dataset-hrrr")
+    coord = NoaaHrrrSourceFileCoord(
+        init_time=pd.Timestamp("2025-01-01"),
+        lead_time=pd.Timedelta(hours=2),
+        domain="conus",
+        file_type="sfc",
+        data_vars=template_config.data_vars[:1],
+    )
+    monkeypatch.setattr(
+        NoaaHrrrRegionJob, "get_download_source", lambda self, t: "nomads"
+    )
+    mock_download = Mock(return_value=Mock())
+    monkeypatch.setattr(
+        "reformatters.noaa.hrrr.region_job.http_download_to_disk", mock_download
+    )
+    monkeypatch.setattr(
+        "reformatters.noaa.hrrr.region_job.grib_message_byte_ranges_from_index",
+        Mock(return_value=([0], [100])),
+    )
+
+    region_job.download_file(coord)
+
+    urls_called = [call.args[0] for call in mock_download.call_args_list]
+    assert all(url.startswith("https://nomads.ncep.noaa.gov") for url in urls_called)
+
+
+def test_download_file_falls_back_to_s3_on_generic_error(
+    template_config: NoaaHrrrCommonTemplateConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file falls back to S3 when NOMADS raises GenericError (bare redirect)."""
+    region_job = _make_hrrr_region_job(template_config)
+    coord = NoaaHrrrSourceFileCoord(
+        init_time=pd.Timestamp("2025-01-01"),
+        lead_time=pd.Timedelta(hours=2),
+        domain="conus",
+        file_type="sfc",
+        data_vars=template_config.data_vars[:1],
+    )
+    monkeypatch.setattr(
+        NoaaHrrrRegionJob, "get_download_source", lambda self, t: "nomads"
+    )
+    # Disable retry sleep for fast tests
+    monkeypatch.setattr("reformatters.common.retry.time.sleep", lambda _: None)
+
+    s3_result = Mock()
+    nomads_call_count = 0
+
+    def mock_download_from_source(
+        self: NoaaHrrrRegionJob,
+        coord: NoaaHrrrSourceFileCoord,
+        source: str,
+    ) -> Path:
+        nonlocal nomads_call_count
+        if source == "nomads":
+            nomads_call_count += 1
+            raise GenericError("Received redirect without LOCATION")
+        return s3_result
+
+    monkeypatch.setattr(
+        NoaaHrrrRegionJob, "_download_from_source", mock_download_from_source
+    )
+
+    result = region_job.download_file(coord)
+
+    assert result == s3_result
+    # Should have retried NOMADS 4 times before falling back
+    assert nomads_call_count == 4
+
+
+def test_download_file_falls_back_to_s3_on_file_not_found(
+    template_config: NoaaHrrrCommonTemplateConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file falls back to S3 when NOMADS raises FileNotFoundError."""
+    region_job = _make_hrrr_region_job(template_config)
+    coord = NoaaHrrrSourceFileCoord(
+        init_time=pd.Timestamp("2025-01-01"),
+        lead_time=pd.Timedelta(hours=2),
+        domain="conus",
+        file_type="sfc",
+        data_vars=template_config.data_vars[:1],
+    )
+    monkeypatch.setattr(
+        NoaaHrrrRegionJob, "get_download_source", lambda self, t: "nomads"
+    )
+
+    s3_result = Mock()
+
+    def mock_download_from_source(
+        self: NoaaHrrrRegionJob,
+        coord: NoaaHrrrSourceFileCoord,
+        source: str,
+    ) -> Path:
+        if source == "nomads":
+            raise FileNotFoundError("Not found on NOMADS")
+        return s3_result
+
+    monkeypatch.setattr(
+        NoaaHrrrRegionJob, "_download_from_source", mock_download_from_source
+    )
+
+    result = region_job.download_file(coord)
+    assert result == s3_result
+
+
+def test_download_file_skips_nomads_for_old_data(
+    template_config: NoaaHrrrCommonTemplateConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_file goes directly to S3 for old data."""
+    region_job = _make_hrrr_region_job(template_config)
+    coord = NoaaHrrrSourceFileCoord(
+        init_time=pd.Timestamp("2025-01-01"),
+        lead_time=pd.Timedelta(hours=2),
+        domain="conus",
+        file_type="sfc",
+        data_vars=template_config.data_vars[:1],
+    )
+    monkeypatch.setattr(NoaaHrrrRegionJob, "get_download_source", lambda self, t: "s3")
+
+    s3_result = Mock()
+
+    def mock_download_from_source(
+        self: NoaaHrrrRegionJob,
+        coord: NoaaHrrrSourceFileCoord,
+        source: str,
+    ) -> Path:
+        assert source == "s3"
+        return s3_result
+
+    monkeypatch.setattr(
+        NoaaHrrrRegionJob, "_download_from_source", mock_download_from_source
+    )
+
+    result = region_job.download_file(coord)
+    assert result == s3_result
+
+
+@pytest.mark.slow
+def test_download_file_from_nomads_hrrr() -> None:
+    """Download a recent HRRR init time from NOMADS and read all template variables."""
+    template_config = NoaaHrrrForecast48HourTemplateConfig()
+    # 6h-old init time is within the 18h NOMADS window and typically complete
+    init_time = (pd.Timestamp.now() - pd.Timedelta(hours=6)).floor("h")
+
+    region_job = NoaaHrrrForecast48HourRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=template_config.get_template(pd.Timestamp.now()),
+        data_vars=template_config.data_vars,
+        append_dim=template_config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+    # lead_time=2h: all vars (instant and accumulated) are present in the f02 GRIB file
+    lead_time = pd.Timedelta(hours=2)
+    for group in NoaaHrrrForecast48HourRegionJob.source_groups(
+        template_config.data_vars
+    ):
+        file_type = group[0].internal_attrs.hrrr_file_type
+        coord = NoaaHrrrForecast48HourSourceFileCoord(
+            init_time=init_time,
+            lead_time=lead_time,
+            domain="conus",
+            file_type=file_type,
+            data_vars=group,
+        )
+        coord = replace(coord, downloaded_path=region_job.download_file(coord))
+
+        for data_var in group:
+            data = region_job.read_data(coord, data_var)
+            assert np.all(np.isfinite(data)), f"Non-finite values for {data_var.name}"


### PR DESCRIPTION
## Summary
This PR adds support for downloading NOAA HRRR and GFS forecast data from NOMADS (NOAA's Operational Model Archive and Distribution System) as a primary source for recent data, with automatic fallback to S3 for older data or when NOMADS is unavailable.

## Key Changes

### Core Download Logic
- **Dual-source download strategy**: Implemented `get_download_source()` method that returns "nomads" for data within the last 18 hours and "s3" for older data
- **Fallback mechanism**: `download_file()` now attempts NOMADS downloads with retry logic (4 attempts), automatically falling back to S3 on `GenericError` or `FileNotFoundError`
- **Concurrency control**: Added a semaphore (`_nomads_semaphore`) to limit concurrent NOMADS requests to 4, preventing server overload

### URL Generation
- Updated `get_url()` and `get_idx_url()` methods in both `NoaaHrrrSourceFileCoord` and `NoaaGfsSourceFileCoord` to accept a `source` parameter
- NOMADS URLs use the base `https://nomads.ncep.noaa.gov/pub/data/nccf/com/{product}/prod/` while S3 URLs use AWS bucket URLs
- Both sources share the same path structure for consistency

### Retry Enhancement
- Extended `retry()` utility function to support `retryable_exceptions` parameter, allowing selective retry on specific exception types
- This enables retrying on transient NOMADS errors while immediately failing on permanent errors

### Testing
- Added comprehensive test coverage for NOMADS URL generation
- Added tests for download source selection logic
- Added tests for fallback behavior on various error conditions
- Added integration test (`test_download_file_from_nomads_hrrr` and `test_download_file_from_nomads_gfs`) to verify actual downloads from NOMADS

## Implementation Details
- Used `threading.Semaphore` for thread-safe concurrency control
- Leveraged `obstore.exceptions.GenericError` to detect bare redirect responses from NOMADS
- Maintained backward compatibility by defaulting `source` parameter to "s3"
- Added user agent header to HTTP requests for better server tracking

https://claude.ai/code/session_01CnivfwHHzd2Li1TEbWDMej