### PR TITLE
Improve shard validation error messages with better formatting

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -347,10 +347,14 @@ def check_for_expected_shards(store: Store, ds: xr.Dataset) -> ValidationResult:
             f"{var} ({len(var_missing_shard_indexes[var])} missing)"
             for var in problem_vars
         )
-        details = ", ".join(
-            f"{var}: {_truncate_shards(var_missing_shard_indexes[var])}"
-            for var in problem_vars
-        )
+        shard_lists = [var_missing_shard_indexes[var] for var in problem_vars]
+        if len(problem_vars) > 1 and all(s == shard_lists[0] for s in shard_lists[1:]):
+            details = f"all missing the same shards: {_truncate_shards(shard_lists[0])}"
+        else:
+            details = ", ".join(
+                f"{var}: {_truncate_shards(var_missing_shard_indexes[var])}"
+                for var in problem_vars
+            )
         return ValidationResult(
             passed=False,
             message=f"Missing shards: {summary}. {details}",

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -1,5 +1,4 @@
 import itertools
-import json
 from collections.abc import Sequence
 from datetime import timedelta
 from functools import partial
@@ -344,16 +343,31 @@ def check_for_expected_shards(store: Store, ds: xr.Dataset) -> ValidationResult:
             var_missing_shard_indexes[var] = sorted(missing_shard_indexes)
 
     if len(problem_vars) > 0:
-        var_missing_shards_json = json.dumps(var_missing_shard_indexes)
+        summary = ", ".join(
+            f"{var} ({len(var_missing_shard_indexes[var])} missing)"
+            for var in problem_vars
+        )
+        details = ", ".join(
+            f"{var}: {_truncate_shards(var_missing_shard_indexes[var])}"
+            for var in problem_vars
+        )
         return ValidationResult(
             passed=False,
-            message=f"{problem_vars} are missing expected shards: {var_missing_shards_json[:2000]}",
+            message=f"Missing shards: {summary}. {details}",
         )
 
     return ValidationResult(
         passed=True,
         message="All variables have expected shards",
     )
+
+
+def _truncate_shards(shards: Sequence[str], keep: int = 3) -> str:
+    if len(shards) <= keep * 2:
+        return f"[{', '.join(shards)}]"
+    head = ", ".join(shards[:keep])
+    tail = ", ".join(shards[-keep:])
+    return f"[{head}, ..., {tail}]"
 
 
 def _sync_list_shards(store: Store, var: str) -> set[str]:

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -546,7 +546,7 @@ def test_check_for_expected_shards_fails_missing_shards(
 
     assert not result.passed
     assert "temperature" in result.message
-    assert "missing expected shards" in result.message
+    assert "Missing shards" in result.message
 
 
 def test_check_for_expected_shards_passes_with_extra_shards(

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -522,6 +522,10 @@ def test_check_for_expected_shards_fails_missing_shards(
                 ["time", "y", "x"],
                 rng.standard_normal((len(times), len(y), len(x))),
             ),
+            "humidity": (
+                ["time", "y", "x"],
+                rng.standard_normal((len(times), len(y), len(x))),
+            ),
         },
         coords={"time": times, "y": y, "x": x},
         attrs={"dataset_id": "test-dataset"},
@@ -538,15 +542,64 @@ def test_check_for_expected_shards_fails_missing_shards(
     store = zarr.storage.MemoryStore()
     ds.to_zarr(store, mode="w", consolidated=False)
 
-    # Manually delete a shard to simulate missing data
-    # Delete shard 0/0/0 for temperature using sync wrapper
+    # Delete different shards per variable to exercise the per-var details branch
     zarr.core.sync.sync(store.delete("temperature/c/0/0/0"))
+    zarr.core.sync.sync(store.delete("humidity/c/1/0/0"))
+    zarr.core.sync.sync(store.delete("humidity/c/2/0/0"))
 
     result = validation.check_for_expected_shards(store, ds)
 
     assert not result.passed
-    assert "temperature" in result.message
-    assert "Missing shards" in result.message
+    assert result.message == (
+        "Missing shards: temperature (1 missing), humidity (2 missing). "
+        "temperature: [0/0/0], humidity: [1/0/0, 2/0/0]"
+    )
+
+
+def test_check_for_expected_shards_fails_same_missing_shards_across_vars(
+    rng: np.random.Generator,
+) -> None:
+    """When all problem vars are missing the same shards the message is collapsed."""
+    times = pd.date_range("2024-01-01", periods=16, freq="1h")
+    x = np.arange(10)
+    y = np.arange(8)
+
+    ds = xr.Dataset(
+        {
+            "temperature": (
+                ["time", "y", "x"],
+                rng.standard_normal((len(times), len(y), len(x))),
+            ),
+            "humidity": (
+                ["time", "y", "x"],
+                rng.standard_normal((len(times), len(y), len(x))),
+            ),
+        },
+        coords={"time": times, "y": y, "x": x},
+        attrs={"dataset_id": "test-dataset"},
+    )
+
+    chunk_sizes = (4, 4, 5)
+    shard_sizes = (4, 4, 5)
+    for var in ds.data_vars.values():
+        var.encoding["chunks"] = chunk_sizes
+        var.encoding["shards"] = shard_sizes
+
+    store = zarr.storage.MemoryStore()
+    ds.to_zarr(store, mode="w", consolidated=False)
+
+    # Delete the same shards for both variables
+    for var in ("temperature", "humidity"):
+        zarr.core.sync.sync(store.delete(f"{var}/c/0/0/0"))
+        zarr.core.sync.sync(store.delete(f"{var}/c/1/0/0"))
+
+    result = validation.check_for_expected_shards(store, ds)
+
+    assert not result.passed
+    assert result.message == (
+        "Missing shards: temperature (2 missing), humidity (2 missing). "
+        "all missing the same shards: [0/0/0, 1/0/0]"
+    )
 
 
 def test_check_for_expected_shards_passes_with_extra_shards(


### PR DESCRIPTION
## Summary
Refactored the error message formatting in the shard validation check to provide clearer, more readable output instead of raw JSON dumps.

## Key Changes
- Removed `json` import and replaced JSON serialization with custom formatting logic
- Created new `_truncate_shards()` helper function to intelligently truncate long shard lists (showing first and last 3 items with ellipsis)
- Improved error message structure with:
  - A summary line showing each variable and count of missing shards
  - Detailed information that either shows common missing shards (when all variables are missing the same shards) or lists shards per variable
- Updated test assertion to match new message format ("Missing shards" instead of "missing expected shards")

## Implementation Details
- The `_truncate_shards()` function keeps full lists under 6 items but truncates longer lists to show first 3 and last 3 items
- Error messages now distinguish between two cases:
  1. All variables missing identical shards: displays them once with "all missing the same shards"
  2. Variables missing different shards: lists shards individually per variable
- This approach maintains readability while avoiding excessively long error messages

https://claude.ai/code/session_011qcxsfN1HuVmxBqrLTPC68