### PR TITLE
Improve store representation in zarr logging messages

### DIFF
--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -16,6 +16,11 @@ log = get_logger(__name__)
 
 _LOCAL_ZARR_STORE_BASE_PATH = "data/output"
 
+
+def _store_repr(store: Store) -> str:
+    return repr(store).replace("\n", " ")
+
+
 BLOSC_2BYTE_ZSTD_LEVEL3_SHUFFLE = BloscCodec(
     typesize=2,
     cname="zstd",
@@ -56,19 +61,19 @@ def copy_data_var(
 
     for replica_store in replica_stores:
         log.info(
-            f"Copying data var chunks to replica store ({replica_store}) for {relative_dir}."
+            f"Copying data var chunks to replica store ({_store_repr(replica_store)}) for {relative_dir}."
         )
         _copy_data_var_chunks(tmp_store, relative_dir, replica_store)
         log.info(
-            f"Done copying data var chunks to replica store ({replica_store}) for {relative_dir}."
+            f"Done copying data var chunks to replica store ({_store_repr(replica_store)}) for {relative_dir}."
         )
 
     log.info(
-        f"Copying data var chunks to primary store ({primary_store}) for {relative_dir}."
+        f"Copying data var chunks to primary store ({_store_repr(primary_store)}) for {relative_dir}."
     )
     _copy_data_var_chunks(tmp_store, relative_dir, primary_store)
     log.info(
-        f"Done copying data var chunks to primary store ({primary_store}) for {relative_dir}."
+        f"Done copying data var chunks to primary store ({_store_repr(primary_store)}) for {relative_dir}."
     )
 
     try:
@@ -135,14 +140,16 @@ def copy_zarr_metadata(
             continue
 
         log.info(
-            f"Copying metadata to replica store ({replica_store}) from {tmp_store}"
+            f"Copying metadata to replica store ({_store_repr(replica_store)}) from {tmp_store}"
         )
         _copy_metadata_files(metadata_files, tmp_store, replica_store)
 
     if _should_skip(primary_store):
         return
 
-    log.info(f"Copying metadata to primary store ({primary_store}) from {tmp_store}")
+    log.info(
+        f"Copying metadata to primary store ({_store_repr(primary_store)}) from {tmp_store}"
+    )
     _copy_metadata_files(metadata_files, tmp_store, primary_store)
 
 

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -18,7 +18,7 @@ _LOCAL_ZARR_STORE_BASE_PATH = "data/output"
 
 
 def _store_repr(store: Store) -> str:
-    return repr(store).replace("\n", " ")
+    return str(store).replace("\n", " ")
 
 
 BLOSC_2BYTE_ZSTD_LEVEL3_SHUFFLE = BloscCodec(


### PR DESCRIPTION
## Summary
This PR improves the readability of zarr store logging messages by introducing a helper function that formats store objects in a more compact way.

## Key Changes
- Added `_store_repr()` helper function that converts store objects to their string representation and removes newlines for single-line log output
- Updated all logging statements in `copy_data_var()` and `_copy_metadata_files()` functions to use `_store_repr()` when displaying store objects
- This prevents multi-line store representations from breaking log message formatting

## Implementation Details
The new `_store_repr()` function takes a `Store` object and returns a compact string representation by:
1. Converting the store to its repr() string
2. Replacing all newline characters with spaces to ensure single-line log output

This change affects 6 logging statements across the zarr module, making logs more consistent and easier to parse.

https://claude.ai/code/session_01Ac9bHWTzfQuU5d9iYHwzta