### PR TITLE
Add per-variable NaN validation for MRMS with tighter allowed lags on radar only vars

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -155,6 +155,8 @@ def check_analysis_recent_nans(  # noqa: PLR0912
     max_expected_delay: timedelta = timedelta(hours=12),
     max_nan_percentage: float = 5,
     spatial_sampling: Literal["random", "quarter"] = "random",
+    include_vars: Sequence[str] | None = None,
+    exclude_vars: Sequence[str] | None = None,
 ) -> ValidationResult:
     """Check for NaN values in the most recent day of data. Fails if more than max_nan_percentage of sampled data is NaN."""
 
@@ -198,6 +200,10 @@ def check_analysis_recent_nans(  # noqa: PLR0912
 
     problem_vars = []
     for var_name, da in sample_ds.data_vars.items():
+        if include_vars is not None and var_name not in include_vars:
+            continue
+        if exclude_vars is not None and var_name in exclude_vars:
+            continue
         nan_percentage = da.isnull().mean().compute() * 100
         if nan_percentage > max_nan_percentage:
             problem_vars.append((var_name, nan_percentage))

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
@@ -67,7 +67,7 @@ class NoaaMrmsConusAnalysisHourlyDataset(
             partial(
                 validation.check_analysis_recent_nans,
                 max_expected_delay=max_expected_delay,
-                max_nan_percentage=0,
+                max_nan_percentage=15,
                 exclude_vars=lagged_vars,
             ),
             partial(

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
@@ -52,6 +52,13 @@ class NoaaMrmsConusAnalysisHourlyDataset(
 
     def validators(self) -> Sequence[validation.DataValidator]:
         max_expected_delay = timedelta(hours=3, minutes=30)
+        # Pass 1 and Pass 2 multi-sensor products have additional gauge-collection latency;
+        # radar-only and precipitation_surface (which falls back to radar) are always current.
+        lagged_vars = [
+            "precipitation_pass_1_surface",
+            "precipitation_pass_2_surface",
+            "categorical_precipitation_type_surface",
+        ]
         return (
             partial(
                 validation.check_analysis_current_data,
@@ -60,5 +67,13 @@ class NoaaMrmsConusAnalysisHourlyDataset(
             partial(
                 validation.check_analysis_recent_nans,
                 max_expected_delay=max_expected_delay,
+                max_nan_percentage=0,
+                exclude_vars=lagged_vars,
+            ),
+            partial(
+                validation.check_analysis_recent_nans,
+                max_expected_delay=max_expected_delay,
+                max_nan_percentage=50,
+                include_vars=lagged_vars,
             ),
         )

--- a/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
@@ -216,5 +216,5 @@ def test_operational_kubernetes_resources(
 
 def test_validators(dataset: NoaaMrmsConusAnalysisHourlyDataset) -> None:
     validators = tuple(dataset.validators())
-    assert len(validators) == 2
+    assert len(validators) == 3
     assert all(isinstance(v, validation.DataValidator) for v in validators)


### PR DESCRIPTION
Adds include_vars/exclude_vars to check_analysis_recent_nans so different
variables can be validated with different thresholds. MRMS now checks that
radar-only and precipitation_surface are never NaN, while gauge-corrected
and categorical vars allow up to 50% NaN to account for gauge-collection latency.