### PR TITLE
Improve table of contents styling and dataset name extraction

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -85,10 +85,12 @@ Open `validation_summary.md` first. It provides text-based information which can
 
 Statistics miss the visual failure modes. Open the images and walk through the checklist in section 4.
 
+Every per-variable PNG must be reviewed: for each variable, open all three of `nulls_<var>.png`, `spatial_<var>.png`, and `temporal_<var>.png`. Do not stop after a representative sample — issues can be variable-specific (a unit bug at one level, a flipped map for one field) and only surface when every plot is checked. The only plots you may skip are the three `combined_*.png` files, and only as noted below.
+
 A good working rhythm:
 
 1. If you are a human, open the three `combined_*.png` files first. Scroll through each to get an overview of all variables together — this quickly surfaces patterns across variables (e.g. radiation peaks coinciding with cloud cover minima) and spots any variable that looks dramatically off relative to its neighbors. Skip this step if you are an AI assistant, the `combined_*.png` image pixel dimensions exceeds standard limits and attempting to read them can blow up your context or stall the session.
-2. For each variable that looked fine in combined or that you want to inspect more closely, open `nulls_<var>.png`, `spatial_<var>.png`, and `temporal_<var>.png`. The per-variable PNGs are higher-resolution. Filenames are consistent, so a pattern like `*_<var>.png` opens all of them at once in most viewers.
+2. Open `nulls_<var>.png`, `spatial_<var>.png`, and `temporal_<var>.png` for **every** variable in the dataset — not a sample. The per-variable PNGs are higher-resolution. Filenames are consistent, so a pattern like `*_<var>.png` opens all three at once in most viewers.
 3. Cross-check against the variable's row in `validation_summary.md` (units, long_name, stats).
 4. Apply the checklist below. Note anomalies as `<variable> + <file> + what's wrong` so they can be acted on.
 

--- a/src/scripts/validation/render.py
+++ b/src/scripts/validation/render.py
@@ -224,6 +224,7 @@ section.variable.hidden { display: none; }
 @media (max-width: 880px) {
   .toc-toggle { display: block; }
   .toc { transform: translateX(-100%); transition: transform 180ms ease;
+         padding-top: 5.6rem;
          box-shadow: 0.4rem 0 1.2rem var(--shadow-color, rgba(0,0,0,0.4)); }
   body.toc-open .toc { transform: translateX(0); }
   body.toc-open::after { content: ""; position: fixed; inset: 0;

--- a/src/scripts/validation/render.py
+++ b/src/scripts/validation/render.py
@@ -164,7 +164,8 @@ li { margin: 0.2rem 0; }
   border: 1px solid var(--border-color); background: var(--bg-color);
   color: var(--header-color);
   width: 3.6rem; height: 3.6rem; font-size: 1.6rem; cursor: pointer;
-  display: none; padding: 0;
+  display: none; padding: 0; line-height: 1;
+  align-items: center; justify-content: center;
 }
 .toc-toggle:hover { background: var(--header-color); color: var(--bg-color); }
 
@@ -174,8 +175,8 @@ li { margin: 0.2rem 0; }
   overflow-y: auto; background: var(--bg-color); z-index: 20;
 }
 .toc-heading {
-  font-size: 1.1rem; text-transform: uppercase; letter-spacing: 1px;
-  color: var(--muted-text); margin: 2rem 0 0.8rem; font-weight: 700;
+  font-size: 1.4rem; color: var(--header-color);
+  margin: 2rem 0 0.8rem; font-weight: 700;
 }
 .toc-heading:first-child { margin-top: 0; }
 .toc ul { list-style: none; padding: 0; margin: 0; }
