### PR TITLE
Rework validation plots for per-variable output and add docs/validation.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ docs/
 ├── dataset_integration_guide.md      # Step-by-step new dataset integration walkthrough
 ├── parallel_processing.md            # How parallel writes coordinate across workers
 ├── add_new_variable.md               # Add new variable to an existing dataset
+├── validation.md                     # Run + read validation plots; data quality checklist
 ├── chunk_shard_layout_tool.md        # Zarr V3 chunk/shard layout optimizer
 ├── source_data_exploration_guide.md  # Explore/document source data structure before integration
 ├── ops_card.md                       # Operations: monitoring, troubleshooting, manual updates

--- a/docs/add_new_variable.md
+++ b/docs/add_new_variable.md
@@ -52,23 +52,7 @@ DYNAMICAL_ENV=prod uv run main <DATASET_ID> backfill-kubernetes \
 
 ## 3. Validate
 
-Run the plotting tools and inspect the generated images in `data/output/<dataset-id>/`.
-
-```bash
-uv run src/scripts/validation/plots.py run-all <DATASET_URL>
-```
-
-Common issues to look out for:
-- Unexpected missing data (nulls/holes where you expect coverage).
-- Units vs values mismatch (e.g. mm/h vs mm/s).
-- Over-quantization (step changes in spatial or time series plots due to a too low `keep_mantissa_bits` value)
-- Time misalignment (e.g. diurnal cycle peaks shifted vs a reference dataset).
-
-Notes
-- `DATASET_URL` is the complete, direct URL to the dataset (`bucket-prefix/dataset-id/version`), e.g. `s3://us-west-2.opendata.source.coop/dynamical/ecmwf-ifs-ens-forecast-15-day-0-25-degree/v0.1.0.zarr` or `s3://dynamical-noaa-hrrr/noaa-hrrr-analysis/v0.1.0.icechunk`. The bucket prefix can be found in `__main__.py` and the dataset id and version in the `TemplateConfig.dataset_attributes`.
-- The spatial and timeseries plots will plot the data against a reference dataset (GEFS analysis by default) to highlight unexpected differences.
-- You can also run each validation plot individually, see `uv run src/scripts/validation/plots.py --help`.
-- You can add additional `--variable` flags if side by side plots help add context (e.g. show solar radiation alongside cloud cover).
+Follow [docs/validation.md](validation.md) — it walks through running `run-all`, reading `validation_summary.md`, inspecting every plot, and the full data quality checklist. When validating a new variable it is often useful to restrict with `--variable <name>` to iterate faster.
 
 ## 4. Update dataset catalog documentation
 

--- a/docs/dataset_integration_guide.md
+++ b/docs/dataset_integration_guide.md
@@ -142,23 +142,7 @@ The details here depend on the computing resources and the Zarr storage location
 
 ## 7. Validate
 
-Run the plotting tools and inspect the generated images in `data/output/<dataset-id>/`.
-
-```bash
-uv run src/scripts/validation/plots.py run-all <DATASET_URL>
-```
-
-Common issues to look out for:
-- Unexpected missing data (nulls/holes where you expect coverage).
-- Units vs values mismatch (e.g. mm/h vs mm/s).
-- Over-quantization (step changes in spatial or time series plots due to a too low `keep_mantissa_bits` value)
-- Time misalignment (e.g. diurnal cycle peaks shifted vs a reference dataset).
-
-Notes
-- `DATASET_URL` is the complete, direct URL to the dataset (`bucket-prefix/dataset-id/version`), e.g. `s3://us-west-2.opendata.source.coop/dynamical/ecmwf-ifs-ens-forecast-15-day-0-25-degree/v0.1.0.zarr` or `s3://dynamical-noaa-hrrr/noaa-hrrr-analysis/v0.1.0.icechunk`. The bucket prefix can be found in `__main__.py` and the dataset id and version in the `TemplateConfig.dataset_attributes`.
-- The spatial and timeseries plots will plot the data against a reference dataset (GEFS analysis by default) to highlight unexpected differences.
-- You can also run each validation plot individually, see `uv run src/scripts/validation/plots.py --help`.
-- You can add additional `--variable` flags if side by side plots help add context (e.g. show solar radiation alongside cloud cover).
+Follow [docs/validation.md](validation.md) — it walks through running `run-all`, reading `validation_summary.md`, inspecting every plot, and the full data quality checklist.
 
 ## 8. Update dataset catalog documentation
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,7 +2,7 @@
 
 Validate a reformatted dataset by producing and inspecting per-variable plots against a reference dataset. Use this after any backfill, after adding a new variable, or when investigating a regression.
 
-The tool is deliberately visual — read the images. Statistics alone cannot catch many of the most common data quality problems (flipped maps, coordinate-axis errors, land/sea edge artifacts, quantization banding, unit conversion bugs that only bite at certain lead times). Stats narrow your attention; images confirm correctness.
+The tool is deliberately visual – view the images. Statistics alone cannot catch many of the most common data quality problems (flipped maps, coordinate-axis errors, quantization banding, unit conversion bugs that only bite at certain lead times).
 
 ## 1. Run
 
@@ -12,7 +12,6 @@ uv run src/scripts/validation/plots.py run-all <DATASET_URL>
 
 `DATASET_URL` is the complete, direct URL to the dataset (`bucket-prefix/dataset-id/version`). Examples:
 
-- `s3://us-west-2.opendata.source.coop/dynamical/ecmwf-ifs-ens-forecast-15-day-0-25-degree/v0.1.0.zarr`
 - `s3://dynamical-noaa-hrrr/noaa-hrrr-analysis/v0.1.0.icechunk`
 - `s3://dynamical-dwd-icon-eu/dwd-icon-eu-forecast-5-day/v0.2.0.icechunk`
 
@@ -20,17 +19,17 @@ The bucket prefix can be found in `src/reformatters/__main__.py`. The dataset id
 
 Expect the run to take ~30–60 seconds per variable, mostly bounded by S3 reads (a ~20-variable dataset finishes in ~10–15 minutes). Progress is logged: one line per variable per plot type.
 
-When the run completes, stdout prints the path of `validation_summary.md` (relative to the repo root) — open that file first.
+When the run completes, stdout prints the path of `validation_summary.md` (relative to the repo root). Open that file first.
 
-### Useful options
+### Options
 
 - `--reference-url` Reference dataset for side-by-side comparison (default: NOAA GEFS analysis). Change if your dataset is outside the reference's temporal or spatial coverage. Variables not present in the reference still get validation-only plots and stats.
-- `--variable <name>` (repeatable, alias `-v`) Restrict to specific variables. Especially useful while iterating on a single new variable — brings total runtime down to under a minute.
+- `--variable <name>` (repeatable, alias `-v`) Restrict to specific variables. Especially useful while iterating on a single new variable — brings total runtime down to under a minute. To compare related variables side-by-side, pass `--variable` multiple times: `-v downward_short_wave_radiation_flux_surface -v total_cloud_cover_atmosphere`.
 - `--start-date <YYYY-MM-DD>` / `--end-date <YYYY-MM-DD>` Restrict the append dimension. Useful for reproducing an issue in a specific window.
 - `--init-time` / `--lead-time` (forecast) or `--time` (analysis) Pick the exact spatial snapshot instead of a random one. Use this to reproduce a spatial anomaly deterministically.
 - `--output-dir <path>` Write into an existing directory instead of a new one (useful if rerunning a single plot type into an existing run dir).
 
-You can also run a single plot type with `compare-spatial`, `compare-timeseries`, or `report-nulls`. `run-all` is the default workflow and is the only command that produces the `validation_summary.md` index.
+You can also run a single plot type with `compare-spatial`, `compare-timeseries`, or `report-nulls`. The primary entry point `run-all` runs all three of those steps and is the only command that produces the `validation_summary.md` index.
 
 ## 2. Output layout
 
@@ -52,9 +51,9 @@ The directory path itself is dense enough to identify the run: dataset id + vers
 
 ### What each plot type shows
 
-- **`nulls_<var>.png`** — null fraction over time at two spatial points. A flat line at 0 on both panels is the healthy outcome. Catches missing source files, partial writes, or a variable that's silently all-NaN at a subset of timestamps.
-- **`spatial_<var>.png`** — 3 panels at one time step: reference map (left), validation map (middle), value distribution histogram (right). If the variable isn't in the reference dataset, the left panel reads "Variable not available" and the histogram plots only the validation distribution. Catches flipped / rotated / mis-projected maps, wrong coordinate extents, and unit-scale mismatches (different histograms).
-- **`temporal_<var>.png`** — time series at two spatial points, validation (red) vs reference (blue). If the variable isn't in the reference, only the validation series is plotted. Catches time misalignment, diurnal-cycle phase errors, unit mismatches, and trend-level biases.
+- **`nulls_<var>.png`** — null fraction over time at two spatial points. A flat line at 0 on both panels is the healthy outcome. Catches missing source files, partial writes, or a variable that's silently all-NaN at a subset of timestamps. Missing data is expected for some variables; note the pattern.
+- **`spatial_<var>.png`** — 3 panels at one time step: reference map (left), validation map (middle), value distribution histogram (right). If the variable isn't in the reference dataset, the left panel reads "Variable not available" and the histogram plots only the validation distribution. Catches flipped / rotated / mis-projected maps, wrong coordinate extents, unit-scale mismatches (different histograms), and over-quantization (visible as banding).
+- **`temporal_<var>.png`** — time series at two spatial points, validation (red) vs reference (blue). If the variable isn't in the reference, only the validation series is plotted. Catches time misalignment, diurnal-cycle phase errors, unit mismatches, trend-level biases, missing/incorrect deaccumulation, and projection errors (uncorrelated / offset timeseries).
 - **`combined_*.png`** — every variable stacked into one tall image per plot type. Use these for a first scroll through the run (seeing multiple variables together helps spot cross-variable inconsistencies — e.g. radiation peaking while cloud cover is also high — and is fast to open in a single viewer). The per-variable PNGs are higher-resolution for detailed inspection.
 
 ### `validation_summary.md`
@@ -66,17 +65,15 @@ The entry point for every run. It contains, in order:
 - Links to the three `combined_*.png` images.
 - Missing-timestamp summary (count, pointer to `missing_timestamps.txt` if any were detected).
 - A variables table with nulls at the two points and links to the three per-variable images.
-- Per-variable details: metadata (units, long/short/standard name, step type), spatial + temporal min/max/mean for both validation **and reference**, and nulls.
-
-The summary is intentionally just data — no instructions. The review procedure lives here in `validation.md`.
+- Per-variable details: metadata (units, long/short/standard name, step type), spatial + temporal min/max/mean for both validation and reference, and nulls.
 
 ## 3. Step-by-step inspection
 
-Work in this order. Each step is cheap; together they catch the common failure modes.
+Work in this order.
 
-### 3a. Read `validation_summary.md` top to bottom
+### 3a. Read `validation_summary.md` entirely
 
-Open `validation_summary.md` first. It is structured to front-load the information that narrows where to look.
+Open `validation_summary.md` first. It provides text-based information which can help identify issues that are harder to view in plots.
 
 - [ ] **Datasets block**: confirm the validation dataset id + version match what you intend to review. Note the reference dataset and its time range — if the reference doesn't cover your validation window, temporal + spatial comparisons will be empty (expected, not a bug).
 - [ ] **Run parameters**: confirm the ensemble member (if any), the chosen spatial time (init/lead for forecasts), and the timeseries period. The spatial plot is a single snapshot — if you see something weird, you can pass `--init-time`/`--lead-time`/`--time` to reproduce deterministically.
@@ -90,8 +87,8 @@ Statistics miss the visual failure modes. Open the images and walk through the c
 
 A good working rhythm:
 
-1. Open the three `combined_*.png` files first. Scroll through each to get a gestalt view of all variables together — this quickly surfaces patterns across variables (e.g. radiation peaks coinciding with cloud cover minima) and spots any variable that looks dramatically off relative to its neighbors.
-2. For each variable that looked fine in combined or that you want to inspect more closely, open `nulls_<var>.png`, `spatial_<var>.png`, and `temporal_<var>.png`. The per-variable PNGs are higher-resolution. Filenames are consistent, so a pattern like `spatial_*.png` opens all of them at once in most viewers.
+1. Open the three `combined_*.png` files first. Scroll through each to get an overview of all variables together — this quickly surfaces patterns across variables (e.g. radiation peaks coinciding with cloud cover minima) and spots any variable that looks dramatically off relative to its neighbors.
+2. For each variable that looked fine in combined or that you want to inspect more closely, open `nulls_<var>.png`, `spatial_<var>.png`, and `temporal_<var>.png`. The per-variable PNGs are higher-resolution. Filenames are consistent, so a pattern like `*_<var>.png` opens all of them at once in most viewers.
 3. Cross-check against the variable's row in `validation_summary.md` (units, long_name, stats).
 4. Apply the checklist below. Note anomalies as `<variable> + <file> + what's wrong` so they can be acted on.
 
@@ -103,22 +100,25 @@ For any anomaly, reproduce it deterministically so a fix can be verified:
 - If temporal: the timeseries period is randomized — it's in `validation_summary.md`. Narrow with `--start-date` / `--end-date`.
 - If nulls: use the `retry-filter:` line in `missing_timestamps.txt` to backfill just those timestamps.
 
+### 3d. Update `validation_summary.md`
+
+When your review is complete, update `validation_summary.md` with notable findings. Insert a `## Summary` section at the top of the file containing two subsections: `### For further review` (definite and possible issues, each with a link to the image(s) where the issue is apparent) and `### What looks good` (a brief summary).
+
 ## 4. Data quality checklist
 
-Look for each of these in every image. They are ordered from "structural problem" (wrong data altogether) to "subtle problem" (wrong-but-plausible values).
+Look for each of these in every image.
 
 ### Geometry and coordinates (from `spatial_<var>.png`)
 
 - [ ] **Map is oriented correctly.** North at the top, east on the right. If the reference map shows a continent and the validation map shows its mirror image or upside-down copy, data and coordinates are out of sync (`pcolormesh` is getting a flipped latitude or longitude axis relative to the data array).
