### PR TITLE
Fix wind_gust_10m NaN at lead times 93h-144h by resolving ECMWF index param name

### DIFF
--- a/src/reformatters/ecmwf/ecmwf_config_models.py
+++ b/src/reformatters/ecmwf/ecmwf_config_models.py
@@ -10,36 +10,24 @@ from reformatters.common.types import Timedelta, Timestamp
 
 
 class EcmwfInternalAttrs(BaseInternalAttrs):
-    """
-    Variable specific attributes used internally to drive processing.
-    Not written to the dataset.
+    """Variable specific attributes used internally to drive processing. Not written to the dataset."""
 
-    Functional fields:
-        window_reset_frequency: for resetting deaccumulation windows
-        grib_index_param: The short name of the param as it exists in the index file. Does not map to any names in the grib.
-        grib_index_param_lead_time_overrides: At certain lead time ranges ECMWF uses different
-            param names in the index file for the same variable. E.g. "10fg3" instead of "10fg"
-            at lead times 93h-144h. Each tuple is (start_lead_time, end_lead_time, override_param).
-        grib_comment: Description of the param as it exists in the grib.
-
-    Additional informational fields, not currently used in processing:
-        grib_element: should be the short name of the param within the grib, but sometimes "unknown"
-        grib_description:  description of the level, not the variable
-    """
-
+    # The short name of the param as it exists in the index file. Does not map to any names in the grib.
     grib_index_param: str
-    # At certain lead time ranges ECMWF uses different param names in the index file
-    # for the same variable. E.g. "10fg3" instead of "10fg" at lead times 93h-144h.
+    # ECMWF sometimes uses different param names in the index at certain lead time ranges.
     # Each tuple is (start_lead_time, end_lead_time, override_param).
     grib_index_param_lead_time_overrides: tuple[
         tuple[Timedelta, Timedelta, str], ...
     ] = ()
+    # Description of the param as it exists in the grib.
     grib_comment: str
 
     grib_index_level_type: Literal["sfc", "pl"] = "sfc"  # surface or pressure level
     grib_index_level_value: float = float("nan")
 
-    # additional informational metadata, not currently used in processing:
+    # Informational metadata, not used in processing.
+    # grib_element: short name of the param within the grib, but sometimes "unknown"
+    # grib_description: description of the level, not the variable
     grib_element: str
     grib_description: str
 

--- a/src/reformatters/ecmwf/ecmwf_config_models.py
+++ b/src/reformatters/ecmwf/ecmwf_config_models.py
@@ -26,10 +26,8 @@ class EcmwfInternalAttrs(BaseInternalAttrs):
     grib_index_level_value: float = float("nan")
 
     # Grib attributes used to select correct message
-    # grib_element: short name of the param within the grib, but sometimes "unknown"
-    # grib_description: description of the level, not the variable
-    grib_element: str
-    grib_description: str
+    grib_element: str  # short name of the param within the grib, sometimes "unknown"
+    grib_description: str  # description of the level, not the variable
 
     scale_factor: float | None = None
 

--- a/src/reformatters/ecmwf/ecmwf_config_models.py
+++ b/src/reformatters/ecmwf/ecmwf_config_models.py
@@ -25,7 +25,7 @@ class EcmwfInternalAttrs(BaseInternalAttrs):
     grib_index_level_type: Literal["sfc", "pl"] = "sfc"  # surface or pressure level
     grib_index_level_value: float = float("nan")
 
-    # Informational metadata, not used in processing.
+    # Grib attributes used to select correct message
     # grib_element: short name of the param within the grib, but sometimes "unknown"
     # grib_description: description of the level, not the variable
     grib_element: str

--- a/src/reformatters/ecmwf/ecmwf_config_models.py
+++ b/src/reformatters/ecmwf/ecmwf_config_models.py
@@ -19,7 +19,7 @@ class EcmwfInternalAttrs(BaseInternalAttrs):
         grib_index_param: The short name of the param as it exists in the index file. Does not map to any names in the grib.
         grib_index_param_lead_time_overrides: At certain lead time ranges ECMWF uses different
             param names in the index file for the same variable. E.g. "10fg3" instead of "10fg"
-            at lead times 93h-144h. Keys are slices of lead_time, values are the param name to use.
+            at lead times 93h-144h. Each tuple is (start_lead_time, end_lead_time, override_param).
         grib_comment: Description of the param as it exists in the grib.
 
     Additional informational fields, not currently used in processing:

--- a/src/reformatters/ecmwf/ecmwf_config_models.py
+++ b/src/reformatters/ecmwf/ecmwf_config_models.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from reformatters.common.config_models import BaseInternalAttrs, DataVar
 from reformatters.common.iterating import item
+from reformatters.common.pydantic import replace
 from reformatters.common.types import Timedelta, Timestamp
 
 
@@ -16,6 +17,9 @@ class EcmwfInternalAttrs(BaseInternalAttrs):
     Functional fields:
         window_reset_frequency: for resetting deaccumulation windows
         grib_index_param: The short name of the param as it exists in the index file. Does not map to any names in the grib.
