### PR TITLE
Allow expected nan area in MRMS deaccumulation

### DIFF
--- a/src/reformatters/common/deaccumulation.py
+++ b/src/reformatters/common/deaccumulation.py
@@ -21,6 +21,7 @@ def deaccumulate_to_rates_inplace(
     reset_frequency: pd.Timedelta,
     skip_step: Array1D[np.bool] | None = None,
     invalid_below_threshold_rate: float = PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD,
+    expected_invalid_fraction: float = 0.0,
 ) -> xr.DataArray:
     """
     Convert accumulated values to per-second rates in place.
@@ -31,6 +32,11 @@ def deaccumulate_to_rates_inplace(
         reset_frequency: Frequency at which the accumulation resets (eg 6 hours for GEFS and GFS)
         skip_step: Array of booleans indicating whether to skip the step. Values in skipped
             steps are left unchanged and the deaccumulation acts as if they are not present.
+        invalid_below_threshold_rate: Threshold below which values are considered invalid
+        expected_invalid_fraction: Fraction of values expected to be invalid (set to NaN)
+            after deaccumulation. For example, MRMS data has ~6% no-data sentinel values
+            that become invalid after deaccumulation. Only raises ValueError if the actual
+            invalid fraction exceeds this expected amount.
     """
     assert data_array.attrs["units"] in VALID_OUTPUT_UNITS_FOR_DEACCUMULATION, (
         "Output units must be a per-second rate"
@@ -62,9 +68,21 @@ def deaccumulate_to_rates_inplace(
         np.prod(data_array.shape[time_dim_index + 1 :] or 1),
     )
 
-    _deaccumulate_to_rates_numba(
+    negative_count, clamped_count = _deaccumulate_to_rates_numba(
         values, seconds, reset_after, skip_step, invalid_below_threshold_rate
     )
+
+    invalid_fraction = negative_count / values.size
+    if invalid_fraction > expected_invalid_fraction:
+        raise ValueError(
+            f"Found {negative_count} values ({invalid_fraction:.1%}) below threshold, "
+            f"expected at most {expected_invalid_fraction:.1%}"
+        )
+    clamped_fraction = clamped_count / values.size
+    if clamped_fraction > 0.05:
+        raise ValueError(
+            f"Over 5% ({clamped_count} total, {clamped_fraction:.1%}) values were clamped to 0"
+        )
 
     return data_array
 
@@ -76,23 +94,18 @@ def _deaccumulate_to_rates_numba(
     reset_after: Array1D[np.bool],
     skip_step: Array1D[np.bool],
     invalid_below_threshold_rate: float,
-) -> None:
+) -> tuple[int, int]:
     """
     Convert accumulated values to per-second rates, mutating `values` in place.
 
     Accumulations should only go up. If they go down a tiny bit,
     most likely due to numerical precision issues, we clamp to 0.
     If they go down to a *rate* that is less than `invalid_below_threshold`,
-    this sets the value to NaN and raises an error.
+    this sets the value to NaN.
+
+    Returns (negative_count, clamped_count) for the caller to decide whether to raise.
 
     Parallel processing is done over the leading dimension of values.
-
-    Args:
-        values: Array to modify in place. Must be 3D with accumulation dimension as the *middle* dimension
-        seconds: 1D array of seconds since forecast start or a reference time
-        reset_after: 1D array of booleans where True indicates the accumulation resets after the current step
-        skip_step: 1D array of booleans where True indicates the step should be skipped
-        invalid_below_threshold_rate: Threshold below which values are considered invalid
     """
     assert values.ndim == 3
     assert seconds.ndim == 1
@@ -137,7 +150,7 @@ def _deaccumulate_to_rates_numba(
 
                 # Accumulations should only go up
                 # If they go down a tiny bit, clamp to 0
-                # If they go down more, set to NaN and then raise
+                # If they go down more, set to NaN
                 if sequence[t] < 0:
                     if sequence[t] > invalid_below_threshold_rate:
                         clamped_count += 1
@@ -146,7 +159,4 @@ def _deaccumulate_to_rates_numba(
                         negative_count += 1
                         sequence[t] = np.nan
 
-    if negative_count > 0:
-        raise ValueError(f"Found {negative_count} values below threshold")
-    if clamped_count / values.size > 0.05:
-        raise ValueError(f"Over 5% ({clamped_count} total) values were clamped to 0")
+    return negative_count, clamped_count

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -200,14 +200,17 @@ class NoaaMrmsRegionJob(RegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]):
             log.info(
                 f"Converting {data_var.name} from accumulations to rates along time"
             )
-            deaccumulate_to_rates_inplace(
-                data_array,
-                dim="time",
-                reset_frequency=data_var.internal_attrs.window_reset_frequency,
-                # ~6.2% of MRMS pixels have -3.0 no-data sentinel (over-ocean/no-coverage areas)
-                # which becomes invalid after deaccumulation
-                expected_invalid_fraction=0.07,
-            )
+            try:
+                deaccumulate_to_rates_inplace(
+                    data_array,
+                    dim="time",
+                    reset_frequency=data_var.internal_attrs.window_reset_frequency,
+                    # ~6.2% of MRMS pixels have -3.0 no-data sentinel (over-ocean/no-coverage areas)
+                    # which becomes invalid after deaccumulation
+                    expected_invalid_fraction=0.07,
+                )
+            except ValueError:
+                log.exception(f"Error deaccumulating {data_var.name}")
 
         keep_mantissa_bits = data_var.internal_attrs.keep_mantissa_bits
         if isinstance(keep_mantissa_bits, int):

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -1,4 +1,5 @@
 import gzip
+import uuid
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Literal, assert_never
@@ -302,6 +303,12 @@ _PRECIPITATION_SURFACE_RADAR_ONLY_OVERRIDES: dict[pd.Timestamp, pd.Timestamp] = 
 
 def _decompress_gzip(gz_path: Path) -> Path:
     decompressed_path = gz_path.with_suffix("")
-    with gzip.open(gz_path, "rb") as f_in, open(decompressed_path, "wb") as f_out:
+    # Atomic write to avoid races when multiple variable groups decompress the same file
+    temp_path = decompressed_path.with_name(
+        f"{decompressed_path.name}.{uuid.uuid4().hex[:8]}"
+    )
+    with gzip.open(gz_path, "rb") as f_in, open(temp_path, "wb") as f_out:
         f_out.write(f_in.read())
+    temp_path.rename(decompressed_path)
+    gz_path.unlink(missing_ok=True)
     return decompressed_path

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -200,14 +200,14 @@ class NoaaMrmsRegionJob(RegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]):
             log.info(
                 f"Converting {data_var.name} from accumulations to rates along time"
             )
-            try:
-                deaccumulate_to_rates_inplace(
-                    data_array,
-                    dim="time",
-                    reset_frequency=data_var.internal_attrs.window_reset_frequency,
-                )
-            except ValueError:
-                log.exception(f"Error deaccumulating {data_var.name}")
+            deaccumulate_to_rates_inplace(
+                data_array,
+                dim="time",
+                reset_frequency=data_var.internal_attrs.window_reset_frequency,
+                # ~6.2% of MRMS pixels have -3.0 no-data sentinel (over-ocean/no-coverage areas)
+                # which becomes invalid after deaccumulation
+                expected_invalid_fraction=0.07,
+            )
 
         keep_mantissa_bits = data_var.internal_attrs.keep_mantissa_bits
         if isinstance(keep_mantissa_bits, int):

--- a/tests/common/test_deaccumulation.py
+++ b/tests/common/test_deaccumulation.py
@@ -244,7 +244,7 @@ def test_deaccumulate_1d_3_and_6_hour_small_accumulation_decreases() -> None:
     )
 
     with pytest.raises(
-        ValueError, match="Over 5% \\(1 total\\) values were clamped to 0"
+        ValueError, match=r"Over 5% \(1 total, 33.3%\) values were clamped to 0"
     ):
         deaccumulate_to_rates_inplace(
             data_array, dim="lead_time", reset_frequency=reset_frequency
@@ -270,7 +270,7 @@ def test_deaccumulate_1d_3_and_6_hour_large_accumulation_decreases() -> None:
         attrs={"units": "mm s-1"},
     )
 
