### PR TITLE
Add GFS virtual icechunk dataset prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ depot.json
 
 # Temporary files created when copying files from DWD's HTTPS server
 copyurls.csv
+
+# Prototype output artifacts
+prototype_output/

--- a/prototypes/gfs_icechunk_virtual.py
+++ b/prototypes/gfs_icechunk_virtual.py
@@ -429,6 +429,97 @@ def fill_missing_lead_times(
     report_dataset_state(repo, "After Phase 3 (fill missing lead times)")
 
 
+def read_dataset_as_new_reader(repo_path: Path) -> None:
+    """Open the repository from scratch as a reader would and pull out real values."""
+    log.info("\n%s", "=" * 60)
+    log.info("READER: Opening repository fresh from disk")
+    log.info("=" * 60)
+
+    # -- This is the code a reader would use --
+    storage = icechunk.local_filesystem_storage(str(repo_path))
+    config = icechunk.RepositoryConfig.default()
+    s3_store_cfg = icechunk.s3_store(region="us-east-1")
+    container = icechunk.VirtualChunkContainer(S3_VIRTUAL_PREFIX, s3_store_cfg)
+    config.set_virtual_chunk_container(container)
+
+    repo = icechunk.Repository.open(
+        storage,
+        config=config,
+        authorize_virtual_chunk_access=icechunk.containers_credentials(
+            {S3_VIRTUAL_PREFIX: icechunk.s3_anonymous_credentials()}
+        ),
+    )
+    session = repo.readonly_session(branch="main")
+    ds = xr.open_zarr(session.store, consolidated=False)
+    # -- End reader code --
+
+    log.info(f"Dataset: {ds}")
+    log.info(f"Dimensions: {dict(ds.sizes)}")
+
+    # Pull real values from a populated chunk
+    # temperature_2m at init_time=2026-03-10 00:00, lead_time=0h
+    t2m = ds["temperature_2m"].isel(init_time=0, lead_time=0)
+    t2m_values = t2m.values  # triggers S3 fetch + gribberish decode
+    log.info(
+        f"\ntemperature_2m[init_time=0, lead_time=0h] "
+        f"shape={t2m_values.shape} dtype={t2m_values.dtype}"
+    )
+    log.info(
+        f"  min={np.nanmin(t2m_values):.2f}  max={np.nanmax(t2m_values):.2f}  "
+        f"mean={np.nanmean(t2m_values):.2f}"
+    )
+
+    # A few point samples across the globe
+    sample_points = [
+        ("New York ~40.7N, 74.0W", {"latitude": 40.75, "longitude": -74.0}),
+        ("London ~51.5N, 0.1W", {"latitude": 51.5, "longitude": -0.25}),
+        ("Tokyo ~35.7N, 139.75E", {"latitude": 35.75, "longitude": 139.75}),
+        ("Sydney ~33.9S, 151.2E", {"latitude": -33.75, "longitude": 151.25}),
+    ]
+
+    log.info("\nPoint samples at init_time=2026-03-10 00:00Z, lead_time=0h:")
+    sel = ds.sel(init_time=ds["init_time"][0], lead_time=ds["lead_time"][0])
+    for label, coords in sample_points:
+        point = sel.sel(**coords, method="nearest")
+        t2m_val = float(point["temperature_2m"].values)
+        sp_val = float(point["pressure_surface"].values)
+        u10_val = float(point["wind_u_10m"].values)
+        log.info(
+            f"  {label}: "
+            f"temperature_2m={t2m_val:.1f}K  "
+            f"pressure_surface={sp_val:.0f}Pa  "
+            f"wind_u_10m={u10_val:.1f}m/s"
+        )
+
+    # Show a value from the partially-filled 4th init time (populated lead time)
+    log.info("\nPoint sample from 4th init time (partial), lead_time=1h, New York:")
+    point = ds.sel(
+        init_time=ds["init_time"][3],
+        lead_time=ds["lead_time"][1],
+        latitude=40.75,
+        longitude=-74.0,
+        method="nearest",
+    )
+    log.info(
+        f"  temperature_2m={float(point['temperature_2m'].values):.1f}K  "
+        f"pressure_surface={float(point['pressure_surface'].values):.0f}Pa"
+    )
+
+    # Show a value from an unfilled lead time (should be NaN)
+    log.info("\nPoint sample from 4th init time, lead_time=6h (unfilled):")
+    point = ds.sel(
+        init_time=ds["init_time"][3],
+        lead_time=ds["lead_time"][6],
+        latitude=40.75,
+        longitude=-74.0,
+        method="nearest",
+    )
+    t2m_unfilled = float(point["temperature_2m"].values)
+    log.info(f"  temperature_2m={t2m_unfilled} (NaN = unfilled chunk)")
+
+    ds.close()
+
+
 def run_prototype() -> None:
     data_vars = get_prototype_data_vars()
     log.info(f"Prototype variables: {[v.name for v in data_vars]}")
@@ -470,6 +561,9 @@ def run_prototype() -> None:
     total_size = sum(f.stat().st_size for f in output_dir.rglob("*") if f.is_file())
     log.info(f"\nOn-disk repository size: {total_size / 1024:.1f} KB")
     log.info("(Data variable chunks are virtual references to S3, not stored locally)")
+
+    # Demonstrate reading from the repo as a fresh reader
+    read_dataset_as_new_reader(output_dir)
 
 
 if __name__ == "__main__":

--- a/prototypes/gfs_icechunk_virtual.py
+++ b/prototypes/gfs_icechunk_virtual.py
@@ -1,0 +1,428 @@
+# ruff: noqa: INP001
+"""
+Prototype: Virtual Icechunk dataset from NOAA GFS GRIB files on S3.
+
+Creates a virtual zarr dataset backed by icechunk where data variable chunks
+point to byte ranges within remote GRIB2 files on S3, decoded at read time
+by GribberishCodec. Coordinate arrays are stored as real (non-virtual) data.
+
+Phases demonstrated:
+1. Initialize and backfill (3 init times, 7 lead times each)
+2. Update: add a new init time
+3. Update: add 2 new lead times to a previously incomplete init time
+"""
+
+import shutil
+from pathlib import Path
+
+import icechunk
+import numpy as np
+import pandas as pd
+import xarray as xr
+import zarr
+from gribberish.zarr.codec import GribberishCodec
+
+from reformatters.common.download import http_download_to_disk
+from reformatters.common.logging import get_logger
+from reformatters.noaa.gfs.forecast.template_config import NoaaGfsForecastTemplateConfig
+from reformatters.noaa.models import NoaaDataVar
+from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
+
+log = get_logger(__name__)
+
+S3_BUCKET = "noaa-gfs-bdp-pds"
+S3_BASE_URL = f"https://{S3_BUCKET}.s3.amazonaws.com"
+S3_VIRTUAL_PREFIX = f"s3://{S3_BUCKET}/"
+
+# Use a small subset of variables for the prototype: 3 instant variables
+PROTOTYPE_VAR_NAMES = frozenset(
+    {
+        "temperature_2m",
+        "pressure_surface",
+        "wind_u_10m",
+    }
+)
+
+# Use recent init times that are reliably available on S3
+INIT_TIMES = pd.to_datetime(
+    [
+        "2026-03-10T00:00",
+        "2026-03-10T06:00",
+        "2026-03-10T12:00",
+        "2026-03-10T18:00",
+    ]
+)
+
+LEAD_TIMES = pd.timedelta_range("0h", "6h", freq="1h")
+
+# GFS native grid: 721 lat x 1440 lon at 0.25 degree resolution
+N_LAT = 721
+N_LON = 1440
+
+OUTPUT_DIR = Path("prototype_output/gfs_icechunk_virtual")
+
+
+def get_prototype_data_vars() -> list[NoaaDataVar]:
+    """Get the subset of data variables we want for this prototype."""
+    config = NoaaGfsForecastTemplateConfig()
+    return [v for v in config.data_vars if v.name in PROTOTYPE_VAR_NAMES]
+
+
+def gfs_s3_path(init_time: pd.Timestamp, lead_time: pd.Timedelta) -> str:
+    """Return the S3 key for a GFS GRIB file."""
+    init_date = init_time.strftime("%Y%m%d")
+    init_hour = init_time.strftime("%H")
+    lead_hours = int(lead_time.total_seconds() // 3600)
+    return f"gfs.{init_date}/{init_hour}/atmos/gfs.t{init_hour}z.pgrb2.0p25.f{lead_hours:03d}"
+
+
+def gfs_s3_url(init_time: pd.Timestamp, lead_time: pd.Timedelta) -> str:
+    return f"{S3_VIRTUAL_PREFIX}{gfs_s3_path(init_time, lead_time)}"
+
+
+def gfs_http_url(init_time: pd.Timestamp, lead_time: pd.Timedelta) -> str:
+    return f"{S3_BASE_URL}/{gfs_s3_path(init_time, lead_time)}"
+
+
+def download_and_parse_index(
+    init_time: pd.Timestamp,
+    lead_time: pd.Timedelta,
+    data_vars: list[NoaaDataVar],
+) -> dict[str, tuple[int, int]]:
+    """Download a GRIB index file and parse byte ranges for each variable.
+
+    Returns a dict mapping variable name to (offset, length).
+    """
+    idx_url = f"{gfs_http_url(init_time, lead_time)}.idx"
+    idx_path = http_download_to_disk(idx_url, "gfs-icechunk-prototype")
+
+    starts, ends = grib_message_byte_ranges_from_index(
+        idx_path, data_vars, init_time, lead_time
+    )
+
+    result: dict[str, tuple[int, int]] = {}
+    for var, start, end in zip(data_vars, starts, ends, strict=True):
+        result[var.name] = (start, end - start)
+
+    return result
+
+
+def create_repository(output_dir: Path) -> icechunk.Repository:
+    """Create a new icechunk repository on local disk."""
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+    storage = icechunk.local_filesystem_storage(str(output_dir))
+
+    config = icechunk.RepositoryConfig.default()
+    s3_store = icechunk.s3_store(region="us-east-1")
+    container = icechunk.VirtualChunkContainer(S3_VIRTUAL_PREFIX, s3_store)
+    config.set_virtual_chunk_container(container)
+
+    repo = icechunk.Repository.create(
+        storage,
+        config=config,
+        authorize_virtual_chunk_access=icechunk.containers_credentials(
+            {S3_VIRTUAL_PREFIX: icechunk.s3_anonymous_credentials()}
+        ),
+    )
+    return repo
+
+
+def initialize_zarr_metadata(
+    store: icechunk.IcechunkStore,
+    init_times: pd.DatetimeIndex,
+    lead_times: pd.TimedeltaIndex,
+    data_vars: list[NoaaDataVar],
+) -> None:
+    """Write zarr v3 metadata and coordinate arrays to the store.
+
+    Data variable arrays use GribberishCodec with chunk shape matching
+    individual GRIB messages: (1, 1, 721, 1440).
+    """
+    root = zarr.open_group(store, mode="w")
+
+    # Write coordinate arrays with real data (not virtual)
+    init_time_seconds = np.array(
+        (init_times - pd.Timestamp("1970-01-01")).total_seconds(), dtype="int64"
+    )
+    arr = root.create_array(
+        "init_time",
+        data=init_time_seconds,
+        chunks=(len(init_times),),
+        fill_value=0,
+        dimension_names=("init_time",),
+    )
+    arr.attrs.update(
+        {
+            "calendar": "proleptic_gregorian",
+            "units": "seconds since 1970-01-01 00:00:00",
+            "long_name": "Forecast initialization time",
+        }
+    )
+
+    lead_time_seconds = np.array(lead_times.total_seconds(), dtype="int64")
+    arr = root.create_array(
+        "lead_time",
+        data=lead_time_seconds,
+        chunks=(len(lead_times),),
+        fill_value=-1,
+        dimension_names=("lead_time",),
+    )
+    arr.attrs.update(
+        {
+            "units": "seconds",
+            "long_name": "Forecast lead time",
+        }
+    )
+
+    lat_values = np.flip(np.arange(-90, 90.25, 0.25))
+    arr = root.create_array(
+        "latitude",
+        data=lat_values,
+        chunks=(N_LAT,),
+        fill_value=np.nan,
+        dimension_names=("latitude",),
+    )
+    arr.attrs.update(
+        {
+            "units": "degree_north",
+            "long_name": "Latitude",
+            "standard_name": "latitude",
+        }
+    )
+
+    lon_values = np.arange(-180, 180, 0.25)
+    arr = root.create_array(
+        "longitude",
+        data=lon_values,
+        chunks=(N_LON,),
+        fill_value=np.nan,
+        dimension_names=("longitude",),
+    )
+    arr.attrs.update(
+        {
+            "units": "degree_east",
+            "long_name": "Longitude",
+            "standard_name": "longitude",
+        }
+    )
+
+    # Create data variable arrays with GribberishCodec
+    # Each chunk = one GRIB message = one (init_time, lead_time) slice for a variable
+    for var in data_vars:
+        codec = GribberishCodec(var=var.internal_attrs.grib_element)
+        arr = root.create_array(
+            var.name,
+            shape=(len(init_times), len(lead_times), N_LAT, N_LON),
+            chunks=(1, 1, N_LAT, N_LON),
+            dtype="float32",
+            fill_value=np.nan,
+            serializer=codec,
+            compressors=(),
+            filters=(),
+            dimension_names=("init_time", "lead_time", "latitude", "longitude"),
+        )
+        var_attrs: dict[str, str] = {
+            "long_name": var.attrs.long_name,
+            "units": var.attrs.units,
+        }
+        if var.attrs.standard_name:
+            var_attrs["standard_name"] = var.attrs.standard_name
+        arr.attrs.update(var_attrs)
+
+
+def set_virtual_refs_for_file(
+    store: icechunk.IcechunkStore,
+    init_time: pd.Timestamp,
+    lead_time: pd.Timedelta,
+    init_time_idx: int,
+    lead_time_idx: int,
+    data_vars: list[NoaaDataVar],
+    byte_ranges: dict[str, tuple[int, int]],
+) -> None:
+    """Set virtual references for all variables in a single GRIB file."""
+    s3_url = gfs_s3_url(init_time, lead_time)
+
+    for var in data_vars:
+        offset, length = byte_ranges[var.name]
+        chunk_key = f"{var.name}/c/{init_time_idx}/{lead_time_idx}/0/0"
+        store.set_virtual_ref(
+            chunk_key,
+            location=s3_url,
+            offset=offset,
+            length=length,
+        )
+
+
+def report_dataset_state(repo: icechunk.Repository, label: str) -> None:
+    """Open the dataset read-only and report its shape and NaN fractions."""
+    session = repo.readonly_session(branch="main")
+    store = session.store
+
+    ds = xr.open_zarr(store, consolidated=False)
+
+    log.info(f"\n{'=' * 60}")
+    log.info(f"Dataset state: {label}")
+    log.info(f"{'=' * 60}")
+    log.info(f"Dimensions: {dict(ds.sizes)}")
+
+    init_times = pd.to_datetime(ds["init_time"].values, unit="s", origin="unix")
+    lead_times = pd.to_timedelta(ds["lead_time"].values, unit="s")
+    log.info(f"Init times: {init_times.tolist()}")
+    log.info(f"Lead times: {lead_times.tolist()}")
+    log.info(f"Data variables: {list(ds.data_vars)}")
+
+    # Report NaN fraction per init_time for each variable
+    for var_name in ds.data_vars:
+        log.info(f"\n  {var_name}:")
+        var_data = ds[var_name]
+        for i, it in enumerate(init_times):
+            slice_data = var_data.isel(init_time=i)
+            total = slice_data.size
+            # Count non-NaN: load one lead time at a time to manage memory
+            non_nan_count = 0
+            for lt_idx in range(len(lead_times)):
+                lt_slice = slice_data.isel(lead_time=lt_idx).values
+                non_nan_count += int(np.count_nonzero(~np.isnan(lt_slice)))
+            fraction = non_nan_count / total
+            log.info(
+                f"    init_time={it}: non-NaN fraction = {fraction:.4f} ({non_nan_count}/{total})"
+            )
+
+    ds.close()
+
+
+def backfill_init_times(
+    repo: icechunk.Repository,
+    init_times_all: pd.DatetimeIndex,
+    lead_times_all: pd.TimedeltaIndex,
+    data_vars: list[NoaaDataVar],
+) -> None:
+    """Phase 1: Initialize metadata and backfill 3 init times (3rd partial)."""
+    log.info("\n%s", "=" * 60)
+    log.info("PHASE 1: Initialize and backfill")
+    log.info("=" * 60)
+
+    session = repo.writable_session("main")
+    store = session.store
+
+    initialize_zarr_metadata(store, init_times_all, lead_times_all, data_vars)
+    log.info("Zarr metadata written")
+
+    for init_idx in range(2):
+        init_time = init_times_all[init_idx]
+        log.info(f"Backfilling init_time={init_time} (all lead times)")
+        for lt_idx, lead_time in enumerate(lead_times_all):
+            byte_ranges = download_and_parse_index(init_time, lead_time, data_vars)
+            set_virtual_refs_for_file(
+                store, init_time, lead_time, init_idx, lt_idx, data_vars, byte_ranges
+            )
+
+    # 3rd init time: only lead times 0-4h (incomplete)
+    init_idx = 2
+    init_time = init_times_all[init_idx]
+    incomplete_lead_times = lead_times_all[:5]
+    log.info(f"Backfilling init_time={init_time} (partial: lead times 0-4h only)")
+    for lt_idx, lead_time in enumerate(incomplete_lead_times):
+        byte_ranges = download_and_parse_index(init_time, lead_time, data_vars)
+        set_virtual_refs_for_file(
+            store, init_time, lead_time, init_idx, lt_idx, data_vars, byte_ranges
+        )
+
+    snapshot_id = session.commit(
+        "Phase 1: Initialize and backfill 3 init times (3rd partial)"
+    )
+    log.info(f"Phase 1 committed: {snapshot_id}")
+    report_dataset_state(repo, "After Phase 1 (backfill)")
+
+
+def add_new_init_time(
+    repo: icechunk.Repository,
+    init_times_all: pd.DatetimeIndex,
+    lead_times_all: pd.TimedeltaIndex,
+    data_vars: list[NoaaDataVar],
+) -> None:
+    """Phase 2: Add a new (4th) init time with all lead times."""
+    log.info("\n%s", "=" * 60)
+    log.info("PHASE 2: Add new init time")
+    log.info("=" * 60)
+
+    session = repo.writable_session("main")
+    store = session.store
+
+    init_idx = 3
+    init_time = init_times_all[init_idx]
+    log.info(f"Adding init_time={init_time} (all lead times)")
+    for lt_idx, lead_time in enumerate(lead_times_all):
+        byte_ranges = download_and_parse_index(init_time, lead_time, data_vars)
+        set_virtual_refs_for_file(
+            store, init_time, lead_time, init_idx, lt_idx, data_vars, byte_ranges
+        )
+
+    snapshot_id = session.commit("Phase 2: Add 4th init time")
+    log.info(f"Phase 2 committed: {snapshot_id}")
+    report_dataset_state(repo, "After Phase 2 (new init time)")
+
+
+def fill_missing_lead_times(
+    repo: icechunk.Repository,
+    init_times_all: pd.DatetimeIndex,
+    lead_times_all: pd.TimedeltaIndex,
+    data_vars: list[NoaaDataVar],
+) -> None:
+    """Phase 3: Fill in lead times 5h and 6h for the previously incomplete 3rd init time."""
+    log.info("\n%s", "=" * 60)
+    log.info("PHASE 3: Add lead times to incomplete init time")
+    log.info("=" * 60)
+
+    session = repo.writable_session("main")
+    store = session.store
+
+    init_idx = 2
+    init_time = init_times_all[init_idx]
+    missing_lead_times = lead_times_all[5:]
+    log.info(
+        f"Filling in lead times {missing_lead_times.tolist()} for init_time={init_time}"
+    )
+    for lead_time in missing_lead_times:
+        lt_idx_raw = lead_times_all.get_loc(lead_time)
+        assert isinstance(lt_idx_raw, int)
+        lt_idx = lt_idx_raw
+        byte_ranges = download_and_parse_index(init_time, lead_time, data_vars)
+        set_virtual_refs_for_file(
+            store, init_time, lead_time, init_idx, lt_idx, data_vars, byte_ranges
+        )
+
+    snapshot_id = session.commit("Phase 3: Fill missing lead times for 3rd init time")
+    log.info(f"Phase 3 committed: {snapshot_id}")
+    report_dataset_state(repo, "After Phase 3 (fill missing lead times)")
+
+
+def run_prototype() -> None:
+    data_vars = get_prototype_data_vars()
+    log.info(f"Prototype variables: {[v.name for v in data_vars]}")
+    log.info(f"Init times: {INIT_TIMES.tolist()}")
+    log.info(f"Lead times: {LEAD_TIMES.tolist()}")
+
+    output_dir = OUTPUT_DIR
+    repo = create_repository(output_dir)
+
+    backfill_init_times(repo, INIT_TIMES, LEAD_TIMES, data_vars)
+    add_new_init_time(repo, INIT_TIMES, LEAD_TIMES, data_vars)
+    fill_missing_lead_times(repo, INIT_TIMES, LEAD_TIMES, data_vars)
+
+    log.info("\n%s", "=" * 60)
+    log.info("Snapshot history")
+    log.info("=" * 60)
+    for info in repo.ancestry(branch="main"):
+        log.info(f"  {info.id[:12]}  {info.written_at}  {info.message}")
+
+    total_size = sum(f.stat().st_size for f in output_dir.rglob("*") if f.is_file())
+    log.info(f"\nOn-disk repository size: {total_size / 1024:.1f} KB")
+    log.info("(Data variable chunks are virtual references to S3, not stored locally)")
+
+
+if __name__ == "__main__":
+    run_prototype()

--- a/prototypes/gfs_icechunk_virtual.py
+++ b/prototypes/gfs_icechunk_virtual.py
@@ -7,9 +7,9 @@ point to byte ranges within remote GRIB2 files on S3, decoded at read time
 by GribberishCodec. Coordinate arrays are stored as real (non-virtual) data.
 
 Phases demonstrated:
-1. Initialize and backfill (3 init times, 7 lead times each)
-2. Update: add a new init time
-3. Update: add 2 new lead times to a previously incomplete init time
+1. Initialize and backfill 3 init times with all lead times
+2. Resize the dataset to add a 4th init time, fill 3 of its lead times
+3. Fill in 2 more lead times for the 4th init time
 """
 
 import shutil
@@ -294,13 +294,37 @@ def report_dataset_state(repo: icechunk.Repository, label: str) -> None:
     ds.close()
 
 
-def backfill_init_times(
-    repo: icechunk.Repository,
-    init_times_all: pd.DatetimeIndex,
-    lead_times_all: pd.TimedeltaIndex,
+def resize_init_time_dimension(
+    store: icechunk.IcechunkStore,
+    new_init_time: pd.Timestamp,
+    new_init_time_count: int,
+    lead_time_count: int,
     data_vars: list[NoaaDataVar],
 ) -> None:
-    """Phase 1: Initialize metadata and backfill 3 init times (3rd partial)."""
+    """Grow the init_time dimension by one, updating coordinate and data arrays."""
+    root = zarr.open_group(store, mode="r+")
+
+    # Resize and append to the init_time coordinate array
+    init_time_arr = root["init_time"]
+    assert isinstance(init_time_arr, zarr.Array)
+    init_time_arr.resize((new_init_time_count,))
+    new_value = int((new_init_time - pd.Timestamp("1970-01-01")).total_seconds())
+    init_time_arr[new_init_time_count - 1] = new_value
+
+    # Resize all data variable arrays
+    for var in data_vars:
+        arr = root[var.name]
+        assert isinstance(arr, zarr.Array)
+        arr.resize((new_init_time_count, lead_time_count, N_LAT, N_LON))
+
+
+def backfill_init_times(
+    repo: icechunk.Repository,
+    backfill_init_times_idx: pd.DatetimeIndex,
+    lead_times: pd.TimedeltaIndex,
+    data_vars: list[NoaaDataVar],
+) -> None:
+    """Phase 1: Initialize metadata and backfill 3 init times with all lead times."""
     log.info("\n%s", "=" * 60)
     log.info("PHASE 1: Initialize and backfill")
     log.info("=" * 60)
@@ -308,94 +332,99 @@ def backfill_init_times(
     session = repo.writable_session("main")
     store = session.store
 
-    initialize_zarr_metadata(store, init_times_all, lead_times_all, data_vars)
+    initialize_zarr_metadata(store, backfill_init_times_idx, lead_times, data_vars)
     log.info("Zarr metadata written")
 
-    for init_idx in range(2):
-        init_time = init_times_all[init_idx]
+    for init_idx, init_time in enumerate(backfill_init_times_idx):
         log.info(f"Backfilling init_time={init_time} (all lead times)")
-        for lt_idx, lead_time in enumerate(lead_times_all):
+        for lt_idx, lead_time in enumerate(lead_times):
             byte_ranges = download_and_parse_index(init_time, lead_time, data_vars)
             set_virtual_refs_for_file(
                 store, init_time, lead_time, init_idx, lt_idx, data_vars, byte_ranges
             )
 
-    # 3rd init time: only lead times 0-4h (incomplete)
-    init_idx = 2
-    init_time = init_times_all[init_idx]
-    incomplete_lead_times = lead_times_all[:5]
-    log.info(f"Backfilling init_time={init_time} (partial: lead times 0-4h only)")
-    for lt_idx, lead_time in enumerate(incomplete_lead_times):
-        byte_ranges = download_and_parse_index(init_time, lead_time, data_vars)
-        set_virtual_refs_for_file(
-            store, init_time, lead_time, init_idx, lt_idx, data_vars, byte_ranges
-        )
-
-    snapshot_id = session.commit(
-        "Phase 1: Initialize and backfill 3 init times (3rd partial)"
-    )
+    snapshot_id = session.commit("Phase 1: Initialize and backfill 3 init times")
     log.info(f"Phase 1 committed: {snapshot_id}")
     report_dataset_state(repo, "After Phase 1 (backfill)")
 
 
 def add_new_init_time(
     repo: icechunk.Repository,
-    init_times_all: pd.DatetimeIndex,
-    lead_times_all: pd.TimedeltaIndex,
+    new_init_time: pd.Timestamp,
+    new_init_time_idx: int,
+    lead_times: pd.TimedeltaIndex,
+    partial_lead_times: pd.TimedeltaIndex,
     data_vars: list[NoaaDataVar],
 ) -> None:
-    """Phase 2: Add a new (4th) init time with all lead times."""
+    """Phase 2: Resize the dataset to add a 4th init time, fill 3 of its lead times."""
     log.info("\n%s", "=" * 60)
-    log.info("PHASE 2: Add new init time")
+    log.info("PHASE 2: Add new init time (partial)")
     log.info("=" * 60)
 
     session = repo.writable_session("main")
     store = session.store
 
-    init_idx = 3
-    init_time = init_times_all[init_idx]
-    log.info(f"Adding init_time={init_time} (all lead times)")
-    for lt_idx, lead_time in enumerate(lead_times_all):
-        byte_ranges = download_and_parse_index(init_time, lead_time, data_vars)
+    resize_init_time_dimension(
+        store, new_init_time, new_init_time_idx + 1, len(lead_times), data_vars
+    )
+    log.info(f"Resized dataset: init_time dimension is now {new_init_time_idx + 1}")
+
+    log.info(
+        f"Adding init_time={new_init_time} (lead times {partial_lead_times[0]}-{partial_lead_times[-1]})"
+    )
+    for lead_time in partial_lead_times:
+        lt_idx_raw = lead_times.get_loc(lead_time)
+        assert isinstance(lt_idx_raw, int)
+        byte_ranges = download_and_parse_index(new_init_time, lead_time, data_vars)
         set_virtual_refs_for_file(
-            store, init_time, lead_time, init_idx, lt_idx, data_vars, byte_ranges
+            store,
+            new_init_time,
+            lead_time,
+            new_init_time_idx,
+            lt_idx_raw,
+            data_vars,
+            byte_ranges,
         )
 
-    snapshot_id = session.commit("Phase 2: Add 4th init time")
+    snapshot_id = session.commit("Phase 2: Add 4th init time with partial lead times")
     log.info(f"Phase 2 committed: {snapshot_id}")
-    report_dataset_state(repo, "After Phase 2 (new init time)")
+    report_dataset_state(repo, "After Phase 2 (new init time, partial)")
 
 
 def fill_missing_lead_times(
     repo: icechunk.Repository,
-    init_times_all: pd.DatetimeIndex,
-    lead_times_all: pd.TimedeltaIndex,
+    init_time: pd.Timestamp,
+    init_time_idx: int,
+    lead_times: pd.TimedeltaIndex,
+    missing_lead_times: pd.TimedeltaIndex,
     data_vars: list[NoaaDataVar],
 ) -> None:
-    """Phase 3: Fill in lead times 5h and 6h for the previously incomplete 3rd init time."""
+    """Phase 3: Fill in remaining lead times for the 4th init time."""
     log.info("\n%s", "=" * 60)
-    log.info("PHASE 3: Add lead times to incomplete init time")
+    log.info("PHASE 3: Fill missing lead times")
     log.info("=" * 60)
 
     session = repo.writable_session("main")
     store = session.store
 
-    init_idx = 2
-    init_time = init_times_all[init_idx]
-    missing_lead_times = lead_times_all[5:]
     log.info(
         f"Filling in lead times {missing_lead_times.tolist()} for init_time={init_time}"
     )
     for lead_time in missing_lead_times:
-        lt_idx_raw = lead_times_all.get_loc(lead_time)
+        lt_idx_raw = lead_times.get_loc(lead_time)
         assert isinstance(lt_idx_raw, int)
-        lt_idx = lt_idx_raw
         byte_ranges = download_and_parse_index(init_time, lead_time, data_vars)
         set_virtual_refs_for_file(
-            store, init_time, lead_time, init_idx, lt_idx, data_vars, byte_ranges
+            store,
+            init_time,
+            lead_time,
+            init_time_idx,
+            lt_idx_raw,
+            data_vars,
+            byte_ranges,
         )
 
-    snapshot_id = session.commit("Phase 3: Fill missing lead times for 3rd init time")
+    snapshot_id = session.commit("Phase 3: Fill remaining lead times for 4th init time")
     log.info(f"Phase 3 committed: {snapshot_id}")
     report_dataset_state(repo, "After Phase 3 (fill missing lead times)")
 
@@ -403,15 +432,34 @@ def fill_missing_lead_times(
 def run_prototype() -> None:
     data_vars = get_prototype_data_vars()
     log.info(f"Prototype variables: {[v.name for v in data_vars]}")
-    log.info(f"Init times: {INIT_TIMES.tolist()}")
+    log.info(f"All init times: {INIT_TIMES.tolist()}")
     log.info(f"Lead times: {LEAD_TIMES.tolist()}")
 
     output_dir = OUTPUT_DIR
     repo = create_repository(output_dir)
 
-    backfill_init_times(repo, INIT_TIMES, LEAD_TIMES, data_vars)
-    add_new_init_time(repo, INIT_TIMES, LEAD_TIMES, data_vars)
-    fill_missing_lead_times(repo, INIT_TIMES, LEAD_TIMES, data_vars)
+    # Phase 1: Backfill first 3 init times with all lead times
+    backfill_init_times(repo, INIT_TIMES[:3], LEAD_TIMES, data_vars)
+
+    # Phase 2: Resize to add 4th init time, fill only first 3 lead times (0h-2h)
+    add_new_init_time(
+        repo,
+        INIT_TIMES[3],
+        new_init_time_idx=3,
+        lead_times=LEAD_TIMES,
+        partial_lead_times=LEAD_TIMES[:3],
+        data_vars=data_vars,
+    )
+
+    # Phase 3: Fill in lead times 3h-4h for the 4th init time
+    fill_missing_lead_times(
+        repo,
+        init_time=INIT_TIMES[3],
+        init_time_idx=3,
+        lead_times=LEAD_TIMES,
+        missing_lead_times=LEAD_TIMES[3:5],
+        data_vars=data_vars,
+    )
 
     log.info("\n%s", "=" * 60)
     log.info("Snapshot history")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "icechunk==1.1.15",
     "google-crc32c>=1.8.0",
     "httpx>=0.28.1",
+    "gribberish>=0.29.0",
 ]
 
 [build-system]

--- a/reports/gfs_icechunk_virtual_prototype.md
+++ b/reports/gfs_icechunk_virtual_prototype.md
@@ -16,6 +16,7 @@ Related: [Issue #509](https://github.com/dynamical-org/reformatters/issues/509)
    - Parse byte ranges for each variable using our existing `grib_message_byte_ranges_from_index`
    - Set virtual references via `store.set_virtual_ref()` pointing to the S3 GRIB file at the parsed byte offset/length
 4. Commit each phase as an icechunk snapshot
+5. To add a new init_time, `resize()` the coordinate and data arrays then set virtual refs for the new chunks
 
 ### Key design choices
 
@@ -26,76 +27,81 @@ Related: [Issue #509](https://github.com/dynamical-org/reformatters/issues/509)
 
 ### Dataset structure
 
-- **Dimensions**: `init_time` (4) x `lead_time` (7) x `latitude` (721) x `longitude` (1440)
+- **Dimensions**: `init_time` x `lead_time` (7) x `latitude` (721) x `longitude` (1440)
 - **Variables**: `temperature_2m`, `pressure_surface`, `wind_u_10m` (3 instant variables)
 - **Init times**: 2026-03-10 00Z, 06Z, 12Z, 18Z
 - **Lead times**: 0h through 6h (hourly)
 
 ## Prototype phases and logs
 
-### Phase 1: Initialize and backfill
+### Phase 1: Backfill
 
-Backfill 2 init times fully (all 7 lead times) and 1 init time partially (lead times 0-4h only).
-The 4th init time slot exists in the array shape but has no virtual references yet.
+Initialize the dataset with 3 init times, each with all 7 lead times fully populated.
 
 ```
 PHASE 1: Initialize and backfill
 Zarr metadata written
 Backfilling init_time=2026-03-10 00:00:00 (all lead times)
 Backfilling init_time=2026-03-10 06:00:00 (all lead times)
-Backfilling init_time=2026-03-10 12:00:00 (partial: lead times 0-4h only)
-Phase 1 committed: V2PJMJ40H0GZQ2F7KFSG
+Backfilling init_time=2026-03-10 12:00:00 (all lead times)
+Phase 1 committed: 7MWMJRTPSQXA6T1F03A0
 ```
 
 **Dataset state after Phase 1:**
 
 ```
-Dimensions: {'init_time': 4, 'lead_time': 7, 'latitude': 721, 'longitude': 1440}
-Init times: [2026-03-10 00:00, 2026-03-10 06:00, 2026-03-10 12:00, 2026-03-10 18:00]
+Dimensions: {'init_time': 3, 'lead_time': 7, 'latitude': 721, 'longitude': 1440}
+Init times: [2026-03-10 00:00, 2026-03-10 06:00, 2026-03-10 12:00]
 Lead times: [0h, 1h, 2h, 3h, 4h, 5h, 6h]
-Data variables: [temperature_2m, wind_u_10m, pressure_surface]
 ```
 
 | init_time | temperature_2m | wind_u_10m | pressure_surface |
 |---|---|---|---|
 | 2026-03-10 00:00 | 1.0000 (7267680/7267680) | 1.0000 | 1.0000 |
 | 2026-03-10 06:00 | 1.0000 (7267680/7267680) | 1.0000 | 1.0000 |
-| 2026-03-10 12:00 | 0.7143 (5191200/7267680) | 0.7143 | 0.7143 |
-| 2026-03-10 18:00 | 0.0000 (0/7267680) | 0.0000 | 0.0000 |
+| 2026-03-10 12:00 | 1.0000 (7267680/7267680) | 1.0000 | 1.0000 |
 
-The 3rd init time shows 5/7 = 0.7143 non-NaN fraction (lead times 0-4h populated, 5-6h missing).
-The 4th init time is entirely NaN (no virtual references set yet).
+All 3 init times are fully populated across all 7 lead times.
 
-### Phase 2: Add a new init time
+### Phase 2: Add a new init time (partial)
 
-Add all 7 lead times for the 4th init time (2026-03-10 18:00Z).
+Resize the dataset to add a 4th init time (2026-03-10 18:00Z). This grows the
+`init_time` coordinate and all data variable arrays. Only 3 of 7 lead times
+(0h-2h) are filled, simulating a forecast that is still being produced.
 
 ```
-PHASE 2: Add new init time
-Adding init_time=2026-03-10 18:00:00 (all lead times)
-Phase 2 committed: ZSPT9SW7K2W8YR5N09EG
+PHASE 2: Add new init time (partial)
+Resized dataset: init_time dimension is now 4
+Adding init_time=2026-03-10 18:00:00 (lead times 0 days 00:00:00-0 days 02:00:00)
+Phase 2 committed: ANS558Z79ZY93X14BYR0
 ```
 
 **Dataset state after Phase 2:**
+
+```
+Dimensions: {'init_time': 4, 'lead_time': 7, 'latitude': 721, 'longitude': 1440}
+Init times: [2026-03-10 00:00, 2026-03-10 06:00, 2026-03-10 12:00, 2026-03-10 18:00]
+```
 
 | init_time | temperature_2m | wind_u_10m | pressure_surface |
 |---|---|---|---|
 | 2026-03-10 00:00 | 1.0000 | 1.0000 | 1.0000 |
 | 2026-03-10 06:00 | 1.0000 | 1.0000 | 1.0000 |
-| 2026-03-10 12:00 | 0.7143 | 0.7143 | 0.7143 |
-| 2026-03-10 18:00 | 1.0000 | 1.0000 | 1.0000 |
+| 2026-03-10 12:00 | 1.0000 | 1.0000 | 1.0000 |
+| 2026-03-10 18:00 | 0.4286 (3114720/7267680) | 0.4286 | 0.4286 |
 
-The 4th init time is now fully populated. The 3rd remains incomplete.
+The 4th init time shows 3/7 = 0.4286 non-NaN fraction (lead times 0-2h populated, 3-6h missing).
+Missing chunks return NaN fill values automatically — no pre-allocation needed.
 
 ### Phase 3: Fill missing lead times
 
-Add lead times 5h and 6h to the previously incomplete 3rd init time (2026-03-10 12:00Z),
-simulating updates arriving as a forecast is produced by the source agency.
+Add lead times 3h and 4h to the 4th init time, simulating updates arriving as
+the source agency produces more forecast hours.
 
 ```
-PHASE 3: Add lead times to incomplete init time
-Filling in lead times [5h, 6h] for init_time=2026-03-10 12:00:00
-Phase 3 committed: W75YVXJFNGWAQKX3TGG0
+PHASE 3: Fill missing lead times
+Filling in lead times [3h, 4h] for init_time=2026-03-10 18:00:00
+Phase 3 committed: 15YA6YR7RF2PY5SCJKQG
 ```
 
 **Dataset state after Phase 3:**
@@ -105,26 +111,28 @@ Phase 3 committed: W75YVXJFNGWAQKX3TGG0
 | 2026-03-10 00:00 | 1.0000 | 1.0000 | 1.0000 |
 | 2026-03-10 06:00 | 1.0000 | 1.0000 | 1.0000 |
 | 2026-03-10 12:00 | 1.0000 | 1.0000 | 1.0000 |
-| 2026-03-10 18:00 | 1.0000 | 1.0000 | 1.0000 |
+| 2026-03-10 18:00 | 0.7143 (5191200/7267680) | 0.7143 | 0.7143 |
 
-All init times and lead times are now fully populated.
+The 4th init time now has 5/7 = 0.7143 non-NaN fraction. Lead times 5h and 6h
+remain unfilled, as they would be in a real scenario where the forecast run
+hasn't produced those hours yet.
 
 ## Snapshot history
 
 ```
-W75YVXJFNGWA  2026-03-14 17:42:54  Phase 3: Fill missing lead times for 3rd init time
-ZSPT9SW7K2W8  2026-03-14 17:42:43  Phase 2: Add 4th init time
-V2PJMJ40H0GZ  2026-03-14 17:42:31  Phase 1: Initialize and backfill 3 init times (3rd partial)
-1CECHNKREP0F  2026-03-14 17:42:29  Repository initialized
+15YA6YR7RF2P  2026-03-14 18:21:18  Phase 3: Fill remaining lead times for 4th init time
+ANS558Z79ZY9  2026-03-14 18:21:09  Phase 2: Add 4th init time with partial lead times
+7MWMJRTPSQXA  2026-03-14 18:20:57  Phase 1: Initialize and backfill 3 init times
+1CECHNKREP0F  2026-03-14 18:20:55  Repository initialized
 ```
 
 ## Repository size
 
 ```
-On-disk repository size: 15.4 KB
+On-disk repository size: 15.5 KB
 ```
 
-The entire repository is 15.4 KB on disk. Data variable chunks are virtual references to
+The entire repository is 15.5 KB on disk. Data variable chunks are virtual references to
 S3 GRIB files — no weather data is stored locally. The repository contains only:
 - Icechunk metadata (snapshots, manifests, chunk references)
 - Coordinate arrays (init_time, lead_time, latitude, longitude)
@@ -136,6 +144,7 @@ For comparison, the same data stored as float32 arrays would be:
 
 1. **Write speed**: Setting virtual references is extremely fast (~1s per phase) since only byte offsets are recorded, not actual data.
 2. **Read speed**: Reading data requires fetching GRIB bytes from S3 and decoding with gribberish at read time. Each chunk read fetches one GRIB message (~1MB compressed).
-3. **Incremental updates**: Icechunk's transactional model naturally supports adding new init times and filling in missing lead times as separate commits with snapshot history.
-4. **Index parsing**: Our existing `grib_message_byte_ranges_from_index` works directly — it parses `.idx` files to extract byte offsets per variable, which map 1:1 to virtual chunk references.
-5. **Chunk alignment**: GFS GRIB messages are naturally one-per-file-per-variable, so the chunk shape `(1, 1, 721, 1440)` aligns perfectly with the virtual reference model.
+3. **Incremental updates**: Icechunk's transactional model naturally supports resizing to add new init times and filling in lead times as separate commits with full snapshot history.
+4. **Resize for new init times**: Growing the dataset along `init_time` requires calling `resize()` on the coordinate array and all data variable arrays, then writing the new coordinate value. New chunks default to NaN fill values until virtual references are set.
+5. **Index parsing**: Our existing `grib_message_byte_ranges_from_index` works directly — it parses `.idx` files to extract byte offsets per variable, which map 1:1 to virtual chunk references.
+6. **Chunk alignment**: GFS GRIB messages are naturally one-per-file-per-variable, so the chunk shape `(1, 1, 721, 1440)` aligns perfectly with the virtual reference model.

--- a/reports/gfs_icechunk_virtual_prototype.md
+++ b/reports/gfs_icechunk_virtual_prototype.md
@@ -1,0 +1,141 @@
+# GFS Virtual Icechunk Dataset Prototype
+
+Prototype demonstrating a virtual icechunk dataset backed by NOAA GFS GRIB2 files on S3.
+Data variable chunks are virtual references to byte ranges within remote GRIB files,
+decoded at read time by GribberishCodec. Only coordinate arrays and icechunk metadata
+are stored locally.
+
+Related: [Issue #509](https://github.com/dynamical-org/reformatters/issues/509)
+
+## Approach
+
+1. Create a local icechunk repository with a virtual chunk container pointing at `s3://noaa-gfs-bdp-pds/`
+2. Write zarr v3 metadata and coordinate arrays (real data) to the store
+3. For each init_time/lead_time combination:
+   - Download the GRIB `.idx` index file
+   - Parse byte ranges for each variable using our existing `grib_message_byte_ranges_from_index`
+   - Set virtual references via `store.set_virtual_ref()` pointing to the S3 GRIB file at the parsed byte offset/length
+4. Commit each phase as an icechunk snapshot
+
+### Key design choices
+
+- **Codec**: `GribberishCodec` (zarr v3 `ArrayBytesCodec`) decodes raw GRIB2 messages at read time
+- **Chunk shape**: `(1, 1, 721, 1440)` — one chunk per GRIB message, matching the native grid
+- **No shards**: Virtual references map 1:1 to GRIB messages, sharding is unnecessary
+- **No compression**: GribberishCodec handles the full decode pipeline; no additional compressors or filters
+
+### Dataset structure
+
+- **Dimensions**: `init_time` (4) x `lead_time` (7) x `latitude` (721) x `longitude` (1440)
+- **Variables**: `temperature_2m`, `pressure_surface`, `wind_u_10m` (3 instant variables)
+- **Init times**: 2026-03-10 00Z, 06Z, 12Z, 18Z
+- **Lead times**: 0h through 6h (hourly)
+
+## Prototype phases and logs
+
+### Phase 1: Initialize and backfill
+
+Backfill 2 init times fully (all 7 lead times) and 1 init time partially (lead times 0-4h only).
+The 4th init time slot exists in the array shape but has no virtual references yet.
+
+```
+PHASE 1: Initialize and backfill
+Zarr metadata written
+Backfilling init_time=2026-03-10 00:00:00 (all lead times)
+Backfilling init_time=2026-03-10 06:00:00 (all lead times)
+Backfilling init_time=2026-03-10 12:00:00 (partial: lead times 0-4h only)
+Phase 1 committed: V2PJMJ40H0GZQ2F7KFSG
+```
+
+**Dataset state after Phase 1:**
+
+```
+Dimensions: {'init_time': 4, 'lead_time': 7, 'latitude': 721, 'longitude': 1440}
+Init times: [2026-03-10 00:00, 2026-03-10 06:00, 2026-03-10 12:00, 2026-03-10 18:00]
+Lead times: [0h, 1h, 2h, 3h, 4h, 5h, 6h]
+Data variables: [temperature_2m, wind_u_10m, pressure_surface]
+```
+
+| init_time | temperature_2m | wind_u_10m | pressure_surface |
+|---|---|---|---|
+| 2026-03-10 00:00 | 1.0000 (7267680/7267680) | 1.0000 | 1.0000 |
+| 2026-03-10 06:00 | 1.0000 (7267680/7267680) | 1.0000 | 1.0000 |
+| 2026-03-10 12:00 | 0.7143 (5191200/7267680) | 0.7143 | 0.7143 |
+| 2026-03-10 18:00 | 0.0000 (0/7267680) | 0.0000 | 0.0000 |
+
+The 3rd init time shows 5/7 = 0.7143 non-NaN fraction (lead times 0-4h populated, 5-6h missing).
+The 4th init time is entirely NaN (no virtual references set yet).
+
+### Phase 2: Add a new init time
+
+Add all 7 lead times for the 4th init time (2026-03-10 18:00Z).
+
+```
+PHASE 2: Add new init time
+Adding init_time=2026-03-10 18:00:00 (all lead times)
+Phase 2 committed: ZSPT9SW7K2W8YR5N09EG
+```
+
+**Dataset state after Phase 2:**
+
+| init_time | temperature_2m | wind_u_10m | pressure_surface |
+|---|---|---|---|
+| 2026-03-10 00:00 | 1.0000 | 1.0000 | 1.0000 |
+| 2026-03-10 06:00 | 1.0000 | 1.0000 | 1.0000 |
+| 2026-03-10 12:00 | 0.7143 | 0.7143 | 0.7143 |
+| 2026-03-10 18:00 | 1.0000 | 1.0000 | 1.0000 |
+
+The 4th init time is now fully populated. The 3rd remains incomplete.
+
+### Phase 3: Fill missing lead times
+
+Add lead times 5h and 6h to the previously incomplete 3rd init time (2026-03-10 12:00Z),
+simulating updates arriving as a forecast is produced by the source agency.
+
+```
+PHASE 3: Add lead times to incomplete init time
+Filling in lead times [5h, 6h] for init_time=2026-03-10 12:00:00
+Phase 3 committed: W75YVXJFNGWAQKX3TGG0
+```
+
+**Dataset state after Phase 3:**
+
+| init_time | temperature_2m | wind_u_10m | pressure_surface |
+|---|---|---|---|
+| 2026-03-10 00:00 | 1.0000 | 1.0000 | 1.0000 |
+| 2026-03-10 06:00 | 1.0000 | 1.0000 | 1.0000 |
+| 2026-03-10 12:00 | 1.0000 | 1.0000 | 1.0000 |
+| 2026-03-10 18:00 | 1.0000 | 1.0000 | 1.0000 |
+
+All init times and lead times are now fully populated.
+
+## Snapshot history
+
+```
+W75YVXJFNGWA  2026-03-14 17:42:54  Phase 3: Fill missing lead times for 3rd init time
+ZSPT9SW7K2W8  2026-03-14 17:42:43  Phase 2: Add 4th init time
+V2PJMJ40H0GZ  2026-03-14 17:42:31  Phase 1: Initialize and backfill 3 init times (3rd partial)
+1CECHNKREP0F  2026-03-14 17:42:29  Repository initialized
+```
+
+## Repository size
+
+```
+On-disk repository size: 15.4 KB
+```
+
+The entire repository is 15.4 KB on disk. Data variable chunks are virtual references to
+S3 GRIB files — no weather data is stored locally. The repository contains only:
+- Icechunk metadata (snapshots, manifests, chunk references)
+- Coordinate arrays (init_time, lead_time, latitude, longitude)
+
+For comparison, the same data stored as float32 arrays would be:
+`3 vars x 4 init_times x 7 lead_times x 721 lat x 1440 lon x 4 bytes = ~350 MB`
+
+## Observations
+
+1. **Write speed**: Setting virtual references is extremely fast (~1s per phase) since only byte offsets are recorded, not actual data.
+2. **Read speed**: Reading data requires fetching GRIB bytes from S3 and decoding with gribberish at read time. Each chunk read fetches one GRIB message (~1MB compressed).
+3. **Incremental updates**: Icechunk's transactional model naturally supports adding new init times and filling in missing lead times as separate commits with snapshot history.
+4. **Index parsing**: Our existing `grib_message_byte_ranges_from_index` works directly — it parses `.idx` files to extract byte offsets per variable, which map 1:1 to virtual chunk references.
+5. **Chunk alignment**: GFS GRIB messages are naturally one-per-file-per-variable, so the chunk shape `(1, 1, 721, 1440)` aligns perfectly with the virtual reference model.

--- a/reports/gfs_icechunk_virtual_prototype.md
+++ b/reports/gfs_icechunk_virtual_prototype.md
@@ -140,6 +140,64 @@ S3 GRIB files — no weather data is stored locally. The repository contains onl
 For comparison, the same data stored as float32 arrays would be:
 `3 vars x 4 init_times x 7 lead_times x 721 lat x 1440 lon x 4 bytes = ~350 MB`
 
+## Reading the dataset
+
+Open the repository from disk as a new reader — no knowledge of how it was
+created, just the path and the S3 virtual container config:
+
+```python
+import icechunk
+import xarray as xr
+
+storage = icechunk.local_filesystem_storage(str(repo_path))
+config = icechunk.RepositoryConfig.default()
+s3_store_cfg = icechunk.s3_store(region="us-east-1")
+container = icechunk.VirtualChunkContainer("s3://noaa-gfs-bdp-pds/", s3_store_cfg)
+config.set_virtual_chunk_container(container)
+
+repo = icechunk.Repository.open(
+    storage,
+    config=config,
+    authorize_virtual_chunk_access=icechunk.containers_credentials(
+        {"s3://noaa-gfs-bdp-pds/": icechunk.s3_anonymous_credentials()}
+    ),
+)
+session = repo.readonly_session(branch="main")
+ds = xr.open_zarr(session.store, consolidated=False)
+```
+
+Selecting a variable and calling `.values` triggers the S3 fetch and
+GribberishCodec decode. Each chunk fetches one GRIB message (~1 MB compressed).
+
+### Global stats
+
+```
+temperature_2m[init_time=0, lead_time=0h] shape=(721, 1440) dtype=float32
+  min=219.73  max=310.59  mean=277.13
+```
+
+### Point samples (init_time=2026-03-10 00:00Z, lead_time=0h)
+
+| Location | temperature_2m (K) | pressure_surface (Pa) | wind_u_10m (m/s) |
+|---|---|---|---|
+| New York ~40.7N, 74.0W | 274.1 | 100930 | -2.3 |
+| London ~51.5N, 0.1W | 274.8 | 101700 | 6.4 |
+| Tokyo ~35.7N, 139.75E | 290.0 | 101760 | -3.5 |
+| Sydney ~33.9S, 151.2E | 292.7 | 101640 | 2.2 |
+
+### Partially-filled init time
+
+```
+4th init time (2026-03-10 18:00Z), lead_time=1h, New York:
+  temperature_2m=276.3K  pressure_surface=101020Pa
+
+4th init time, lead_time=6h (unfilled):
+  temperature_2m=nan (NaN = unfilled chunk)
+```
+
+Unfilled chunks return NaN automatically — the reader does not need to know
+which lead times have been populated.
+
 ## Observations
 
 1. **Write speed**: Setting virtual references is extremely fast (~1s per phase) since only byte offsets are recorded, not actual data.

--- a/uv.lock
+++ b/uv.lock
@@ -677,6 +677,35 @@ wheels = [
 ]
 
 [[package]]
+name = "gribberish"
+version = "0.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/c5/f8e47d158a80f5617af9b3105f4a15e332d0ece524abd0987032758eec32/gribberish-0.29.0.tar.gz", hash = "sha256:37f39c30e7e529182d142d89dfac190513897b61dc376a1ce4e8505b48fb3198", size = 3729567, upload-time = "2026-03-12T16:07:09.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/90/9dfa38b7653ecd00de4dff45677c45347b453ff3774469f68f28e8beaa3d/gribberish-0.29.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:baa1615af33b3233944c1b2cdf8327ceab24bf7470dc2074532674d3cf2d67e9", size = 663438, upload-time = "2026-03-12T16:06:47.238Z" },
+    { url = "https://files.pythonhosted.org/packages/af/86/739f6217be44dcae3e63163d1b1b5f7a4c52cbd899f94c57d28c0f892633/gribberish-0.29.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d803908ae867957ffbfe988e57f345266a046987fa1a39803f53a65b234f2252", size = 613110, upload-time = "2026-03-12T16:06:41.413Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0c/768799482e09d6eea022c522d7ff02ea5d61178ee2f4b1ebb5c9c72c3c1b/gribberish-0.29.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd4d3a212f61bd98d1665c48f2613b9854a8b4d486446e11f40640e85e8b6338", size = 651198, upload-time = "2026-03-12T16:06:23.882Z" },
+    { url = "https://files.pythonhosted.org/packages/74/13/593c6a56058a6429e23b30c195b7e8f5c11f6a0d0d33f9aaefd003b33c06/gribberish-0.29.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8c4df2d8163202aff42bc9974867b3988ebcde75996a532188614ec5de5913df", size = 670861, upload-time = "2026-03-12T16:06:29.77Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/74/8f001948cc3e55ab1f494ef25696fd7ef5e99533ce8a04076af15e950929/gribberish-0.29.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82ebcc2d9380c1ec605914ab35590876d957b2aa2a699c611a91b7d6e9586e7c", size = 689979, upload-time = "2026-03-12T16:06:35.263Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b7/4a67c93b427b30aaf8bd420ad7ea84a13eb1f2686ac5e0836cf5cb738f0c/gribberish-0.29.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eb00f012a6147df3b41309251dc25f5a58f47ca0ad5784db5f8ddcd9a6e42db8", size = 835417, upload-time = "2026-03-12T16:06:52.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/9b/d1f40e1e0d1abf518e2de367f52b22fb8713193dbba152c7133134c9e2da/gribberish-0.29.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:c3dff27d37149e1c6dc91164da211a274b760192bae3b8a538eea0d86844bb3a", size = 949053, upload-time = "2026-03-12T16:06:59.189Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a820056844abe96f3b890fd0befd4f08a4012ba81734ec2d0d00478fd416/gribberish-0.29.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c9179683aa48e7e653b72e9f56eb1326998705fe52121d1609e493ddd3a8649d", size = 904941, upload-time = "2026-03-12T16:07:05.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/36/4e728eb42832877017086693ec71b5195eb6dfc495e76ba673a7187c1ca3/gribberish-0.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:2a1650aa0e4d5542ed3804d007b8bafafc65eafb81cd8954f0c96b7a80d1c350", size = 585108, upload-time = "2026-03-12T16:07:12.407Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d3/80c98e8e380d2cbf707998e9155c9390eb420e82d130cc9decc406e6a601/gribberish-0.29.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d7b8b8d776aa448c8e2a0bbf3602adbb6bb08dff5954d9e8674f4333d571220b", size = 663228, upload-time = "2026-03-12T16:06:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/c08c815ba4b4ca26c42840688b6847af370da11cb50ab410179bfcc769c9/gribberish-0.29.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f38efc91034725618b5539698b3dc9e3f968ce147e7537ed28d7adc92f6fe633", size = 612735, upload-time = "2026-03-12T16:06:42.82Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e7/76846bc134455883ad6e4c494a4f3b24506e3135598957006b2486cbec3e/gribberish-0.29.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff5f135f06714805aa6cdfcae883c262c99c98fbf9fb4a083ecfceeab9a84475", size = 650849, upload-time = "2026-03-12T16:06:25.308Z" },
+    { url = "https://files.pythonhosted.org/packages/72/32/d300109fed8b8feab75a2978113c946cfe3cf49ab3ddc75d8666c4826409/gribberish-0.29.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eab91c012f29fcb895bf412ab463db9806c841e2d98b5a67aefc8172ac263b9e", size = 671107, upload-time = "2026-03-12T16:06:30.898Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4e/b3f785b3ef748f2d16b5493744e4cc295bb2e9c01b19ba899e46b191ee57/gribberish-0.29.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e561e73c4d737c917a912ac05a2ae68d044cfa8da9ca4ecb5912bfe5ada90f88", size = 690142, upload-time = "2026-03-12T16:06:36.573Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d3/e0bd37510417852e50daafe7b7c83dc97418bb3944f6bb1d7775b900abb4/gribberish-0.29.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7437768a5885d09606307872e1d7065e633129488ee939862c1741e0eadb5bf", size = 835560, upload-time = "2026-03-12T16:06:54.129Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/4f/14880eea3ff71b72629030d95a9110d69d2bdb26026a529603bacfd3ff8e/gribberish-0.29.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33b0ba6342697b203c448777412c2783a045e95746f14d7eee8da0f4298683a8", size = 949063, upload-time = "2026-03-12T16:07:00.324Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/443571e6cc5e52bd3a4f9e42142db0b6de10337216f57889c678fb47160b/gribberish-0.29.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b61a47da4e540d605211ccb4648c80121748e389f07b8d767b9f4c6eb4d0c459", size = 904946, upload-time = "2026-03-12T16:07:06.642Z" },
+    { url = "https://files.pythonhosted.org/packages/75/87/c36b4758d8a92a801ce7bbb6249172cd676fd954b32286a9f5a19a4f820e/gribberish-0.29.0-cp314-cp314-win_amd64.whl", hash = "sha256:905396c9bff356698b49690847501b767d3b72eb07ca821f45261f16f48eaba4", size = 585027, upload-time = "2026-03-12T16:07:13.414Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1772,6 +1801,7 @@ source = { editable = "." }
 dependencies = [
     { name = "dask" },
     { name = "google-crc32c" },
+    { name = "gribberish" },
     { name = "httpx" },
     { name = "icechunk" },
     { name = "kubernetes" },
@@ -1810,6 +1840,7 @@ dev = [
 requires-dist = [
     { name = "dask", specifier = "~=2026.0" },
     { name = "google-crc32c", specifier = ">=1.8.0" },
+    { name = "gribberish", specifier = ">=0.29.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "icechunk", specifier = "==1.1.15" },
     { name = "kubernetes", specifier = "~=33.1" },


### PR DESCRIPTION
Prototype demonstrating a virtual icechunk dataset backed by NOAA GFS
GRIB2 files on S3. Data variable chunks are virtual references decoded
at read time by GribberishCodec. Coordinates stored as real data.

Demonstrates three phases: backfill with partial init times, adding a
new init time, and filling missing lead times for an incomplete forecast.

https://claude.ai/code/session_01UsSdT7E8S9bnrabtM5gNvp