### PR TITLE
Update GitHub Actions to latest versions, get ready for node 24 requirement

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,16 +21,16 @@ jobs:
 
     # Keep deploy-staging.yaml and these steps in sync
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: "Set up Python"
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: ".python-version"
 
@@ -58,4 +58,4 @@ jobs:
         run: uv run pytest -p no:sugar --verbose
 
       - name: Ensure SHA pinned actions
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fc87bb5b5a97953d987372e74478de634726b3e5 # v3
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # v5

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -58,4 +58,6 @@ jobs:
         run: uv run pytest -p no:sugar --verbose
 
       - name: Ensure SHA pinned actions
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # v5
+        # TODO: bump to v5 (ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066) which runs on Node 24
+        # once the dynamical-org Actions allowlist is updated. v3 still uses Node 20.
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fc87bb5b5a97953d987372e74478de634726b3e5 # v3

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -58,6 +58,4 @@ jobs:
         run: uv run pytest -p no:sugar --verbose
 
       - name: Ensure SHA pinned actions
-        # TODO: bump to v5 (ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066) which runs on Node 24
-        # once the dynamical-org Actions allowlist is updated. v3 still uses Node 20.
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fc87bb5b5a97953d987372e74478de634726b3e5 # v3
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # v5

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,10 +26,10 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/deploy-operational-updates.yml
+++ b/.github/workflows/deploy-operational-updates.yml
@@ -24,16 +24,16 @@ jobs:
 
     # Keep deploy-staging.yaml and these steps in sync
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: "Set up Python"
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: ".python-version"
 
@@ -41,13 +41,13 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b # v5
         with:
           version: 'latest'
 
@@ -56,13 +56,13 @@ jobs:
           aws eks update-kubeconfig --name ${{ secrets.EKS_CLUSTER_NAME }} --region ${{ secrets.AWS_REGION }}
 
       - name: Set up Depot CLI
-        uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
 
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: login-ecr
 
-      - uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1
+      - uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1
         with:
           project: ${{ secrets.DEPOT_PROJECT }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,16 +23,16 @@ jobs:
 
     # Keep code-quality.yaml and these steps in sync
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: "Set up Python"
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: ".python-version"
 
@@ -62,7 +62,7 @@ jobs:
 
     # Keep deploy-operational-updates.yaml and these steps in sync
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Fetch main so deploy-staging can compare versions via git show
           fetch-depth: 0
@@ -87,13 +87,13 @@ jobs:
           echo "Parsed dataset_id=${DATASET_ID}, version=${VERSION}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: "Set up Python"
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: ".python-version"
 
@@ -101,13 +101,13 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b # v5
         with:
           version: 'latest'
 
@@ -116,13 +116,13 @@ jobs:
           aws eks update-kubeconfig --name ${{ secrets.EKS_CLUSTER_NAME }} --region ${{ secrets.AWS_REGION }}
 
       - name: Set up Depot CLI
-        uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
 
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: login-ecr
 
-      - uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1
+      - uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1
         with:
           project: ${{ secrets.DEPOT_PROJECT }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/manual-create-job-from-cronjob.yml
+++ b/.github/workflows/manual-create-job-from-cronjob.yml
@@ -49,16 +49,16 @@ jobs:
     runs-on: ubuntu-24.04
     environment: prod
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         sparse-checkout: .
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ secrets.AWS_REGION }}
     - name: Install kubectl
-      uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8
+      uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b
       with:
         version: latest
     - name: Update kubeconfig

--- a/.github/workflows/manual-get-jobs.yml
+++ b/.github/workflows/manual-get-jobs.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-24.04
     environment: prod
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         sparse-checkout: .
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ secrets.AWS_REGION }}
     - name: Install kubectl
-      uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8
+      uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b
       with:
         version: latest
     - name: Update kubeconfig

--- a/.github/workflows/manual-get-pods.yml
+++ b/.github/workflows/manual-get-pods.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-24.04
     environment: prod
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         sparse-checkout: .
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ secrets.AWS_REGION }}
     - name: Install kubectl
-      uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8
+      uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b
       with:
         version: latest
     - name: Update kubeconfig