+        grib_index_param_lead_time_overrides: At certain lead time ranges ECMWF uses different
+            param names in the index file for the same variable. E.g. "10fg3" instead of "10fg"
+            at lead times 93h-144h. Keys are slices of lead_time, values are the param name to use.
         grib_comment: Description of the param as it exists in the grib.
 
     Additional informational fields, not currently used in processing:
@@ -24,6 +28,12 @@ class EcmwfInternalAttrs(BaseInternalAttrs):
     """
 
     grib_index_param: str
+    # At certain lead time ranges ECMWF uses different param names in the index file
+    # for the same variable. E.g. "10fg3" instead of "10fg" at lead times 93h-144h.
+    # Each tuple is (start_lead_time, end_lead_time, override_param).
+    grib_index_param_lead_time_overrides: tuple[
+        tuple[Timedelta, Timedelta, str], ...
+    ] = ()
     grib_comment: str
 
     grib_index_level_type: Literal["sfc", "pl"] = "sfc"  # surface or pressure level
@@ -54,6 +64,31 @@ def vars_available(
     """Check if a group of vars (which must share the same date_available) are available at init_time."""
     date_available = item({v.internal_attrs.date_available for v in data_var_group})
     return date_available is None or date_available <= init_time
+
+
+def _resolve_grib_index_param(
+    data_var: EcmwfDataVar, lead_time: Timedelta
+) -> EcmwfDataVar:
+    for (
+        start,
+        end,
+        param_override,
+    ) in data_var.internal_attrs.grib_index_param_lead_time_overrides:
+        if start <= lead_time <= end:
+            return replace(
+                data_var,
+                internal_attrs=replace(
+                    data_var.internal_attrs, grib_index_param=param_override
+                ),
+            )
+    return data_var
+
+
+def resolve_grib_index_params(
+    data_vars: Sequence[EcmwfDataVar], lead_time: Timedelta
+) -> Sequence[EcmwfDataVar]:
+    """Return data_vars with grib_index_param adjusted for lead_time-specific overrides."""
+    return [_resolve_grib_index_param(v, lead_time) for v in data_vars]
 
 
 def has_hour_0_values(data_var: EcmwfDataVar) -> bool:

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -33,6 +33,7 @@ from reformatters.common.types import (
 from reformatters.ecmwf.ecmwf_config_models import (
     EcmwfDataVar,
     has_hour_0_values,
+    resolve_grib_index_params,
     vars_available,
 )
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
@@ -160,9 +161,10 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
         idx_local_path = http_download_to_disk(idx_url, self.dataset_id)
 
         # Download the grib messages for the data vars in the coord using byte ranges
+        data_vars = resolve_grib_index_params(coord.data_var_group, coord.lead_time)
         byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(
             idx_local_path,
-            coord.data_var_group,
+            data_vars,
             coord.ensemble_member,
         )
         suffix = digest(

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
@@ -680,6 +680,9 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
                     grib_description='10[m] HTGL="Specified height level above ground"',
                     grib_element="GUST",
                     grib_index_param="10fg",
+                    grib_index_param_lead_time_overrides=(
+                        (pd.Timedelta("93h"), pd.Timedelta("144h"), "10fg3"),
+                    ),
                     keep_mantissa_bits=6,
                     date_available=pd.Timestamp("2024-11-13T00:00"),
                 ),

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job_test.py
@@ -282,13 +282,14 @@ def test_download_file_from_ecmwf_open_data() -> None:
         reformat_job_name="test",
     )
 
-    # Test over lead_times [0h, 3h] to catch bugs where variables are missing from the
-    # index at certain lead times (e.g. 10fg/wind_gust is absent at lead_time=0h since
-    # it is a max-window variable with no prior post-processing step at t=0).
-    test_ds = full_template.isel(
-        init_time=slice(-1, None),
-        lead_time=slice(0, 2),  # 0h and 3h
-        ensemble_member=slice(0, 1),
+    # Test over lead_times [0h, 3h, 96h] to catch bugs where variables are missing from
+    # the index at certain lead times. In particular:
+    # - 0h: max-window variables (e.g. 10fg/wind_gust) are absent
+    # - 96h: ECMWF uses explicitly-windowed param names (e.g. "10fg3" instead of "10fg")
+    test_ds = full_template.sel(
+        init_time=slice(init_time, None),
+        lead_time=[pd.Timedelta("0h"), pd.Timedelta("3h"), pd.Timedelta("96h")],
+        ensemble_member=[0],
     )
 
     def check_data_var(data_var: EcmwfDataVar) -> None:


### PR DESCRIPTION
ECMWF uses "10fg3" instead of "10fg" in their grib index at lead times 93h-144h. Add grib_index_param_lead_time_overrides to EcmwfInternalAttrs so the correct param name is used per lead time range. Also update the slow integration test to cover lead_time=96h to catch this class of bug.

Towards #515 