### PR TITLE
Tune deaccumulation clamp and invalid fraction alert thresholds (#514)

### DIFF
--- a/src/reformatters/common/deaccumulation.py
+++ b/src/reformatters/common/deaccumulation.py
@@ -22,6 +22,7 @@ def deaccumulate_to_rates_inplace(
     skip_step: Array1D[np.bool] | None = None,
     invalid_below_threshold_rate: float = PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD,
     expected_invalid_fraction: float = 0.0,
+    expected_clamp_fraction: float = 0.05,
 ) -> xr.DataArray:
     """
     Convert accumulated values to per-second rates in place.
@@ -37,6 +38,9 @@ def deaccumulate_to_rates_inplace(
             after deaccumulation. For example, MRMS data has ~6% no-data sentinel values
             that become invalid after deaccumulation. Only raises ValueError if the actual
             invalid fraction exceeds this expected amount.
+        expected_clamp_fraction: Fraction of values expected to be clamped to 0 (small
+            negative rates from lossy compression artifacts). Raises ValueError if actual
+            clamped fraction exceeds this.
     """
     assert data_array.attrs["units"] in VALID_OUTPUT_UNITS_FOR_DEACCUMULATION, (
         "Output units must be a per-second rate"
@@ -68,20 +72,20 @@ def deaccumulate_to_rates_inplace(
         np.prod(data_array.shape[time_dim_index + 1 :] or 1),
     )
 
-    negative_count, clamped_count = _deaccumulate_to_rates_numba(
+    invalid_negative_count, clamped_count = _deaccumulate_to_rates_numba(
         values, seconds, reset_after, skip_step, invalid_below_threshold_rate
     )
 
-    invalid_fraction = negative_count / values.size
+    invalid_fraction = invalid_negative_count / values.size
     if invalid_fraction > expected_invalid_fraction:
         raise ValueError(
-            f"Found {negative_count} values ({invalid_fraction:.1%}) below threshold, "
+            f"Found {invalid_negative_count} values ({invalid_fraction:.1%}) below threshold, "
             f"expected at most {expected_invalid_fraction:.1%}"
         )
     clamped_fraction = clamped_count / values.size
-    if clamped_fraction > 0.05:
+    if clamped_fraction > expected_clamp_fraction:
         raise ValueError(
-            f"Over 5% ({clamped_count} total, {clamped_fraction:.1%}) values were clamped to 0"
+            f"Over {expected_clamp_fraction:.0%} ({clamped_count} total, {clamped_fraction:.1%}) values were clamped to 0"
         )
 
     return data_array
@@ -103,7 +107,7 @@ def _deaccumulate_to_rates_numba(
     If they go down to a *rate* that is less than `invalid_below_threshold`,
     this sets the value to NaN.
 
-    Returns (negative_count, clamped_count) for the caller to decide whether to raise.
+    Returns (invalid_negative_count, clamped_count) for the caller to decide whether to raise.
 
     Parallel processing is done over the leading dimension of values.
     """
@@ -117,7 +121,7 @@ def _deaccumulate_to_rates_numba(
 
     n_lead_times = values.shape[1]
 
-    negative_count = 0
+    invalid_negative_count = 0
     clamped_count = 0
 
     for i in prange(values.shape[0]):  # ty: ignore[not-iterable]
@@ -156,7 +160,7 @@ def _deaccumulate_to_rates_numba(
                         clamped_count += 1
                         sequence[t] = 0
                     else:
-                        negative_count += 1
+                        invalid_negative_count += 1
                         sequence[t] = np.nan
 
-    return negative_count, clamped_count
+    return invalid_negative_count, clamped_count

--- a/src/reformatters/ecmwf/aifs_deterministic/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_deterministic/forecast/region_job.py
@@ -189,6 +189,8 @@ class EcmwfAifsDeterministicForecastRegionJob(
                     dim="lead_time",
                     reset_frequency=reset_freq,
                     invalid_below_threshold_rate=deaccumulation_invalid_below_threshold_rate,
+                    # Short wave radiation sees 5-7% clamped due to lossy grib2 compression
+                    expected_clamp_fraction=0.08,
                 )
             except ValueError:
                 log.exception(f"Error deaccumulating {data_var.name}")

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -246,6 +246,8 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
                     dim="lead_time",
                     reset_frequency=reset_freq,
                     invalid_below_threshold_rate=deaccumulation_invalid_below_threshold_rate,
+                    # Short wave radiation sees 5-7% clamped due to lossy grib2 compression
+                    expected_clamp_fraction=0.08,
                 )
             except ValueError:
                 log.exception(f"Error deaccumulating {data_var.name}")

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -213,9 +213,7 @@ class NoaaMrmsRegionJob(RegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]):
                     data_array,
                     dim="time",
                     reset_frequency=data_var.internal_attrs.window_reset_frequency,
-                    # ~6.2% of MRMS pixels have -3.0 no-data sentinel (over-ocean/no-coverage areas)
-                    # which becomes invalid after deaccumulation
-                    expected_invalid_fraction=0.07,
+                    expected_invalid_fraction=data_var.internal_attrs.expected_invalid_fraction,
                 )
             except ValueError:
                 log.exception(f"Error deaccumulating {data_var.name}")

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
@@ -38,6 +38,7 @@ class NoaaMrmsInternalAttrs(BaseInternalAttrs):
     available_from: Timestamp | None = None
     # For deaccumulation: MRMS hourly QPE is a 1-hour fixed window accumulation
     window_reset_frequency: Timedelta | None = None
+    expected_invalid_fraction: float = 0.07
 
 
 class NoaaMrmsDataVar(DataVar[NoaaMrmsInternalAttrs]):
@@ -293,6 +294,7 @@ class NoaaMrmsConusAnalysisHourlyTemplateConfig(TemplateConfig[NoaaMrmsDataVar])
                     deaccumulate_to_rate=True,
                     window_reset_frequency=qpe_window_reset_frequency,
                     keep_mantissa_bits=default_keep_mantissa_bits,
+                    expected_invalid_fraction=0.35,
                 ),
             ),
             NoaaMrmsDataVar(

--- a/tests/common/test_deaccumulation.py
+++ b/tests/common/test_deaccumulation.py
@@ -251,6 +251,67 @@ def test_deaccumulate_1d_3_and_6_hour_small_accumulation_decreases() -> None:
         )
 
 
+def test_deaccumulate_expected_clamp_fraction_suppresses_error() -> None:
+    """When expected_clamp_fraction covers the actual clamp fraction, no error is raised."""
+    reset_frequency = pd.Timedelta(hours=6)
+
+    values = [
+        {"lt": 0, "in": np.nan, "out": np.nan},
+        {"lt": 3, "in": 4. , "out": 4.0 / (3 * SECONDS_PER_HOUR)},
+        {"lt": 6, "in": 3.9, "out": 0.0},  # small negative accumulation clamped to 0
+    ]  # fmt: off
+
+    lead_times = pd.to_timedelta([step["lt"] for step in values], unit="h")
+    data = np.array([step["in"] for step in values], dtype=np.float32)
+    expected = np.array([step["out"] for step in values], dtype=np.float32)
+
+    data_array = xr.DataArray(
+        data,
+        coords={"lead_time": lead_times},
+        dims=["lead_time"],
+        attrs={"units": "mm s-1"},
+    )
+
+    result = deaccumulate_to_rates_inplace(
+        data_array,
+        dim="lead_time",
+        reset_frequency=reset_frequency,
+        expected_clamp_fraction=0.34,
+    )
+    np.testing.assert_equal(result.values, expected)
+
+
+def test_deaccumulate_expected_clamp_fraction_still_raises_when_exceeded() -> None:
+    """When actual clamp fraction exceeds expected_clamp_fraction, error is still raised."""
+    reset_frequency = pd.Timedelta(hours=6)
+
+    values = [
+        {"lt": 0, "in": 0., "out": 0.},
+        {"lt": 3, "in": 4. , "out": 4.0 / (3 * SECONDS_PER_HOUR)},
+        {"lt": 6, "in": 3.9, "out": 0.0},  # small negative accumulation clamped to 0 (1 of 3 = 33%)
+    ]  # fmt: off
+
+    lead_times = pd.to_timedelta([step["lt"] for step in values], unit="h")
+    data = np.array([step["in"] for step in values], dtype=np.float32)
+
+    data_array = xr.DataArray(
+        data,
+        coords={"lead_time": lead_times},
+        dims=["lead_time"],
+        attrs={"units": "mm s-1"},
+    )
+
+    with pytest.raises(
+        ValueError, match=r"Over 10% \(1 total, 33.3%\) values were clamped to 0"
+    ):
+        deaccumulate_to_rates_inplace(
+            data_array,
+            dim="lead_time",
+            reset_frequency=reset_frequency,
+            expected_clamp_fraction=0.10,
+        )
+
+
 def test_deaccumulate_1d_3_and_6_hour_large_accumulation_decreases() -> None:
     reset_frequency = pd.Timedelta(hours=6)
 


### PR DESCRIPTION
- Add expected_clamp_fraction param to deaccumulate_to_rates_inplace (keep default of 0.05)
- MRMS: add per-variable expected_invalid_fraction attr, set 0.35 for precipitation_radar_only_surface
- ECMWF AIFS & IFS ENS: pass expected_clamp_fraction=0.08 for lossy grib2 compression artifacts

Towards #514 