### PR TITLE
Add ECMWF AIFS deterministic forecast dataset integration (#448)

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -24,7 +24,9 @@ from reformatters.contrib.noaa.ndvi_cdr.analysis import (
 )
 from reformatters.contrib.uarizona.swann.analysis import UarizonaSwannAnalysisDataset
 from reformatters.dwd.icon_eu.forecast import DwdIconEuForecastDataset
-from reformatters.ecmwf.aifs_deterministic.forecast import EcmwfAifsForecastDataset
+from reformatters.ecmwf.aifs_deterministic.forecast import (
+    EcmwfAifsDeterministicForecastDataset,
+)
 from reformatters.ecmwf.ifs_ens.forecast_15_day_0_25_degree.dynamical_dataset import (
     EcmwfIfsEnsForecast15Day025DegreeDataset,
 )
@@ -80,7 +82,7 @@ class EcmwfIfsEnsIcechunkAwsOpenDataDatasetStorageConfig(StorageConfig):
     format: DatasetFormat = DatasetFormat.ICECHUNK
 
 
-class EcmwfAifsIcechunkAwsOpenDataDatasetStorageConfig(StorageConfig):
+class EcmwfAifsDeterministicIcechunkAwsOpenDataDatasetStorageConfig(StorageConfig):
     """ECMWF AIFS in Icechunk on AWS Open Data."""
 
     base_path: str = "s3://dynamical-ecmwf-aifs-deterministic"
@@ -153,9 +155,11 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
         primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
         replica_storage_configs=[EcmwfIfsEnsIcechunkAwsOpenDataDatasetStorageConfig()],
     ),
