### PR TITLE
Raise MRMS gauge_latency_vars NaN threshold from 40% to 48%

### DIFF
--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
@@ -76,9 +76,9 @@ class NoaaMrmsConusAnalysisHourlyDataset(
             partial(
                 validation.check_analysis_recent_nans,
                 max_expected_delay=max_expected_delay,
-                # pass_1 and pass_2 worst-case quarter-sampled NaN is ~38% (1 of 3 checked
+                # pass_1 and pass_2 worst-case quarter-sampled NaN is ~45.5% (1 of 3 checked
                 # timestamps is 100% NaN due to gauge-collection latency, rest are ~6%).
-                max_nan_percentage=40,
+                max_nan_percentage=48,
                 spatial_sampling="quarter",
                 include_vars=gauge_latency_vars,
             ),


### PR DESCRIPTION
Quarter sampling shows up to 45.5% NaN in practice for pass_1/pass_2 vars.

https://claude.ai/code/session_01CBpMZptsUurm6iGP6BXdTt