-- [ ] **Longitude axis goes −180 → +180 with east on the right.** If there's a vertical seam in the middle of the map, the data likely uses a 0–360 convention and needs conversion. If features are shifted 180° east/west, the longitude convention is wrong.
+- [ ] **Longitude axis is increasing with east on the right.** If there's a vertical seam in the middle of the map, the data likely uses a 0–360 convention and needs conversion. If features are shifted 180° east/west, the longitude convention is wrong. We expect global datasets to go from −180 to +180 (not 0–360).
 - [ ] **Coastlines/land features land at expected coordinates.** Locate a known landmark (e.g. the UK, Italy, the Great Lakes, southern Africa). Verify it sits at the correct lat/lon in the validation map. If it's shifted, the coordinate arrays are offset relative to the data array (off-by-one, wrong origin, or wrong grid spacing).
-- [ ] **No rotation / shearing artifacts.** Projected grids reprojected to lat/lon should still show straight horizontal coastlines. Diagonal "staircase" edges suggest a bad reprojection or a swap of `y`/`x` axes.
 - [ ] **Spatial extent matches the declared grid.** Domain bounds in the plot should match what the dataset's `TemplateConfig` declares. An extent truncation or overshoot means the coordinates or slicing is wrong.
 
 ### Values (from `spatial_<var>.png` histogram and `validation_summary.md` stats)
 
 - [ ] **Validation histogram overlaps the reference histogram** for variables that are also in the reference dataset. A large horizontal offset is a unit or scale bug. A large width difference is a quantization or smoothing bug.
-- [ ] **Validation min/max is physically plausible.** Temperature in K should roughly be 220–320; in °C roughly −50 to +50. Pressure in Pa is ~50000–110000; in hPa ~500–1100. Precipitation rate mm/s is tiny (10⁻⁵); mm/h is 0–50. Wind speed m/s is 0–100; kt is different. Check `units` in `validation_summary.md` vs observed range.
+- [ ] **Validation min/max is physically plausible.** Temperature in °C roughly −50 to +50. Pressure in Pa is ~50000–110000. Precipitation rate mm/s is tiny (10⁻⁵). Wind speed m/s is 0–100. Check `units` in `validation_summary.md` vs observed range.
 - [ ] **No obvious quantization banding in the spatial map.** Large flat patches of identical values or "staircasing" in smooth gradients indicates `keep_mantissa_bits` is too low.
 - [ ] **No suspicious sentinel values showing through.** Values like 9999 / -9999 / 32767 / 1e20 appearing as a color extreme mean a source nodata value was not translated to NaN.
 
@@ -131,25 +131,14 @@ Look for each of these in every image. They are ordered from "structural problem
 
 ### Missing data (from `nulls_<var>.png` and `missing_timestamps.txt`)
 
-- [ ] **Null fraction is 0 or explained.** Any non-zero null fraction should have a reason: known source outage, ocean point for a land-only variable. Unexplained nulls are the bug.
+- [ ] **Null fraction is 0 or explained.** Any non-zero null fraction should have a reason: source data unavailable before a date for a specific variable, known source outage, ocean point for a land-only variable. Unexplained nulls are the bug.
 - [ ] **Missing pattern is not structural.** Nulls concentrated at specific lead times, specific hours of day, or specific forecast cycles suggest a processing or indexing bug, not a random source outage.
 
 Note on `step_type` ≠ `instant` variables (accumulation / average / max): the first lead time of each forecast is structurally NaN (there is no prior window to accumulate/average over). The tool excludes that slice from the null count and from `missing_timestamps.txt`, so a "0 / N nulls — none" line for an accumulated variable means *no unexpected* nulls — the structural analysis-step NaN is not counted.
+
+For a sampling of unexplained nulls, go manually fetch source data files and inspect them. Do they have the data we expect, or is the data really not available at the source?
 
 ### Cross-dataset checks
 
 - [ ] **Reference availability.** If the reference dataset doesn't cover your window, `validation_summary.md` will show `variable not available in reference dataset` — that is not a bug in the validation dataset, but spatial / temporal comparisons lose their signal. Consider a different reference or re-run on a time range the reference covers.
 - [ ] **Ensemble member is plausible.** For ensemble datasets `validation_summary.md` records the randomly-selected member. Rerun once more to confirm that a different member also looks right.
