### PR TITLE
Add SpatialResolution Literal type and align AIFS with 0.25 deg datasets

### DIFF
--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -10,6 +10,16 @@ from reformatters.common.types import TimedeltaUnits, TimestampUnits
 
 type AttributeStr = Annotated[str, pydantic.Field(pattern=r"^[A-Z0-9].*[^.]$")]
 type Sentence = Annotated[str, pydantic.Field(pattern=r"^[A-Z].*\.$")]
+type SpatialResolution = Literal[
+    "0.01 degrees (~1km)",
+    "0.05 degrees (~5km)",
+    "0.0625 degrees (~7km)",
+    "0.25 degrees (~20km)",
+    "0-240 hours: 0.25 degrees (~20km), 243-840 hours: 0.5 degrees (~40km)",
+    "3 km",
+    "4 km",
+    "36 km",
+]
 
 
 class DatasetAttributes(FrozenBaseModel):
@@ -19,7 +29,7 @@ class DatasetAttributes(FrozenBaseModel):
     description: Sentence
     attribution: Sentence
     spatial_domain: AttributeStr
-    spatial_resolution: AttributeStr
+    spatial_resolution: SpatialResolution
     time_domain: AttributeStr
     time_resolution: AttributeStr
     forecast_domain: AttributeStr | None = None

--- a/src/reformatters/ecmwf/aifs_deterministic/forecast/template_config.py
+++ b/src/reformatters/ecmwf/aifs_deterministic/forecast/template_config.py
@@ -48,7 +48,7 @@ class EcmwfAifsDeterministicForecastTemplateConfig(TemplateConfig[EcmwfDataVar])
             description="Weather forecasts from the ECMWF Artificial Intelligence Forecasting System (AIFS) deterministic model.",
             attribution="ECMWF AIFS deterministic forecast data processed by dynamical.org from ECMWF Open Data.",
             spatial_domain="Global",
-            spatial_resolution="0.25 degrees (~25km)",
+            spatial_resolution="0.25 degrees (~20km)",
             time_domain=f"Forecasts initialized {self.append_dim_start} UTC to Present",
             time_resolution=f"Forecasts initialized every {self.append_dim_frequency.total_seconds() / 3600:.0f} hours",
             forecast_domain="Forecast lead time 0-360 hours (0-15 days) ahead",

--- a/src/reformatters/ecmwf/aifs_deterministic/forecast/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/aifs_deterministic/forecast/templates/latest.zarr/zarr.json
@@ -6,7 +6,7 @@
     "description": "Weather forecasts from the ECMWF Artificial Intelligence Forecasting System (AIFS) deterministic model.",
     "attribution": "ECMWF AIFS deterministic forecast data processed by dynamical.org from ECMWF Open Data.",
     "spatial_domain": "Global",
-    "spatial_resolution": "0.25 degrees (~25km)",
+    "spatial_resolution": "0.25 degrees (~20km)",
     "time_domain": "Forecasts initialized 2024-04-01 00:00:00 UTC to Present",
     "time_resolution": "Forecasts initialized every 6 hours",
     "forecast_domain": "Forecast lead time 0-360 hours (0-15 days) ahead",

--- a/tests/common/test_config_models.py
+++ b/tests/common/test_config_models.py
@@ -88,7 +88,7 @@ class TestDatasetAttributes:
             description="A test dataset for unit tests.",
             attribution="Test attribution source.",
             spatial_domain="Global",
-            spatial_resolution="0.25 degree",
+            spatial_resolution="0.25 degrees (~20km)",
             time_domain="2020-01-01 to present",
             time_resolution="1 hour",
         )
@@ -103,7 +103,7 @@ class TestDatasetAttributes:
                 description="A test dataset.",
                 attribution="Test attribution.",
                 spatial_domain="Global",
-                spatial_resolution="0.25 degree",
+                spatial_resolution="0.25 degrees (~20km)",
                 time_domain="2020-01-01 to present",
                 time_resolution="1 hour",
             )

--- a/tests/noaa/hrrr/template_config_test.py
+++ b/tests/noaa/hrrr/template_config_test.py
@@ -21,7 +21,7 @@ def template_config(monkeypatch: pytest.MonkeyPatch) -> NoaaHrrrCommonTemplateCo
         description="Test dataset.",
         attribution="Test.",
         spatial_domain="CONUS",
-        spatial_resolution="3km",
+        spatial_resolution="3 km",
         time_domain="Test",
         time_resolution="1h",
     )


### PR DESCRIPTION
Constrain spatial_resolution to a Literal type with all existing values.
Change AIFS from "~25km" to "~20km" to match other 0.25 degree datasets.

https://claude.ai/code/session_01JvrzdePWndD6Qr7TfJmG4c