### PR TITLE
Add FLASH QPE-to-FFG ratio maximum variable to MRMS dataset

### DIFF
--- a/docs/add_new_variable.md
+++ b/docs/add_new_variable.md
@@ -4,20 +4,22 @@ How to add a new data variable to an existing dataset.
 
 ## 1. Add the variable to the template
 
-1a. Add a new `DataVar` to your dataset’s `TemplateConfig.data_vars` (usually in `src/reformatters/<provider>/<model>/<variant>/template_config.py`).
+1a. Download a real, recent source file for the new variable. Open it (e.g. with `rasterio`, `gdalinfo`, or `xarray`) to inspect its attributes (units, grid dimensions, CRS, nodata/sentinel values) and data values (range, NaN/missing coverage, geographic distribution). This grounds the variable configuration in observed data rather than assumptions.
+
+1b. Add a new `DataVar` to your dataset’s `TemplateConfig.data_vars` (usually in `src/reformatters/<provider>/<model>/<variant>/template_config.py`).
    - **Name + externally visible attrs**: match existing naming/attrs used in this repo where possible; otherwise follow CF Conventions. Variable names generally follow the format `<long name>_<level>`.
    - **Internal attrs**: derive from `gdalinfo` output on a representative source file (and GRIB index if relevant)
    - **Encoding**: match existing variables, setting `keep_mantissa_bits` to 7 by default, 6 for wind variables, and 10 for pressure variables with units `pa`.
 
-1b. Regenerate the checked-in Zarr template metadata:
+1c. Regenerate the checked-in Zarr template metadata:
 
 ```bash
 uv run main <DATASET_ID> update-template
 ```
 
-1c. Edit the `test_backfill_local_and_operational_update` test in the dataset's dynamical_dataset_test.py to add the new variable. Run the test and add a quick print or plot to confirm data is successfully being processed for the new variable. Abandon these test changes after confirming to keep our integration tests from getting slow.
+1d. Edit the `test_backfill_local_and_operational_update` test in the dataset's dynamical_dataset_test.py to add the new variable. Run the test and add a quick print or plot to confirm data is successfully being processed for the new variable. Abandon these test changes after confirming to keep our integration tests from getting slow.
 
-1d. Open and merge a PR containing the template changes (`template_config.py` and zarr metadata in `templates/latest.zarr/`)
+1e. Open and merge a PR containing the template changes (`template_config.py` and zarr metadata in `templates/latest.zarr/`)
 
 ## 2. Write data for the new variable
 

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
@@ -58,6 +58,7 @@ class NoaaMrmsConusAnalysisHourlyDataset(
             "precipitation_pass_2_surface",
         ]
         radar_only_var = ["precipitation_radar_only_surface"]
+        flash_var = ["flash_qpe_ffg_max_surface"]
         return (
             partial(
                 validation.check_analysis_current_data,
@@ -71,7 +72,7 @@ class NoaaMrmsConusAnalysisHourlyDataset(
                 # categorical (PrecipFlag) is radar-derived with no gauge latency, similar coverage to radar_only.
                 max_nan_percentage=40,
                 spatial_sampling="quarter",
-                exclude_vars=gauge_latency_vars + radar_only_var,
+                exclude_vars=gauge_latency_vars + radar_only_var + flash_var,
             ),
             partial(
                 validation.check_analysis_recent_nans,
@@ -90,5 +91,14 @@ class NoaaMrmsConusAnalysisHourlyDataset(
                 max_nan_percentage=63,
                 spatial_sampling="quarter",
                 include_vars=radar_only_var,
+            ),
+            partial(
+                validation.check_analysis_recent_nans,
+                max_expected_delay=max_expected_delay,
+                # FLASH QPE/FFG ratio has ~64% structural NaN (outside radar/FFG coverage).
+                # With quarter sampling this can reach ~68%.
+                max_nan_percentage=70,
+                spatial_sampling="quarter",
+                include_vars=flash_var,
             ),
         )

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -173,7 +173,7 @@ class NoaaMrmsRegionJob(RegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]):
     def read_data(
         self,
         coord: NoaaMrmsSourceFileCoord,
-        data_var: NoaaMrmsDataVar,  # noqa: ARG002
+        data_var: NoaaMrmsDataVar,
     ) -> ArrayFloat32:
         assert coord.downloaded_path is not None
         with rasterio.open(coord.downloaded_path) as reader:
@@ -198,7 +198,12 @@ class NoaaMrmsRegionJob(RegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]):
                 )
                 rasterio_band = 1
             result: ArrayFloat32 = reader.read(rasterio_band, out_dtype=np.float32)
