### PR TITLE
Tighten GEFS schedule based on NOMADS file availability

### DIFF
--- a/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
@@ -22,7 +22,8 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="0 0,6,12,18 * * *",  # UTC
+            # GEFS f006 (last lead time used) available ~3h48m after init on NOMADS. +3 min buffer.
+            schedule="51 3,9,15,21 * * *",
             pod_active_deadline=timedelta(hours=1),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -34,7 +35,7 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="10 0,6,12,18 * * *",  # UTC 10 minutes after update starts
+            schedule="51 4,10,16,22 * * *",  # 1h (pod_active_deadline) after reformat
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/noaa/gefs/forecast_35_day/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/dynamical_dataset.py
@@ -24,7 +24,8 @@ class GefsForecast35DayDataset(
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="0 7 * * *",  # At 7:00 UTC every day.
+            # GEFS f384 last perturbed member available ~6h30m after 00z init on NOMADS. +3 min buffer.
+            schedule="33 6 * * *",
             pod_active_deadline=timedelta(hours=3.5),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -36,7 +37,7 @@ class GefsForecast35DayDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="30 11 * * *",  # At 11:30 UTC every day.
+            schedule="3 10 * * *",  # 3h30m (pod_active_deadline) after reformat at 06:33
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/tests/noaa/gefs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/analysis/dynamical_dataset_test.py
@@ -24,7 +24,7 @@ def test_operational_kubernetes_resources(dataset: GefsAnalysisDataset) -> None:
 
     # Check update job
     assert update_cron_job.name == f"{dataset.dataset_id}-update"
-    assert update_cron_job.schedule == "0 0,6,12,18 * * *"  # Every 6 hours
+    assert update_cron_job.schedule == "51 3,9,15,21 * * *"
     assert update_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert update_cron_job.cpu == "14"
     assert update_cron_job.memory == "30G"
@@ -33,9 +33,7 @@ def test_operational_kubernetes_resources(dataset: GefsAnalysisDataset) -> None:
 
     # Check validation job
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
-    assert (
-        validation_cron_job.schedule == "10 0,6,12,18 * * *"
-    )  # 10 minutes after updates
+    assert validation_cron_job.schedule == "51 4,10,16,22 * * *"
     assert validation_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert validation_cron_job.cpu == "1.3"
     assert validation_cron_job.memory == "7G"

--- a/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
@@ -26,7 +26,7 @@ def test_operational_kubernetes_resources(dataset: GefsForecast35DayDataset) -> 
 
     # Check update job
     assert update_cron_job.name == f"{dataset.dataset_id}-update"
-    assert update_cron_job.schedule == "0 7 * * *"  # Daily at 7:00 UTC
+    assert update_cron_job.schedule == "33 6 * * *"
     assert update_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert update_cron_job.cpu == "6"
     assert update_cron_job.memory.endswith("G")
@@ -35,7 +35,7 @@ def test_operational_kubernetes_resources(dataset: GefsForecast35DayDataset) -> 
 
     # Check validation job
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
-    assert validation_cron_job.schedule == "30 11 * * *"  # Daily at 11:30 UTC
+    assert validation_cron_job.schedule == "3 10 * * *"
     assert validation_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert validation_cron_job.cpu == "3"
     assert validation_cron_job.memory == "30G"


### PR DESCRIPTION
Reviewed actual file modified times on NOMADS and average end times from https://www.nco.ncep.noaa.gov/pmb/nwprod/prodstat/ to set schedules as close as possible to when data is available, with a 3-minute buffer.

GEFS 35-day forecast schedule updated to wait for f384 (not f240): all 30 perturbed ensemble members' f384 files land at ~6h30m after init.

Reformat schedule changes (all times UTC, relative to init):
- GEFS analysis:     00,06,12,18 UTC → :51 3,9,15,21 (3h51m after init; f006 ready ~3h48m)
- GEFS forecast 35d: 07:00 daily    → 06:33 daily    (6h33m after 00z; f384 ready ~6h30m)

Validation schedule: set to exactly pod_active_deadline after reformat start.