### PR TITLE
Lower NOMADS rate limiter threshold from 110 to 100 requests/minute

### DIFF
--- a/src/reformatters/noaa/noaa_utils.py
+++ b/src/reformatters/noaa/noaa_utils.py
@@ -3,7 +3,7 @@ from reformatters.common.download import RateLimiter
 
 # Documented NOMADS rate limit is 120 requests/minute
 # When you get rate limited it's hard to get out, so set a little under.
-nomads_rate_limiter = RateLimiter(max_per_minute=110)
+nomads_rate_limiter = RateLimiter(max_per_minute=100)
 
 # Retry on server errors, rate limits, and redirects (Akamai bot mitigation returns 302)
 NOMADS_RETRY_STATUS_CODES = {302, 429, 500, 502, 503, 504}


### PR DESCRIPTION
## Summary
Reduced the NOMADS API rate limiter threshold to provide a safer margin below the documented rate limit.

## Changes
- Decreased `nomads_rate_limiter` max_per_minute from 110 to 100 requests/minute
  - The NOMADS API documents a 120 requests/minute limit
  - This change increases the safety buffer from 10 to 20 requests/minute below the limit
  - Helps prevent rate limiting issues which are difficult to recover from once triggered

## Implementation Details
This is a conservative adjustment to the rate limiting configuration to improve reliability when interacting with the NOMADS API. The increased buffer provides better protection against hitting the hard rate limit during normal operation.

https://claude.ai/code/session_015rDRdAYp8R7PxFeENtC32v