-            return result
+
+        nodata_sentinel = data_var.internal_attrs.nodata_sentinel
+        if nodata_sentinel is not None:
+            result[result == nodata_sentinel] = np.nan
+
+        return result
 
     def apply_data_transformations(
         self, data_array: xr.DataArray, data_var: NoaaMrmsDataVar

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
@@ -39,6 +39,8 @@ class NoaaMrmsInternalAttrs(BaseInternalAttrs):
     # For deaccumulation: MRMS hourly QPE is a 1-hour fixed window accumulation
     window_reset_frequency: Timedelta | None = None
     expected_invalid_fraction: float = 0.07
+    # Source files use this value instead of NaN for missing/out-of-coverage pixels
+    nodata_sentinel: float | None = None
 
 
 class NoaaMrmsDataVar(DataVar[NoaaMrmsInternalAttrs]):
@@ -312,6 +314,26 @@ class NoaaMrmsConusAnalysisHourlyTemplateConfig(TemplateConfig[NoaaMrmsDataVar])
                     mrms_product_pre_v12="PrecipFlag",
                     mrms_level="00.00",
                     keep_mantissa_bits="no-rounding",
+                ),
+            ),
+            NoaaMrmsDataVar(
+                name="flash_qpe_ffg_max_surface",
+                encoding=encoding_float32_default,
+                attrs=DataVarAttrs(
+                    short_name="FLASH_QPE_FFGMAX",
+                    long_name="FLASH QPE-to-FFG ratio maximum",
+                    units="1",
+                    step_type="instant",
+                    comment="Maximum ratio of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Dimensionless ratio where values > 1 indicate QPE exceeds FFG. Available from October 2020 onward.",
+                ),
+                internal_attrs=NoaaMrmsInternalAttrs(
+                    mrms_product="FLASH_QPE_FFGMAX",
+                    mrms_product_pre_v12="unavailable-pre-v12",
+                    mrms_level="00.00",
+                    available_from=MRMS_V12_START,
+                    keep_mantissa_bits=default_keep_mantissa_bits,
+                    expected_invalid_fraction=0.65,
+                    nodata_sentinel=-999.0,
                 ),
             ),
         ]

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/flash_qpe_ffg_max_surface/zarr.json
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/flash_qpe_ffg_max_surface/zarr.json
@@ -1,0 +1,84 @@
+{
+  "shape": [
+    1,
+    3500,
+    7000
+  ],
+  "data_type": "float32",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [
+        648,
+        700,
+        1400
+      ]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": "NaN",
+  "codecs": [
+    {
+      "name": "sharding_indexed",
+      "configuration": {
+        "chunk_shape": [
+          648,
+          100,
+          100
+        ],
+        "codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "blosc",
+            "configuration": {
+              "typesize": 4,
+              "cname": "zstd",
+              "clevel": 3,
+              "shuffle": "shuffle",
+              "blocksize": 0
+            }
+          }
+        ],
+        "index_codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "crc32c"
+          }
+        ],
+        "index_location": "end"
+      }
+    }
+  ],
+  "attributes": {
+    "long_name": "FLASH QPE-to-FFG ratio maximum",
+    "short_name": "FLASH_QPE_FFGMAX",
+    "units": "1",
+    "comment": "Maximum ratio of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Dimensionless ratio where values > 1 indicate QPE exceeds FFG. Available from October 2020 onward.",
+    "step_type": "instant",
+    "coordinates": "spatial_ref",
+    "_FillValue": "AAAAAAAA+H8="
+  },
+  "dimension_names": [
+    "time",
+    "latitude",
+    "longitude"
+  ],
+  "zarr_format": 3,
+  "node_type": "array",
+  "storage_transformers": []
+}

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/zarr.json
@@ -99,6 +99,90 @@
         "node_type": "array",
         "storage_transformers": []
       },