@@ -222,7 +223,7 @@ section.variable.hidden { display: none; }
 }
 
 @media (max-width: 880px) {
-  .toc-toggle { display: block; }
+  .toc-toggle { display: flex; }
   .toc { transform: translateX(-100%); transition: transform 180ms ease;
          padding-top: 5.6rem;
          box-shadow: 0.4rem 0 1.2rem var(--shadow-color, rgba(0,0,0,0.4)); }
@@ -281,7 +282,7 @@ _JS = r"""
 
 
 def _build_toc(
-    sections: list[tuple[str, str]], variables: list[str], dataset_id: str
+    sections: list[tuple[str, str]], variables: list[str], dataset_name: str
 ) -> str:
     section_items = "".join(
         f'<li><a href="#{slug}">{title}</a></li>' for slug, title in sections
@@ -293,7 +294,7 @@ def _build_toc(
     )
     return f"""
 <nav class="toc" aria-label="Table of contents">
-  <div class="toc-heading">{dataset_id}</div>
+  <div class="toc-heading">{dataset_name}</div>
   <ul>{section_items}</ul>
   <div class="toc-heading">Variables</div>
   <div class="var-actions">
@@ -305,6 +306,11 @@ def _build_toc(
 """
 
 
+def _extract_dataset_name(md_text: str, fallback: str) -> str:
+    m = re.search(r"^\|\s*Validation\s*\|\s*([^|]+?)\s*\|", md_text, flags=re.MULTILINE)
+    return m.group(1) if m else fallback
+
+
 def render_html(md_text: str, dataset_id: str) -> str:
     md = MarkdownIt("commonmark").enable("table")
     html = md.render(md_text)
@@ -314,7 +320,8 @@ def render_html(md_text: str, dataset_id: str) -> str:
     html = _annotate_non_var_h3(html)
     html = _wrap_variable_sections(html)
     html = _wrap_tables(html)
-    toc = _build_toc(sections, variables, dataset_id)
+    dataset_name = _extract_dataset_name(md_text, dataset_id)
+    toc = _build_toc(sections, variables, dataset_name)
     title = f"Validation report — {dataset_id}"
     return f"""<!doctype html>
 <html lang="en">

--- a/src/scripts/validation/report_nulls.py
+++ b/src/scripts/validation/report_nulls.py
@@ -112,10 +112,15 @@ def write_missing_timestamps_file(output_dir: Path, ctx: RunContext) -> str | No
     filename = "missing_timestamps.txt"
     path = output_dir / filename
     total = sum(len(m) for _, _, m in entries)
+    all_missing = sorted({ts for _, _, missing in entries for ts in missing})
+    combined_filter = " ".join(f"--filter-contains {ts}" for ts in all_missing)
     lines = [
         "# Missing timestamps",
         f"# Total: {total} across {len(entries)} (variable, point) combinations.",
         "# Use --filter-contains <timestamp> to retry those source files with backfill.",
+        "",
+        f"# Combined retry filter ({len(all_missing)} unique timestamps across all variables):",
+        f"combined-retry-filter: {combined_filter}",
         "",
     ]
     for var, point_label, missing in entries:


### PR DESCRIPTION
## Summary
This PR enhances the validation report's table of contents (TOC) UI and improves how dataset names are displayed. It also adds a convenience feature for retrying missing timestamps during validation.

## Key Changes

### Validation Report Rendering (`render.py`)
- **TOC Toggle Button**: Updated styling to use flexbox (`display: flex`) with proper centering (`align-items: center; justify-content: center`) and adjusted line-height for better icon alignment
- **TOC Heading**: Increased font size from 1.1rem to 1.4rem, changed color from muted text to header color, and removed uppercase text-transform and letter-spacing for a cleaner appearance
- **TOC Container**: Added `padding-top: 5.6rem` on mobile to prevent content from being hidden behind the toggle button
- **Dataset Name Extraction**: Added new `_extract_dataset_name()` function that parses the markdown table to extract the actual dataset name from the "Validation" row, falling back to the dataset_id if not found
- **Parameter Rename**: Changed `_build_toc()` parameter from `dataset_id` to `dataset_name` to reflect its new purpose

### Missing Timestamps Report (`report_nulls.py`)
- **Retry Filter Generation**: Added automatic generation of a combined retry filter command that includes all unique missing timestamps across all variables, making it easier to retry failed source files with a single command

### Documentation (`validation.md`)
- **Review Instructions**: Clarified that every per-variable PNG must be reviewed (not just a sample), emphasizing that issues can be variable-specific and only surface when all plots are checked
- **Workflow Emphasis**: Updated step 2 to explicitly state "**every** variable in the dataset" rather than conditional review based on combined plots

## Implementation Details
- The dataset name extraction uses regex to find the "Validation" row in the markdown table, providing a more user-friendly display name in the TOC while maintaining backward compatibility with the dataset_id fallback
- The combined retry filter is generated as a space-separated string of `--filter-contains` flags for direct CLI usage

https://claude.ai/code/session_01XUZfoyCZgaqDZ63w59dnBR