-    EcmwfAifsForecastDataset(
+    EcmwfAifsDeterministicForecastDataset(
         primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[EcmwfAifsIcechunkAwsOpenDataDatasetStorageConfig()],
+        replica_storage_configs=[
+            EcmwfAifsDeterministicIcechunkAwsOpenDataDatasetStorageConfig()
+        ],
     ),
     # DWD
     DwdIconEuForecastDataset(

--- a/src/reformatters/ecmwf/aifs_deterministic/forecast/__init__.py
+++ b/src/reformatters/ecmwf/aifs_deterministic/forecast/__init__.py
@@ -1,1 +1,3 @@
-from .dynamical_dataset import EcmwfAifsForecastDataset as EcmwfAifsForecastDataset
+from .dynamical_dataset import (
+    EcmwfAifsDeterministicForecastDataset as EcmwfAifsDeterministicForecastDataset,
+)

--- a/src/reformatters/ecmwf/aifs_deterministic/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_deterministic/forecast/dynamical_dataset.py
@@ -6,21 +6,28 @@ from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar
 
-from .region_job import EcmwfAifsForecastRegionJob, EcmwfAifsForecastSourceFileCoord
-from .template_config import EcmwfAifsForecastTemplateConfig
+from .region_job import (
+    EcmwfAifsDeterministicForecastRegionJob,
+    EcmwfAifsDeterministicForecastSourceFileCoord,
+)
+from .template_config import EcmwfAifsDeterministicForecastTemplateConfig
 
 
-class EcmwfAifsForecastDataset(
-    DynamicalDataset[EcmwfDataVar, EcmwfAifsForecastSourceFileCoord]
+class EcmwfAifsDeterministicForecastDataset(
+    DynamicalDataset[EcmwfDataVar, EcmwfAifsDeterministicForecastSourceFileCoord]
 ):
-    template_config: EcmwfAifsForecastTemplateConfig = EcmwfAifsForecastTemplateConfig()
-    region_job_class: type[EcmwfAifsForecastRegionJob] = EcmwfAifsForecastRegionJob
+    template_config: EcmwfAifsDeterministicForecastTemplateConfig = (
+        EcmwfAifsDeterministicForecastTemplateConfig()
+    )
+    region_job_class: type[EcmwfAifsDeterministicForecastRegionJob] = (
+        EcmwfAifsDeterministicForecastRegionJob
+    )
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         suspend = True
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="25 /6 * * *",
+            schedule="25 */6 * * *",
             suspend=suspend,
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -33,7 +40,7 @@ class EcmwfAifsForecastDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="55 /6 * * *",
+            schedule="55 */6 * * *",
             suspend=suspend,
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/ecmwf/aifs_deterministic/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_deterministic/forecast/region_job.py
@@ -47,7 +47,7 @@ _PRECIP_ALT_GRIB_METADATA: dict[str, tuple[str, str]] = {
 }
 
 
-class EcmwfAifsForecastSourceFileCoord(SourceFileCoord):
+class EcmwfAifsDeterministicForecastSourceFileCoord(SourceFileCoord):
     init_time: Timestamp
     lead_time: Timedelta
     data_var_group: Sequence[EcmwfDataVar]
@@ -83,8 +83,8 @@ class EcmwfAifsForecastSourceFileCoord(SourceFileCoord):
         }
 
 
-class EcmwfAifsForecastRegionJob(
-    RegionJob[EcmwfDataVar, EcmwfAifsForecastSourceFileCoord]
+class EcmwfAifsDeterministicForecastRegionJob(
+    RegionJob[EcmwfDataVar, EcmwfAifsDeterministicForecastSourceFileCoord]
 ):
     max_vars_per_download_group: ClassVar[int] = 10
 
@@ -99,7 +99,7 @@ class EcmwfAifsForecastRegionJob(
         self,
         processing_region_ds: xr.Dataset,
         data_var_group: Sequence[EcmwfDataVar],
-    ) -> Sequence[EcmwfAifsForecastSourceFileCoord]:
+    ) -> Sequence[EcmwfAifsDeterministicForecastSourceFileCoord]:
         coords = []
         for init_time, lead_time in itertools.product(
             processing_region_ds["init_time"].values,
@@ -109,7 +109,7 @@ class EcmwfAifsForecastRegionJob(
                 continue
 
             coords.append(
-                EcmwfAifsForecastSourceFileCoord(
+                EcmwfAifsDeterministicForecastSourceFileCoord(
                     init_time=init_time,
                     lead_time=lead_time,
                     data_var_group=data_var_group,
@@ -117,7 +117,9 @@ class EcmwfAifsForecastRegionJob(
             )
         return coords
 
-    def download_file(self, coord: EcmwfAifsForecastSourceFileCoord) -> Path:
+    def download_file(
+        self, coord: EcmwfAifsDeterministicForecastSourceFileCoord
+    ) -> Path:
         idx_url = coord.get_index_url()
         idx_local_path = http_download_to_disk(idx_url, self.dataset_id)
 
@@ -137,7 +139,7 @@ class EcmwfAifsForecastRegionJob(
 
     def read_data(
         self,
-        coord: EcmwfAifsForecastSourceFileCoord,
+        coord: EcmwfAifsDeterministicForecastSourceFileCoord,
         data_var: EcmwfDataVar,
     ) -> ArrayFloat32:
         expected_comment = data_var.internal_attrs.grib_comment
@@ -185,7 +187,9 @@ class EcmwfAifsForecastRegionJob(
         all_data_vars: Sequence[EcmwfDataVar],
         reformat_job_name: str,
     ) -> tuple[
-        Sequence["RegionJob[EcmwfDataVar, EcmwfAifsForecastSourceFileCoord]"],
+        Sequence[
+            "RegionJob[EcmwfDataVar, EcmwfAifsDeterministicForecastSourceFileCoord]"
+        ],
         xr.Dataset,
     ]:
         existing_ds = xr.open_zarr(primary_store, chunks=None)

--- a/src/reformatters/ecmwf/aifs_deterministic/forecast/template_config.py
+++ b/src/reformatters/ecmwf/aifs_deterministic/forecast/template_config.py
@@ -26,7 +26,7 @@ from reformatters.common.zarr import (
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, EcmwfInternalAttrs
 
 
-class EcmwfAifsForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
+class EcmwfAifsDeterministicForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
     dims: tuple[Dim, ...] = ("init_time", "lead_time", "latitude", "longitude")
     append_dim: AppendDim = "init_time"
     # Start from 2024-04-01 when PL u/v are available and the grid is regular 0.25 degree.

--- a/tests/ecmwf/aifs_deterministic/forecast/dynamical_dataset_test.py
+++ b/tests/ecmwf/aifs_deterministic/forecast/dynamical_dataset_test.py
@@ -7,19 +7,21 @@ import xarray as xr
 
 from reformatters.common import validation
 from reformatters.ecmwf.aifs_deterministic.forecast.dynamical_dataset import (
-    EcmwfAifsForecastDataset,
+    EcmwfAifsDeterministicForecastDataset,
 )
 from tests.common.dynamical_dataset_test import NOOP_STORAGE_CONFIG
 
 
 @pytest.fixture
-def dataset() -> EcmwfAifsForecastDataset:
-    return EcmwfAifsForecastDataset(primary_storage_config=NOOP_STORAGE_CONFIG)
+def dataset() -> EcmwfAifsDeterministicForecastDataset:
+    return EcmwfAifsDeterministicForecastDataset(
+        primary_storage_config=NOOP_STORAGE_CONFIG
+    )
 
 
 @pytest.mark.slow
 def test_backfill_local_and_operational_update(
-    monkeypatch: pytest.MonkeyPatch, dataset: EcmwfAifsForecastDataset
+    monkeypatch: pytest.MonkeyPatch, dataset: EcmwfAifsDeterministicForecastDataset
 ) -> None:
     variables_to_check = ["temperature_2m", "precipitation_surface"]
     monkeypatch.setattr(
@@ -112,7 +114,7 @@ def test_backfill_local_and_operational_update(
 
 
 def test_operational_kubernetes_resources(
-    dataset: EcmwfAifsForecastDataset,
+    dataset: EcmwfAifsDeterministicForecastDataset,
 ) -> None:
     cron_jobs = dataset.operational_kubernetes_resources("test-image-tag")
 
@@ -128,7 +130,7 @@ def test_operational_kubernetes_resources(
     ]
 
 
-def test_validators(dataset: EcmwfAifsForecastDataset) -> None:
+def test_validators(dataset: EcmwfAifsDeterministicForecastDataset) -> None:
     validators = tuple(dataset.validators())
     assert len(validators) == 2
     assert all(isinstance(v, validation.DataValidator) for v in validators)

--- a/tests/ecmwf/aifs_deterministic/forecast/region_job_test.py
+++ b/tests/ecmwf/aifs_deterministic/forecast/region_job_test.py
@@ -12,17 +12,17 @@ from reformatters.common.iterating import item
 from reformatters.common.storage import DatasetFormat, StorageConfig, StoreFactory
 from reformatters.ecmwf.aifs_deterministic.forecast.region_job import (
     AIFS_SINGLE_PATH_CHANGE_DATE,
-    EcmwfAifsForecastRegionJob,
-    EcmwfAifsForecastSourceFileCoord,
+    EcmwfAifsDeterministicForecastRegionJob,
+    EcmwfAifsDeterministicForecastSourceFileCoord,
 )
 from reformatters.ecmwf.aifs_deterministic.forecast.template_config import (
-    EcmwfAifsForecastTemplateConfig,
+    EcmwfAifsDeterministicForecastTemplateConfig,
 )
 
 
 def test_source_file_coord_url_before_path_change() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
-    coord = EcmwfAifsForecastSourceFileCoord(
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
+    coord = EcmwfAifsDeterministicForecastSourceFileCoord(
         init_time=pd.Timestamp("2024-07-01T12:00"),
         lead_time=pd.Timedelta("6h"),
         data_var_group=list(config.data_vars[:1]),
@@ -36,8 +36,8 @@ def test_source_file_coord_url_before_path_change() -> None:
 
 
 def test_source_file_coord_url_after_path_change() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
-    coord = EcmwfAifsForecastSourceFileCoord(
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
+    coord = EcmwfAifsDeterministicForecastSourceFileCoord(
         init_time=AIFS_SINGLE_PATH_CHANGE_DATE,
         lead_time=pd.Timedelta("12h"),
         data_var_group=list(config.data_vars[:1]),
@@ -48,10 +48,10 @@ def test_source_file_coord_url_after_path_change() -> None:
 
 
 def test_source_file_coord_out_loc() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     init_time = pd.Timestamp("2024-04-01T00:00")
     lead_time = pd.Timedelta("6h")
-    coord = EcmwfAifsForecastSourceFileCoord(
+    coord = EcmwfAifsDeterministicForecastSourceFileCoord(
         init_time=init_time,
         lead_time=lead_time,
         data_var_group=list(config.data_vars[:1]),
@@ -62,8 +62,8 @@ def test_source_file_coord_out_loc() -> None:
 
 
 def test_source_groups() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
-    groups = EcmwfAifsForecastRegionJob.source_groups(config.data_vars)
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
+    groups = EcmwfAifsDeterministicForecastRegionJob.source_groups(config.data_vars)
     assert len(groups) == 2
 
     group_without_date = [
@@ -79,10 +79,10 @@ def test_source_groups() -> None:
 
 
 def test_generate_source_file_coords() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     template_ds = config.get_template(pd.Timestamp("2024-04-03"))
 
-    region_job = EcmwfAifsForecastRegionJob.model_construct(
+    region_job = EcmwfAifsDeterministicForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=template_ds.isel(
             init_time=slice(0, 4),
@@ -93,19 +93,24 @@ def test_generate_source_file_coords() -> None:
         region=slice(0, 4),
         reformat_job_name="test",
     )
-    processing_region_ds, _ = region_job._get_region_datasets()
-    groups = EcmwfAifsForecastRegionJob.source_groups(config.data_vars)
+    processing_region_ds, output_region_ds = region_job._get_region_datasets()
+    assert processing_region_ds.equals(output_region_ds)
+
+    groups = EcmwfAifsDeterministicForecastRegionJob.source_groups(config.data_vars)
 
     coords = region_job.generate_source_file_coords(processing_region_ds, groups[0])
     # 4 init_times x 3 lead_times = 12
     assert len(coords) == 4 * 3
 
+    for coord in coords:
+        assert isinstance(coord, EcmwfAifsDeterministicForecastSourceFileCoord)
+
 
 def test_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     template_ds = config.get_template(pd.Timestamp("2024-04-02"))
 
-    region_job = EcmwfAifsForecastRegionJob.model_construct(
+    region_job = EcmwfAifsDeterministicForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=template_ds,
         data_vars=config.data_vars,
@@ -114,7 +119,7 @@ def test_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
         reformat_job_name="test",
     )
     t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
-    source_file_coord = EcmwfAifsForecastSourceFileCoord(
+    source_file_coord = EcmwfAifsDeterministicForecastSourceFileCoord(
         init_time=pd.Timestamp("2024-04-01"),
         lead_time=pd.Timedelta("6h"),
         data_var_group=[t2m_var],
@@ -149,10 +154,10 @@ def test_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_read_data(monkeypatch: pytest.MonkeyPatch) -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     template_ds = config.get_template(pd.Timestamp("2024-04-02"))
 
-    region_job = EcmwfAifsForecastRegionJob.model_construct(
+    region_job = EcmwfAifsDeterministicForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=template_ds,
         data_vars=config.data_vars,
@@ -161,7 +166,7 @@ def test_read_data(monkeypatch: pytest.MonkeyPatch) -> None:
         reformat_job_name="test",
     )
     t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
-    coord = EcmwfAifsForecastSourceFileCoord(
+    coord = EcmwfAifsDeterministicForecastSourceFileCoord(
         init_time=pd.Timestamp("2024-04-01"),
         lead_time=pd.Timedelta("6h"),
         data_var_group=[t2m_var],
@@ -190,17 +195,17 @@ def test_read_data(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_read_data_multi_band(monkeypatch: pytest.MonkeyPatch) -> None:
     """When max_vars_per_download_group > 1, the GRIB has multiple bands."""
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
     d2m_var = item(v for v in config.data_vars if v.name == "dew_point_temperature_2m")
-    coord = EcmwfAifsForecastSourceFileCoord(
+    coord = EcmwfAifsDeterministicForecastSourceFileCoord(
         init_time=pd.Timestamp("2024-04-01"),
         lead_time=pd.Timedelta("6h"),
         data_var_group=[t2m_var, d2m_var],
         downloaded_path=Path("fake/path.grib2"),
     )
 
-    region_job = EcmwfAifsForecastRegionJob.model_construct(
+    region_job = EcmwfAifsDeterministicForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=Mock(),
         data_vars=config.data_vars,
@@ -237,12 +242,10 @@ def test_read_data_multi_band(monkeypatch: pytest.MonkeyPatch) -> None:
     rasterio_reader.read.assert_called_once_with(2, out_dtype=np.float32)
 
 
-def test_apply_data_transformations_scale_factor(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_apply_data_transformations_scale_factor() -> None:
     """scale_factor is applied in-place, converting geopotential (m²/s²) to height (m)."""
-    config = EcmwfAifsForecastTemplateConfig()
-    region_job = EcmwfAifsForecastRegionJob.model_construct(
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
+    region_job = EcmwfAifsDeterministicForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=Mock(),
         data_vars=config.data_vars,
@@ -270,12 +273,10 @@ def test_apply_data_transformations_scale_factor(
     np.testing.assert_allclose(data_array.values, expected_gh, atol=1.0)
 
 
-def test_apply_data_transformations_no_scale_factor(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_apply_data_transformations_no_scale_factor() -> None:
     """Variables without scale_factor are not modified."""
-    config = EcmwfAifsForecastTemplateConfig()
-    region_job = EcmwfAifsForecastRegionJob.model_construct(
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
+    region_job = EcmwfAifsDeterministicForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=Mock(),
         data_vars=config.data_vars,
@@ -301,8 +302,8 @@ def test_apply_data_transformations_no_scale_factor(
 
 def test_read_data_alt_precip_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     """tp variable can be read using alt GRIB metadata (table v34+)."""
-    config = EcmwfAifsForecastTemplateConfig()
-    region_job = EcmwfAifsForecastRegionJob.model_construct(
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
+    region_job = EcmwfAifsDeterministicForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=Mock(),
         data_vars=config.data_vars,
@@ -312,7 +313,7 @@ def test_read_data_alt_precip_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     precip_var = item(v for v in config.data_vars if v.name == "precipitation_surface")
-    coord = EcmwfAifsForecastSourceFileCoord(
+    coord = EcmwfAifsDeterministicForecastSourceFileCoord(
         init_time=pd.Timestamp("2024-04-01"),
         lead_time=pd.Timedelta("6h"),
         data_var_group=[precip_var],
@@ -343,7 +344,7 @@ def test_read_data_alt_precip_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_operational_update_jobs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     store_factory = StoreFactory(
         primary_storage_config=StorageConfig(
             base_path="fake-prod-path",
@@ -361,7 +362,7 @@ def test_operational_update_jobs(
     existing_ds = config.get_template(pd.Timestamp("2024-04-01T06:01"))
     template_utils.write_metadata(existing_ds, store_factory)
 
-    jobs, template_ds = EcmwfAifsForecastRegionJob.operational_update_jobs(
+    jobs, template_ds = EcmwfAifsDeterministicForecastRegionJob.operational_update_jobs(
         primary_store=store_factory.primary_store(),
         tmp_store=tmp_path / "tmp_ds.zarr",
         get_template_fn=config.get_template,
@@ -373,4 +374,5 @@ def test_operational_update_jobs(
     assert template_ds.init_time.max() == pd.Timestamp("2024-04-02T06:00")
     assert len(jobs) > 0
     for job in jobs:
-        assert isinstance(job, EcmwfAifsForecastRegionJob)
+        assert isinstance(job, EcmwfAifsDeterministicForecastRegionJob)
+        assert job.data_vars == config.data_vars

--- a/tests/ecmwf/aifs_deterministic/forecast/template_config_test.py
+++ b/tests/ecmwf/aifs_deterministic/forecast/template_config_test.py
@@ -9,12 +9,23 @@ import xarray as xr
 from reformatters.common.iterating import item
 from reformatters.common.template_config import SPATIAL_REF_COORDS
 from reformatters.ecmwf.aifs_deterministic.forecast.template_config import (
-    EcmwfAifsForecastTemplateConfig,
+    EcmwfAifsDeterministicForecastTemplateConfig,
 )
 
 
+def test_template_config_attrs() -> None:
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
+
+    assert config.dims == ("init_time", "lead_time", "latitude", "longitude")
+    assert config.append_dim == "init_time"
+    assert config.append_dim_start == pd.Timestamp("2024-04-01T00:00")
+    assert config.append_dim_frequency == pd.Timedelta("6h")
+
+    assert len(config.data_vars) > 0
+
+
 def test_dataset_attributes() -> None:
-    cfg = EcmwfAifsForecastTemplateConfig()
+    cfg = EcmwfAifsDeterministicForecastTemplateConfig()
     attrs = cfg.dataset_attributes
     assert attrs.dataset_id == "ecmwf-aifs-deterministic-forecast"
     assert re.match(r"\d+\.\d+\.\d+", attrs.dataset_version) is not None
@@ -23,7 +34,7 @@ def test_dataset_attributes() -> None:
 
 
 def test_dimension_coordinates() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     coords = config.dimension_coordinates()
 
     assert config.append_dim == "init_time"
@@ -48,7 +59,7 @@ def test_dimension_coordinates() -> None:
 
 
 def test_dimension_coordinates_shapes_and_values() -> None:
-    cfg = EcmwfAifsForecastTemplateConfig()
+    cfg = EcmwfAifsDeterministicForecastTemplateConfig()
     dc = cfg.dimension_coordinates()
     assert set(dc) == {"init_time", "lead_time", "latitude", "longitude"}
 
@@ -79,7 +90,7 @@ def test_dimension_coordinates_shapes_and_values() -> None:
 
 
 def test_data_vars_date_available() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     expanded_date = pd.Timestamp("2025-02-26T00:00")
 
     vars_with_date = [
@@ -97,7 +108,7 @@ def test_data_vars_date_available() -> None:
 
 
 def test_template_variables_have_required_attrs() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
 
     for var in config.data_vars:
         assert var.name
@@ -110,7 +121,7 @@ def test_template_variables_have_required_attrs() -> None:
 
 
 def test_geopotential_height_vars_have_scale_factor() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     gh_vars = [v for v in config.data_vars if "geopotential_height" in v.name]
     assert len(gh_vars) == 3  # 500, 850, 925 hPa
 
@@ -124,7 +135,7 @@ def test_geopotential_height_vars_have_scale_factor() -> None:
 
 
 def test_derive_coordinates() -> None:
-    config = EcmwfAifsForecastTemplateConfig()
+    config = EcmwfAifsDeterministicForecastTemplateConfig()
     ds = config.get_template(config.append_dim_start + config.append_dim_frequency)
 
     assert "valid_time" in ds.coords
@@ -138,7 +149,7 @@ def test_derive_coordinates() -> None:
 
 
 def test_derive_coordinates_and_spatial_ref() -> None:
-    cfg = EcmwfAifsForecastTemplateConfig()
+    cfg = EcmwfAifsDeterministicForecastTemplateConfig()
     dc = cfg.dimension_coordinates()
     ds = xr.Dataset(coords=dc)
     derived = cfg.derive_coordinates(ds)
@@ -168,7 +179,7 @@ def test_derive_coordinates_and_spatial_ref() -> None:
 
 
 def test_coords_property_order_and_names() -> None:
-    cfg = EcmwfAifsForecastTemplateConfig()
+    cfg = EcmwfAifsDeterministicForecastTemplateConfig()
     names = [c.name for c in cfg.coords]
     assert names == [
         "init_time",
@@ -183,7 +194,7 @@ def test_coords_property_order_and_names() -> None:
 
 
 def test_get_template_spatial_ref() -> None:
-    template_config = EcmwfAifsForecastTemplateConfig()
+    template_config = EcmwfAifsDeterministicForecastTemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=10)
     )


### PR DESCRIPTION
Implements the ECMWF AIFS (Artificial Intelligence Forecasting System)
deterministic forecast product as a new dataset with 16 variables,
0.25° global grid, 6-hourly inits, 0-360h lead times. Handles the S3
path change (aifs/ -> aifs-single/) on 2025-02-26 and GRIB master table
version differences for precipitation variables between early and
current data.