### PR TITLE
Mark all HRRR precipitation related variables as missing hour 0 values

### DIFF
--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -159,6 +159,9 @@ class Coordinate(FrozenBaseModel):
 class BaseInternalAttrs(FrozenBaseModel):
     keep_mantissa_bits: int | Literal["no-rounding"]
     deaccumulate_to_rate: bool = False
+    # If None, defers to attrs.step_type. Useful when an instantaneous variable does not have hour 0 values.
+    # Access via has_hour_0_values(data_var), not directly.
+    hour_0_values_override: bool | None = None
 
 
 INTERNAL_ATTRS_co = TypeVar(

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -360,6 +360,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=82,
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     hrrr_file_type="sfc",
+                    hour_0_values_override=False,
                 ),
             ),
             NoaaHrrrDataVar(
@@ -398,6 +399,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=91,
                     keep_mantissa_bits="no-rounding",
                     hrrr_file_type="sfc",
+                    hour_0_values_override=False,
                 ),
             ),
             NoaaHrrrDataVar(
@@ -417,6 +419,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=90,
                     keep_mantissa_bits="no-rounding",
                     hrrr_file_type="sfc",
+                    hour_0_values_override=False,
                 ),
             ),
             NoaaHrrrDataVar(
@@ -436,6 +439,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=92,
                     keep_mantissa_bits="no-rounding",
                     hrrr_file_type="sfc",
+                    hour_0_values_override=False,
                 ),
             ),
             NoaaHrrrDataVar(
@@ -455,6 +459,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=93,
                     keep_mantissa_bits="no-rounding",
                     hrrr_file_type="sfc",
+                    hour_0_values_override=False,
                 ),
             ),
             NoaaHrrrDataVar(

--- a/src/reformatters/noaa/noaa_utils.py
+++ b/src/reformatters/noaa/noaa_utils.py
@@ -10,4 +10,6 @@ NOMADS_RETRY_STATUS_CODES = {302, 429, 500, 502, 503, 504}
 
 
 def has_hour_0_values(data_var: DataVar[INTERNAL_ATTRS_co]) -> bool:
+    if data_var.internal_attrs.hour_0_values_override is not None:
+        return data_var.internal_attrs.hour_0_values_override
     return data_var.attrs.step_type == "instant"


### PR DESCRIPTION
There are values for categorical and % freezing precip in HRRR f000 files but they are all zeros.

This change will cause HRRR analysis to pull the f001 values for the correct valid times so the HRRR analysis dataset gets useful categorical and % forzen precipitation values. It will also leave nans rather than 0 in HRRR forecast lead time = 0