### PR TITLE
Disk cache grib index files

### DIFF
--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -131,6 +131,7 @@ def http_download_to_disk(
     dataset_id: str,
     byte_ranges: tuple[Sequence[int], Sequence[int]] | None = None,
     local_path_suffix: str = "",
+    use_local_cache: bool = False,
 ) -> Path:
     parsed_url = urlparse(url)
     base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
@@ -140,7 +141,7 @@ def http_download_to_disk(
         store,
         parsed_url.path,
         local_path,
-        overwrite_existing=True,
+        overwrite_existing=not use_local_cache,
         byte_ranges=byte_ranges,
     )
     return local_path
@@ -284,10 +285,13 @@ def httpx_download_to_disk(
     local_path_suffix: str = "",
     rate_limiter: RateLimiter | None = None,
     retry_status_codes: set[int] = _DEFAULT_RETRY_STATUS_CODES,
+    use_local_cache: bool = False,
 ) -> Path:
     """httpx based download which supports redirects and maintains cookies."""
     parsed_url = urlparse(url)
     local_path = get_local_path(dataset_id, parsed_url.path, local_path_suffix)
+    if use_local_cache and local_path.exists():
+        return local_path
     local_path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = local_path.with_name(f"{local_path.name}.{uuid.uuid4().hex[:8]}")
 

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -40,9 +40,9 @@ def download_to_disk(
     local_path: Path,
     *,
     byte_ranges: tuple[Sequence[int], Sequence[int]] | None = None,
-    overwrite_existing: bool,
+    disk_cache: bool = False,
 ) -> None:
-    if not overwrite_existing and local_path.exists():
+    if disk_cache and local_path.exists():
         return
 
     local_path.parent.mkdir(parents=True, exist_ok=True)
@@ -131,7 +131,7 @@ def http_download_to_disk(
     dataset_id: str,
     byte_ranges: tuple[Sequence[int], Sequence[int]] | None = None,
     local_path_suffix: str = "",
-    use_local_cache: bool = False,
+    disk_cache: bool = False,
 ) -> Path:
     parsed_url = urlparse(url)
     base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
@@ -141,7 +141,7 @@ def http_download_to_disk(
         store,
         parsed_url.path,
         local_path,
-        overwrite_existing=not use_local_cache,
+        disk_cache=disk_cache,
         byte_ranges=byte_ranges,
     )
     return local_path
@@ -285,12 +285,12 @@ def httpx_download_to_disk(
     local_path_suffix: str = "",
     rate_limiter: RateLimiter | None = None,
     retry_status_codes: set[int] = _DEFAULT_RETRY_STATUS_CODES,
-    use_local_cache: bool = False,
+    disk_cache: bool = False,
 ) -> Path:
     """httpx based download which supports redirects and maintains cookies."""
     parsed_url = urlparse(url)
     local_path = get_local_path(dataset_id, parsed_url.path, local_path_suffix)