-
-## 5. Tips
-
-- Running `run-all` is cheap compared to a backfill — rerun freely while iterating.
-- To side-by-side two related variables (e.g. solar radiation alongside cloud cover), pass `--variable` twice: `-v downward_short_wave_radiation_flux_surface -v total_cloud_cover_atmosphere`.
-- Each run goes into a fresh timestamped directory, so previous runs are preserved for before/after comparison.
-
-## 6. When you're done
-
-Walk back through the anomalies you noted. For each one, either:
-
-- File or reference an issue with a reproduction command (`run-all --variable X --init-time T --lead-time H`), or
-- Fix the underlying code, rerun `run-all`, and confirm the anomaly is gone in the new run directory (the previous directory is preserved for comparison).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,155 @@
+# Dataset validation
+
+Validate a reformatted dataset by producing and inspecting per-variable plots against a reference dataset. Use this after any backfill, after adding a new variable, or when investigating a regression.
+
+The tool is deliberately visual — read the images. Statistics alone cannot catch many of the most common data quality problems (flipped maps, coordinate-axis errors, land/sea edge artifacts, quantization banding, unit conversion bugs that only bite at certain lead times). Stats narrow your attention; images confirm correctness.
+
+## 1. Run
+
+```bash
+uv run src/scripts/validation/plots.py run-all <DATASET_URL>
+```
+
+`DATASET_URL` is the complete, direct URL to the dataset (`bucket-prefix/dataset-id/version`). Examples:
+
+- `s3://us-west-2.opendata.source.coop/dynamical/ecmwf-ifs-ens-forecast-15-day-0-25-degree/v0.1.0.zarr`
+- `s3://dynamical-noaa-hrrr/noaa-hrrr-analysis/v0.1.0.icechunk`
+- `s3://dynamical-dwd-icon-eu/dwd-icon-eu-forecast-5-day/v0.2.0.icechunk`
+
+The bucket prefix can be found in `src/reformatters/__main__.py`. The dataset id and version are in the `TemplateConfig.dataset_attributes`.
+
+Expect the run to take ~30–60 seconds per variable, mostly bounded by S3 reads (a ~20-variable dataset finishes in ~10–15 minutes). Progress is logged: one line per variable per plot type.
+
+When the run completes, stdout prints the path of `validation_summary.md` (relative to the repo root) — open that file first.
+
+### Useful options
+
+- `--reference-url` Reference dataset for side-by-side comparison (default: NOAA GEFS analysis). Change if your dataset is outside the reference's temporal or spatial coverage. Variables not present in the reference still get validation-only plots and stats.
+- `--variable <name>` (repeatable, alias `-v`) Restrict to specific variables. Especially useful while iterating on a single new variable — brings total runtime down to under a minute.
+- `--start-date <YYYY-MM-DD>` / `--end-date <YYYY-MM-DD>` Restrict the append dimension. Useful for reproducing an issue in a specific window.
+- `--init-time` / `--lead-time` (forecast) or `--time` (analysis) Pick the exact spatial snapshot instead of a random one. Use this to reproduce a spatial anomaly deterministically.
+- `--output-dir <path>` Write into an existing directory instead of a new one (useful if rerunning a single plot type into an existing run dir).
+
+You can also run a single plot type with `compare-spatial`, `compare-timeseries`, or `report-nulls`. `run-all` is the default workflow and is the only command that produces the `validation_summary.md` index.
+
+## 2. Output layout
+
+Each run writes to a fresh directory under `data/output/`:
+
+```
+data/output/<dataset-id>/<version>_<YYYY-MM-DDTHH-MM>/
+├── validation_summary.md           # start here
+├── combined_nulls.png              # all variables, one image
+├── combined_spatial.png            # all variables, one image
+├── combined_temporal.png           # all variables, one image
+├── nulls_<var>.png                 # one per variable
+├── spatial_<var>.png               # one per variable
+├── temporal_<var>.png              # one per variable
+└── missing_timestamps.txt          # only if any nulls were detected
+```
+
+The directory path itself is dense enough to identify the run: dataset id + version + minute-precision timestamp. Multiple runs of the same dataset group under a shared `<dataset-id>/` parent.
+
+### What each plot type shows
+
+- **`nulls_<var>.png`** — null fraction over time at two spatial points. A flat line at 0 on both panels is the healthy outcome. Catches missing source files, partial writes, or a variable that's silently all-NaN at a subset of timestamps.
+- **`spatial_<var>.png`** — 3 panels at one time step: reference map (left), validation map (middle), value distribution histogram (right). If the variable isn't in the reference dataset, the left panel reads "Variable not available" and the histogram plots only the validation distribution. Catches flipped / rotated / mis-projected maps, wrong coordinate extents, and unit-scale mismatches (different histograms).
+- **`temporal_<var>.png`** — time series at two spatial points, validation (red) vs reference (blue). If the variable isn't in the reference, only the validation series is plotted. Catches time misalignment, diurnal-cycle phase errors, unit mismatches, and trend-level biases.
+- **`combined_*.png`** — every variable stacked into one tall image per plot type. Use these for a first scroll through the run (seeing multiple variables together helps spot cross-variable inconsistencies — e.g. radiation peaking while cloud cover is also high — and is fast to open in a single viewer). The per-variable PNGs are higher-resolution for detailed inspection.
+
+### `validation_summary.md`
+
+The entry point for every run. It contains, in order:
+
+- Validation and reference dataset identity (name, id, version, URL), time ranges, and scope.
+- Run parameters (ensemble member, spatial points, chosen init/lead/time for the spatial plot, timeseries period).
+- Links to the three `combined_*.png` images.
+- Missing-timestamp summary (count, pointer to `missing_timestamps.txt` if any were detected).
+- A variables table with nulls at the two points and links to the three per-variable images.
+- Per-variable details: metadata (units, long/short/standard name, step type), spatial + temporal min/max/mean for both validation **and reference**, and nulls.
+
+The summary is intentionally just data — no instructions. The review procedure lives here in `validation.md`.
+
+## 3. Step-by-step inspection
+
+Work in this order. Each step is cheap; together they catch the common failure modes.
+
+### 3a. Read `validation_summary.md` top to bottom
+
+Open `validation_summary.md` first. It is structured to front-load the information that narrows where to look.
+
+- [ ] **Datasets block**: confirm the validation dataset id + version match what you intend to review. Note the reference dataset and its time range — if the reference doesn't cover your validation window, temporal + spatial comparisons will be empty (expected, not a bug).
+- [ ] **Run parameters**: confirm the ensemble member (if any), the chosen spatial time (init/lead for forecasts), and the timeseries period. The spatial plot is a single snapshot — if you see something weird, you can pass `--init-time`/`--lead-time`/`--time` to reproduce deterministically.
+- [ ] **Missing timestamps**: if any, open `missing_timestamps.txt`. The file lists exact timestamps by (variable, point) and provides a ready-to-paste `--filter-contains` argument string for a targeted backfill retry.
+- [ ] **Variables overview table**: scan the null counts. Unexpected non-zero values are your first lead.
+- [ ] **Per-variable details**: for each variable, compare validation stats to reference stats. Validation min/max that is orders of magnitude off from the reference is a near-certain unit mismatch.
+
+### 3b. Read every PNG — do not skip this
+
+Statistics miss the visual failure modes. Open the images and walk through the checklist in section 4.
+
+A good working rhythm:
+
+1. Open the three `combined_*.png` files first. Scroll through each to get a gestalt view of all variables together — this quickly surfaces patterns across variables (e.g. radiation peaks coinciding with cloud cover minima) and spots any variable that looks dramatically off relative to its neighbors.
+2. For each variable that looked fine in combined or that you want to inspect more closely, open `nulls_<var>.png`, `spatial_<var>.png`, and `temporal_<var>.png`. The per-variable PNGs are higher-resolution. Filenames are consistent, so a pattern like `spatial_*.png` opens all of them at once in most viewers.
+3. Cross-check against the variable's row in `validation_summary.md` (units, long_name, stats).
+4. Apply the checklist below. Note anomalies as `<variable> + <file> + what's wrong` so they can be acted on.
+
+### 3c. Investigate anomalies
+
+For any anomaly, reproduce it deterministically so a fix can be verified:
+
+- If spatial: rerun `run-all` with `--variable <name> --init-time <t> --lead-time <h>` (forecast) or `--time <t>` (analysis).
+- If temporal: the timeseries period is randomized — it's in `validation_summary.md`. Narrow with `--start-date` / `--end-date`.
+- If nulls: use the `retry-filter:` line in `missing_timestamps.txt` to backfill just those timestamps.
+
+## 4. Data quality checklist
+
+Look for each of these in every image. They are ordered from "structural problem" (wrong data altogether) to "subtle problem" (wrong-but-plausible values).
+
+### Geometry and coordinates (from `spatial_<var>.png`)
+
+- [ ] **Map is oriented correctly.** North at the top, east on the right. If the reference map shows a continent and the validation map shows its mirror image or upside-down copy, data and coordinates are out of sync (`pcolormesh` is getting a flipped latitude or longitude axis relative to the data array).
+- [ ] **Longitude axis goes −180 → +180 with east on the right.** If there's a vertical seam in the middle of the map, the data likely uses a 0–360 convention and needs conversion. If features are shifted 180° east/west, the longitude convention is wrong.
+- [ ] **Coastlines/land features land at expected coordinates.** Locate a known landmark (e.g. the UK, Italy, the Great Lakes, southern Africa). Verify it sits at the correct lat/lon in the validation map. If it's shifted, the coordinate arrays are offset relative to the data array (off-by-one, wrong origin, or wrong grid spacing).
+- [ ] **No rotation / shearing artifacts.** Projected grids reprojected to lat/lon should still show straight horizontal coastlines. Diagonal "staircase" edges suggest a bad reprojection or a swap of `y`/`x` axes.
+- [ ] **Spatial extent matches the declared grid.** Domain bounds in the plot should match what the dataset's `TemplateConfig` declares. An extent truncation or overshoot means the coordinates or slicing is wrong.
+
+### Values (from `spatial_<var>.png` histogram and `validation_summary.md` stats)
+
+- [ ] **Validation histogram overlaps the reference histogram** for variables that are also in the reference dataset. A large horizontal offset is a unit or scale bug. A large width difference is a quantization or smoothing bug.
+- [ ] **Validation min/max is physically plausible.** Temperature in K should roughly be 220–320; in °C roughly −50 to +50. Pressure in Pa is ~50000–110000; in hPa ~500–1100. Precipitation rate mm/s is tiny (10⁻⁵); mm/h is 0–50. Wind speed m/s is 0–100; kt is different. Check `units` in `validation_summary.md` vs observed range.
+- [ ] **No obvious quantization banding in the spatial map.** Large flat patches of identical values or "staircasing" in smooth gradients indicates `keep_mantissa_bits` is too low.
+- [ ] **No suspicious sentinel values showing through.** Values like 9999 / -9999 / 32767 / 1e20 appearing as a color extreme mean a source nodata value was not translated to NaN.
+
+### Time alignment (from `temporal_<var>.png`)
+
+- [ ] **Diurnal cycle is in phase with the reference.** Shortwave radiation, 2m temperature, and similar variables should peak at the same local hour as the reference. Phase-shift is a time-coordinate bug (e.g. UTC vs local, or off-by-one lead time).
+- [ ] **Trend magnitudes match.** The validation and reference should have similar day-to-day ranges. A consistent offset points to a calibration or unit issue; a consistent scale difference points to a unit conversion.
+- [ ] **No unexpected flatlines or spikes.** Flatlines at one value for many steps can be a read error or a stuck sentinel; isolated spikes can be unit bugs at specific lead times (common in accumulated variables).
+- [ ] **Accumulated variables reset as expected.** Precipitation and radiation accumulators should typically reset each forecast — check the `step_type` in `validation_summary.md` and confirm the shape.
+
+### Missing data (from `nulls_<var>.png` and `missing_timestamps.txt`)
+
+- [ ] **Null fraction is 0 or explained.** Any non-zero null fraction should have a reason: known source outage, ocean point for a land-only variable. Unexplained nulls are the bug.
+- [ ] **Missing pattern is not structural.** Nulls concentrated at specific lead times, specific hours of day, or specific forecast cycles suggest a processing or indexing bug, not a random source outage.
+
+Note on `step_type` ≠ `instant` variables (accumulation / average / max): the first lead time of each forecast is structurally NaN (there is no prior window to accumulate/average over). The tool excludes that slice from the null count and from `missing_timestamps.txt`, so a "0 / N nulls — none" line for an accumulated variable means *no unexpected* nulls — the structural analysis-step NaN is not counted.
+
+### Cross-dataset checks
+
+- [ ] **Reference availability.** If the reference dataset doesn't cover your window, `validation_summary.md` will show `variable not available in reference dataset` — that is not a bug in the validation dataset, but spatial / temporal comparisons lose their signal. Consider a different reference or re-run on a time range the reference covers.
+- [ ] **Ensemble member is plausible.** For ensemble datasets `validation_summary.md` records the randomly-selected member. Rerun once more to confirm that a different member also looks right.
+
+## 5. Tips
+
+- Running `run-all` is cheap compared to a backfill — rerun freely while iterating.
+- To side-by-side two related variables (e.g. solar radiation alongside cloud cover), pass `--variable` twice: `-v downward_short_wave_radiation_flux_surface -v total_cloud_cover_atmosphere`.
+- Each run goes into a fresh timestamped directory, so previous runs are preserved for before/after comparison.
+
+## 6. When you're done
+
+Walk back through the anomalies you noted. For each one, either:
+
+- File or reference an issue with a reproduction command (`run-all --variable X --init-time T --lead-time H`), or
+- Fix the underlying code, rerun `run-all`, and confirm the anomaly is gone in the new run directory (the previous directory is preserved for comparison).

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
@@ -120,7 +120,6 @@ class DwdIconEuForecast5DayRegionJob(
         lead_times = pd.to_timedelta(processing_region_ds["lead_time"].values)
         data_var = item(data_var_group)
 
-        # Sanity checks
         assert len(init_times) > 0
         assert len(lead_times) > 0
 

--- a/src/scripts/validation/compare_spatial.py
+++ b/src/scripts/validation/compare_spatial.py
@@ -1,19 +1,27 @@
+from pathlib import Path
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import typer
 import xarray as xr
 import zarr
+from matplotlib.axes import Axes
 
 from reformatters.common.logging import get_logger
 from reformatters.common.time_utils import whole_hours
 from scripts.validation.utils import (
+    RunContext,
+    VariableStats,
     end_date_option,
-    get_output_filepath,
+    get_two_random_points,
     is_forecast_dataset,
     load_zarr_dataset,
+    output_dir_option,
+    resolve_output_dir,
     scope_time_period,
     select_random_ensemble_member,
+    select_variables_for_plotting,
     start_date_option,
     variables_option,
 )
@@ -38,78 +46,36 @@ def align_to_valid_time_forecast(
     init_time: str | None,
     lead_time: str | None,
 ) -> tuple[xr.Dataset, xr.Dataset]:
-    """Align forecast dataset to reference dataset by selecting init_time/lead_time."""
     rng = np.random.default_rng()
 
-    if init_time is None:
-        selected_init_time = pd.Timestamp(rng.choice(ds.init_time, 1)[0])
-    else:
-        selected_init_time = pd.Timestamp(init_time)
-
-    if lead_time is None:
-        selected_lead_time = rng.choice(ds.lead_time, 1)[0]
-    else:
-        selected_lead_time = lead_time
-
-    ds = ds.sel(
-        init_time=selected_init_time,
-        lead_time=selected_lead_time,
+    selected_init_time = (
+        pd.Timestamp(rng.choice(ds.init_time, 1)[0])
+        if init_time is None
+        else pd.Timestamp(init_time)
+    )
+    selected_lead_time = (
+        rng.choice(ds.lead_time, 1)[0] if lead_time is None else lead_time
     )
 
+    ds = ds.sel(init_time=selected_init_time, lead_time=selected_lead_time)
     valid_time = pd.Timestamp(ds.valid_time.item())
-
     reference_ds = reference_ds.sel(time=valid_time, method="nearest")
     return ds, reference_ds
 
 
 def align_to_valid_time_analysis(
-    ds: xr.Dataset,
-    reference_ds: xr.Dataset,
-    time: str | None,
+    ds: xr.Dataset, reference_ds: xr.Dataset, time: str | None
 ) -> tuple[xr.Dataset, xr.Dataset]:
-    """Align analysis dataset to reference dataset by selecting a time."""
     rng = np.random.default_rng()
-
-    if time is None:
-        selected_time = pd.Timestamp(rng.choice(ds.time, 1)[0])
-    else:
-        selected_time = pd.Timestamp(time)
-
+    selected_time = (
+        pd.Timestamp(rng.choice(ds.time, 1)[0]) if time is None else pd.Timestamp(time)
+    )
     ds = ds.sel(time=selected_time)
     reference_ds = reference_ds.sel(time=selected_time, method="nearest")
     return ds, reference_ds
 
 
-def create_comparison_plot(  # noqa: PLR0915 PLR0912
-    validation_ds: xr.Dataset,
-    reference_ds: xr.Dataset,
-    variables: list[str],
-    validation_url: str,
-    ensemble_member: int | None = None,
-    init_time: str | None = None,
-    lead_time: str | None = None,
-    time: str | None = None,
-) -> None:
-    """Create comparison plot matching the example image format"""
-    is_forecast = is_forecast_dataset(validation_ds)
-
-    # Align datasets to a common time point (done once for all variables)
-    if is_forecast:
-        ds, ref_ds = align_to_valid_time_forecast(
-            validation_ds,
-            reference_ds,
-            init_time,
-            lead_time,
-        )
-    else:
-        ds, ref_ds = align_to_valid_time_analysis(
-            validation_ds,
-            reference_ds,
-            time,
-        )
-
-    # Downsample high-resolution spatial data for plotting efficiency
-    max_plot_dim = 1000
+def _downsample_for_plot(ds: xr.Dataset, max_plot_dim: int = 1000) -> xr.Dataset:
     strides: dict[str, int] = {}
     for dim in ("latitude", "longitude", "y", "x"):
         if dim in ds.dims and ds.sizes[dim] > max_plot_dim:
@@ -118,209 +84,271 @@ def create_comparison_plot(  # noqa: PLR0915 PLR0912
         ds = ds.isel(
             {dim: slice(None, None, stride) for dim, stride in strides.items()}
         )
-        log.info(f"Downsampled validation data with strides {strides} for plotting")
+    return ds
 
-    # Format timestamps for titles (done once for all variables)
+
+def _format_spatial_time_label(ds: xr.Dataset, is_forecast: bool) -> str:
     if is_forecast:
-        ds_init_time = pd.Timestamp(ds.init_time.item()).strftime("%Y-%m-%dT%H:%M")
-        ds_lead_time_hours = whole_hours(pd.Timedelta(ds.lead_time.item()))
-        ds_lead_time_str = f"{ds_lead_time_hours:g}h"
-        ds_time = f"{ds_init_time}+{ds_lead_time_str}"
-    else:
-        ds_time = pd.Timestamp(ds.time.item()).strftime("%Y-%m-%dT%H:%M")
-    ref_time = pd.Timestamp(ref_ds.time.item()).strftime("%Y-%m-%dT%H:%M")
+        init_str = pd.Timestamp(ds.init_time.item()).strftime("%Y-%m-%dT%H:%M")
+        lead_hours = whole_hours(pd.Timedelta(ds.lead_time.item()))
+        return f"init={init_str}, lead={lead_hours:g}h"
+    return pd.Timestamp(ds.time.item()).strftime("%Y-%m-%dT%H:%M")
 
-    n_vars = len(variables)
-    plt.figure(figsize=(15, 3 * n_vars))
 
-    for i, var in enumerate(variables):
-        # Get validation data array
-        data = ds[var].load()
-
-        # Check if variable exists in reference dataset
-        var_in_reference = var in reference_ds.data_vars
-
-        if var_in_reference:
-            ref_data = ref_ds[var].load()
-            vmin = min(float(data.min()), float(ref_data.min()))
-            vmax = max(float(data.max()), float(ref_data.max()))
-        else:
-            vmin = float(data.min())
-            vmax = float(data.max())
-
-        if var_in_reference:
-            log.info(
-                f"Plotting {var} for {ds.attrs['name']} ({ds_time}) and {ref_ds.attrs['name']} ({ref_time})"
-            )
-        else:
-            log.info(
-                f"Plotting {var} for {ds.attrs['name']} ({ds_time}) - variable not found in reference dataset"
-            )
-
-        ds_title = f"{ds.attrs['name']}"
-        if ensemble_member is not None:
-            ds_title += f" (Ensemble Member {ensemble_member})"
-        ds_title += f" - {var}\n{ds_time}"
-
-        if var_in_reference:
-            ref_title = f"{ref_ds.attrs['name']} - {var}\n{ref_time}"
-        else:
-            ref_title = f"{ref_ds.attrs['name']} - {var}\n(Variable not available)"
-
-        # Left plot - reference dataset (or empty if variable doesn't exist)
-        ax1 = plt.subplot(n_vars, 3, i * 3 + 1)
-
-        if var_in_reference:
-            im1 = ax1.pcolormesh(
-                ref_data.longitude,  # ty: ignore[possibly-unresolved-reference]
-                ref_data.latitude,  # ty: ignore[possibly-unresolved-reference]
-                ref_data.values,  # ty: ignore[possibly-unresolved-reference]
-                vmin=vmin,
-                vmax=vmax,
-            )
-            plt.colorbar(im1, ax=ax1)
-
-            # Use combined bounds from both datasets for consistent axis ranges
-            lon_min = min(float(ref_data.longitude.min()), float(data.longitude.min()))  # ty: ignore[possibly-unresolved-reference]
-            lon_max = max(float(ref_data.longitude.max()), float(data.longitude.max()))  # ty: ignore[possibly-unresolved-reference]
-            lat_min = min(float(ref_data.latitude.min()), float(data.latitude.min()))  # ty: ignore[possibly-unresolved-reference]
-            lat_max = max(float(ref_data.latitude.max()), float(data.latitude.max()))  # ty: ignore[possibly-unresolved-reference]
-        else:
-            # Show empty plot for missing variable
-            ax1.text(
-                0.5,
-                0.5,
-                "Variable not\navailable in\nreference dataset",
-                ha="center",
-                va="center",
-                transform=ax1.transAxes,
-                fontsize=12,
-                color="gray",
-            )
-            ax1.set_xlim(0, 1)
-            ax1.set_ylim(0, 1)
-
-            # Use validation dataset bounds when reference doesn't have the variable
-            lon_min = float(data.longitude.min())
-            lon_max = float(data.longitude.max())
-            lat_min = float(data.latitude.min())
-            lat_max = float(data.latitude.max())
-
-        ax1.set_title(ref_title)
-        ax1.set_aspect("auto")
-        ax1.set_xlabel("Longitude")
-        ax1.set_ylabel("Latitude")
-
-        # Middle plot - validation dataset
-        ax2 = plt.subplot(n_vars, 3, i * 3 + 2)
-        im2 = ax2.pcolormesh(
-            data.longitude,
-            data.latitude,
-            data.values,
-            vmin=vmin,
-            vmax=vmax,
+def _compute_spatial_stats(
+    data: xr.DataArray, ref_data: xr.DataArray | None, stats: VariableStats
+) -> tuple[np.ndarray, np.ndarray]:
+    """Update stats and return (data_clean, ref_clean) flattened arrays."""
+    data_clean = data.values.flat[~np.isnan(data.values.flat)]
+    if data_clean.size == 0:
+        stats.val_spatial_min = stats.val_spatial_max = stats.val_spatial_mean = float(
+            "nan"
         )
-        plt.colorbar(im2, ax=ax2)
-        ax2.set_title(ds_title)
-        ax2.set_aspect("auto")
-        ax2.set_xlabel("Longitude")
-        ax2.set_ylabel("Latitude")
+    else:
+        stats.val_spatial_min = float(np.min(data_clean))
+        stats.val_spatial_max = float(np.max(data_clean))
+        stats.val_spatial_mean = float(np.mean(data_clean))
 
-        ax2.set_xlim(lon_min, lon_max)
-        ax2.set_ylim(lat_min, lat_max)
+    if ref_data is not None:
+        ref_clean = ref_data.values.flat[~np.isnan(ref_data.values.flat)]
+        stats.ref_available_spatial = True
+        if ref_clean.size:
+            stats.ref_spatial_min = float(np.min(ref_clean))
+            stats.ref_spatial_max = float(np.max(ref_clean))
+            stats.ref_spatial_mean = float(np.mean(ref_clean))
+    else:
+        ref_clean = np.array([])
+        stats.ref_available_spatial = False
 
-        # Right plot - histogram comparison
-        ax3 = plt.subplot(n_vars, 3, i * 3 + 3)
+    return data_clean, ref_clean
 
-        # Flatten validation data and remove NaN values in one step
-        data_values_flat = data.values.flat
-        data_clean = data_values_flat[~np.isnan(data_values_flat)]
 
-        if len(data_clean) == 0:
-            ax3.text(
-                0.5,
-                0.5,
-                "All data in validated\ndataset is nan at this step",
-                ha="center",
-                va="center",
-                transform=ax3.transAxes,
-                fontsize=12,
-                color="gray",
-            )
-            ax1.set_xlim(0, 1)
-            ax1.set_ylim(0, 1)
-            continue
+def _draw_spatial_triplet(
+    ax_ref: Axes,
+    ax_val: Axes,
+    ax_hist: Axes,
+    var: str,
+    data: xr.DataArray,
+    ref_data: xr.DataArray | None,
+    data_clean: np.ndarray,
+    ref_clean: np.ndarray,
+    units: str | None,
+    ds_title: str,
+    ref_title: str,
+) -> None:
+    """Draw reference map, validation map, and histogram onto provided axes."""
+    if ref_data is not None:
+        vmin = min(float(data.min()), float(ref_data.min()))
+        vmax = max(float(data.max()), float(ref_data.max()))
+    else:
+        vmin = float(data.min()) if data_clean.size else 0.0
+        vmax = float(data.max()) if data_clean.size else 1.0
 
-        if var_in_reference and not np.isnan(ref_data.values).all():  # ty: ignore[possibly-unresolved-reference]
-            # Include reference data in histogram if available
-            ref_values_flat = ref_data.values.flat  # ty: ignore[possibly-unresolved-reference]
-            ref_clean = ref_values_flat[~np.isnan(ref_values_flat)]
+    # Reference map
+    if ref_data is not None:
+        im1 = ax_ref.pcolormesh(
+            ref_data.longitude, ref_data.latitude, ref_data.values, vmin=vmin, vmax=vmax
+        )
+        plt.colorbar(im1, ax=ax_ref, label=units or "")
+        lon_min = min(float(ref_data.longitude.min()), float(data.longitude.min()))
+        lon_max = max(float(ref_data.longitude.max()), float(data.longitude.max()))
+        lat_min = min(float(ref_data.latitude.min()), float(data.latitude.min()))
+        lat_max = max(float(ref_data.latitude.max()), float(data.latitude.max()))
+    else:
+        ax_ref.text(
+            0.5,
+            0.5,
+            "Variable not\navailable in\nreference dataset",
+            ha="center",
+            va="center",
+            transform=ax_ref.transAxes,
+            fontsize=12,
+            color="gray",
+        )
+        lon_min = float(data.longitude.min())
+        lon_max = float(data.longitude.max())
+        lat_min = float(data.latitude.min())
+        lat_max = float(data.latitude.max())
+    ax_ref.set_title(ref_title, fontsize=10)
+    ax_ref.set_aspect("auto")
+    ax_ref.set_xlabel("Longitude")
+    ax_ref.set_ylabel("Latitude")
 
-            # Calculate combined range for consistent bins
-            data_min, data_max = (
-                min(np.min(data_clean), np.min(ref_clean)),
-                max(np.max(data_clean), np.max(ref_clean)),
-            )
+    # Validation map
+    im2 = ax_val.pcolormesh(
+        data.longitude, data.latitude, data.values, vmin=vmin, vmax=vmax
+    )
+    plt.colorbar(im2, ax=ax_val, label=units or "")
+    ax_val.set_title(ds_title, fontsize=10)
+    ax_val.set_aspect("auto")
+    ax_val.set_xlabel("Longitude")
+    ax_val.set_ylabel("Latitude")
+    ax_val.set_xlim(lon_min, lon_max)
+    ax_val.set_ylim(lat_min, lat_max)
 
-            # Create histograms with consistent bins
-            ax3.hist(
-                ref_clean,
-                bins=40,
-                alpha=0.7,
-                label=ref_ds.attrs["name"],
-                color="blue",
-                range=(data_min, data_max),
-                density=True,
-                stacked=True,
-            )
-        else:
-            # Only validation data available
-            data_min, data_max = np.min(data_clean), np.max(data_clean)
+    # Histogram
+    if data_clean.size == 0:
+        ax_hist.text(
+            0.5,
+            0.5,
+            "All validation data is\nNaN at this step",
+            ha="center",
+            va="center",
+            transform=ax_hist.transAxes,
+            fontsize=12,
+            color="gray",
+        )
+        return
 
-        ax3.hist(
-            data_clean,
+    if ref_data is not None and ref_clean.size:
+        data_min = min(np.min(data_clean), np.min(ref_clean))
+        data_max = max(np.max(data_clean), np.max(ref_clean))
+        ax_hist.hist(
+            ref_clean,
             bins=40,
             alpha=0.7,
-            label=ds.attrs["name"],
-            color="red",
+            label=ref_title.splitlines()[0] if ref_title else "reference",
+            color="blue",
             range=(data_min, data_max),
             density=True,
             stacked=True,
         )
+    else:
+        data_min = float(np.min(data_clean))
+        data_max = float(np.max(data_clean))
 
-        # Set x-axis limits to match the data range (only if there's actual range)
-        if data_min != data_max:
-            ax3.set_xlim(data_min, data_max)
+    ax_hist.hist(
+        data_clean,
+        bins=40,
+        alpha=0.7,
+        label=ds_title.splitlines()[0] if ds_title else "validation",
+        color="red",
+        range=(data_min, data_max),
+        density=True,
+        stacked=True,
+    )
+    if data_min != data_max:
+        ax_hist.set_xlim(data_min, data_max)
+    ax_hist.set_xlabel(f"{var}" + (f" [{units}]" if units else ""))
+    ax_hist.set_ylabel("Density")
+    ax_hist.set_title(f"Distribution — {var}", fontsize=10)
+    ax_hist.legend(fontsize="small", frameon=False)
+    ax_hist.grid(True, alpha=0.3)
 
-        ax3.set_xlabel(f"{var}")
-        ax3.set_ylabel("Frequency")
-        ax3.set_title(f"Distribution - {var}")
 
-        # Position legend below the title
-        ax3.legend(
-            bbox_to_anchor=(0.5, 0.95),
-            loc="center",
-            ncol=2,
-            fontsize="small",
-            frameon=False,
-            columnspacing=1.0,
+def run_compare_spatial(
+    ctx: RunContext,
+    init_time: str | None = None,
+    lead_time: str | None = None,
+    time: str | None = None,
+) -> None:
+    """Produce per-variable + combined spatial comparison plots in ctx.output_dir."""
+    assert ctx.reference_ds is not None, "compare-spatial requires a reference dataset"
+
+    is_forecast = is_forecast_dataset(ctx.validation_ds)
+    spatially_aligned_ref = align_reference_spatially(
+        ctx.validation_ds, ctx.reference_ds
+    )
+
+    if is_forecast:
+        ds, ref_ds = align_to_valid_time_forecast(
+            ctx.validation_ds, spatially_aligned_ref, init_time, lead_time
         )
-        ax3.grid(True, alpha=0.3)
+    else:
+        ds, ref_ds = align_to_valid_time_analysis(
+            ctx.validation_ds, spatially_aligned_ref, time
+        )
+    ds = _downsample_for_plot(ds)
 
-    plt.tight_layout()
-    filename_parts = [
-        validation_ds.attrs["dataset_id"],
-        validation_ds.attrs["dataset_version"],
-        ds_time,
-        reference_ds.attrs["dataset_id"],
-        reference_ds.attrs["dataset_version"],
-        ref_time,
-        f"{len(variables)}_variables",
-    ]
-    base_filename = "_".join(filename_parts)
-    filepath = get_output_filepath(base_filename, validation_url)
-    plt.savefig(filepath, dpi=300, bbox_inches="tight")
-    log.info(f"Comparison plot saved to {filepath}")
+    val_time_label = _format_spatial_time_label(ds, is_forecast)
+    ref_time_label = pd.Timestamp(ref_ds.time.item()).strftime("%Y-%m-%dT%H:%M")
+    val_label = ctx.validation_ds.attrs.get("name", "validation")
+    ref_label = ctx.reference_ds.attrs.get("name", "reference")
+    ctx.spatial_time_label = val_time_label
+    ctx.ref_spatial_time_label = ref_time_label
+
+    n_vars = len(ctx.variables)
+    log.info(
+        f"compare-spatial: {n_vars} variables at {val_time_label} "
+        f"(ref {ref_time_label})"
+    )
+
+    fig_c, axes_c = plt.subplots(n_vars, 3, figsize=(15, 3.375 * n_vars), squeeze=False)
+
+    for i, var in enumerate(ctx.variables):
+        stats = ctx.stats_for(var)
+
+        data = ds[var].load()
+        ref_data = ref_ds[var].load() if var in ref_ds.data_vars else None
+        data_clean, ref_clean = _compute_spatial_stats(data, ref_data, stats)
+
+        stats.spatial_time_label = val_time_label
+        stats.spatial_plot = f"spatial_{var}.png"
+
+        ds_title = val_label
+        if ctx.ensemble_member is not None:
+            ds_title += f" (ensemble {ctx.ensemble_member})"
+        ds_title += f"\n{var} @ {val_time_label}"
+        ref_title = (
+            f"{ref_label}\n{var} @ {ref_time_label}"
+            if ref_data is not None
+            else f"{ref_label}\n{var} (not available)"
+        )
+
+        # Per-variable figure
+        fig_v, axes_v = plt.subplots(1, 3, figsize=(15, 3.375), squeeze=False)
+        _draw_spatial_triplet(
+            axes_v[0, 0],
+            axes_v[0, 1],
+            axes_v[0, 2],
+            var,
+            data,
+            ref_data,
+            data_clean,
+            ref_clean,
+            stats.units,
+            ds_title,
+            ref_title,
+        )
+        fig_v.tight_layout()
+        fig_v.savefig(ctx.output_dir / stats.spatial_plot, dpi=150, bbox_inches="tight")
+        plt.close(fig_v)
+
+        # Combined row
+        _draw_spatial_triplet(
+            axes_c[i, 0],
+            axes_c[i, 1],
+            axes_c[i, 2],
+            var,
+            data,
+            ref_data,
+            data_clean,
+            ref_clean,
+            stats.units,
+            ds_title,
+            ref_title,
+        )
+
+        ref_note = (
+            f"ref[{stats.ref_spatial_min:.3g}, {stats.ref_spatial_max:.3g}]"
+            if stats.ref_available_spatial and stats.ref_spatial_min is not None
+            else "ref=n/a"
+        )
+        log.info(
+            f"  spatial {var}: val[{stats.val_spatial_min:.3g}, "
+            f"{stats.val_spatial_max:.3g}] mean={stats.val_spatial_mean:.3g} {ref_note}"
+        )
+
+    fig_c.suptitle(
+        f"Spatial comparison — all variables\n{val_label} @ {val_time_label} vs "
+        f"{ref_label} @ {ref_time_label}",
+        fontsize=13,
+    )
+    fig_c.tight_layout()
+    combined_path = ctx.output_dir / "combined_spatial.png"
+    fig_c.savefig(combined_path, dpi=120, bbox_inches="tight")
+    plt.close(fig_c)
+    ctx.combined_spatial_plot = combined_path.name
 
 
 def compare_spatial(
@@ -333,64 +361,57 @@ def compare_spatial(
     time: str | None = None,
     start_date: str | None = start_date_option,
     end_date: str | None = end_date_option,
+    output_dir: Path | None = output_dir_option,
 ) -> None:
-    """Create comparison plots between two zarr datasets.
-
-    For forecast datasets (with init_time and lead_time dimensions), use
-    --init-time and --lead-time to specify the point to plot.
-
-    For analysis datasets (with time dimension), use --time to specify
-    the point to plot.
-    """
-
-    log.info(f"Loading validation dataset from: {validation_url}")
+    """Create per-variable + combined spatial comparison plots between two zarr datasets."""
+    log.info(f"Loading validation dataset: {validation_url}")
     validation_ds = load_zarr_dataset(validation_url)
     if start_date or end_date:
         validation_ds = scope_time_period(validation_ds, start_date, end_date)
 
     is_forecast = is_forecast_dataset(validation_ds)
-    log.info(
-        f"Detected {'forecast' if is_forecast else 'analysis'} dataset "
-        f"(dimensions: {list(validation_ds.sizes.keys())})"
-    )
+    log.info(f"Detected {'forecast' if is_forecast else 'analysis'} dataset")
 
-    log.info(f"Loading reference dataset from: {reference_url}")
+    log.info(f"Loading reference dataset: {reference_url}")
     reference_ds = load_zarr_dataset(reference_url)
 
     validation_vars = [str(k) for k in validation_ds.data_vars]
-    log.info(f"Found {len(validation_vars)} variables in validation dataset")
-
     if variables:
-        # Use specified variables that exist in validation dataset
-        selected_vars = [var for var in variables if var in validation_ds.data_vars]
-        missing_vars = set(variables) - set(validation_vars)
-
-        if missing_vars:
-            log.warning(f"Variables not found in validation dataset: {missing_vars}")
-
+        selected_vars = [v for v in variables if v in validation_vars]
+        missing = set(variables) - set(validation_vars)
+        if missing:
+            log.warning(f"Variables not in validation dataset: {missing}")
         if not selected_vars:
             typer.echo("Error: No valid variables specified", err=True)
             raise typer.Exit(1)
     else:
-        selected_vars = validation_vars
-
-    log.info(f"Plotting variables: {selected_vars}")
+        selected_vars = select_variables_for_plotting(validation_ds, None)
 
     validation_ds, ensemble_member = select_random_ensemble_member(validation_ds)
-    spatially_aligned_reference_ds = align_reference_spatially(
-        validation_ds, reference_ds
+    point1_sel, point2_sel, (lat1, lon1), (lat2, lon2) = get_two_random_points(
+        validation_ds
     )
 
-    create_comparison_plot(
-        validation_ds,
-        spatially_aligned_reference_ds,
-        selected_vars,
+    out = resolve_output_dir(validation_url, output_dir)
+    log.info(f"output dir: {out}")
+
+    ctx = RunContext(
+        output_dir=out,
         validation_url=validation_url,
+        reference_url=reference_url,
+        validation_ds=validation_ds,
+        reference_ds=reference_ds,
+        started_at=pd.Timestamp.now(),
+        point1_sel=point1_sel,
+        point2_sel=point2_sel,
+        point1_lat=lat1,
+        point1_lon=lon1,
+        point2_lat=lat2,
+        point2_lon=lon2,
         ensemble_member=ensemble_member,
-        init_time=init_time,
-        lead_time=lead_time,
-        time=time,
+        variables=selected_vars,
     )
+    run_compare_spatial(ctx, init_time=init_time, lead_time=lead_time, time=time)
 
     if show_plot:
         plt.show()

--- a/src/scripts/validation/compare_timeseries.py
+++ b/src/scripts/validation/compare_timeseries.py
@@ -1,18 +1,22 @@
+from pathlib import Path
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import xarray as xr
 import zarr
 from matplotlib.axes import Axes
-from matplotlib.figure import Figure
 
 from reformatters.common.logging import get_logger
 from scripts.validation.utils import (
+    RunContext,
+    VariableStats,
     end_date_option,
-    get_output_filepath,
     get_two_random_points,
     is_forecast_dataset,
     load_zarr_dataset,
+    output_dir_option,
+    resolve_output_dir,
     scope_time_period,
     select_random_ensemble_member,
     select_variables_for_plotting,
@@ -30,118 +34,91 @@ GEFS_ANALYSIS_URL = "https://data.dynamical.org/noaa/gefs/analysis/latest.zarr"
 def select_time_period_for_comparison(
     validation_ds: xr.Dataset, reference_ds: xr.Dataset
 ) -> tuple[xr.Dataset, xr.Dataset, str, str, str]:
-    """Selects appropriate time periods for validation and reference datasets."""
+    """Select appropriate time periods for validation and reference datasets."""
     rng = np.random.default_rng()
     if is_forecast_dataset(validation_ds):
-        log.info("Detected forecast dataset - selecting random init_time")
         selected_init_time = pd.Timestamp(rng.choice(validation_ds.init_time, 1)[0])
         validation_subset = validation_ds.sel(init_time=selected_init_time)
-        log.info(f"Selected init_time: {selected_init_time}")
 
         valid_time_start = validation_subset.valid_time.min().item()
         valid_time_end = validation_subset.valid_time.max().item()
         reference_subset = reference_ds.sel(
             time=slice(pd.Timestamp(valid_time_start), pd.Timestamp(valid_time_end))
         )
-
         title_suffix = (
             f"Forecast init_time: {selected_init_time.strftime('%Y-%m-%dT%H:%M')}"
         )
-        time_coord = "valid_time"
-        ref_time_coord = "time"
+        return validation_subset, reference_subset, title_suffix, "valid_time", "time"
 
+    time_start = pd.Timestamp(validation_ds.time.min().item())
+    time_end = pd.Timestamp(validation_ds.time.max().item())
+    ten_days = pd.Timedelta(days=10)
+
+    if time_end - time_start < ten_days:
+        selected_start = time_start
+        selected_end = time_end
     else:
-        log.info("Detected analysis dataset - selecting random 10-day period")
+        latest_start = time_end - ten_days
+        time_range_seconds = (latest_start - time_start).total_seconds()
+        random_offset = rng.integers(0, int(time_range_seconds) + 1)
+        selected_start = time_start + pd.Timedelta(seconds=random_offset)
+        selected_end = selected_start + ten_days
 
-        time_start = pd.Timestamp(validation_ds.time.min().item())
-        time_end = pd.Timestamp(validation_ds.time.max().item())
-        ten_days = pd.Timedelta(days=10)
-
-        if time_end - time_start < ten_days:
-            validation_subset = validation_ds
-            selected_start = time_start
-            selected_end = time_end
-            log.info("Dataset shorter than 10 days, using entire time range")
-        else:
-            latest_start = time_end - ten_days
-            time_range_seconds = (latest_start - time_start).total_seconds()
-            random_offset = rng.integers(0, int(time_range_seconds) + 1)
-            selected_start = time_start + pd.Timedelta(seconds=random_offset)
-            selected_end = selected_start + ten_days
-            log.info(f"Selected time period: {selected_start} to {selected_end}")
-
-        validation_subset = validation_ds.sel(time=slice(selected_start, selected_end))
-        reference_subset = reference_ds.sel(time=slice(selected_start, selected_end))
-
-        title_suffix = "Analysis period: 10-day sample"
-        time_coord = "time"
-        ref_time_coord = "time"
-
-    return validation_subset, reference_subset, title_suffix, time_coord, ref_time_coord
+    validation_subset = validation_ds.sel(time=slice(selected_start, selected_end))
+    reference_subset = reference_ds.sel(time=slice(selected_start, selected_end))
+    title_suffix = (
+        f"Analysis period: {selected_start.strftime('%Y-%m-%dT%H:%M')} - "
+        f"{selected_end.strftime('%Y-%m-%dT%H:%M')}"
+    )
+    return validation_subset, reference_subset, title_suffix, "time", "time"
 
 
-def plot_single_variable_at_point(
+def _compute_point_stats(
+    da: xr.DataArray,
+) -> tuple[float, float, float] | tuple[None, None, None]:
+    vals = da.values
+    vals = vals[~np.isnan(vals)]
+    if vals.size == 0:
+        return None, None, None
+    return float(np.min(vals)), float(np.max(vals)), float(np.mean(vals))
+
+
+def _draw_timeseries_at_point(
     ax: Axes,
     var: str,
-    point_sel: dict[str, int],
-    lat: float,
-    lon: float,
-    validation_subset: xr.Dataset,
-    reference_subset: xr.Dataset,
+    val_series: xr.DataArray,
+    ref_series: xr.DataArray | None,
     time_coord: str,
     ref_time_coord: str,
+    val_label: str,
+    ref_label: str,
+    units: str,
+    title: str,
 ) -> None:
-    """Plots a single variable at a specific spatial point for both datasets."""
-    # Select validation data for this point
-    val_point_data = validation_subset[var].isel(point_sel)
-
-    # Debug the data
-    log.info(
-        f"Validation data min/max for {var}: {float(val_point_data.min()):.3f} / {float(val_point_data.max()):.3f}"
-    )
-    log.info(f"Point selection: {point_sel}")
-    log.info(f"First few values for {var}: {val_point_data.values[:5]}")
-
-    # Plot validation data
     ax.plot(
-        val_point_data[time_coord],
-        val_point_data,
+        val_series[time_coord],
+        val_series,
         marker="o",
         linestyle="-",
         markersize=3,
         color="red",
-        label=validation_subset.attrs.get("name", "Validation"),
+        label=val_label,
         alpha=0.8,
     )
-
-    # Plot reference data if variable exists
-    if var in reference_subset.data_vars:
-        assert "latitude" in reference_subset.dims, (
-            "Reference datasets must have latitude dimension"
-        )
-        assert "longitude" in reference_subset.dims, (
-            "Reference datasets must have longitude dimension"
-        )
-
-        ref_point_data = reference_subset[var].sel(
-            latitude=lat, longitude=lon, method="nearest"
-        )
-
+    if ref_series is not None:
         ax.plot(
-            ref_point_data[ref_time_coord],
-            ref_point_data,
+            ref_series[ref_time_coord],
+            ref_series,
             marker="s",
             linestyle="-",
             markersize=3,
             color="blue",
-            label=reference_subset.attrs.get("name", "Reference"),
+            label=ref_label,
             alpha=0.8,
         )
-
-    # Formatting
     ax.set_xlabel("Valid Time" if time_coord == "valid_time" else "Time")
-    ax.set_ylabel(f"{var}")
-    ax.set_title(f"{var} - (lat={lat:.2f}, lon={lon:.2f})", fontsize=10)
+    ax.set_ylabel(f"{var}" + (f" [{units}]" if units else ""))
+    ax.set_title(title, fontsize=10)
     ax.grid(True, alpha=0.3)
     ax.legend(fontsize=8)
     ax.tick_params(axis="x", rotation=45)
@@ -149,15 +126,181 @@ def plot_single_variable_at_point(
     ax.autoscale_view()
 
 
-def save_and_show_plot(
-    fig: Figure, dataset_id: str, validation_url: str, show_plot: bool
+def _load_timeseries_for_var(
+    var: str,
+    ctx: RunContext,
+    validation_subset: xr.Dataset,
+    reference_subset: xr.Dataset,
+) -> tuple[xr.DataArray, xr.DataArray | None, xr.DataArray, xr.DataArray | None]:
+    val_p1 = validation_subset[var].isel(ctx.point1_sel).load()
+    val_p2 = validation_subset[var].isel(ctx.point2_sel).load()
+    ref_p1: xr.DataArray | None = None
+    ref_p2: xr.DataArray | None = None
+    if var in reference_subset.data_vars:
+        assert "latitude" in reference_subset.dims
+        assert "longitude" in reference_subset.dims
+        ref_p1 = (
+            reference_subset[var]
+            .sel(latitude=ctx.point1_lat, longitude=ctx.point1_lon, method="nearest")
+            .load()
+        )
+        ref_p2 = (
+            reference_subset[var]
+            .sel(latitude=ctx.point2_lat, longitude=ctx.point2_lon, method="nearest")
+            .load()
+        )
+    return val_p1, ref_p1, val_p2, ref_p2
+
+
+def _store_temporal_stats(
+    stats: VariableStats,
+    val_p1: xr.DataArray,
+    val_p2: xr.DataArray,
+    ref_p1: xr.DataArray | None,
+    ref_p2: xr.DataArray | None,
 ) -> None:
-    base_filename = f"{dataset_id}_timeseries_comparison"
-    filepath = get_output_filepath(base_filename, validation_url)
-    fig.savefig(filepath, dpi=300, bbox_inches="tight")
-    log.info(f"Saved to {filepath}")
-    if show_plot:
-        fig.show()
+    (
+        stats.val_temporal_min_p1,
+        stats.val_temporal_max_p1,
+        stats.val_temporal_mean_p1,
+    ) = _compute_point_stats(val_p1)
+    (
+        stats.val_temporal_min_p2,
+        stats.val_temporal_max_p2,
+        stats.val_temporal_mean_p2,
+    ) = _compute_point_stats(val_p2)
+    if ref_p1 is not None:
+        stats.ref_available_temporal = True
+        (
+            stats.ref_temporal_min_p1,
+            stats.ref_temporal_max_p1,
+            stats.ref_temporal_mean_p1,
+        ) = _compute_point_stats(ref_p1)
+    if ref_p2 is not None:
+        stats.ref_available_temporal = True
+        (
+            stats.ref_temporal_min_p2,
+            stats.ref_temporal_max_p2,
+            stats.ref_temporal_mean_p2,
+        ) = _compute_point_stats(ref_p2)
+
+
+def _fmt(v: float | None) -> str:
+    return f"{v:.3g}" if v is not None else "n/a"
+
+
+def run_compare_timeseries(ctx: RunContext) -> None:
+    """Produce per-variable + combined timeseries comparison plots in ctx.output_dir."""
+    assert ctx.reference_ds is not None, (
+        "compare-timeseries requires a reference dataset"
+    )
+
+    (
+        validation_subset,
+        reference_subset,
+        title_suffix,
+        time_coord,
+        ref_time_coord,
+    ) = select_time_period_for_comparison(ctx.validation_ds, ctx.reference_ds)
+
+    val_label = ctx.validation_ds.attrs.get("name", "validation")
+    ref_label = ctx.reference_ds.attrs.get("name", "reference")
+    ctx.temporal_period_label = title_suffix
+
+    n_vars = len(ctx.variables)
+    log.info(f"compare-timeseries: {n_vars} variables — {title_suffix}")
+
+    fig_c, axes_c = plt.subplots(
+        n_vars, 2, figsize=(14, 3.0 * n_vars), squeeze=False, constrained_layout=True
+    )
+
+    p1_title_suffix = f"(lat={ctx.point1_lat:.2f}, lon={ctx.point1_lon:.2f})"
+    p2_title_suffix = f"(lat={ctx.point2_lat:.2f}, lon={ctx.point2_lon:.2f})"
+
+    for i, var in enumerate(ctx.variables):
+        stats = ctx.stats_for(var)
+        val_p1, ref_p1, val_p2, ref_p2 = _load_timeseries_for_var(
+            var, ctx, validation_subset, reference_subset
+        )
+        _store_temporal_stats(stats, val_p1, val_p2, ref_p1, ref_p2)
+        units = stats.units or ""
+
+        # Per-variable figure
+        fig_v, axes_v = plt.subplots(
+            1, 2, figsize=(14, 3.375), squeeze=False, constrained_layout=True
+        )
+        _draw_timeseries_at_point(
+            axes_v[0, 0],
+            var,
+            val_p1,
+            ref_p1,
+            time_coord,
+            ref_time_coord,
+            val_label,
+            ref_label,
+            units,
+            f"{var} — {p1_title_suffix}",
+        )
+        _draw_timeseries_at_point(
+            axes_v[0, 1],
+            var,
+            val_p2,
+            ref_p2,
+            time_coord,
+            ref_time_coord,
+            val_label,
+            ref_label,
+            units,
+            f"{var} — {p2_title_suffix}",
+        )
+        fig_v.suptitle(
+            f"{var}\n{val_label} vs {ref_label}\n{title_suffix}", fontsize=11
+        )
+        out_path = ctx.output_dir / f"temporal_{var}.png"
+        fig_v.savefig(out_path, dpi=150, bbox_inches="tight")
+        plt.close(fig_v)
+        stats.temporal_plot = out_path.name
+
+        # Combined row
+        _draw_timeseries_at_point(
+            axes_c[i, 0],
+            var,
+            val_p1,
+            ref_p1,
+            time_coord,
+            ref_time_coord,
+            val_label,
+            ref_label,
+            units,
+            f"{var} — {p1_title_suffix}",
+        )
+        _draw_timeseries_at_point(
+            axes_c[i, 1],
+            var,
+            val_p2,
+            ref_p2,
+            time_coord,
+            ref_time_coord,
+            val_label,
+            ref_label,
+            units,
+            f"{var} — {p2_title_suffix}",
+        )
+
+        log.info(
+            f"  temporal {var}: "
+            f"P1 val=[{_fmt(stats.val_temporal_min_p1)}, {_fmt(stats.val_temporal_max_p1)}] "
+            f"P2 val=[{_fmt(stats.val_temporal_min_p2)}, {_fmt(stats.val_temporal_max_p2)}]"
+        )
+
+    fig_c.suptitle(
+        f"Timeseries comparison — all variables\n{val_label} vs {ref_label}\n{title_suffix}",
+        fontsize=13,
+    )
+    combined_path = ctx.output_dir / "combined_temporal.png"
+    fig_c.savefig(combined_path, dpi=120, bbox_inches="tight")
+    plt.close(fig_c)
+    ctx.combined_temporal_plot = combined_path.name
 
 
 def compare_timeseries(
@@ -167,72 +310,40 @@ def compare_timeseries(
     show_plot: bool = False,
     start_date: str | None = start_date_option,
     end_date: str | None = end_date_option,
+    output_dir: Path | None = output_dir_option,
 ) -> None:
-    """Compare timeseries between validation and reference datasets."""
-
+    """Create per-variable + combined timeseries comparison plots."""
     validation_ds = load_zarr_dataset(validation_url)
     if start_date or end_date:
         validation_ds = scope_time_period(validation_ds, start_date, end_date)
     reference_ds = load_zarr_dataset(reference_url)
 
     selected_vars = select_variables_for_plotting(validation_ds, variables)
-
     validation_ds, ensemble_member = select_random_ensemble_member(validation_ds)
-
     point1_sel, point2_sel, (lat1, lon1), (lat2, lon2) = get_two_random_points(
         validation_ds
     )
 
-    (
-        validation_subset,
-        reference_subset,
-        title_suffix,
-        time_coord,
-        ref_time_coord,
-    ) = select_time_period_for_comparison(validation_ds, reference_ds)
+    out = resolve_output_dir(validation_url, output_dir)
+    log.info(f"output dir: {out}")
 
-    fig, axes = plt.subplots(
-        len(selected_vars),
-        2,
-        figsize=(12, 4 * len(selected_vars)),
-        squeeze=False,
-        constrained_layout=True,
+    ctx = RunContext(
+        output_dir=out,
+        validation_url=validation_url,
+        reference_url=reference_url,
+        validation_ds=validation_ds,
+        reference_ds=reference_ds,
+        started_at=pd.Timestamp.now(),
+        point1_sel=point1_sel,
+        point2_sel=point2_sel,
+        point1_lat=lat1,
+        point1_lon=lon1,
+        point2_lat=lat2,
+        point2_lon=lon2,
+        ensemble_member=ensemble_member,
+        variables=selected_vars,
     )
+    run_compare_timeseries(ctx)
 
-    for i, var in enumerate(selected_vars):
-        log.info(f"Plotting {var}")
-
-        plot_single_variable_at_point(
-            axes[i, 0],
-            var,
-            point1_sel,
-            lat1,
-            lon1,
-            validation_subset,
-            reference_subset,
-            time_coord,
-            ref_time_coord,
-        )
-
-        plot_single_variable_at_point(
-            axes[i, 1],
-            var,
-            point2_sel,
-            lat2,
-            lon2,
-            validation_subset,
-            reference_subset,
-            time_coord,
-            ref_time_coord,
-        )
-
-    dataset_id = validation_ds.attrs.get("dataset_id", "")
-    ds_title = validation_ds.attrs.get("name", "")
-    if ensemble_member is not None:
-        ds_title += f" (Ensemble Member {ensemble_member})"
-    ref_title = reference_ds.attrs.get("name", "")
-    fig.suptitle(
-        f"Timeseries Comparison\n{ds_title} vs {ref_title}\n{title_suffix}", fontsize=14
-    )
-
-    save_and_show_plot(fig, dataset_id, validation_url, show_plot)
+    if show_plot:
+        plt.show()

--- a/src/scripts/validation/plots.py
+++ b/src/scripts/validation/plots.py
@@ -1,79 +1,136 @@
+from pathlib import Path
+
+import pandas as pd
 import typer
 
-from scripts.validation.compare_spatial import compare_spatial
-from scripts.validation.compare_timeseries import GEFS_ANALYSIS_URL, compare_timeseries
-from scripts.validation.report_nulls import report_nulls
+from reformatters.common.logging import get_logger
+from scripts.validation.compare_spatial import (
+    GEFS_ANALYSIS_URL,
+    compare_spatial,
+    run_compare_spatial,
+)
+from scripts.validation.compare_timeseries import (
+    compare_timeseries,
+    run_compare_timeseries,
+)
+from scripts.validation.report_nulls import report_nulls, run_report_nulls
+from scripts.validation.summary import write_summary_md
 from scripts.validation.utils import (
+    RunContext,
+    create_run_output_dir,
     end_date_option,
+    get_two_random_points,
+    is_forecast_dataset,
+    load_zarr_dataset,
+    output_dir_option,
+    scope_time_period,
+    select_random_ensemble_member,
+    select_variables_for_plotting,
     start_date_option,
     variables_option,
 )
+
+log = get_logger(__name__)
 
 app = typer.Typer(
     help="Dataset validation plotting tools", pretty_exceptions_show_locals=False
 )
 
-app.command("compare-spatial", help="Compare two datasets")(compare_spatial)
-app.command("compare-timeseries", help="Compare timeseries between datasets")(
+app.command("compare-spatial", help="Spatial comparison, one PNG per variable")(
+    compare_spatial
+)
+app.command("compare-timeseries", help="Timeseries comparison, one PNG per variable")(
     compare_timeseries
 )
-app.command("report-nulls", help="Analyze null values")(report_nulls)
+app.command("report-nulls", help="Null analysis, one PNG per variable")(report_nulls)
 
 
-@app.command("run-all", help="Run all validation plots")
+@app.command(
+    "run-all",
+    help="Run all validation plots into a single run directory, with a validation_summary.md index.",
+)
 def run_all(
     dataset_url: str,
     reference_url: str = typer.Option(
         GEFS_ANALYSIS_URL, "--reference-url", help="Reference dataset URL"
     ),
     variables: list[str] | None = variables_option,
-    show_plot: bool = typer.Option(False, "--show-plot", help="Display plots"),
     start_date: str | None = start_date_option,
     end_date: str | None = end_date_option,
     init_time: str | None = typer.Option(
-        None, "--init-time", help="Forecast init_time (for spatial plots)"
+        None,
+        "--init-time",
+        help="Forecast init_time for spatial plots (default: random)",
     ),
     lead_time: str | None = typer.Option(
-        None, "--lead-time", help="Forecast lead_time (for spatial plots)"
+        None,
+        "--lead-time",
+        help="Forecast lead_time for spatial plots (default: random)",
     ),
     time: str | None = typer.Option(
-        None, "--time", help="Analysis time (for spatial plots)"
+        None, "--time", help="Analysis time for spatial plots (default: random)"
     ),
+    output_dir: Path | None = output_dir_option,
 ) -> None:
-    """Run all three validation plots: report-nulls, compare-timeseries, and compare-spatial."""
-    typer.echo("Running report-nulls...")
-    report_nulls(
-        dataset_url=dataset_url,
-        variables=variables,
-        show_plot=show_plot,
-        start_date=start_date,
-        end_date=end_date,
+    """Produce nulls / spatial / temporal plots, one per variable, in one directory + validation_summary.md."""
+    started_at = pd.Timestamp.now()
+
+    log.info(f"Loading validation dataset: {dataset_url}")
+    validation_ds = load_zarr_dataset(dataset_url)
+    if start_date or end_date:
+        validation_ds = scope_time_period(validation_ds, start_date, end_date)
+
+    log.info(f"Loading reference dataset:  {reference_url}")
+    reference_ds = load_zarr_dataset(reference_url)
+
+    is_forecast = is_forecast_dataset(validation_ds)
+    log.info(f"Validation dataset type: {'forecast' if is_forecast else 'analysis'}")
+
+    selected_vars = select_variables_for_plotting(validation_ds, variables)
+    log.info(f"Variables ({len(selected_vars)}): {', '.join(selected_vars)}")
+
+    validation_ds, ensemble_member = select_random_ensemble_member(validation_ds)
+    if ensemble_member is not None:
+        log.info(f"Ensemble member (random): {ensemble_member}")
+
+    point1_sel, point2_sel, (lat1, lon1), (lat2, lon2) = get_two_random_points(
+        validation_ds
     )
 
-    typer.echo("Running compare-timeseries...")
-    compare_timeseries(
+    out = (
+        Path(output_dir)
+        if output_dir
+        else create_run_output_dir(dataset_url, started_at)
+    )
+    out.mkdir(parents=True, exist_ok=True)
+    log.info(f"Output dir: {out}")
+
+    ctx = RunContext(
+        output_dir=out,
         validation_url=dataset_url,
         reference_url=reference_url,
-        variables=variables,
-        show_plot=show_plot,
+        validation_ds=validation_ds,
+        reference_ds=reference_ds,
+        started_at=started_at,
+        point1_sel=point1_sel,
+        point2_sel=point2_sel,
+        point1_lat=lat1,
+        point1_lon=lon1,
+        point2_lat=lat2,
+        point2_lon=lon2,
+        ensemble_member=ensemble_member,
+        variables=selected_vars,
         start_date=start_date,
         end_date=end_date,
     )
 
-    typer.echo("Running compare-spatial...")
-    compare_spatial(
-        validation_url=dataset_url,
-        reference_url=reference_url,
-        variables=variables,
-        show_plot=show_plot,
-        init_time=init_time,
-        lead_time=lead_time,
-        time=time,
-        start_date=start_date,
-        end_date=end_date,
-    )
+    run_report_nulls(ctx)
+    run_compare_timeseries(ctx)
+    run_compare_spatial(ctx, init_time=init_time, lead_time=lead_time, time=time)
 
-    typer.echo("All validation plots completed!")
+    summary_path = write_summary_md(ctx)
+    log.info(f"Done. Summary: {summary_path}")
+    typer.echo(str(summary_path))
 
 
 if __name__ == "__main__":

--- a/src/scripts/validation/report_nulls.py
+++ b/src/scripts/validation/report_nulls.py
@@ -1,12 +1,19 @@
+from pathlib import Path
+
 import matplotlib.pyplot as plt
+import pandas as pd
+import xarray as xr
 import zarr
+from matplotlib.axes import Axes
 
 from reformatters.common.logging import get_logger
 from scripts.validation.utils import (
+    RunContext,
     end_date_option,
-    get_output_filepath,
     get_two_random_points,
     load_zarr_dataset,
+    output_dir_option,
+    resolve_output_dir,
     scope_time_period,
     select_variables_for_plotting,
     start_date_option,
@@ -18,128 +25,206 @@ log = get_logger(__name__)
 zarr.config.set({"async.concurrency": 32})
 
 
+def _compute_nulls_for_point(
+    ds_point: xr.Dataset, var: str
+) -> tuple[xr.DataArray, list[str], int, int]:
+    """Compute null fraction over time, plus (filtered) missing timestamps + counts.
+
+    For accumulated/avg variables, excludes the first lead_time (analysis step) from the
+    "unexpected nulls" tally — it's structurally NaN by design.
+    """
+    non_time_dims = [
+        dim for dim in ds_point[var].dims if dim not in ("time", "init_time")
+    ]
+    null_mask = ds_point[var].isnull()
+    null_frac = null_mask.mean(dim=non_time_dims)
+
+    check_mask = null_mask
+    if (
+        ds_point[var].attrs.get("step_type") != "instant"
+        and "lead_time" in ds_point[var].dims
+    ):
+        check_mask = null_mask.isel(lead_time=slice(1, None))
+
+    if check_mask.any():
+        time_dim = next(d for d in ("time", "init_time") if d in null_frac.dims)
+        log_null = check_mask.mean(dim=non_time_dims)
+        missing = log_null[time_dim].where(log_null > 0, drop=True)
+        missing_strs = missing.dt.strftime("%Y-%m-%dT%H:%M:%S").values.tolist()
+    else:
+        missing_strs = []
+
+    return (
+        null_frac,
+        missing_strs,
+        int(check_mask.sum().item()),
+        int(check_mask.size),
+    )
+
+
+def _draw_null_trace(ax: Axes, null_data: xr.DataArray, color: str, title: str) -> None:
+    time_dim = next(d for d in ("time", "init_time") if d in null_data.dims)
+    ax.plot(
+        null_data[time_dim],
+        null_data,
+        marker="o",
+        linestyle="-",
+        markersize=3,
+        color=color,
+    )
+    ax.set_xlabel(time_dim.replace("_", " ").title())
+    ax.set_title(title, fontsize=10)
+    ax.set_ylabel("Null Fraction")
+    ax.set_ylim(0, 1)
+    ax.grid(True, alpha=0.3)
+
+
+def _format_missing_summary(missing: list[str]) -> str:
+    if not missing:
+        return "none"
+    if len(missing) <= 6:
+        return f"{len(missing)} ({', '.join(missing)})"
+    head = ", ".join(missing[:3])
+    tail = ", ".join(missing[-3:])
+    return f"{len(missing)} (first: {head} … last: {tail})"
+
+
+def write_missing_timestamps_file(output_dir: Path, ctx: RunContext) -> str | None:
+    """Write missing_timestamps.txt aggregating every (var, point) with nulls. Returns filename or None."""
+    entries = []
+    for var, stats in ctx.stats.items():
+        for point_label, missing in (
+            (
+                f"Point 1 (lat={ctx.point1_lat:.2f}, lon={ctx.point1_lon:.2f})",
+                stats.missing_timestamps_p1,
+            ),
+            (
+                f"Point 2 (lat={ctx.point2_lat:.2f}, lon={ctx.point2_lon:.2f})",
+                stats.missing_timestamps_p2,
+            ),
+        ):
+            if missing:
+                entries.append((var, point_label, missing))
+
+    if not entries:
+        return None
+
+    filename = "missing_timestamps.txt"
+    path = output_dir / filename
+    total = sum(len(m) for _, _, m in entries)
+    lines = [
+        "# Missing timestamps",
+        f"# Total: {total} across {len(entries)} (variable, point) combinations.",
+        "# Use --filter-contains <timestamp> to retry those source files with backfill.",
+        "",
+    ]
+    for var, point_label, missing in entries:
+        lines.append(f"## {var} @ {point_label}")
+        lines.append(f"count: {len(missing)}")
+        lines.extend(missing)
+        lines.append("")
+        lines.append(
+            "retry-filter: " + " ".join(f"--filter-contains {m}" for m in missing)
+        )
+        lines.append("")
+    path.write_text("\n".join(lines))
+    return filename
+
+
+def run_report_nulls(ctx: RunContext) -> None:
+    """Produce per-variable null plots + a combined plot in ctx.output_dir and update ctx.stats."""
+    ds_p1 = ctx.validation_ds.isel(ctx.point1_sel)
+    ds_p2 = ctx.validation_ds.isel(ctx.point2_sel)
+
+    n_vars = len(ctx.variables)
+    p1_label = f"Point 1 (lat={ctx.point1_lat:.2f}, lon={ctx.point1_lon:.2f})"
+    p2_label = f"Point 2 (lat={ctx.point2_lat:.2f}, lon={ctx.point2_lon:.2f})"
+
+    log.info(f"report-nulls: {n_vars} variables at {p1_label} / {p2_label}")
+
+    fig_c, axes_c = plt.subplots(n_vars, 2, figsize=(12, 2.625 * n_vars), squeeze=False)
+
+    for i, var in enumerate(ctx.variables):
+        stats = ctx.stats_for(var)
+
+        null_p1, missing_p1, n_p1, total_p1 = _compute_nulls_for_point(ds_p1, var)
+        null_p2, missing_p2, n_p2, total_p2 = _compute_nulls_for_point(ds_p2, var)
+
+        stats.missing_timestamps_p1 = missing_p1
+        stats.missing_timestamps_p2 = missing_p2
+        stats.null_count_p1 = n_p1
+        stats.null_count_p2 = n_p2
+        stats.total_count_p1 = total_p1
+        stats.total_count_p2 = total_p2
+
+        # Per-variable figure.
+        fig_v, axes_v = plt.subplots(1, 2, figsize=(12, 3), squeeze=False)
+        _draw_null_trace(axes_v[0, 0], null_p1, "blue", p1_label)
+        _draw_null_trace(axes_v[0, 1], null_p2, "orange", p2_label)
+        fig_v.suptitle(var, fontsize=11)
+        fig_v.tight_layout()
+        out_path = ctx.output_dir / f"nulls_{var}.png"
+        fig_v.savefig(out_path, dpi=150, bbox_inches="tight")
+        plt.close(fig_v)
+        stats.null_plot = out_path.name
+
+        # Combined figure row.
+        _draw_null_trace(axes_c[i, 0], null_p1, "blue", f"{var} — {p1_label}")
+        _draw_null_trace(axes_c[i, 1], null_p2, "orange", f"{var} — {p2_label}")
+
+        p1_fmt = _format_missing_summary(missing_p1)
+        p2_fmt = _format_missing_summary(missing_p2)
+        log.info(f"  nulls {var}: P1 missing={p1_fmt} | P2 missing={p2_fmt}")
+
+    fig_c.suptitle("Null analysis — all variables", fontsize=13)
+    fig_c.tight_layout()
+    combined_path = ctx.output_dir / "combined_nulls.png"
+    fig_c.savefig(combined_path, dpi=120, bbox_inches="tight")
+    plt.close(fig_c)
+    ctx.combined_nulls_plot = combined_path.name
+
+    missing_file = write_missing_timestamps_file(ctx.output_dir, ctx)
+    ctx.missing_timestamps_file = missing_file
+    if missing_file:
+        log.info(f"  wrote missing timestamp list -> {missing_file}")
+
+
 def report_nulls(
     dataset_url: str,
     variables: list[str] | None = variables_option,
     show_plot: bool = False,
     start_date: str | None = start_date_option,
     end_date: str | None = end_date_option,
+    output_dir: Path | None = output_dir_option,
 ) -> None:
-    """Analyze null values at two spatial points across time dimensions."""
-
+    """Analyze null values for each data variable at two spatial points across time."""
     ds = load_zarr_dataset(dataset_url)
     if start_date or end_date:
         ds = scope_time_period(ds, start_date, end_date)
 
     selected_vars = select_variables_for_plotting(ds, variables)
-
-    # Get two random spatial points (indices and coordinates)
     point1_sel, point2_sel, (lat1, lon1), (lat2, lon2) = get_two_random_points(ds)
-    ds_p1 = ds.isel(point1_sel)
-    ds_p2 = ds.isel(point2_sel)
 
-    log.info(f"Point 1: lat={lat1:.2f}, lon={lon1:.2f}")
-    log.info(f"Point 2: lat={lat2:.2f}, lon={lon2:.2f}")
+    out = resolve_output_dir(dataset_url, output_dir)
+    log.info(f"output dir: {out}")
 
-    # Create plots
-    _fig, axes = plt.subplots(
-        len(selected_vars), 2, figsize=(12, 4 * len(selected_vars)), squeeze=False
+    ctx = RunContext(
+        output_dir=out,
+        validation_url=dataset_url,
+        reference_url=None,
+        validation_ds=ds,
+        reference_ds=None,
+        started_at=pd.Timestamp.now(),
+        point1_sel=point1_sel,
+        point2_sel=point2_sel,
+        point1_lat=lat1,
+        point1_lon=lon1,
+        point2_lat=lat2,
+        point2_lon=lon2,
+        ensemble_member=None,
+        variables=selected_vars,
     )
-
-    for i, var in enumerate(selected_vars):
-        log.info(f"Plotting {var}")
-
-        # Calculate null data for both points (for plotting)
-        non_time_dims = [
-            dim for dim in ds_p1[var].dims if dim not in ["time", "init_time"]
-        ]
-
-        # Load null masks once for both points
-        null_mask_p1 = ds_p1[var].isnull()
-        null_mask_p2 = ds_p2[var].isnull()
-
-        # Calculate null fractions for plotting
-        null_p1 = null_mask_p1.mean(dim=non_time_dims)
-        null_p2 = null_mask_p2.mean(dim=non_time_dims)
-
-        # Find time dimension for x-axis
-        time_dim = next(dim for dim in ["time", "init_time"] if dim in null_p1.dims)
-
-        # Plot both points
-        for j, (null_data, null_mask, ds_point, point_name, color) in enumerate(
-            [
-                (
-                    null_p1,
-                    null_mask_p1,
-                    ds_p1,
-                    f"Point 1 (lat={lat1:.2f}, lon={lon1:.2f})",
-                    "blue",
-                ),
-                (
-                    null_p2,
-                    null_mask_p2,
-                    ds_p2,
-                    f"Point 2 (lat={lat2:.2f}, lon={lon2:.2f})",
-                    "orange",
-                ),
-            ]
-        ):
-            ax = axes[i, j]
-
-            ax.plot(
-                null_data[time_dim],
-                null_data,
-                marker="o",
-                linestyle="-",
-                markersize=3,
-                color=color,
-            )
-            ax.set_xlabel(time_dim.replace("_", " ").title())
-            ax.set_title(f"{var} - {point_name}")
-            ax.set_ylabel("Null Fraction")
-            ax.set_ylim(0, 1)
-            ax.grid(True, alpha=0.3)
-
-            # For logging, filter lead_time if needed
-            check_mask = null_mask
-            if (
-                ds_point[var].attrs.get("step_type") != "instant"
-                and "lead_time" in ds_point[var].dims
-            ):
-                # For accumulated variables, exclude the first lead_time (analysis)
-                check_mask = null_mask.isel(lead_time=slice(1, None))
-
-            # Check if there are any nulls in the filtered data
-            if check_mask.any():
-                # Calculate null fraction for the filtered data to get specific coordinates
-                log_null_data = check_mask.mean(dim=non_time_dims)
-
-                # Report all times with any missing values
-                missing_times = log_null_data[time_dim].where(
-                    log_null_data > 0, drop=True
-                )
-                if len(missing_times) > 0:
-                    missing_timestamp_strs = missing_times.dt.strftime(
-                        "%Y-%m-%dT%H:%M:%S"
-                    ).values.tolist()
-                    log.info(
-                        f"{point_name} - {var} missing at: {missing_timestamp_strs}"
-                    )
-                    log.info(
-                        " ".join(
-                            f"--filter-contains {m}" for m in missing_timestamp_strs
-                        ),
-                    )
-            else:
-                log.info(f"{point_name} - {var}: No missing values found")
-
-    plt.tight_layout()
-
-    # Save plot
-    base_filename = f"{ds.attrs['dataset_id']}_null_analysis"
-    filepath = get_output_filepath(base_filename, dataset_url)
-    plt.savefig(filepath, dpi=300, bbox_inches="tight")
-    log.info(f"Saved to {filepath}")
+    run_report_nulls(ctx)
 
     if show_plot:
         plt.show()

--- a/src/scripts/validation/summary.py
+++ b/src/scripts/validation/summary.py
@@ -1,0 +1,249 @@
+import math
+from pathlib import Path
+
+from scripts.validation.utils import (
+    RunContext,
+    VariableStats,
+    dataset_id_and_version,
+    is_forecast_dataset,
+)
+
+
+def _fmt_num(v: float | None) -> str:
+    if v is None:
+        return "n/a"
+    if math.isnan(v):
+        return "NaN"
+    return f"{v:.4g}"
+
+
+def _fmt_count(n: int | None, total: int | None) -> str:
+    if n is None or total is None:
+        return "n/a"
+    return f"{n}/{total}"
+
+
+def _missing_summary(missing: list[str]) -> str:
+    if not missing:
+        return "none"
+    if len(missing) <= 6:
+        return f"{len(missing)} missing: {', '.join(missing)}"
+    head = ", ".join(missing[:3])
+    tail = ", ".join(missing[-3:])
+    return f"{len(missing)} missing (first: {head} … last: {tail})"
+
+
+def _link(label: str, filename: str | None) -> str:
+    return f"[{label}]({filename})" if filename else f"~~{label}~~"
+
+
+def _dataset_time_range(ctx: RunContext) -> str:
+    ds = ctx.validation_ds
+    if is_forecast_dataset(ds):
+        init_min = str(ds.init_time.min().values)[:16]
+        init_max = str(ds.init_time.max().values)[:16]
+        return f"init_time {init_min} → {init_max}"
+    time_min = str(ds.time.min().values)[:16]
+    time_max = str(ds.time.max().values)[:16]
+    return f"time {time_min} → {time_max}"
+
+
+def _reference_time_range(ctx: RunContext) -> str:
+    if ctx.reference_ds is None or "time" not in ctx.reference_ds.dims:
+        return "n/a"
+    t_min = str(ctx.reference_ds.time.min().values)[:16]
+    t_max = str(ctx.reference_ds.time.max().values)[:16]
+    return f"time {t_min} → {t_max}"
+
+
+def _variable_row(stats: VariableStats) -> str:
+    plots = (
+        f"{_link('nulls', stats.null_plot)} · "
+        f"{_link('spatial', stats.spatial_plot)} · "
+        f"{_link('temporal', stats.temporal_plot)}"
+    )
+    null_p1 = _fmt_count(stats.null_count_p1, stats.total_count_p1)
+    null_p2 = _fmt_count(stats.null_count_p2, stats.total_count_p2)
+    return (
+        f"| `{stats.name}` | {stats.units or ''} | {stats.long_name or ''} "
+        f"| {null_p1} | {null_p2} | {plots} |"
+    )
+
+
+def _variable_section(stats: VariableStats, ctx: RunContext) -> str:
+    lines = [
+        f"### `{stats.name}`",
+        "",
+        "**Metadata**",
+        "",
+        f"- units: `{stats.units or 'n/a'}`",
+        f"- long_name: {stats.long_name or 'n/a'}",
+        f"- short_name: {stats.short_name or 'n/a'}",
+        f"- standard_name: {stats.standard_name or 'n/a'}",
+        f"- step_type: {stats.step_type or 'n/a'}",
+        "",
+        "**Spatial comparison**",
+        "",
+        f"- plot: `{stats.spatial_plot or 'n/a'}`",
+        f"- time: {stats.spatial_time_label or 'n/a'} "
+        f"(reference at {ctx.ref_spatial_time_label or 'n/a'})",
+        f"- validation: min={_fmt_num(stats.val_spatial_min)}, "
+        f"max={_fmt_num(stats.val_spatial_max)}, mean={_fmt_num(stats.val_spatial_mean)}",
+    ]
+    if stats.ref_available_spatial:
+        lines.append(
+            f"- reference:  min={_fmt_num(stats.ref_spatial_min)}, "
+            f"max={_fmt_num(stats.ref_spatial_max)}, mean={_fmt_num(stats.ref_spatial_mean)}"
+        )
+    else:
+        lines.append("- reference:  variable not available in reference dataset")
+    lines += [
+        "",
+        "**Temporal comparison**",
+        "",
+        f"- plot: `{stats.temporal_plot or 'n/a'}`",
+        f"- period: {ctx.temporal_period_label or 'n/a'}",
+        f"- validation @ P1 (lat={ctx.point1_lat:.2f}, lon={ctx.point1_lon:.2f}): "
+        f"min={_fmt_num(stats.val_temporal_min_p1)}, "
+        f"max={_fmt_num(stats.val_temporal_max_p1)}, "
+        f"mean={_fmt_num(stats.val_temporal_mean_p1)}",
+        f"- validation @ P2 (lat={ctx.point2_lat:.2f}, lon={ctx.point2_lon:.2f}): "
+        f"min={_fmt_num(stats.val_temporal_min_p2)}, "
+        f"max={_fmt_num(stats.val_temporal_max_p2)}, "
+        f"mean={_fmt_num(stats.val_temporal_mean_p2)}",
+    ]
+    if stats.ref_available_temporal:
+        lines += [
+            f"- reference  @ P1: min={_fmt_num(stats.ref_temporal_min_p1)}, "
+            f"max={_fmt_num(stats.ref_temporal_max_p1)}, "
+            f"mean={_fmt_num(stats.ref_temporal_mean_p1)}",
+            f"- reference  @ P2: min={_fmt_num(stats.ref_temporal_min_p2)}, "
+            f"max={_fmt_num(stats.ref_temporal_max_p2)}, "
+            f"mean={_fmt_num(stats.ref_temporal_mean_p2)}",
+        ]
+    else:
+        lines.append("- reference:  variable not available in reference dataset")
+
+    lines += [
+        "",
+        "**Nulls**",
+        "",
+        f"- P1 nulls: {_fmt_count(stats.null_count_p1, stats.total_count_p1)} — "
+        f"{_missing_summary(stats.missing_timestamps_p1)}",
+        f"- P2 nulls: {_fmt_count(stats.null_count_p2, stats.total_count_p2)} — "
+        f"{_missing_summary(stats.missing_timestamps_p2)}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_summary_md(ctx: RunContext) -> Path:  # noqa: PLR0915
+    """Write validation_summary.md aggregating a full validation run. Returns the path."""
+    ds = ctx.validation_ds
+    ref = ctx.reference_ds
+
+    val_id, val_ver = dataset_id_and_version(ctx.validation_url)
+    val_name = ds.attrs.get("name", val_id)
+    ref_id = ref.attrs.get("dataset_id", "n/a") if ref is not None else "n/a"
+    ref_ver = ref.attrs.get("dataset_version", "n/a") if ref is not None else "n/a"
+    ref_name = ref.attrs.get("name", ref_id) if ref is not None else "n/a"
+
+    is_forecast = is_forecast_dataset(ds)
+
+    scope_line = "full dataset"
+    if ctx.start_date or ctx.end_date:
+        scope_line = f"start={ctx.start_date or 'dataset start'}, end={ctx.end_date or 'dataset end'}"
+
+    missing_entries = []
+    for var, stats in ctx.stats.items():
+        if stats.missing_timestamps_p1:
+            missing_entries.append((var, "P1", len(stats.missing_timestamps_p1)))
+        if stats.missing_timestamps_p2:
+            missing_entries.append((var, "P2", len(stats.missing_timestamps_p2)))
+    missing_total = sum(n for _, _, n in missing_entries)
+
+    lines: list[str] = []
+    lines.append(f"# Validation run — `{val_id}` `{val_ver}`")
+    lines.append("")
+    lines.append(f"Started: {ctx.started_at.strftime('%Y-%m-%dT%H:%M:%S')} local")
+    lines.append("")
+    lines.append("## Datasets")
+    lines.append("")
+    lines.append("| Role | Name | ID / Version | URL |")
+    lines.append("|---|---|---|---|")
+    lines.append(
+        f"| Validation | {val_name} | `{val_id}` `{val_ver}` | `{ctx.validation_url}` |"
+    )
+    lines.append(
+        f"| Reference  | {ref_name} | `{ref_id}` `{ref_ver}` | "
+        f"`{ctx.reference_url or 'n/a'}` |"
+    )
+    lines.append("")
+    lines.append("## Run parameters")
+    lines.append("")
+    lines.append(
+        f"- Validation dataset type: **{'forecast' if is_forecast else 'analysis'}**"
+    )
+    lines.append(f"- Validation time range: {_dataset_time_range(ctx)}")
+    lines.append(f"- Reference time range:  {_reference_time_range(ctx)}")
+    lines.append(f"- Time scope: {scope_line}")
+    lines.append(
+        f"- Ensemble member: "
+        f"{ctx.ensemble_member if ctx.ensemble_member is not None else 'n/a'}"
+    )
+    lines.append(f"- Point 1: lat={ctx.point1_lat:.4f}, lon={ctx.point1_lon:.4f}")
+    lines.append(f"- Point 2: lat={ctx.point2_lat:.4f}, lon={ctx.point2_lon:.4f}")
+    lines.append(
+        f"- Spatial comparison time: "
+        f"{ctx.spatial_time_label or 'n/a'} (reference at {ctx.ref_spatial_time_label or 'n/a'})"
+    )
+    lines.append(f"- Timeseries period: {ctx.temporal_period_label or 'n/a'}")
+    lines.append("")
+
+    lines.append("## Combined plots")
+    lines.append("")
+    combined_items = [
+        ("nulls", ctx.combined_nulls_plot),
+        ("spatial", ctx.combined_spatial_plot),
+        ("temporal", ctx.combined_temporal_plot),
+    ]
+    for label, filename in combined_items:
+        if filename:
+            lines.append(f"- {label}: [`{filename}`]({filename})")
+    lines.append("")
+
+    lines.append("## Missing timestamps")
+    lines.append("")
+    if not missing_entries:
+        lines.append("None detected at the two sampled points.")
+    else:
+        lines.append(
+            f"**{missing_total}** missing timestamps across **{len(missing_entries)}** "
+            f"(variable, point) combinations."
+        )
+        lines.append("")
+        lines.append(
+            f"Full list: [`{ctx.missing_timestamps_file or 'missing_timestamps.txt'}`]"
+            f"({ctx.missing_timestamps_file or 'missing_timestamps.txt'})"
+        )
+        lines.append("")
+        lines.append("| Variable | Point | Count |")
+        lines.append("|---|---|---|")
+        for var, point, count in missing_entries:
+            lines.append(f"| `{var}` | {point} | {count} |")
+    lines.append("")
+
+    lines.append("## Variables overview")
+    lines.append("")
+    lines.append("| Variable | Units | Long name | Nulls @ P1 | Nulls @ P2 | Plots |")
+    lines.append("|---|---|---|---|---|---|")
+    lines.extend(_variable_row(ctx.stats[var]) for var in ctx.variables)
+    lines.append("")
+
+    lines.append("## Per-variable details")
+    lines.append("")
+    lines.extend(_variable_section(ctx.stats[var], ctx) for var in ctx.variables)
+
+    path = ctx.output_dir / "validation_summary.md"
+    path.write_text("\n".join(lines))
+    return path

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -1,5 +1,7 @@
+from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
+from typing import Any
 
 import icechunk
 import numpy as np
@@ -31,6 +33,98 @@ end_date_option = typer.Option(
     help="Scope analysis to times before this date",
 )
 
+output_dir_option = typer.Option(
+    None,
+    "--output-dir",
+    help="Write outputs into this directory instead of creating a new run directory.",
+)
+
+
+@dataclass
+class VariableStats:
+    """Stats + metadata accumulated for one variable across plot types."""
+
+    name: str
+    units: str | None = None
+    long_name: str | None = None
+    short_name: str | None = None
+    standard_name: str | None = None
+    step_type: str | None = None
+
+    # Null analysis
+    null_plot: str | None = None
+    null_count_p1: int | None = None
+    null_count_p2: int | None = None
+    total_count_p1: int | None = None
+    total_count_p2: int | None = None
+    missing_timestamps_p1: list[str] = field(default_factory=list)
+    missing_timestamps_p2: list[str] = field(default_factory=list)
+
+    # Spatial comparison
+    spatial_plot: str | None = None
+    spatial_time_label: str | None = None
+    val_spatial_min: float | None = None
+    val_spatial_max: float | None = None
+    val_spatial_mean: float | None = None
+    ref_spatial_min: float | None = None
+    ref_spatial_max: float | None = None
+    ref_spatial_mean: float | None = None
+    ref_available_spatial: bool = False
+
+    # Timeseries comparison
+    temporal_plot: str | None = None
+    val_temporal_min_p1: float | None = None
+    val_temporal_max_p1: float | None = None
+    val_temporal_mean_p1: float | None = None
+    val_temporal_min_p2: float | None = None
+    val_temporal_max_p2: float | None = None
+    val_temporal_mean_p2: float | None = None
+    ref_temporal_min_p1: float | None = None
+    ref_temporal_max_p1: float | None = None
+    ref_temporal_mean_p1: float | None = None
+    ref_temporal_min_p2: float | None = None
+    ref_temporal_max_p2: float | None = None
+    ref_temporal_mean_p2: float | None = None
+    ref_available_temporal: bool = False
+
+
+@dataclass
+class RunContext:
+    """Shared state for a validation run. Built by run-all or lazily by individual commands."""
+
+    output_dir: Path
+    validation_url: str
+    reference_url: str | None
+    validation_ds: xr.Dataset
+    reference_ds: xr.Dataset | None
+    started_at: pd.Timestamp
+    # Spatial points used by null + timeseries plots.
+    point1_sel: dict[str, int]
+    point2_sel: dict[str, int]
+    point1_lat: float
+    point1_lon: float
+    point2_lat: float
+    point2_lon: float
+    ensemble_member: int | None
+    variables: list[str]
+    start_date: str | None = None
+    end_date: str | None = None
+    spatial_time_label: str | None = None
+    ref_spatial_time_label: str | None = None
+    temporal_period_label: str | None = None
+    missing_timestamps_file: str | None = None
+    combined_nulls_plot: str | None = None
+    combined_spatial_plot: str | None = None
+    combined_temporal_plot: str | None = None
+    stats: dict[str, VariableStats] = field(default_factory=dict)
+
+    def stats_for(self, var: str) -> VariableStats:
+        if var not in self.stats:
+            self.stats[var] = VariableStats(
+                name=var, **extract_variable_metadata(self.validation_ds, var)
+            )
+        return self.stats[var]
+
 
 def is_forecast_dataset(ds: xr.Dataset) -> bool:
     """Check if dataset is a forecast (has init_time and lead_time) or analysis (has time)."""
@@ -41,9 +135,7 @@ def scope_time_period(
     ds: xr.Dataset, start_date: str | None, end_date: str | None
 ) -> xr.Dataset:
     append_dim = "init_time" if is_forecast_dataset(ds) else "time"
-    if start_date:
-        ds = ds.sel({append_dim: slice(start_date, end_date)})
-    if end_date:
+    if start_date or end_date:
         ds = ds.sel({append_dim: slice(start_date, end_date)})
     return ds
 
@@ -152,24 +244,53 @@ def select_random_ensemble_member(ds: xr.Dataset) -> tuple[xr.Dataset, int | Non
     if "ensemble_member" not in ds.dims:
         return ds, None
     rng = np.random.default_rng()
-    ensemble_member = rng.choice(ds.ensemble_member, 1)[0]
+    ensemble_member = int(rng.choice(ds.ensemble_member, 1)[0])
     return (
         ds.sel(ensemble_member=ensemble_member),
         ensemble_member,
     )
 
 
-def get_output_filepath(base_filename: str, url: str) -> Path:
+def extract_variable_metadata(ds: xr.Dataset, var: str) -> dict[str, Any]:
+    """Pull commonly-referenced attrs (units, long_name, etc.) from a variable."""
+    attrs = ds[var].attrs
+    return {
+        "units": attrs.get("units"),
+        "long_name": attrs.get("long_name"),
+        "short_name": attrs.get("short_name"),
+        "standard_name": attrs.get("standard_name"),
+        "step_type": attrs.get("step_type"),
+    }
+
+
+def dataset_id_and_version(url: str) -> tuple[str, str]:
+    """Parse `.../<dataset-id>/<version>{.zarr|.icechunk}` from a URL.
+
+    Strips the `.zarr` / `.icechunk` suffix from the version so it's usable in file paths.
     """
-    Get output filepath by generating a filename with timestamp and
-    version suffix and creating the parent directory organized by dataset id.
-    """
-    timestamp_str = pd.Timestamp.now().strftime("%Y-%m-%dT%H-%M-%S")
     url_clean = url.removesuffix("/")
-    path_components = url_clean.split("/")
-    url_suffix = path_components[-1].removesuffix("/")
-    dataset_id = path_components[-2]
-    filename = f"{base_filename}_{url_suffix}_{timestamp_str}.png"
-    filepath = Path(OUTPUT_DIR) / dataset_id / filename
-    filepath.parent.mkdir(parents=True, exist_ok=True)
-    return filepath
+    parts = url_clean.split("/")
+    version = parts[-1].removesuffix(".zarr").removesuffix(".icechunk")
+    dataset_id = parts[-2]
+    return dataset_id, version
+
+
+def create_run_output_dir(
+    validation_url: str, base_timestamp: pd.Timestamp | None = None
+) -> Path:
+    """Create the per-run output directory: data/output/<dataset-id>/<version>_<YYYY-MM-DDTHH-MM>/"""
+    ts = base_timestamp if base_timestamp is not None else pd.Timestamp.now()
+    timestamp_str = ts.strftime("%Y-%m-%dT%H-%M")
+    dataset_id, version = dataset_id_and_version(validation_url)
+    run_dir = Path(OUTPUT_DIR) / dataset_id / f"{version}_{timestamp_str}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def resolve_output_dir(validation_url: str, output_dir: Path | str | None) -> Path:
+    """Resolve the output dir: use the provided one, or create a new per-run dir."""
+    if output_dir is not None:
+        path = Path(output_dir)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    return create_run_output_dir(validation_url)


### PR DESCRIPTION
Produce per-variable PNGs plus combined figures for nulls, spatial, and temporal comparisons, organized under `<dataset-id>/<version>_<timestamp>/` with a `validation_summary.md` index. Add `docs/validation.md` covering how to run, inspect output, and apply a data-quality checklist.