### PR TITLE
Add dataset-urls subcommand to print canonical store URLs

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -15,7 +15,7 @@ uv run src/scripts/validation/plots.py run-all <DATASET_URL>
 - `s3://dynamical-noaa-hrrr/noaa-hrrr-analysis/v0.1.0.icechunk`
 - `s3://dynamical-dwd-icon-eu/dwd-icon-eu-forecast-5-day/v0.2.0.icechunk`
 
-The bucket prefix can be found in `src/reformatters/__main__.py`. The dataset id and version are in the `TemplateConfig.dataset_attributes`.
+To look up the URLs for a dataset, run `uv run main <dataset-id> dataset-urls`. It prints the primary and replica URLs; pass `--format json` for a machine-readable form.
 
 Expect the run to take ~30–60 seconds per variable, mostly bounded by S3 reads (a ~20-variable dataset finishes in ~10–15 minutes). Progress is logged: one line per variable per plot type.
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -531,8 +531,11 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 typer.echo(primary)
                 typer.echo("")
                 typer.echo("Replicas:")
-                for url in replicas:
-                    typer.echo(url)
+                if replicas:
+                    for url in replicas:
+                        typer.echo(url)
+                else:
+                    typer.echo("(none)")
 
     def get_cli(
         self,

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -4,7 +4,6 @@ import subprocess
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from datetime import datetime
-from enum import StrEnum
 from functools import partial
 from pathlib import Path
 from typing import Annotated, Any, Generic, Literal, TypeVar
@@ -48,11 +47,6 @@ DATA_VAR = TypeVar("DATA_VAR", bound=DataVar[Any])
 SOURCE_FILE_COORD = TypeVar("SOURCE_FILE_COORD", bound=SourceFileCoord)
 
 log = get_logger(__name__)
-
-
-class DatasetUrlsFormat(StrEnum):
-    text = "text"
-    json = "json"
 
 
 class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
@@ -513,20 +507,20 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     def dataset_urls(
         self,
         output_format: Annotated[
-            DatasetUrlsFormat,
+            Literal["text", "json"],
             typer.Option("--format", help="Output format"),
-        ] = DatasetUrlsFormat.text,
+        ] = "text",
     ) -> None:
         """Print the canonical production URLs for this dataset's primary and replica stores."""
         primary = self.store_factory.primary_url()
         replicas = self.store_factory.replica_urls()
 
         match output_format:
-            case DatasetUrlsFormat.json:
+            case "json":
                 typer.echo(
                     json.dumps({"primary": primary, "replicas": replicas}, indent=2)
                 )
-            case DatasetUrlsFormat.text:
+            case "text":
                 typer.echo("Primary:")
                 typer.echo(primary)
                 typer.echo("")

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -4,6 +4,7 @@ import subprocess
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from datetime import datetime
+from enum import StrEnum
 from functools import partial
 from pathlib import Path
 from typing import Annotated, Any, Generic, Literal, TypeVar
@@ -47,6 +48,11 @@ DATA_VAR = TypeVar("DATA_VAR", bound=DataVar[Any])
 SOURCE_FILE_COORD = TypeVar("SOURCE_FILE_COORD", bound=SourceFileCoord)
 
 log = get_logger(__name__)
+
+
+class DatasetUrlsFormat(StrEnum):
+    text = "text"
+    json = "json"
 
 
 class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
@@ -504,6 +510,30 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 )
                 log.info(f"Done validating {replica_store}")
 
+    def dataset_urls(
+        self,
+        output_format: Annotated[
+            DatasetUrlsFormat,
+            typer.Option("--format", help="Output format"),
+        ] = DatasetUrlsFormat.text,
+    ) -> None:
+        """Print the canonical production URLs for this dataset's primary and replica stores."""
+        primary = self.store_factory.primary_url()
+        replicas = self.store_factory.replica_urls()
+
+        match output_format:
+            case DatasetUrlsFormat.json:
+                typer.echo(
+                    json.dumps({"primary": primary, "replicas": replicas}, indent=2)
+                )
+            case DatasetUrlsFormat.text:
+                typer.echo("Primary:")
+                typer.echo(primary)
+                typer.echo("")
+                typer.echo("Replicas:")
+                for url in replicas:
+                    typer.echo(url)
+
     def get_cli(
         self,
     ) -> typer.Typer:
@@ -514,6 +544,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         app.command()(self.backfill_kubernetes)
         app.command()(self.backfill_local)
         app.command()(self.backfill)
+        app.command()(self.dataset_urls)
         # Avoid method name conflict with pydantic's validate while keeping cli commands consistent
         app.command("validate")(self.validate_dataset)
         return app

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -251,33 +251,34 @@ def get_local_tmp_store() -> Path:
     return Path(f"data/tmp/{uuid4()}-tmp.zarr").absolute()
 
 
-def _dataset_format_extension(dataset_format: DatasetFormat) -> str:
+def _format_dataset_path(
+    base_path: str, dataset_id: str, version: str, dataset_format: DatasetFormat
+) -> str:
     match dataset_format:
         case DatasetFormat.ZARR3:
-            return "zarr"
+            extension = "zarr"
         case DatasetFormat.ICECHUNK:
-            return "icechunk"
+            extension = "icechunk"
         case _ as unreachable:
             assert_never(unreachable)
+    return f"{base_path}/{dataset_id}/v{version}.{extension}"
 
 
 def _get_store_path(
     dataset_id: str, version: str, storage_config: StorageConfig
 ) -> str:
-    if Config.is_prod:
-        base_path = storage_config.base_path
-    else:
-        base_path = _LOCAL_ZARR_STORE_BASE_PATH
-
-    extension = _dataset_format_extension(storage_config.format)
-    return f"{base_path}/{dataset_id}/v{version}.{extension}"
+    base_path = (
+        storage_config.base_path if Config.is_prod else _LOCAL_ZARR_STORE_BASE_PATH
+    )
+    return _format_dataset_path(base_path, dataset_id, version, storage_config.format)
 
 
 def _build_dataset_url(
     dataset_id: str, version: str, storage_config: StorageConfig
 ) -> str:
-    extension = _dataset_format_extension(storage_config.format)
-    return f"{storage_config.base_path}/{dataset_id}/v{version}.{extension}"
+    return _format_dataset_path(
+        storage_config.base_path, dataset_id, version, storage_config.format
+    )
 
 
 def _get_store(

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -276,6 +276,12 @@ def _get_store_path(
 def _build_dataset_url(
     dataset_id: str, version: str, storage_config: StorageConfig
 ) -> str:
+    """Canonical production URL for a dataset, regardless of `Config.env`.
+
+    Unlike `_get_store_path`, this always uses `storage_config.base_path` and
+    is intended for human-readable output (e.g. the `dataset-urls` CLI),
+    not for opening a store.
+    """
     return _format_dataset_path(
         storage_config.base_path, dataset_id, version, storage_config.format
     )

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -76,6 +76,19 @@ class StoreFactory(FrozenBaseModel):
             *[config.k8s_secret_name for config in self.replica_storage_configs],
         ]
 
+    def primary_url(self) -> str:
+        """Canonical production URL for the primary store, regardless of environment."""
+        return _build_dataset_url(
+            self.dataset_id, self.template_config_version, self.primary_storage_config
+        )
+
+    def replica_urls(self) -> list[str]:
+        """Canonical production URLs for replica stores, regardless of environment."""
+        return [
+            _build_dataset_url(self.dataset_id, self.template_config_version, config)
+            for config in self.replica_storage_configs
+        ]
+
     def primary_store(self, writable: bool = False, branch: str = "main") -> Store:
         store_path = _get_store_path(
             self.dataset_id,
@@ -238,6 +251,16 @@ def get_local_tmp_store() -> Path:
     return Path(f"data/tmp/{uuid4()}-tmp.zarr").absolute()
 
 
+def _dataset_format_extension(dataset_format: DatasetFormat) -> str:
+    match dataset_format:
+        case DatasetFormat.ZARR3:
+            return "zarr"
+        case DatasetFormat.ICECHUNK:
+            return "icechunk"
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
 def _get_store_path(
     dataset_id: str, version: str, storage_config: StorageConfig
 ) -> str:
@@ -246,15 +269,15 @@ def _get_store_path(
     else:
         base_path = _LOCAL_ZARR_STORE_BASE_PATH
 
-    match storage_config.format:
-        case DatasetFormat.ZARR3:
-            extension = "zarr"
-        case DatasetFormat.ICECHUNK:
-            extension = "icechunk"
-        case _ as unreachable:
-            assert_never(unreachable)
-
+    extension = _dataset_format_extension(storage_config.format)
     return f"{base_path}/{dataset_id}/v{version}.{extension}"
+
+
+def _build_dataset_url(
+    dataset_id: str, version: str, storage_config: StorageConfig
+) -> str:
+    extension = _dataset_format_extension(storage_config.format)
+    return f"{storage_config.base_path}/{dataset_id}/v{version}.{extension}"
 
 
 def _get_store(

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -134,6 +134,7 @@ def test_dynamical_dataset_methods_exist() -> None:
         "backfill",
         "update",
         "validate_dataset",
+        "dataset_urls",
     ]
     for method in methods:
         assert hasattr(DynamicalDataset, method), f"{method} missing"

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -51,6 +51,40 @@ def test_get_store_path(
     assert result == f"{expected_base}/dataset/v1.0{expected_extension}"
 
 
+@pytest.mark.parametrize("env", [Env.dev, Env.prod, Env.test])
+def test_store_factory_urls_use_production_paths_and_template_version(
+    monkeypatch: pytest.MonkeyPatch, env: Env
+) -> None:
+    """primary_url/replica_urls always return canonical production URLs and use
+    the template_config_version (not the env-dependent "dev" version)."""
+    monkeypatch.setattr(Config, "env", env)
+    monkeypatch.setattr(
+        "reformatters.common.storage._LOCAL_ZARR_STORE_BASE_PATH", "local/output"
+    )
+
+    factory = StoreFactory(
+        primary_storage_config=StorageConfig(
+            base_path="s3://primary-bucket/data", format=DatasetFormat.ZARR3
+        ),
+        replica_storage_configs=[
+            StorageConfig(
+                base_path="s3://replica-bucket-a/data", format=DatasetFormat.ICECHUNK
+            ),
+            StorageConfig(
+                base_path="s3://replica-bucket-b/data", format=DatasetFormat.ZARR3
+            ),
+        ],
+        dataset_id="my-dataset",
+        template_config_version="0.3.1",
+    )
+
+    assert factory.primary_url() == "s3://primary-bucket/data/my-dataset/v0.3.1.zarr"
+    assert factory.replica_urls() == [
+        "s3://replica-bucket-a/data/my-dataset/v0.3.1.icechunk",
+        "s3://replica-bucket-b/data/my-dataset/v0.3.1.zarr",
+    ]
+
+
 @pytest.mark.parametrize(
     ("env", "expected_version"),
     [

--- a/tests/datasets_test.py
+++ b/tests/datasets_test.py
@@ -97,8 +97,12 @@ def test_cli_dataset_urls_text_format(dataset: DynamicalDataset[Any, Any]) -> No
     assert "Primary:" in result.output
     assert expected_primary in result.output
     assert "Replicas:" in result.output
-    for replica_url in dataset.store_factory.replica_urls():
-        assert replica_url in result.output
+    replica_urls = dataset.store_factory.replica_urls()
+    if replica_urls:
+        for replica_url in replica_urls:
+            assert replica_url in result.output
+    else:
+        assert "(none)" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/datasets_test.py
+++ b/tests/datasets_test.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import pytest
@@ -80,6 +81,44 @@ def test_cli_has_backfill_command(dataset_id: str) -> None:
     assert result.exit_code == 0, (
         f"{dataset_id} backfill --help failed: {result.output}\n{result.exception}"
     )
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    DYNAMICAL_DATASETS,
+    ids=DATASET_IDS,
+)
+def test_cli_dataset_urls_text_format(dataset: DynamicalDataset[Any, Any]) -> None:
+    result = runner.invoke(app, [dataset.dataset_id, "dataset-urls"])
+    assert result.exit_code == 0, (
+        f"{dataset.dataset_id} dataset-urls failed: {result.output}\n{result.exception}"
+    )
+    expected_primary = dataset.store_factory.primary_url()
+    assert "Primary:" in result.output
+    assert expected_primary in result.output
+    assert "Replicas:" in result.output
+    for replica_url in dataset.store_factory.replica_urls():
+        assert replica_url in result.output
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    DYNAMICAL_DATASETS,
+    ids=DATASET_IDS,
+)
+def test_cli_dataset_urls_json_format(dataset: DynamicalDataset[Any, Any]) -> None:
+    result = runner.invoke(
+        app, [dataset.dataset_id, "dataset-urls", "--format", "json"]
+    )
+    assert result.exit_code == 0, (
+        f"{dataset.dataset_id} dataset-urls --format json failed: "
+        f"{result.output}\n{result.exception}"
+    )
+    parsed = json.loads(result.output)
+    assert parsed == {
+        "primary": dataset.store_factory.primary_url(),
+        "replicas": dataset.store_factory.replica_urls(),
+    }
 
 
 def test_cli_has_deploy_command() -> None:


### PR DESCRIPTION
## Summary
- Adds a `dataset-urls` subcommand to every `DynamicalDataset` CLI that prints the canonical production URLs for its primary and replica stores. Supports `--format json` for scripting.
- Exposes `StoreFactory.primary_url()` / `replica_urls()`, which always return the production URL (uses each `StorageConfig.base_path` and `template_config_version`, regardless of `Config.env`).
- Updates `docs/validation.md` so the validation walkthrough points at `uv run main <dataset-id> dataset-urls` instead of asking readers to cross-reference `__main__.py` storage configs with `TemplateConfig.dataset_attributes`.

Example:
```
$ uv run main noaa-hrrr-analysis dataset-urls
Primary:
s3://us-west-2.opendata.source.coop/dynamical/noaa-hrrr-analysis/v0.2.0.zarr

Replicas:
s3://dynamical-noaa-hrrr/noaa-hrrr-analysis/v0.2.0.icechunk
```

## Test plan
- [x] `uv run ruff format && uv run ruff check && uv run ty check`
- [x] `uv run pytest tests/common/test_storage.py tests/common/dynamical_dataset_test.py tests/datasets_test.py -m "not slow"` (284 passed)
- [x] Manual smoke: `uv run main noaa-hrrr-analysis dataset-urls`, `... --format json`, and `uv run main ecmwf-aifs-ens-forecast dataset-urls` (no replicas case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)