### PR TITLE
Update NOAA MRMS CONUS hourly update schedule from 3-hourly to hourly

### DIFF
--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
@@ -23,11 +23,11 @@ class NoaaMrmsConusAnalysisHourlyDataset(
     region_job_class: type[NoaaMrmsRegionJob] = NoaaMrmsRegionJob
 
     def operational_kubernetes_resources(self, image_tag: str) -> Iterable[CronJob]:
-        # Pass 2 has ~60-min latency. Update every 3 hours, 3 min after Pass 2 is expected.
+        # Pass 2 has ~60-min latency. Update hourly, 3 min after Pass 2 is expected.
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="3 */3 * * *",
-            pod_active_deadline=timedelta(minutes=30),
+            schedule="3 * * * *",
+            pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="14",
@@ -39,7 +39,7 @@ class NoaaMrmsConusAnalysisHourlyDataset(
 
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="33 */3 * * *",
+            schedule="13 * * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,


### PR DESCRIPTION
## Summary
Updated the operational Kubernetes cron job schedules for the NOAA MRMS CONUS Analysis Hourly dataset to run hourly instead of every 3 hours, with corresponding adjustments to pod timeout values.

## Key Changes
- **Update job schedule**: Changed from `3 */3 * * *` (every 3 hours at 3 minutes past) to `3 * * * *` (every hour at 3 minutes past)
- **Update job timeout**: Reduced `pod_active_deadline` from 30 minutes to 10 minutes to match the 3 minute update time we see operationally plus some padding.
- **Validation job schedule**: Changed from `33 */3 * * *` (every 3 hours at 33 minutes past) to `13 * * * *` (every hour at 13 minutes past)
- **Updated comment**: Clarified that updates now occur hourly instead of every 3 hours

## Implementation Details
These changes align with the ~60-minute latency of Pass 2 data, allowing for more frequent dataset updates while maintaining the 3-minute offset after Pass 2 is expected to be available. The reduced pod timeout reflects the update time we're seeing operationally (actually 3 minutes, given a little headroom). 

