### PR TITLE
Handle PermissionDeniedError in NOAA MRMS file download

### DIFF
--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import rasterio
 import xarray as xr
+from obstore.exceptions import PermissionDeniedError
 from zarr.abc.store import Store
 
 from reformatters.common.binary_rounding import round_float32_inplace
@@ -166,6 +167,9 @@ class NoaaMrmsRegionJob(RegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]):
                     )
                 except FileNotFoundError as exc:
                     last_exception = exc
+                except PermissionDeniedError as exc:
+                    last_exception = FileNotFoundError(coord.get_url(source))
+                    last_exception.__cause__ = exc
 
         assert last_exception is not None
         raise last_exception


### PR DESCRIPTION
## Summary
Added exception handling for `PermissionDeniedError` when downloading NOAA MRMS CONUS analysis hourly files, converting it to a `FileNotFoundError` for consistent error handling.

## Changes
- Import `PermissionDeniedError` from `obstore.exceptions`
- Catch `PermissionDeniedError` in the `download_file` method's retry loop
- Convert `PermissionDeniedError` to `FileNotFoundError` with the original exception as the cause, maintaining the error chain for debugging

## Details
This change ensures that permission-related errors from object storage operations are handled consistently with other download failures. By converting the exception type and preserving the original exception as the cause, we maintain full error context while providing uniform error handling behavior across different failure modes.

https://claude.ai/code/session_017Y5jvjKujVoZjkG6RAb3SX