### PR TITLE
Add rate limiter and retry 302s for NOMADS downloads

### DIFF
--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -1,4 +1,3 @@
-import threading
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Literal, assert_never
@@ -41,9 +40,6 @@ from reformatters.noaa.noaa_utils import has_hour_0_values
 log = get_logger(__name__)
 
 type DownloadSource = Literal["s3", "nomads"]
-
-# Limit concurrent NOMADS requests to avoid overloading their servers
-_nomads_semaphore = threading.Semaphore(1)
 
 
 class NoaaHrrrSourceFileCoord(SourceFileCoord):
@@ -159,13 +155,10 @@ class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
         """Download a subset of variables from a HRRR file and return the local path."""
         source = self._get_download_source(coord.init_time)
         if source == "nomads":
-
-            def attempt() -> Path:
-                with _nomads_semaphore:
-                    return self._download_from_source(coord, source="nomads")
-
             return retry(
-                attempt, max_attempts=4, retryable_exceptions=(httpx.HTTPError,)
+                lambda: self._download_from_source(coord, source="nomads"),
+                max_attempts=4,
+                retryable_exceptions=(httpx.HTTPError,),
             )
         return self._download_from_source(coord, source=source)
 

--- a/tests/common/test_download.py
+++ b/tests/common/test_download.py
@@ -231,19 +231,10 @@ def _make_httpx_response(
 
 def test_httpx_download_to_disk_no_byte_ranges(tmp_path: Path) -> None:
     file_content = b"full file content here"
-
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.raise_for_status = Mock()
-    mock_response.iter_bytes = Mock(return_value=iter([file_content]))
-    mock_response.__enter__ = Mock(return_value=mock_response)
-    mock_response.__exit__ = Mock(return_value=False)
-
-    mock_client = Mock()
-    mock_client.stream = Mock(return_value=mock_response)
+    response = _make_httpx_response(status_code=200, content=file_content)
 
     with (
-        patch.object(download_module, "_httpx_client", return_value=mock_client),
+        patch.object(download_module, "_httpx_get_with_retry", return_value=response),
         patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
     ):
         result = httpx_download_to_disk(


### PR DESCRIPTION
Replace per-module semaphores with a centralized 120 req/min rate limiter, add 302 to retryable status codes (Akamai bot mitigation), and route the no-byte-ranges path through _httpx_get_with_retry for consistent retry behavior.