+      "flash_qpe_ffg_max_surface": {
+        "shape": [
+          1,
+          3500,
+          7000
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              648,
+              700,
+              1400
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+            "name": "sharding_indexed",
+            "configuration": {
+              "chunk_shape": [
+                648,
+                100,
+                100
+              ],
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "blosc",
+                  "configuration": {
+                    "typesize": 4,
+                    "cname": "zstd",
+                    "clevel": 3,
+                    "shuffle": "shuffle",
+                    "blocksize": 0
+                  }
+                }
+              ],
+              "index_codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "crc32c"
+                }
+              ],
+              "index_location": "end"
+            }
+          }
+        ],
+        "attributes": {
+          "long_name": "FLASH QPE-to-FFG ratio maximum",
+          "short_name": "FLASH_QPE_FFGMAX",
+          "units": "1",
+          "comment": "Maximum ratio of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Dimensionless ratio where values > 1 indicate QPE exceeds FFG. Available from October 2020 onward.",
+          "step_type": "instant",
+          "coordinates": "spatial_ref",
+          "_FillValue": "AAAAAAAA+H8="
+        },
+        "dimension_names": [
+          "time",
+          "latitude",
+          "longitude"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
       "latitude": {
         "shape": [
           3500

--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -317,6 +317,7 @@ ALLOWED_MISSING_STANDARD_NAME: set[str] = {
     "categorical_freezing_rain_surface",
     "categorical_rain_surface",
     "categorical_precipitation_type_surface",
+    "flash_qpe_ffg_max_surface",
     "composite_reflectivity",
     "soil_water_runoff",
     "qa",
@@ -452,6 +453,8 @@ ECMWF_SHORTNAME_EXEMPT: set[str] = {
     # HRRR 80m wind (no ECMWF equivalent)
     "80u",
     "80v",
+    # NOAA MRMS FLASH system (no ECMWF equivalent)
+    "FLASH_QPE_FFGMAX",
 }
 
 ECMWF_LONGNAME_EXEMPT: set[str] = {
@@ -466,6 +469,8 @@ ECMWF_LONGNAME_EXEMPT: set[str] = {
     # HRRR 80m wind (no ECMWF equivalent)
     "80 metre U wind component",
     "80 metre V wind component",
+    # NOAA MRMS FLASH system (no ECMWF equivalent)
+    "FLASH QPE-to-FFG ratio maximum",
 }
 
 

--- a/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
@@ -216,5 +216,5 @@ def test_operational_kubernetes_resources(
 
 def test_validators(dataset: NoaaMrmsConusAnalysisHourlyDataset) -> None:
     validators = tuple(dataset.validators())
-    assert len(validators) == 4
+    assert len(validators) == 5
     assert all(isinstance(v, validation.DataValidator) for v in validators)

--- a/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
@@ -606,3 +606,41 @@ def test_download_and_read_precip_flag(tmp_path: Path) -> None:
     data = region_job.read_data(updated_coord, ptype_var)
     assert data.shape == (3500, 7000)
     assert np.all(np.isfinite(data))
+
+
+@pytest.mark.slow
+def test_download_and_read_flash_qpe_ffg_max(tmp_path: Path) -> None:
+    config = NoaaMrmsConusAnalysisHourlyTemplateConfig()
+    flash_var = next(
+        v for v in config.data_vars if v.name == "flash_qpe_ffg_max_surface"
+    )
+
+    mock_ds = Mock()
+    mock_ds.attrs = {"dataset_id": "noaa-mrms-conus-analysis-hourly"}
+    region_job = NoaaMrmsRegionJob.model_construct(
+        tmp_store=tmp_path,
+        template_ds=mock_ds,
+        data_vars=[flash_var],
+        append_dim=config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+    coord = NoaaMrmsSourceFileCoord(
+        time=pd.Timestamp("2024-01-15T12:00"),
+        product="FLASH_QPE_FFGMAX",
+        level=flash_var.internal_attrs.mrms_level,
+        fallback_products=flash_var.internal_attrs.mrms_fallback_products,
+        data_var_name=flash_var.name,
+    )
+
+    downloaded_path = region_job.download_file(coord)
+    updated_coord = replace(coord, downloaded_path=downloaded_path)
+
+    data = region_job.read_data(updated_coord, flash_var)
+    assert data.shape == (3500, 7000)
+    # Source uses -999 as nodata sentinel, read_data replaces with NaN.
+    # ~64% of pixels are outside radar/FFG coverage.
+    nan_fraction = np.isnan(data).sum() / data.size
+    assert 0.55 < nan_fraction < 0.75
+    assert np.all(np.isfinite(data[~np.isnan(data)]))

--- a/tests/noaa/mrms/conus_analysis_hourly/template_config_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/template_config_test.py
@@ -81,7 +81,7 @@ def test_data_vars() -> None:
     config = NoaaMrmsConusAnalysisHourlyTemplateConfig()
     data_vars = config.data_vars
 
-    assert len(data_vars) == 5
+    assert len(data_vars) == 6
 
     names = [v.name for v in data_vars]
     assert "precipitation_surface" in names
@@ -89,6 +89,7 @@ def test_data_vars() -> None:
     assert "precipitation_pass_2_surface" in names
     assert "precipitation_radar_only_surface" in names
     assert "categorical_precipitation_type_surface" in names
+    assert "flash_qpe_ffg_max_surface" in names
 
 
 def test_precipitation_vars_configured_for_deaccumulation() -> None:


### PR DESCRIPTION
## Summary
Adds support for the FLASH QPE-to-FFG ratio maximum variable (`flash_qpe_ffg_max_surface`) to the NOAA MRMS CONUS Analysis Hourly dataset. This variable represents the maximum ratio of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG), available from October 2020 onward.

## Key Changes

- **Template Configuration**: Added new `NoaaMrmsDataVar` for `flash_qpe_ffg_max_surface` with appropriate metadata, encoding, and internal attributes including:
  - Product name: `FLASH_QPE_FFGMAX`
  - Data type: float32 with default mantissa bit precision
  - Expected invalid fraction: 0.65 (reflects ~64% structural NaN from out-of-coverage areas)
  - Nodata sentinel value: -999.0 (source files use this instead of NaN)

- **Zarr Metadata**: Generated and committed Zarr v3 template metadata for the new variable with sharding_indexed codec configuration matching other MRMS variables

- **Data Reading**: Enhanced `region_job.read_data()` to handle nodata sentinel values by converting them to NaN during data ingestion, using the new `nodata_sentinel` field in `NoaaMrmsInternalAttrs`

- **Validation**: Added dedicated validator for FLASH variable with 70% max NaN tolerance (accounting for structural missing data) and quarter-spatial sampling

- **Testing**: 
  - Added integration test `test_download_and_read_flash_qpe_ffg_max` to verify successful download and reading of real source data
  - Updated template config and dynamical dataset tests to account for the new variable
  - Added CF compliance exemptions for the FLASH-specific short/long names

- **Documentation**: Updated `add_new_variable.md` with guidance to inspect real source files before configuration

## Implementation Details

The nodata sentinel handling is implemented as a post-read transformation in `region_job.read_data()`, allowing source-specific missing value conventions to be transparently converted to NaN without affecting other variables. The high expected invalid fraction (65%) reflects the geographic nature of the FLASH system, which only provides data within radar and FFG coverage areas.

https://claude.ai/code/session_01F4Aa4bssqydxD4ueVDzjD2