--- a/src/scripts/generate_manual_workflows.py
+++ b/src/scripts/generate_manual_workflows.py
@@ -81,12 +81,12 @@ def generate_create_job_workflow(cronjob_names: list[str]) -> dict[str, Any]:
                 "environment": MANUAL_K8S_GITHUB_ENVIRONMENT,
                 "steps": [
                     {
-                        "uses": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
+                        "uses": "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
                         "with": {"sparse-checkout": "."},
                     },
                     {
                         "name": "Configure AWS Credentials",
-                        "uses": "aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502",
+                        "uses": "aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37",
                         "with": {
                             "role-to-assume": "${{ secrets.AWS_ROLE_TO_ASSUME }}",
                             "aws-region": "${{ secrets.AWS_REGION }}",
@@ -94,7 +94,7 @@ def generate_create_job_workflow(cronjob_names: list[str]) -> dict[str, Any]:
                     },
                     {
                         "name": "Install kubectl",
-                        "uses": "azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8",
+                        "uses": "azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b",
                         "with": {"version": "latest"},
                     },
                     {
@@ -180,12 +180,12 @@ def generate_get_jobs_workflow() -> dict[str, Any]:
                 "environment": MANUAL_K8S_GITHUB_ENVIRONMENT,
                 "steps": [
                     {
-                        "uses": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
+                        "uses": "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
                         "with": {"sparse-checkout": "."},
                     },
                     {
                         "name": "Configure AWS Credentials",
-                        "uses": "aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502",
+                        "uses": "aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37",
                         "with": {
                             "role-to-assume": "${{ secrets.AWS_ROLE_TO_ASSUME }}",
                             "aws-region": "${{ secrets.AWS_REGION }}",
@@ -193,7 +193,7 @@ def generate_get_jobs_workflow() -> dict[str, Any]:
                     },
                     {
                         "name": "Install kubectl",
-                        "uses": "azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8",
+                        "uses": "azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b",
                         "with": {"version": "latest"},
                     },
                     {
@@ -252,12 +252,12 @@ def generate_get_pods_workflow() -> dict[str, Any]:
                 "environment": MANUAL_K8S_GITHUB_ENVIRONMENT,
                 "steps": [
                     {
-                        "uses": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
+                        "uses": "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
                         "with": {"sparse-checkout": "."},
                     },
                     {
                         "name": "Configure AWS Credentials",
-                        "uses": "aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502",
+                        "uses": "aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37",
                         "with": {
                             "role-to-assume": "${{ secrets.AWS_ROLE_TO_ASSUME }}",
                             "aws-region": "${{ secrets.AWS_REGION }}",
@@ -265,7 +265,7 @@ def generate_get_pods_workflow() -> dict[str, Any]:
                     },
                     {
                         "name": "Install kubectl",
-                        "uses": "azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8",
+                        "uses": "azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b",
                         "with": {"version": "latest"},
                     },
                     {


### PR DESCRIPTION
## Summary
This PR updates all GitHub Actions used across the CI/CD workflows to their latest versions, ensuring the project benefits from the latest features, security patches, and bug fixes.

## Key Changes
- **actions/checkout**: v4 → v6
- **astral-sh/setup-uv**: v5 → v7
- **actions/setup-python**: v5 → v6
- **aws-actions/configure-aws-credentials**: v4 → v6
- **azure/setup-kubectl**: v3 → v5
- **depot/setup-action**: v1 (hash update)
- **aws-actions/amazon-ecr-login**: v2 (hash update)
- **depot/build-push-action**: v1 (hash update)
- **zgosalvez/github-actions-ensure-sha-pinned-actions**: v3 → v5

## Implementation Details
- Updated all workflow files consistently:
  - `.github/workflows/deploy-staging.yml`
  - `.github/workflows/deploy-operational-updates.yml`
  - `.github/workflows/code-quality.yml`
  - `.github/workflows/copilot-setup-steps.yml`
  - `.github/workflows/manual-create-job-from-cronjob.yml`
  - `.github/workflows/manual-get-jobs.yml`
  - `.github/workflows/manual-get-pods.yml`

- Updated the action generation script (`src/scripts/generate_manual_workflows.py`) to ensure generated workflows use the same updated action versions, maintaining consistency across manually generated and static workflow files.

- All action references are pinned to specific commit SHAs for security and reproducibility.

https://claude.ai/code/session_01PYaY6rEgr6BSo7AFU3TStu