### PR TITLE
Use httpx for NOMADS downloads as attempt to fix Akamai bare redirect errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "kubernetes~=33.1",
     "icechunk==1.1.15",
     "google-crc32c>=1.8.0",
+    "httpx>=0.28.1",
 ]
 
 [build-system]

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import time
 import uuid
 from collections.abc import Sequence
 from datetime import timedelta
@@ -9,10 +10,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+import httpx
+import numpy as np
 import obstore
+
+from reformatters.common.logging import get_logger
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
+
+log = get_logger(__name__)
 
 DOWNLOAD_DIR = Path("data/download/")
 
@@ -136,3 +143,140 @@ def get_local_path(dataset_id: str, path: str, local_path_suffix: str = "") -> P
         if local_path_suffix
         else base_local
     )
+
+
+@functools.cache
+def _httpx_client() -> httpx.Client:
+    return httpx.Client(
+        follow_redirects=True,
+        timeout=httpx.Timeout(connect=4.0, read=120.0, write=120.0, pool=120.0),
+        headers={"User-Agent": "dynamical.org reformatters"},
+    )
+
+
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+_MAX_RETRIES = 16
+_INIT_BACKOFF_SECONDS = 1.0
+_MAX_BACKOFF_SECONDS = 16.0
+_RETRY_TIMEOUT_SECONDS = 300.0
+
+
+def _httpx_get_with_retry(
+    url: str,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    client = _httpx_client()
+    rng = np.random.default_rng()
+    start_time = time.monotonic()
+
+    last_exception: Exception | None = None
+    for attempt in range(_MAX_RETRIES + 1):
+        if time.monotonic() - start_time > _RETRY_TIMEOUT_SECONDS:
+            break
+
+        if attempt > 0:
+            backoff = min(
+                _INIT_BACKOFF_SECONDS * (2 ** (attempt - 1)), _MAX_BACKOFF_SECONDS
+            )
+            jitter = rng.uniform(0.5, 1.5)
+            time.sleep(backoff * jitter)
+
+        try:
+            response = client.get(url, headers=headers)
+        except httpx.TransportError as e:
+            last_exception = e
+            log.warning(f"httpx transport error on attempt {attempt + 1}: {e}")
+            continue
+
+        if response.status_code not in _RETRYABLE_STATUS_CODES:
+            response.raise_for_status()
+            return response
+
+        last_exception = httpx.HTTPStatusError(
+            f"Server returned {response.status_code}",
+            request=response.request,
+            response=response,
+        )
+        log.warning(
+            f"Retryable status {response.status_code} on attempt {attempt + 1} for {url}"
+        )
+
+    assert last_exception is not None
+    raise last_exception
+
+
+def _parse_multipart_byteranges(data: bytes, content_type: str) -> bytes:
+    # Extract boundary from Content-Type: multipart/byteranges; boundary=XXXX
+    _, _, params = content_type.partition(";")
+    boundary = b""
+    for raw_param in params.split(";"):
+        stripped = raw_param.strip()
+        if stripped.startswith("boundary="):
+            boundary = stripped.removeprefix("boundary=").strip().encode()
+            break
+    assert boundary, f"No boundary found in content_type: {content_type}"
+
+    delimiter = b"--" + boundary
+    parts = data.split(delimiter)
+    # First part is empty (before first delimiter), last part is "--\r\n" (closing)
+    body_parts: list[bytes] = []
+    for part in parts[1:]:
+        if part.strip() == b"--" or not part.strip():
+            continue
+        # Each part has headers separated from body by \r\n\r\n
+        header_end = part.find(b"\r\n\r\n")
+        assert header_end != -1, "Malformed multipart part: no header/body separator"
+        body = part[header_end + 4 :]
+        # Strip trailing \r\n that precedes the next delimiter
+        if body.endswith(b"\r\n"):
+            body = body[:-2]
+        body_parts.append(body)
+
+    assert body_parts, "No parts found in multipart response"
+    return b"".join(body_parts)
+
+
+def httpx_download_to_disk(
+    url: str,
+    dataset_id: str,
+    byte_ranges: tuple[Sequence[int], Sequence[int]] | None = None,
+    local_path_suffix: str = "",
+) -> Path:
+    parsed_url = urlparse(url)
+    local_path = get_local_path(dataset_id, parsed_url.path, local_path_suffix)
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = local_path.with_name(f"{local_path.name}.{uuid.uuid4().hex[:8]}")
+
+    try:
+        if byte_ranges is not None:
+            starts, ends = byte_ranges
+            # Build multi-range header. Ends from grib index are exclusive; HTTP Range is inclusive.
+            range_specs = [f"{s}-{e - 1}" for s, e in zip(starts, ends, strict=True)]
+            range_header = f"bytes={', '.join(range_specs)}"
+            response = _httpx_get_with_retry(url, headers={"Range": range_header})
+
+            content_type = response.headers.get("content-type", "")
+            if "multipart/byteranges" in content_type:
+                body = _parse_multipart_byteranges(response.content, content_type)
+            else:
+                # Single range or server returned full content
+                body = response.content
+
+            with open(temp_path, "wb") as f:
+                f.write(body)
+        else:
+            # Stream full file to disk
+            with _httpx_client().stream("GET", url) as response:
+                response.raise_for_status()
+                with open(temp_path, "wb") as f:
+                    f.writelines(response.iter_bytes())
+
+        temp_path.rename(local_path)
+
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            temp_path.unlink()
+            local_path.unlink()
+        raise
+
+    return local_path

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -242,6 +242,7 @@ def httpx_download_to_disk(
     byte_ranges: tuple[Sequence[int], Sequence[int]] | None = None,
     local_path_suffix: str = "",
 ) -> Path:
+    """httpx based download which supports redirects and maintains cookies."""
     parsed_url = urlparse(url)
     local_path = get_local_path(dataset_id, parsed_url.path, local_path_suffix)
     local_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/reformatters/common/logging.py
+++ b/src/reformatters/common/logging.py
@@ -9,6 +9,8 @@ logging.basicConfig(
 )
 # Ensure timestamps are in UTC
 logging.Formatter.converter = time.gmtime
+# Silence httpx per-request INFO logs; warnings and errors still surface
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 _root_logger = logging.getLogger()
 

--- a/src/reformatters/noaa/gefs/utils.py
+++ b/src/reformatters/noaa/gefs/utils.py
@@ -17,10 +17,8 @@ def _download_file_from_gefs_source(
     coord: GefsSourceFileCoord,
     index_url: str,
     source_url: str,
-    download: _DownloadFn | None = None,
+    download: _DownloadFn,
 ) -> Path:
-    if download is None:
-        download = http_download_to_disk
     idx_local_path = download(index_url, dataset_id)
 
     starts, ends = grib_message_byte_ranges_from_index(
@@ -42,7 +40,11 @@ def gefs_download_file(
     """Download file from GEFS source with retry and fallback to alternative source."""
     try:
         return _download_file_from_gefs_source(
-            dataset_id, coord, coord.get_index_url(), coord.get_url()
+            dataset_id,
+            coord,
+            coord.get_index_url(),
+            coord.get_url(),
+            download=http_download_to_disk,
         )
     except FileNotFoundError:
         # if init time is within the last 4 days, try to download from the fallback source (NOMADS)

--- a/src/reformatters/noaa/gefs/utils.py
+++ b/src/reformatters/noaa/gefs/utils.py
@@ -1,12 +1,15 @@
+from collections.abc import Callable
 from pathlib import Path
 
 import pandas as pd
 from obstore.exceptions import PermissionDeniedError
 
-from reformatters.common.download import http_download_to_disk
+from reformatters.common.download import http_download_to_disk, httpx_download_to_disk
 from reformatters.common.iterating import digest
 from reformatters.noaa.gefs.gefs_config_models import GefsSourceFileCoord
 from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
+
+type _DownloadFn = Callable[..., Path]
 
 
 def _download_file_from_gefs_source(
@@ -14,16 +17,17 @@ def _download_file_from_gefs_source(
     coord: GefsSourceFileCoord,
     index_url: str,
     source_url: str,
+    download: _DownloadFn | None = None,
 ) -> Path:
-    # Download grib index file
-    idx_local_path = http_download_to_disk(index_url, dataset_id)
+    if download is None:
+        download = http_download_to_disk
+    idx_local_path = download(index_url, dataset_id)
 
-    # Download the grib messages for the data vars in the coord using byte ranges
     starts, ends = grib_message_byte_ranges_from_index(
         idx_local_path, coord.data_vars, coord.init_time, coord.lead_time
     )
     vars_suffix = digest(f"{s}-{e}" for s, e in zip(starts, ends, strict=True))
-    return http_download_to_disk(
+    return download(
         source_url,
         dataset_id,
         byte_ranges=(starts, ends),
@@ -41,7 +45,7 @@ def gefs_download_file(
             dataset_id, coord, coord.get_index_url(), coord.get_url()
         )
     except FileNotFoundError:
-        # if init time is within the last 4 days, try to download from the fallback source
+        # if init time is within the last 4 days, try to download from the fallback source (NOMADS)
         if coord.init_time >= pd.Timestamp.now() - pd.Timedelta(days=4):
             try:
                 return _download_file_from_gefs_source(
@@ -49,6 +53,7 @@ def gefs_download_file(
                     coord,
                     coord.get_index_url(fallback=True),
                     coord.get_fallback_url(),
+                    download=httpx_download_to_disk,
                 )
             except PermissionDeniedError as e:
                 raise FileNotFoundError(coord.get_url()) from e

--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -3,16 +3,16 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Literal, assert_never
 
+import httpx
 import numpy as np
 import pandas as pd
 import rasterio
 import xarray as xr
-from obstore.exceptions import GenericError
 from zarr.abc.store import Store
 
 from reformatters.common.binary_rounding import round_float32_inplace
 from reformatters.common.deaccumulation import deaccumulate_to_rates_inplace
-from reformatters.common.download import http_download_to_disk
+from reformatters.common.download import http_download_to_disk, httpx_download_to_disk
 from reformatters.common.iterating import digest, group_by, item
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
@@ -138,16 +138,17 @@ class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
     def _download_from_source(
         self, coord: NoaaHrrrSourceFileCoord, source: DownloadSource
     ) -> Path:
-        idx_local_path = http_download_to_disk(
-            coord.get_idx_url(source=source), self.dataset_id
+        download = (
+            httpx_download_to_disk if source == "nomads" else http_download_to_disk
         )
+        idx_local_path = download(coord.get_idx_url(source=source), self.dataset_id)
         byte_range_starts, byte_range_ends = grib_message_byte_ranges_from_index(
             idx_local_path, coord.data_vars, coord.init_time, coord.lead_time
         )
         vars_suffix = digest(
             f"{s}-{e}" for s, e in zip(byte_range_starts, byte_range_ends, strict=True)
         )
-        return http_download_to_disk(
+        return download(
             coord.get_url(source=source),
             self.dataset_id,
             byte_ranges=(byte_range_starts, byte_range_ends),
@@ -163,7 +164,9 @@ class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
                 with _nomads_semaphore:
                     return self._download_from_source(coord, source="nomads")
 
-            return retry(attempt, max_attempts=4, retryable_exceptions=(GenericError,))
+            return retry(
+                attempt, max_attempts=4, retryable_exceptions=(httpx.HTTPError,)
+            )
         return self._download_from_source(coord, source=source)
 
     def read_data(

--- a/tests/common/test_download.py
+++ b/tests/common/test_download.py
@@ -1,17 +1,21 @@
 from collections.abc import Sequence
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
+import httpx
 import obstore.store
 import pytest
 
 from reformatters.common import download as download_module
 from reformatters.common.download import (
     DOWNLOAD_DIR,
+    _httpx_get_with_retry,
+    _parse_multipart_byteranges,
     download_to_disk,
     get_local_path,
     http_download_to_disk,
     http_store,
+    httpx_download_to_disk,
     s3_store,
 )
 
@@ -156,3 +160,284 @@ def test_http_download_to_disk_with_byte_ranges(tmp_path: Path) -> None:
         )
 
     assert captured_ranges[0] == byte_ranges
+
+
+# --- _parse_multipart_byteranges tests ---
+
+
+def test_parse_multipart_byteranges_two_parts() -> None:
+    boundary = "ABCD1234"
+    body = (
+        b"--ABCD1234\r\n"
+        b"Content-Range: bytes 0-4/100\r\n"
+        b"\r\n"
+        b"hello"
+        b"\r\n"
+        b"--ABCD1234\r\n"
+        b"Content-Range: bytes 10-14/100\r\n"
+        b"\r\n"
+        b"world"
+        b"\r\n"
+        b"--ABCD1234--\r\n"
+    )
+    content_type = f"multipart/byteranges; boundary={boundary}"
+    result = _parse_multipart_byteranges(body, content_type)
+    assert result == b"helloworld"
+
+
+def test_parse_multipart_byteranges_single_part() -> None:
+    body = (
+        b"--boundary99\r\nContent-Range: bytes 0-2/10\r\n\r\nabc\r\n--boundary99--\r\n"
+    )
+    result = _parse_multipart_byteranges(
+        body, "multipart/byteranges; boundary=boundary99"
+    )
+    assert result == b"abc"
+
+
+def test_parse_multipart_byteranges_binary_data() -> None:
+    binary_data = bytes(range(256))
+    body = (
+        b"--B\r\n"
+        b"Content-Range: bytes 0-255/256\r\n"
+        b"\r\n" + binary_data + b"\r\n"
+        b"--B--\r\n"
+    )
+    result = _parse_multipart_byteranges(body, "multipart/byteranges; boundary=B")
+    assert result == binary_data
+
+
+def test_parse_multipart_byteranges_no_boundary_raises() -> None:
+    with pytest.raises(AssertionError, match="No boundary"):
+        _parse_multipart_byteranges(b"data", "application/octet-stream")
+
+
+# --- httpx_download_to_disk tests ---
+
+
+def _make_httpx_response(
+    status_code: int = 200,
+    content: bytes = b"",
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    response = httpx.Response(
+        status_code=status_code,
+        content=content,
+        headers=headers or {},
+        request=httpx.Request("GET", "https://example.com/test"),
+    )
+    return response
+
+
+def test_httpx_download_to_disk_no_byte_ranges(tmp_path: Path) -> None:
+    file_content = b"full file content here"
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.iter_bytes = Mock(return_value=iter([file_content]))
+    mock_response.__enter__ = Mock(return_value=mock_response)
+    mock_response.__exit__ = Mock(return_value=False)
+
+    mock_client = Mock()
+    mock_client.stream = Mock(return_value=mock_response)
+
+    with (
+        patch.object(download_module, "_httpx_client", return_value=mock_client),
+        patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
+    ):
+        result = httpx_download_to_disk(
+            "https://example.com/data/file.grib2", "my-dataset"
+        )
+
+    assert result.exists()
+    assert result.read_bytes() == file_content
+
+
+def test_httpx_download_to_disk_with_byte_ranges_multipart(tmp_path: Path) -> None:
+    multipart_body = (
+        b"--BOUNDARY\r\n"
+        b"Content-Range: bytes 0-4/100\r\n"
+        b"\r\n"
+        b"AAAAA"
+        b"\r\n"
+        b"--BOUNDARY\r\n"
+        b"Content-Range: bytes 50-54/100\r\n"
+        b"\r\n"
+        b"BBBBB"
+        b"\r\n"
+        b"--BOUNDARY--\r\n"
+    )
+    response = _make_httpx_response(
+        status_code=206,
+        content=multipart_body,
+        headers={"content-type": "multipart/byteranges; boundary=BOUNDARY"},
+    )
+
+    with (
+        patch.object(download_module, "_httpx_get_with_retry", return_value=response),
+        patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
+    ):
+        result = httpx_download_to_disk(
+            "https://example.com/data/file.grib2",
+            "my-dataset",
+            byte_ranges=([0, 50], [5, 55]),
+        )
+
+    assert result.exists()
+    assert result.read_bytes() == b"AAAAABBBBB"
+
+
+def test_httpx_download_to_disk_with_byte_ranges_single_range(tmp_path: Path) -> None:
+    response = _make_httpx_response(
+        status_code=206,
+        content=b"single range data",
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    with (
+        patch.object(download_module, "_httpx_get_with_retry", return_value=response),
+        patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
+    ):
+        result = httpx_download_to_disk(
+            "https://example.com/data/file.grib2",
+            "my-dataset",
+            byte_ranges=([100], [200]),
+        )
+
+    assert result.exists()
+    assert result.read_bytes() == b"single range data"
+
+
+def test_httpx_download_to_disk_builds_correct_range_header(tmp_path: Path) -> None:
+    """Verify the Range header uses inclusive end (end - 1 from exclusive grib index ends)."""
+    captured_headers: list[dict[str, str] | None] = []
+
+    def fake_get_with_retry(
+        url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        captured_headers.append(headers)
+        return _make_httpx_response(
+            status_code=206,
+            content=b"data",
+            headers={"content-type": "application/octet-stream"},
+        )
+
+    with (
+        patch.object(download_module, "_httpx_get_with_retry", fake_get_with_retry),
+        patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
+    ):
+        httpx_download_to_disk(
+            "https://example.com/data/file.grib2",
+            "my-dataset",
+            byte_ranges=([0, 100, 500], [50, 200, 600]),
+        )
+
+    assert captured_headers[0] is not None
+    # Ends are exclusive from grib index, so HTTP Range should be end-1 (inclusive)
+    assert captured_headers[0]["Range"] == "bytes=0-49, 100-199, 500-599"
+
+
+def test_httpx_download_to_disk_cleans_up_on_error(tmp_path: Path) -> None:
+    with (
+        patch.object(
+            download_module,
+            "_httpx_get_with_retry",
+            side_effect=httpx.ConnectError("failed"),
+        ),
+        patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
+        pytest.raises(httpx.ConnectError),
+    ):
+        httpx_download_to_disk(
+            "https://example.com/data/file.grib2",
+            "my-dataset",
+            byte_ranges=([0], [100]),
+        )
+
+    # No temp or final files should remain
+    all_files = list(tmp_path.rglob("*"))
+    data_files = [f for f in all_files if f.is_file()]
+    assert len(data_files) == 0
+
+
+def test_httpx_download_to_disk_with_suffix(tmp_path: Path) -> None:
+    response = _make_httpx_response(
+        status_code=206,
+        content=b"data",
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    with (
+        patch.object(download_module, "_httpx_get_with_retry", return_value=response),
+        patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
+    ):
+        result = httpx_download_to_disk(
+            "https://example.com/data/file.grib2",
+            "my-dataset",
+            byte_ranges=([0], [100]),
+            local_path_suffix="-abc123",
+        )
+
+    assert result.name == "file.grib2-abc123"
+
+
+# --- _httpx_get_with_retry tests ---
+
+
+def test_httpx_get_with_retry_retries_on_5xx() -> None:
+    call_count = 0
+
+    def mock_get(url: str, **kwargs: object) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            return _make_httpx_response(status_code=503, content=b"unavailable")
+        return _make_httpx_response(status_code=200, content=b"ok")
+
+    mock_client = Mock()
+    mock_client.get = mock_get
+
+    with (
+        patch.object(download_module, "_httpx_client", return_value=mock_client),
+        patch.object(download_module.time, "sleep"),
+    ):
+        response = _httpx_get_with_retry("https://example.com/test")
+
+    assert call_count == 3
+    assert response.status_code == 200
+
+
+def test_httpx_get_with_retry_retries_on_transport_error() -> None:
+    call_count = 0
+
+    def mock_get(url: str, **kwargs: object) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise httpx.ConnectError("connection refused")
+        return _make_httpx_response(status_code=200, content=b"ok")
+
+    mock_client = Mock()
+    mock_client.get = mock_get
+
+    with (
+        patch.object(download_module, "_httpx_client", return_value=mock_client),
+        patch.object(download_module.time, "sleep"),
+    ):
+        response = _httpx_get_with_retry("https://example.com/test")
+
+    assert call_count == 2
+    assert response.status_code == 200
+
+
+def test_httpx_get_with_retry_raises_on_4xx() -> None:
+    mock_client = Mock()
+    mock_client.get = Mock(
+        return_value=_make_httpx_response(status_code=404, content=b"not found")
+    )
+
+    with (
+        patch.object(download_module, "_httpx_client", return_value=mock_client),
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        _httpx_get_with_retry("https://example.com/test")

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -633,29 +633,34 @@ def test_download_file_fallback(
     mock_index_path.read_text.return_value = "ignored"
     mock_data_path = Mock()
 
-    primary_index_url = coord.get_index_url()
     fallback_url = coord.get_fallback_url()
     fallback_index_url = coord.get_index_url(fallback=True)
 
     call_count = 0
 
-    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
+    # Primary source (http_download_to_disk) fails with FileNotFoundError
+    def mock_primary_download(url: str, dataset_id: str, **kwargs: object) -> Mock:
         nonlocal call_count
         call_count += 1
-        # Primary source fails with FileNotFoundError
-        if url == primary_index_url:
-            raise FileNotFoundError(f"Primary index not found: {url}")
-        # Fallback source succeeds
+        raise FileNotFoundError(f"Primary index not found: {url}")
+
+    # Fallback source (httpx_download_to_disk for NOMADS) succeeds
+    def mock_fallback_download(url: str, dataset_id: str, **kwargs: object) -> Mock:
+        nonlocal call_count
+        call_count += 1
         if url == fallback_index_url:
             return mock_index_path
         if url == fallback_url:
             return mock_data_path
-        raise AssertionError(f"Unexpected URL: {url}")
+        raise AssertionError(f"Unexpected fallback URL: {url}")
 
-    mock_download = Mock(side_effect=mock_download_side_effect)
     monkeypatch.setattr(
         "reformatters.noaa.gefs.utils.http_download_to_disk",
-        mock_download,
+        Mock(side_effect=mock_primary_download),
+    )
+    monkeypatch.setattr(
+        "reformatters.noaa.gefs.utils.httpx_download_to_disk",
+        Mock(side_effect=mock_fallback_download),
     )
 
     mock_grib_message_byte_ranges_from_index = Mock(
@@ -672,12 +677,6 @@ def test_download_file_fallback(
 
     # Should have called: primary index (failed) + fallback index + fallback data
     assert call_count == 3
-
-    # Verify fallback URLs were used
-    calls = mock_download.call_args_list
-    assert calls[0][0][0] == primary_index_url  # First tried primary
-    assert calls[1][0][0] == fallback_index_url  # Then fallback index
-    assert calls[2][0][0] == fallback_url  # Then fallback data
 
 
 def test_download_file_no_fallback_for_old_data(
@@ -752,22 +751,15 @@ def test_download_file_fallback_permission_denied_converts_to_file_not_found(
         data_vars=data_vars,
     )
 
-    primary_index_url = coord.get_index_url()
-    fallback_index_url = coord.get_index_url(fallback=True)
-
-    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
-        # Primary source fails with FileNotFoundError
-        if url == primary_index_url:
-            raise FileNotFoundError(f"Primary index not found: {url}")
-        # Fallback source fails with PermissionDeniedError
-        if url == fallback_index_url:
-            raise PermissionDeniedError("Permission denied")
-        raise AssertionError(f"Unexpected URL: {url}")
-
-    mock_download = Mock(side_effect=mock_download_side_effect)
+    # Primary source fails with FileNotFoundError
     monkeypatch.setattr(
         "reformatters.noaa.gefs.utils.http_download_to_disk",
-        mock_download,
+        Mock(side_effect=FileNotFoundError("Primary index not found")),
+    )
+    # Fallback source (NOMADS via httpx) fails with PermissionDeniedError
+    monkeypatch.setattr(
+        "reformatters.noaa.gefs.utils.httpx_download_to_disk",
+        Mock(side_effect=PermissionDeniedError("Permission denied")),
     )
 
     # Should raise FileNotFoundError (not PermissionDeniedError)

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -2,10 +2,10 @@ from collections.abc import Mapping
 from pathlib import Path
 from unittest.mock import Mock
 
+import httpx
 import numpy as np
 import pandas as pd
 import pytest
-from obstore.exceptions import GenericError
 
 from reformatters.common import template_utils
 from reformatters.common.pydantic import replace
@@ -270,7 +270,7 @@ def test_download_file_uses_nomads_for_recent_data(
     )
     mock_download = Mock(return_value=Mock())
     monkeypatch.setattr(
-        "reformatters.noaa.gfs.region_job.http_download_to_disk", mock_download
+        "reformatters.noaa.gfs.region_job.httpx_download_to_disk", mock_download
     )
     monkeypatch.setattr(
         "reformatters.noaa.gfs.region_job.grib_message_byte_ranges_from_index",
@@ -283,10 +283,10 @@ def test_download_file_uses_nomads_for_recent_data(
     assert all(url.startswith("https://nomads.ncep.noaa.gov") for url in urls_called)
 
 
-def test_download_file_retries_nomads_on_generic_error(
+def test_download_file_retries_nomads_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that download_file retries NOMADS 4 times on GenericError (bare redirect)."""
+    """Test that download_file retries NOMADS 4 times on httpx.HTTPError."""
     template_config = NoaaGfsForecastTemplateConfig()
     region_job = _make_gfs_region_job(template_config, pd.Timestamp("2025-01-15T12:00"))
     coord = NoaaGfsForecastSourceFileCoord(
@@ -308,13 +308,13 @@ def test_download_file_retries_nomads_on_generic_error(
     ) -> Path:
         nonlocal call_count
         call_count += 1
-        raise GenericError("Received redirect without LOCATION")
+        raise httpx.ConnectError("connection failed")
 
     monkeypatch.setattr(
         NoaaGfsCommonRegionJob, "_download_from_source", mock_download_from_source
     )
 
-    with pytest.raises(GenericError):
+    with pytest.raises(httpx.ConnectError):
         region_job.download_file(coord)
 
     assert call_count == 4

--- a/uv.lock
+++ b/uv.lock
@@ -137,6 +137,18 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -662,6 +674,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
     { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
     { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1723,6 +1772,7 @@ source = { editable = "." }
 dependencies = [
     { name = "dask" },
     { name = "google-crc32c" },
+    { name = "httpx" },
     { name = "icechunk" },
     { name = "kubernetes" },
     { name = "numba" },
@@ -1760,6 +1810,7 @@ dev = [
 requires-dist = [
     { name = "dask", specifier = "~=2026.0" },
     { name = "google-crc32c", specifier = ">=1.8.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "icechunk", specifier = "==1.1.15" },
     { name = "kubernetes", specifier = "~=33.1" },
     { name = "numba", specifier = "~=0.62" },


### PR DESCRIPTION
obstore's HTTPStore fails intermittently on NOMADS (behind Akamai CDN) with "Received redirect without LOCATION". We think this is because it doesn't maintain cookies or handle Akamai's bot mitigation redirects. Replace with httpx which maintains a cookie jar across requests and handles redirects. Uses a single multi-range HTTP request per file to reduce total request count.