### PR TITLE
Add CITATION.cff and .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,24 @@
+{
+  "title": "dynamical.org reformatters",
+  "description": "Data pipeline that produces the dynamical.org catalog of analysis-ready weather data in Zarr v3 / Icechunk format.",
+  "license": "BSD-3-Clause",
+  "upload_type": "software",
+  "creators": [
+    {"name": "Keefe Sampson, Alden"},
+    {"name": "Moutenot, Marshall"},
+    {"name": "dynamical.org contributors"}
+  ],
+  "keywords": [
+    "weather",
+    "zarr",
+    "climate",
+    "open-data"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://dynamical.org",
+      "relation": "isDocumentedBy",
+      "resource_type": "other"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use dynamical.org data, please cite as below."
 title: "dynamical.org reformatters"
 type: software
-doi: 10.5281/zenodo.18777400
+doi: 10.5281/zenodo.18777399
 url: "https://dynamical.org"
 repository-code: "https://github.com/dynamical-org/reformatters"
 license: BSD-3-Clause

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use dynamical.org data, please cite as below."
+title: "dynamical.org reformatters"
+type: software
+doi: 10.5281/zenodo.18777400
+url: "https://dynamical.org"
+repository-code: "https://github.com/dynamical-org/reformatters"
+license: BSD-3-Clause
+authors:
+  - family-names: Keefe Sampson
+    given-names: Alden
+  - family-names: Moutenot
+    given-names: Marshall
+  - name: "dynamical.org contributors"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # dynamical.org reformatters
+
+[![DOI](https://zenodo.org/badge/859043226.svg)](https://doi.org/10.5281/zenodo.18777399)
+
 Reformat weather datasets into zarr.
 
 Browse the datasets produced by this repo at https://dynamical.org/catalog/.


### PR DESCRIPTION
## Summary
- Adds `CITATION.cff` so GitHub shows a "Cite this repository" widget linking to the Zenodo DOI (10.5281/zenodo.18777400)
- Adds `.zenodo.json` to control metadata for future Zenodo releases

Ref: https://github.com/dynamical-org/dynamical.org/issues/40