-    if use_local_cache and local_path.exists():
+    if disk_cache and local_path.exists():
         return local_path
     local_path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = local_path.with_name(f"{local_path.name}.{uuid.uuid4().hex[:8]}")

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/region_job.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/region_job.py
@@ -145,7 +145,7 @@ class NoaaNdviCdrAnalysisRegionJob(
         remote_path = urlparse(url).path.removeprefix("/")
         local_path = get_local_path(self.dataset_id, remote_path)
 
-        download_to_disk(store, remote_path, local_path, overwrite_existing=True)
+        download_to_disk(store, remote_path, local_path)
         log.debug(f"Downloaded {url} to {local_path}")
 
         return local_path

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -117,7 +117,9 @@ class EcmwfAifsSingleForecastRegionJob(
 
     def download_file(self, coord: EcmwfAifsSingleForecastSourceFileCoord) -> Path:
         idx_url = coord.get_index_url()
-        idx_local_path = http_download_to_disk(idx_url, self.dataset_id)
+        idx_local_path = http_download_to_disk(
+            idx_url, self.dataset_id, use_local_cache=True
+        )
 
         byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(
             idx_local_path,

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -118,7 +118,7 @@ class EcmwfAifsSingleForecastRegionJob(
     def download_file(self, coord: EcmwfAifsSingleForecastSourceFileCoord) -> Path:
         idx_url = coord.get_index_url()
         idx_local_path = http_download_to_disk(
-            idx_url, self.dataset_id, use_local_cache=True
+            idx_url, self.dataset_id, disk_cache=True
         )
 
         byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -110,7 +110,9 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
 
     def download_file(self, coord: IfsEnsSourceFileCoord) -> Path:
         """Download the file for the given coordinate and return the local path."""
-        idx_local_path = http_download_to_disk(coord.get_index_url(), self.dataset_id)
+        idx_local_path = http_download_to_disk(
+            coord.get_index_url(), self.dataset_id, use_local_cache=True
+        )
 
         byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(
             idx_local_path,

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -111,7 +111,7 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
     def download_file(self, coord: IfsEnsSourceFileCoord) -> Path:
         """Download the file for the given coordinate and return the local path."""
         idx_local_path = http_download_to_disk(
-            coord.get_index_url(), self.dataset_id, use_local_cache=True
+            coord.get_index_url(), self.dataset_id, disk_cache=True
         )
 
         byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(

--- a/src/reformatters/noaa/gefs/utils.py
+++ b/src/reformatters/noaa/gefs/utils.py
@@ -19,7 +19,7 @@ def _download_file_from_gefs_source(
     source_url: str,
     download: _DownloadFn,
 ) -> Path:
-    idx_local_path = download(index_url, dataset_id, use_local_cache=True)
+    idx_local_path = download(index_url, dataset_id, disk_cache=True)
 
     starts, ends = grib_message_byte_ranges_from_index(
         idx_local_path, coord.data_vars, coord.init_time, coord.lead_time

--- a/src/reformatters/noaa/gefs/utils.py
+++ b/src/reformatters/noaa/gefs/utils.py
@@ -19,7 +19,7 @@ def _download_file_from_gefs_source(
     source_url: str,
     download: _DownloadFn,
 ) -> Path:
-    idx_local_path = download(index_url, dataset_id)
+    idx_local_path = download(index_url, dataset_id, use_local_cache=True)
 
     starts, ends = grib_message_byte_ranges_from_index(
         idx_local_path, coord.data_vars, coord.init_time, coord.lead_time

--- a/src/reformatters/noaa/gfs/region_job.py
+++ b/src/reformatters/noaa/gfs/region_job.py
@@ -98,7 +98,7 @@ class NoaaGfsCommonRegionJob(RegionJob[NoaaDataVar, NoaaGfsSourceFileCoord]):
             else http_download_to_disk
         )
         idx_local_path = download(
-            coord.get_idx_url(source=source), self.dataset_id, use_local_cache=True
+            coord.get_idx_url(source=source), self.dataset_id, disk_cache=True
         )
         starts, ends = grib_message_byte_ranges_from_index(
             idx_local_path, coord.data_vars, coord.init_time, coord.lead_time

--- a/src/reformatters/noaa/gfs/region_job.py
+++ b/src/reformatters/noaa/gfs/region_job.py
@@ -97,7 +97,9 @@ class NoaaGfsCommonRegionJob(RegionJob[NoaaDataVar, NoaaGfsSourceFileCoord]):
             if source == "nomads"
             else http_download_to_disk
         )
-        idx_local_path = download(coord.get_idx_url(source=source), self.dataset_id)
+        idx_local_path = download(
+            coord.get_idx_url(source=source), self.dataset_id, use_local_cache=True
+        )
         starts, ends = grib_message_byte_ranges_from_index(
             idx_local_path, coord.data_vars, coord.init_time, coord.lead_time
         )

--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -141,7 +141,7 @@ class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
             else http_download_to_disk
         )
         idx_local_path = download(
-            coord.get_idx_url(source=source), self.dataset_id, use_local_cache=True
+            coord.get_idx_url(source=source), self.dataset_id, disk_cache=True
         )
         byte_range_starts, byte_range_ends = grib_message_byte_ranges_from_index(
             idx_local_path,

--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -140,7 +140,9 @@ class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
             if source == "nomads"
             else http_download_to_disk
         )
-        idx_local_path = download(coord.get_idx_url(source=source), self.dataset_id)
+        idx_local_path = download(
+            coord.get_idx_url(source=source), self.dataset_id, use_local_cache=True
+        )
         byte_range_starts, byte_range_ends = grib_message_byte_ranges_from_index(
             idx_local_path,
             coord.data_vars,

--- a/tests/common/test_download.py
+++ b/tests/common/test_download.py
@@ -136,6 +136,31 @@ def test_http_download_to_disk_calls_download(tmp_path: Path) -> None:
     assert result == get_local_path("my-dataset", "/data/file.grib2")
 
 
+def test_http_download_to_disk_use_local_cache_passes_overwrite_false(
+    tmp_path: Path,
+) -> None:
+    captured: list[dict] = []
+
+    def fake_download_to_disk(
+        store: object,
+        path: str,
+        local_path: Path,
+        *,
+        byte_ranges: tuple[Sequence[int], Sequence[int]] | None,
+        overwrite_existing: bool,
+    ) -> None:
+        captured.append({"overwrite_existing": overwrite_existing})
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(b"data")
+
+    with patch.object(download_module, "download_to_disk", fake_download_to_disk):
+        http_download_to_disk(
+            "https://example.com/data/file.idx", "my-dataset", use_local_cache=True
+        )
+
+    assert captured[0]["overwrite_existing"] is False
+
+
 def test_http_download_to_disk_with_byte_ranges(tmp_path: Path) -> None:
     captured_ranges: list = []
 
@@ -349,6 +374,63 @@ def test_httpx_download_to_disk_cleans_up_on_error(tmp_path: Path) -> None:
     all_files = list(tmp_path.rglob("*"))
     data_files = [f for f in all_files if f.is_file()]
     assert len(data_files) == 0
+
+
+def test_httpx_download_to_disk_use_local_cache_skips_when_file_exists(
+    tmp_path: Path,
+) -> None:
+    # Pre-create the cached file
+    local_path = tmp_path / "my-dataset" / "data" / "file.idx"
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    cached_content = b"cached content"
+    local_path.write_bytes(cached_content)
+
+    call_count = 0
+
+    def fake_get_with_retry(*args: object, **kwargs: object) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return _make_httpx_response(status_code=200, content=b"fresh content")
+
+    with (
+        patch.object(download_module, "_httpx_get_with_retry", fake_get_with_retry),
+        patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
+    ):
+        result = httpx_download_to_disk(
+            "https://example.com/data/file.idx",
+            "my-dataset",
+            use_local_cache=True,
+        )
+
+    # Should not have made any HTTP request and should return the existing file
+    assert call_count == 0
+    assert result == local_path
+    assert result.read_bytes() == cached_content
+
+
+def test_httpx_download_to_disk_use_local_cache_downloads_when_missing(
+    tmp_path: Path,
+) -> None:
+    response = _make_httpx_response(status_code=200, content=b"fresh content")
+    call_count = 0
+
+    def fake_get_with_retry(*args: object, **kwargs: object) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return response
+
+    with (
+        patch.object(download_module, "_httpx_get_with_retry", fake_get_with_retry),
+        patch.object(download_module, "DOWNLOAD_DIR", tmp_path),
+    ):
+        result = httpx_download_to_disk(
+            "https://example.com/data/file.idx",
+            "my-dataset",
+            use_local_cache=True,
+        )
+
+    assert call_count == 1
+    assert result.read_bytes() == b"fresh content"
 
 
 def test_httpx_download_to_disk_with_suffix(tmp_path: Path) -> None:

--- a/tests/common/test_download.py
+++ b/tests/common/test_download.py
@@ -59,12 +59,12 @@ def test_s3_store_returns_s3_store() -> None:
     assert isinstance(store, obstore.store.S3Store)
 
 
-def test_download_to_disk_skips_if_exists_and_no_overwrite(tmp_path: Path) -> None:
+def test_download_to_disk_skips_if_exists_and_disk_cache(tmp_path: Path) -> None:
     local_path = tmp_path / "existing_file.bin"
     local_path.write_bytes(b"existing content")
 
     mock_store = MagicMock()
-    download_to_disk(mock_store, "some/path", local_path, overwrite_existing=False)
+    download_to_disk(mock_store, "some/path", local_path, disk_cache=True)
 
     mock_store.get.assert_not_called()
     mock_store.get_ranges.assert_not_called()
@@ -82,7 +82,7 @@ def test_download_to_disk_writes_file(tmp_path: Path) -> None:
         patch("obstore.get", return_value=mock_get_result),
         patch.object(mock_get_result, "stream", return_value=iter([file_content])),
     ):
-        download_to_disk(mock_store, "some/path", local_path, overwrite_existing=True)
+        download_to_disk(mock_store, "some/path", local_path)
 
     assert local_path.exists()
     assert local_path.read_bytes() == file_content
@@ -96,7 +96,7 @@ def test_download_to_disk_cleans_up_temp_on_error(tmp_path: Path) -> None:
         patch("obstore.get", side_effect=OSError("network error")),
         pytest.raises(OSError, match="network error"),
     ):
-        download_to_disk(mock_store, "some/path", local_path, overwrite_existing=True)
+        download_to_disk(mock_store, "some/path", local_path)
 
     assert not local_path.exists()
     temp_files = list(tmp_path.glob("*.???????"))
@@ -112,14 +112,14 @@ def test_http_download_to_disk_calls_download(tmp_path: Path) -> None:
         local_path: Path,
         *,
         byte_ranges: tuple[Sequence[int], Sequence[int]] | None,
-        overwrite_existing: bool,
+        disk_cache: bool,
     ) -> None:
         captured.append(
             {
                 "path": path,
                 "local_path": local_path,
                 "byte_ranges": byte_ranges,
-                "overwrite_existing": overwrite_existing,
+                "disk_cache": disk_cache,
             }
         )
         local_path.parent.mkdir(parents=True, exist_ok=True)
@@ -132,11 +132,11 @@ def test_http_download_to_disk_calls_download(tmp_path: Path) -> None:
 
     assert len(captured) == 1
     assert captured[0]["path"] == "/data/file.grib2"
-    assert captured[0]["overwrite_existing"] is True
+    assert captured[0]["disk_cache"] is False
     assert result == get_local_path("my-dataset", "/data/file.grib2")
 
 
-def test_http_download_to_disk_use_local_cache_passes_overwrite_false(
+def test_http_download_to_disk_disk_cache_passes_through(
     tmp_path: Path,
 ) -> None:
     captured: list[dict] = []
@@ -147,18 +147,18 @@ def test_http_download_to_disk_use_local_cache_passes_overwrite_false(
         local_path: Path,
         *,
         byte_ranges: tuple[Sequence[int], Sequence[int]] | None,
-        overwrite_existing: bool,
+        disk_cache: bool,
     ) -> None:
-        captured.append({"overwrite_existing": overwrite_existing})
+        captured.append({"disk_cache": disk_cache})
         local_path.parent.mkdir(parents=True, exist_ok=True)
         local_path.write_bytes(b"data")
 
     with patch.object(download_module, "download_to_disk", fake_download_to_disk):
         http_download_to_disk(
-            "https://example.com/data/file.idx", "my-dataset", use_local_cache=True
+            "https://example.com/data/file.idx", "my-dataset", disk_cache=True
         )
 
-    assert captured[0]["overwrite_existing"] is False
+    assert captured[0]["disk_cache"] is True
 
 
 def test_http_download_to_disk_with_byte_ranges(tmp_path: Path) -> None:
@@ -170,7 +170,7 @@ def test_http_download_to_disk_with_byte_ranges(tmp_path: Path) -> None:
         local_path: Path,
         *,
         byte_ranges: tuple[Sequence[int], Sequence[int]] | None,
-        overwrite_existing: bool,
+        disk_cache: bool,
     ) -> None:
         captured_ranges.append(byte_ranges)
         local_path.parent.mkdir(parents=True, exist_ok=True)
@@ -376,7 +376,7 @@ def test_httpx_download_to_disk_cleans_up_on_error(tmp_path: Path) -> None:
     assert len(data_files) == 0
 
 
-def test_httpx_download_to_disk_use_local_cache_skips_when_file_exists(
+def test_httpx_download_to_disk_disk_cache_skips_when_file_exists(
     tmp_path: Path,
 ) -> None:
     # Pre-create the cached file
@@ -399,7 +399,7 @@ def test_httpx_download_to_disk_use_local_cache_skips_when_file_exists(
         result = httpx_download_to_disk(
             "https://example.com/data/file.idx",
             "my-dataset",
-            use_local_cache=True,
+            disk_cache=True,
         )
 
     # Should not have made any HTTP request and should return the existing file
@@ -408,7 +408,7 @@ def test_httpx_download_to_disk_use_local_cache_skips_when_file_exists(
     assert result.read_bytes() == cached_content
 
 
-def test_httpx_download_to_disk_use_local_cache_downloads_when_missing(
+def test_httpx_download_to_disk_disk_cache_downloads_when_missing(
     tmp_path: Path,
 ) -> None:
     response = _make_httpx_response(status_code=200, content=b"fresh content")
@@ -426,7 +426,7 @@ def test_httpx_download_to_disk_use_local_cache_downloads_when_missing(
         result = httpx_download_to_disk(
             "https://example.com/data/file.idx",
             "my-dataset",
-            use_local_cache=True,
+            disk_cache=True,
         )
 
     assert call_count == 1

--- a/tests/noaa/hrrr/region_job_test.py
+++ b/tests/noaa/hrrr/region_job_test.py
@@ -179,9 +179,7 @@ def test_region_job_download_file(
         "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t00z.wrfsfcf00.grib2.idx",
         "test-dataset-hrrr",
     )
-    assert mock_http_download_to_disk.call_args_list[0].kwargs == {
-        "use_local_cache": True
-    }
+    assert mock_http_download_to_disk.call_args_list[0].kwargs == {"disk_cache": True}
 
     assert mock_http_download_to_disk.call_args_list[1].args == (
         "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t00z.wrfsfcf00.grib2",

--- a/tests/noaa/hrrr/region_job_test.py
+++ b/tests/noaa/hrrr/region_job_test.py
@@ -179,7 +179,9 @@ def test_region_job_download_file(
         "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t00z.wrfsfcf00.grib2.idx",
         "test-dataset-hrrr",
     )
-    assert mock_http_download_to_disk.call_args_list[0].kwargs == {}
+    assert mock_http_download_to_disk.call_args_list[0].kwargs == {
+        "use_local_cache": True
+    }
 
     assert mock_http_download_to_disk.call_args_list[1].args == (
         "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240229/conus/hrrr.t00z.wrfsfcf00.grib2",


### PR DESCRIPTION
## Summary
Apply local disk caching to grib index files. These are often reused within an update and are small. This is motivated primarily by reducing the request rate to hot prefixes in S3, allowing us to scale out updates with higher parallelism by reducing unnecessary duplicate requests.

Refactored the download functions to use a `disk_cache` parameter instead of `overwrite_existing`, inverting the logic to better represent the intended behavior of caching downloaded files locally.

## Key Changes
- **Parameter rename and logic inversion**: Changed `overwrite_existing` to `disk_cache` in `download_to_disk()`, `http_download_to_disk()`, and `httpx_download_to_disk()` functions
  - `overwrite_existing=False` → `disk_cache=True` (skip download if file exists)
  - `overwrite_existing=True` → `disk_cache=False` (default, always download)
  
- **Default behavior**: Made `disk_cache=False` the default, meaning downloads happen by default unless explicitly cached

- **Cache check in httpx_download_to_disk()**: Added early return when `disk_cache=True` and the local file already exists, preventing unnecessary HTTP requests

- **Updated all call sites**: Applied the new parameter across multiple modules:
  - `aifs_single/forecast/region_job.py`
  - `ifs_ens/forecast_15_day_0_25_degree/region_job.py`
  - `noaa/gfs/region_job.py`
  - `noaa/hrrr/region_job.py`
  - `noaa/gefs/utils.py`
  - `contrib/noaa/ndvi_cdr/analysis/region_job.py`

- **Updated tests**: Modified test cases to reflect the new parameter semantics and added new tests for disk cache behavior in `httpx_download_to_disk()`

## Implementation Details
- The semantic change makes the parameter name more intuitive: `disk_cache=True` clearly indicates "use disk caching" rather than the double-negative of `overwrite_existing=False`
- Index files (.idx) are now consistently downloaded with `disk_cache=True` to avoid re-downloading them on subsequent runs
- The implementation maintains backward compatibility by making `disk_cache` an optional parameter with a sensible default

https://claude.ai/code/session_019UCXuHh9Yxzy5Th3Y3Zek6