### PR TITLE
Set GEFS analysis update parallelism to 2

### DIFF
--- a/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
@@ -18,7 +18,9 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
-        workers = self.num_variable_groups()
+        # GEFS analysis overrides max_vars_per_job to 1 for logic simplicity.
+        # Using num_variable_groups() would create way more parallelism than is useful
+        workers = 2
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
             # GEFS f006 (last lead time used) available ~3h48m after init on NOMADS. +3 min buffer.


### PR DESCRIPTION
GEFS analysis overrides max_vars_per_job to 1 for logic simplicity in the region job. Using num_variable_groups() would create way more parallelism than is useful.