### PR TITLE
Add expected_invalid_fraction parameter to deaccumulation call

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -246,6 +246,7 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
                     dim="lead_time",
                     reset_frequency=reset_freq,
                     invalid_below_threshold_rate=deaccumulation_invalid_below_threshold_rate,
+                    expected_invalid_fraction=0.01,
                     # Short wave radiation sees 5-7% clamped due to lossy grib2 compression
                     expected_clamp_fraction=0.08,
                 )


### PR DESCRIPTION
## Summary
Added the `expected_invalid_fraction` parameter to the deaccumulation transformation in the IFS ensemble forecast data processing pipeline.

## Key Changes
- Added `expected_invalid_fraction=0.01` parameter to the deaccumulation function call in `apply_data_transformations()`
- This parameter allows the deaccumulation process to tolerate up to 1% invalid data, which is consistent with the existing tolerance for clamped values (8%) due to lossy grib2 compression

## Implementation Details
The parameter is set to 0.01 (1%) to account for expected data quality issues in the raw forecast data. This aligns with the existing `expected_clamp_fraction=0.08` parameter that handles lossy compression artifacts in short wave radiation data.

https://claude.ai/code/session_01X4zEqD1p8cLukBn6jCjpLa