### PR TITLE
Update FLASH QPE-to-FFG metric from ratio to percentage

### DIFF
--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
@@ -321,10 +321,10 @@ class NoaaMrmsConusAnalysisHourlyTemplateConfig(TemplateConfig[NoaaMrmsDataVar])
                 encoding=encoding_float32_default,
                 attrs=DataVarAttrs(
                     short_name="FLASH_QPE_FFGMAX",
-                    long_name="FLASH QPE-to-FFG ratio maximum",
-                    units="1",
+                    long_name="FLASH QPE-to-FFG percentage maximum",
+                    units="percent",
                     step_type="instant",
-                    comment="Maximum ratio of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Dimensionless ratio where values > 1 indicate QPE exceeds FFG. Available from October 2020 onward.",
+                    comment="Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. Available from October 2020 onward.",
                 ),
                 internal_attrs=NoaaMrmsInternalAttrs(
                     mrms_product="FLASH_QPE_FFGMAX",

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/flash_qpe_ffg_max_surface/zarr.json
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/flash_qpe_ffg_max_surface/zarr.json
@@ -65,10 +65,10 @@
     }
   ],
   "attributes": {
-    "long_name": "FLASH QPE-to-FFG ratio maximum",
+    "long_name": "FLASH QPE-to-FFG percentage maximum",
     "short_name": "FLASH_QPE_FFGMAX",
-    "units": "1",
-    "comment": "Maximum ratio of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Dimensionless ratio where values > 1 indicate QPE exceeds FFG. Available from October 2020 onward.",
+    "units": "percent",
+    "comment": "Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. Available from October 2020 onward.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/zarr.json
@@ -166,10 +166,10 @@
           }
         ],
         "attributes": {
-          "long_name": "FLASH QPE-to-FFG ratio maximum",
+          "long_name": "FLASH QPE-to-FFG percentage maximum",
           "short_name": "FLASH_QPE_FFGMAX",
-          "units": "1",
-          "comment": "Maximum ratio of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Dimensionless ratio where values > 1 indicate QPE exceeds FFG. Available from October 2020 onward.",
+          "units": "percent",
+          "comment": "Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. Available from October 2020 onward.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -470,7 +470,7 @@ ECMWF_LONGNAME_EXEMPT: set[str] = {
     "80 metre U wind component",
     "80 metre V wind component",
     # NOAA MRMS FLASH system (no ECMWF equivalent)
-    "FLASH QPE-to-FFG ratio maximum",
+    "FLASH QPE-to-FFG percentage maximum",
 }
 
 


### PR DESCRIPTION
## Summary
Updated the FLASH QPE-to-FFG maximum metric to represent percentage values instead of dimensionless ratios, including corresponding changes to units, descriptions, and threshold documentation.

## Key Changes
- Changed units from `"1"` (dimensionless) to `"percent"`
- Updated `long_name` from "FLASH QPE-to-FFG ratio maximum" to "FLASH QPE-to-FFG percentage maximum"
- Updated `comment` field to reflect percentage semantics:
  - Changed "Dimensionless ratio where values > 1 indicate QPE exceeds FFG" to "Percentage where values > 100 indicate QPE exceeds FFG"
  - Updated description from "ratio" to "percentage" terminology
- Applied changes consistently across:
  - Template configuration (`template_config.py`)
  - Zarr metadata templates (both `flash_qpe_ffg_max_surface/zarr.json` and parent `zarr.json`)
  - CF compliance test expectations

## Implementation Details
This change affects the NOAA MRMS CONUS analysis hourly dataset's FLASH system data variable. The metric now correctly represents the QPE-to-FFG comparison as a percentage (0-100+ scale) rather than a ratio (0-1+ scale), making the threshold interpretation more intuitive for users (values > 100 indicate exceedance rather than > 1).

https://claude.ai/code/session_01S9bPgJpVLGoPkf4ucv24Zi