### PR TITLE
Clarify backfill metadata behavior after parallel setup adoption

### DIFF
--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -20,15 +20,15 @@ Readers must always see a consistent view — either the old data or the fully u
 
 Data chunks can be written directly because they occupy new shard regions that readers won't access until the metadata (which defines the dataset's dimensions) is updated. The metadata write is deferred until the last worker completes, making all new data visible atomically.
 
-For backfills, metadata is written before workers start (the dataset is being created, not read). Specifically, `backfill_local` / `backfill_kubernetes` write metadata to final stores before spawning worker execution. `parallel_setup` writes metadata only to local tmp storage (and to temp icechunk branches), not to final zarr v3 stores. For operational updates, metadata is deferred to finalization.
+For backfills, metadata is written before workers start (the dataset is being created, not read). Specifically, `backfill_local` / `backfill_kubernetes` write metadata to final stores before spawning worker execution. `parallel_setup` writes metadata only to local tmp storage, not to final zarr v3 stores. For operational updates, metadata is deferred to finalization.
 
 ### Icechunk stores
 
-All work happens on a temporary branch (`_job_{job_name}`). Readers on `main` are unaffected. The flow:
+All metadata and chunk writes happen on a temporary branch (`_job_{job_name}`). Readers on `main` are unaffected. The flow:
 
 1. **Worker 0 setup** — creates a temp branch from main's current snapshot, copies expanded metadata from the local tmp store, commits on the branch
 2. **All workers** — open sessions on the temp branch, write chunk data, commit with `ConflictDetector` rebase (uncooperative distributed writes)
-3. **Last worker finalization** — writes final metadata on the branch, then atomically resets `main` to the branch tip using `reset_branch("main", snapshot, from_snapshot_id=original)`. The `from_snapshot_id` check ensures no concurrent process moved main.
+3. **Last worker finalization** — writes final metadata on the branch, then atomically resets `main` to the branch tip using `reset_branch("main", snapshot, from_snapshot_id=original)`. This branch reset is what makes all writes visible to readers. The `from_snapshot_id` check ensures no concurrent process moved main.
 
 ## Worker coordination
 

--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -20,7 +20,7 @@ Readers must always see a consistent view — either the old data or the fully u
 
 Data chunks can be written directly because they occupy new shard regions that readers won't access until the metadata (which defines the dataset's dimensions) is updated. The metadata write is deferred until the last worker completes, making all new data visible atomically.
 
-For backfills, metadata is written before workers start (the dataset is being created, not read). Specifically, `backfill_local` / `backfill_kubernetes` write metadata to final stores before spawning worker execution. `parallel_setup` writes metadata only to local tmp storage, not to final zarr v3 stores. For operational updates, metadata is deferred to finalization.
+For backfills, metadata is written before workers start (the dataset is being created, not read). Specifically, `backfill_local` / `backfill_kubernetes` write metadata to final stores before spawning worker execution. Those calls are required for Zarr v3 support; once the project only supports Icechunk, those calls are no longer needed. `parallel_setup` writes metadata to local tmp storage and to temporary Icechunk branches, but not to final zarr v3 stores. For operational updates, metadata is deferred to finalization.
 
 ### Icechunk stores
 

--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -20,7 +20,7 @@ Readers must always see a consistent view — either the old data or the fully u
 
 Data chunks can be written directly because they occupy new shard regions that readers won't access until the metadata (which defines the dataset's dimensions) is updated. The metadata write is deferred until the last worker completes, making all new data visible atomically.
 
-For backfills, metadata is written before workers start (the dataset is being created, not read). For operational updates, metadata is deferred to finalization.
+For backfills, metadata is written before workers start (the dataset is being created, not read). Specifically, `backfill_local` / `backfill_kubernetes` write metadata to final stores before spawning worker execution. `parallel_setup` writes metadata only to local tmp storage (and to temp icechunk branches), not to final zarr v3 stores. For operational updates, metadata is deferred to finalization.
 
 ### Icechunk stores
 
@@ -40,7 +40,7 @@ Worker 0 writes `setup/ready.json` after completing setup (creating branches, wr
 
 ### Results
 
-Each worker writes `results/worker-{N}.pkl` containing its `process_results` dict. The last worker (by index) polls until all result files are present, then aggregates them. For updates, the aggregated results drive `update_template_with_results` to trim the template based on what was actually processed.
+Each worker writes `results/worker-{N}.json` containing its `process_results` dict. The last worker (by index) polls until all result files are present, then aggregates them. For updates, the aggregated results drive `update_template_with_results` to trim the template based on what was actually processed.
 
 ### Cleanup
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -204,6 +204,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             )
             log.info("Writing to existing stores, skipping metadata write.")
         else:
+            # Write metadata to final store. Required for Zarr v3 only, Icechunk metadata is written in parallel_setup.
             template_utils.write_metadata(template_ds, self.store_factory)
 
         num_jobs = len(
@@ -302,6 +303,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         )
 
         template_ds = self._get_template(append_dim_end)
+        # Write metadata to final store. Required for Zarr v3 only, Icechunk metadata is written in parallel_setup.
         template_utils.write_metadata(template_ds, self.store_factory)
 
         self.backfill(


### PR DESCRIPTION
### Motivation
- Make it explicit that `backfill_local`/`backfill_kubernetes` must still write final Zarr v3 metadata before workers start because `parallel_setup` only writes metadata to the local `tmp_store` (and temp icechunk branches), not to final zarr v3 stores, and to correct the documented worker results filename.

### Description
- Updated `docs/parallel_processing.md` to state that backfills still write metadata to final stores and that `parallel_setup` writes metadata only to `tmp_store` and icechunk temp branches, and changed the documented worker results file extension from `.pkl` to `.json`.

### Testing
- Ran formatting and static checks with `uv run ruff format`, `uv run ruff check --fix`, and `uv run ty check`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e439598d788328a417334a02a3dbef)