### PR TITLE
Allow 25% clamp fraction for ICON-EU running-mean radiation deaccumulation

### DIFF
--- a/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
@@ -202,6 +202,11 @@ class DwdIconEuForecast5DayRegionJob(
             )
             if invalid_below is not None:
                 deaccumulate_kwargs["invalid_below_threshold_rate"] = invalid_below
+            expected_clamp = (
+                data_var.internal_attrs.deaccumulation_expected_clamp_fraction
+            )
+            if expected_clamp is not None:
+                deaccumulate_kwargs["expected_clamp_fraction"] = expected_clamp
             try:
                 deaccumulate_to_rates_inplace(
                     data_array,

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/template_config.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/template_config.py
@@ -42,6 +42,8 @@ class DwdIconEuInternalAttrs(BaseInternalAttrs):
         deaccumulation_invalid_below_threshold_rate (float | None): Threshold passed through to
             `deaccumulate_to_rates_inplace` when `deaccumulate_to_rate` is True. Used, for example,
             to tolerate the larger negative noise produced by lossy-compressed radiation fields.
+        deaccumulation_expected_clamp_fraction (float | None): Override for the fraction of values
+            expected to be clamped to 0.
         deaccumulation_type (AccumulationType): Whether the source values are cumulative totals
             ("accumulated", default) or running-mean rates whose averaging window grows from
             forecast start ("running_mean", used for ICON-EU averaged radiation fields).
@@ -51,6 +53,7 @@ class DwdIconEuInternalAttrs(BaseInternalAttrs):
     window_reset_frequency: Timedelta | None = None
     scale_factor: float | None = None
     deaccumulation_invalid_below_threshold_rate: float | None = None
+    deaccumulation_expected_clamp_fraction: float | None = None
     deaccumulation_type: AccumulationType = "accumulated"
 
 
@@ -360,6 +363,8 @@ class DwdIconEuForecast5DayTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                     deaccumulate_to_rate=True,
                     window_reset_frequency=pd.Timedelta.max,
                     deaccumulation_invalid_below_threshold_rate=RADIATION_INVALID_BELOW_THRESHOLD,
+                    # GRIB precision jitter in the running mean drives nighttime clamping to ~20%.
+                    deaccumulation_expected_clamp_fraction=0.25,
                     deaccumulation_type="running_mean",
                 ),
             ),
@@ -385,6 +390,8 @@ class DwdIconEuForecast5DayTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                     deaccumulate_to_rate=True,
                     window_reset_frequency=pd.Timedelta.max,
                     deaccumulation_invalid_below_threshold_rate=RADIATION_INVALID_BELOW_THRESHOLD,
+                    # GRIB precision jitter in the running mean drives nighttime clamping to ~20%.
+                    deaccumulation_expected_clamp_fraction=0.25,
                     deaccumulation_type="running_mean",
                 ),
             ),

--- a/tests/dwd/icon_eu/forecast_5_day/region_job_test.py
+++ b/tests/dwd/icon_eu/forecast_5_day/region_job_test.py
@@ -216,6 +216,44 @@ def test_region_job_apply_data_transformations_deaccumulation(
     )
 
 
+def test_region_job_apply_data_transformations_deaccumulation_optional_kwargs(
+    region_job: DwdIconEuForecast5DayRegionJob,
+    t_2m_data_var: DwdIconEuDataVar,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_freq = pd.Timedelta.max
+    data_var = replace(
+        t_2m_data_var,
+        internal_attrs=replace(
+            t_2m_data_var.internal_attrs,
+            deaccumulate_to_rate=True,
+            window_reset_frequency=reset_freq,
+            deaccumulation_invalid_below_threshold_rate=-50.0,
+            deaccumulation_expected_clamp_fraction=0.25,
+            deaccumulation_type="running_mean",
+        ),
+    )
+    times = pd.date_range("2000-01-01", periods=3, freq="1h")
+    data = np.array([0, 1, 2], dtype=np.float32)
+    data_array = xr.DataArray(data, coords={"lead_time": times}, dims=["lead_time"])
+
+    mock_deaccum = Mock()
+    monkeypatch.setattr(
+        "reformatters.dwd.icon_eu.forecast_5_day.region_job.deaccumulate_to_rates_inplace",
+        mock_deaccum,
+    )
+
+    region_job.apply_data_transformations(data_array, data_var)
+    mock_deaccum.assert_called_once_with(
+        data_array,
+        dim="lead_time",
+        reset_frequency=reset_freq,
+        accumulation_type="running_mean",
+        invalid_below_threshold_rate=-50.0,
+        expected_clamp_fraction=0.25,
+    )
+
+
 def test_region_job_apply_data_transformations_scale_factor(
     region_job: DwdIconEuForecast5DayRegionJob,
     t_2m_data_var: DwdIconEuDataVar,


### PR DESCRIPTION
At night most values are about zero, combined with lossy grib compression leads to a relatively high fraction of very slightly negative values after deaccumulation.