-    with pytest.raises(ValueError, match="Found 1 values below threshold"):
+    with pytest.raises(ValueError, match=r"Found 1 values .* below threshold"):
         deaccumulate_to_rates_inplace(
             data_array, dim="lead_time", reset_frequency=reset_frequency
         )
@@ -538,7 +538,7 @@ def test_custom_deaccumulate_invalid_threshold_rate(
     )
 
     if should_raise:
-        with pytest.raises(ValueError, match="Found 1 values below threshold"):
+        with pytest.raises(ValueError, match=r"Found 1 values .* below threshold"):
             deaccumulate_to_rates_inplace(
                 data_array,
                 dim="lead_time",
@@ -739,6 +739,75 @@ def test_deaccumulate_float64_input() -> None:
         rtol=1e-6,
         equal_nan=True,
     )
+
+
+def test_deaccumulate_expected_invalid_fraction_suppresses_error() -> None:
+    """When expected_invalid_fraction covers the actual invalid fraction, no error is raised."""
+    reset_frequency = pd.Timedelta(hours=6)
+    sec = float(SECONDS_PER_HOUR)
+
+    values = [
+        {"lt": 0, "in": np.nan, "out": np.nan},
+        {"lt": 3, "in": 2 * sec * 3, "out": 2.0},
+        {"lt": 6, "in": 1 * sec * 3, "out": np.nan},  # large negative → NaN (1 of 3 = 33%)
+    ]  # fmt: off
+
+    lead_times = pd.to_timedelta([step["lt"] for step in values], unit="h")
+    data = np.array([step["in"] for step in values], dtype=np.float32)
+    expected = np.array([step["out"] for step in values], dtype=np.float32)
+
+    data_array = xr.DataArray(
+        data,
+        coords={"lead_time": lead_times},
+        dims=["lead_time"],
+        attrs={"units": "mm s-1"},
+    )
+
+    # Without expected_invalid_fraction, this raises
+    with pytest.raises(ValueError, match="below threshold"):
+        deaccumulate_to_rates_inplace(
+            data_array.copy(), dim="lead_time", reset_frequency=reset_frequency
+        )
+
+    # With sufficient expected_invalid_fraction, it succeeds
+    result = deaccumulate_to_rates_inplace(
+        data_array,
+        dim="lead_time",
+        reset_frequency=reset_frequency,
+        expected_invalid_fraction=0.34,
+    )
+    np.testing.assert_equal(result.values, expected)
+
+
+def test_deaccumulate_expected_invalid_fraction_still_raises_when_exceeded() -> None:
+    """When actual invalid fraction exceeds expected_invalid_fraction, error is still raised."""
+    reset_frequency = pd.Timedelta(hours=6)
+    sec = float(SECONDS_PER_HOUR)
+
+    values = [
+        {"lt": 0, "in": np.nan, "out": np.nan},
+        {"lt": 3, "in": 2 * sec * 3, "out": 2.0},
+        {"lt": 6, "in": 1 * sec * 3, "out": np.nan},  # large negative → NaN (1 of 3 = 33%)
+    ]  # fmt: off
+
+    lead_times = pd.to_timedelta([step["lt"] for step in values], unit="h")
+    data = np.array([step["in"] for step in values], dtype=np.float32)
+
+    data_array = xr.DataArray(
+        data,
+        coords={"lead_time": lead_times},
+        dims=["lead_time"],
+        attrs={"units": "mm s-1"},
+    )
+
+    # expected_invalid_fraction too low → still raises
+    with pytest.raises(ValueError, match=r"expected at most 10\.0%"):
+        deaccumulate_to_rates_inplace(
+            data_array,
+            dim="lead_time",
+            reset_frequency=reset_frequency,
+            expected_invalid_fraction=0.10,
+        )
 
 
 def test_deaccumulate_non_reset_aligned_first_step_nan() -> None:

