### PR TITLE
Expect up to 8% invalid deaccumulation in MRMS precipitation_surface

### DIFF
--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
@@ -232,6 +232,7 @@ class NoaaMrmsConusAnalysisHourlyTemplateConfig(TemplateConfig[NoaaMrmsDataVar])
                     ),
                     mrms_level="00.00",
                     deaccumulate_to_rate=True,
+                    expected_invalid_fraction=0.08,  # impact of radar only in most recent time step
                     window_reset_frequency=qpe_window_reset_frequency,
                     keep_mantissa_bits=default_keep_mantissa_bits,
                 ),


### PR DESCRIPTION
pass 1 and 2 have very low nan fractions,
but the most recent time step that includes radar only has ~7.5% invalid due to expected missing regions.