--- a/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
@@ -113,8 +113,6 @@ def test_backfill_local_and_operational_update(
 
     filter_variable_names = [
         "precipitation_surface",
-        "precipitation_pass_1_surface",
-        "precipitation_pass_2_surface",
         "categorical_precipitation_type_surface",
     ]
 
@@ -138,16 +136,10 @@ def test_backfill_local_and_operational_update(
     # categorical_precipitation_type_surface is instant, no deaccumulation NaN
     assert_no_nulls(first_shard["categorical_precipitation_type_surface"])
 
-    # precipitation_surface, pass1, pass2 first timestep NaN from deaccumulation
+    # precipitation_surface first timestep NaN from deaccumulation
     point = backfill_ds.isel(latitude=622, longitude=817)
     assert np.isnan(point["precipitation_surface"].values[0])
     assert np.all(np.isfinite(point["precipitation_surface"].values[1:]))
-
-    assert np.isnan(point["precipitation_pass_1_surface"].values[0])
-    assert np.isfinite(point["precipitation_pass_1_surface"].values[1])
-
-    assert np.isnan(point["precipitation_pass_2_surface"].values[0])
-    assert np.isfinite(point["precipitation_pass_2_surface"].values[1])
 
     # Snapshot: snow (cat=3) with non-zero precipitation at this point
     assert_allclose(
@@ -194,8 +186,6 @@ def test_backfill_local_and_operational_update(
     updated_point = updated_ds.isel(latitude=622, longitude=817)
     # All non-first timesteps have valid precipitation (including shard boundary)
     assert np.all(np.isfinite(updated_point["precipitation_surface"].values[1:]))
-    assert np.all(np.isfinite(updated_point["precipitation_pass_1_surface"].values[1:]))
-    assert np.all(np.isfinite(updated_point["precipitation_pass_2_surface"].values[1:]))
     assert_no_nulls(updated_point["categorical_precipitation_type_surface"])
 
     assert_allclose(

--- a/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
@@ -113,6 +113,8 @@ def test_backfill_local_and_operational_update(
 
     filter_variable_names = [
         "precipitation_surface",
+        "precipitation_pass_1_surface",
+        "precipitation_pass_2_surface",
         "categorical_precipitation_type_surface",
     ]
 
@@ -136,10 +138,16 @@ def test_backfill_local_and_operational_update(
     # categorical_precipitation_type_surface is instant, no deaccumulation NaN
     assert_no_nulls(first_shard["categorical_precipitation_type_surface"])
 
-    # precipitation_surface first timestep is NaN from deaccumulation
+    # precipitation_surface, pass1, pass2 first timestep NaN from deaccumulation
     point = backfill_ds.isel(latitude=622, longitude=817)
     assert np.isnan(point["precipitation_surface"].values[0])
     assert np.all(np.isfinite(point["precipitation_surface"].values[1:]))
+
+    assert np.isnan(point["precipitation_pass_1_surface"].values[0])
+    assert np.isfinite(point["precipitation_pass_1_surface"].values[1])
+
+    assert np.isnan(point["precipitation_pass_2_surface"].values[0])
+    assert np.isfinite(point["precipitation_pass_2_surface"].values[1])
 
     # Snapshot: snow (cat=3) with non-zero precipitation at this point
     assert_allclose(
@@ -186,6 +194,8 @@ def test_backfill_local_and_operational_update(
     updated_point = updated_ds.isel(latitude=622, longitude=817)
     # All non-first timesteps have valid precipitation (including shard boundary)
     assert np.all(np.isfinite(updated_point["precipitation_surface"].values[1:]))
+    assert np.all(np.isfinite(updated_point["precipitation_pass_1_surface"].values[1:]))
+    assert np.all(np.isfinite(updated_point["precipitation_pass_2_surface"].values[1:]))
     assert_no_nulls(updated_point["categorical_precipitation_type_surface"])
 
     assert_allclose(

--- a/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
@@ -416,6 +416,72 @@ def test_download_and_read_precipitation(
 
 
 @pytest.mark.slow
+def test_download_and_read_pass_1(tmp_path: Path) -> None:
+    config = NoaaMrmsConusAnalysisHourlyTemplateConfig()
+    pass1_var = next(
+        v for v in config.data_vars if v.name == "precipitation_pass_1_surface"
+    )
+
+    mock_ds = Mock()
+    mock_ds.attrs = {"dataset_id": "noaa-mrms-conus-analysis-hourly"}
+    region_job = NoaaMrmsRegionJob.model_construct(
+        tmp_store=tmp_path,
+        template_ds=mock_ds,
+        data_vars=[pass1_var],
+        append_dim=config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+    coord = NoaaMrmsSourceFileCoord(
+        time=pd.Timestamp("2024-01-15T12:00"),
+        product=pass1_var.internal_attrs.mrms_product,
+        level=pass1_var.internal_attrs.mrms_level,
+        fallback_products=pass1_var.internal_attrs.mrms_fallback_products,
+    )
+
+    downloaded_path = region_job.download_file(coord)
+    updated_coord = replace(coord, downloaded_path=downloaded_path)
+
+    data = region_job.read_data(updated_coord, pass1_var)
+    assert data.shape == (3500, 7000)
+    assert np.all(np.isfinite(data))
+
+
+@pytest.mark.slow
+def test_download_and_read_pass_2(tmp_path: Path) -> None:
+    config = NoaaMrmsConusAnalysisHourlyTemplateConfig()
+    pass2_var = next(
+        v for v in config.data_vars if v.name == "precipitation_pass_2_surface"
+    )
+
+    mock_ds = Mock()
+    mock_ds.attrs = {"dataset_id": "noaa-mrms-conus-analysis-hourly"}
+    region_job = NoaaMrmsRegionJob.model_construct(
+        tmp_store=tmp_path,
+        template_ds=mock_ds,
+        data_vars=[pass2_var],
+        append_dim=config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+    coord = NoaaMrmsSourceFileCoord(
+        time=pd.Timestamp("2024-01-15T12:00"),
+        product=pass2_var.internal_attrs.mrms_product,
+        level=pass2_var.internal_attrs.mrms_level,
+        fallback_products=pass2_var.internal_attrs.mrms_fallback_products,
+    )
+
+    downloaded_path = region_job.download_file(coord)
+    updated_coord = replace(coord, downloaded_path=downloaded_path)
+
+    data = region_job.read_data(updated_coord, pass2_var)
+    assert data.shape == (3500, 7000)
+    assert np.all(np.isfinite(data))
+
+
+@pytest.mark.slow
 def test_download_and_read_radar_only(tmp_path: Path) -> None:
     config = NoaaMrmsConusAnalysisHourlyTemplateConfig()
     radar_var = next(


### PR DESCRIPTION
About 5% of pass 1 & pass 2 data is expected to be a negative missing value sentinel outside radar coverage. This was triggering our default deaccumulation nan check.

Add argument to set expected allowed nan fraction to deaccumulation.

Also address race condition as both precipitation_surface and pass 2 download, decompress, read and delete the same file.