### PR TITLE
Fix IFS ENS control source after IFS Cycle 50r1 cutover

### DIFF
--- a/src/reformatters/ecmwf/ecmwf_grib_index.py
+++ b/src/reformatters/ecmwf/ecmwf_grib_index.py
@@ -99,9 +99,11 @@ def _parse_index_file(
             df["number"] = 0
         else:
             df["number"] = df["number"].fillna(0).astype(int)
-        # Ensure that every row we filled with number=0 was indeed type "cf" (control forecast)
-        assert (df[df["number"] == 0]["type"] == "cf").all(), (
-            "Parsed row as control member that didn't have type='cf'"
+        # Rows with number=0 must be the control member: either type=cf
+        # (pre-IFS-50r1 enfo) or type=fc (post-50r1 oper, where ex-HRES and
+        # ENS Control were merged into a single forecast).
+        assert df[df["number"] == 0]["type"].isin({"cf", "fc"}).all(), (
+            "Parsed row as control member that didn't have type='cf' or type='fc'"
         )
 
     return df.set_index(index_cols).sort_index()

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
@@ -21,6 +21,11 @@ from reformatters.ecmwf.ecmwf_config_models import (
 
 MARS_OPEN_DATA_CUTOVER = pd.Timestamp("2024-04-01T00:00")
 
+# IFS Cycle 50r1 (2026-05-12 06z) merged ex-HRES and the ENS control into one
+# forecast, disseminated as stream=oper, type=fc instead of stream=enfo, type=cf.
+# From the cutover, the control member lives in oper-fc; perturbed members remain in enfo-ef.
+IFS_CYCLE_50R1_CUTOVER = pd.Timestamp("2026-05-12T06:00")
+
 DYNAMICAL_MARS_GRIB_BASE_URL = (
     "https://data.source.coop/dynamical/ecmwf-ifs-grib/ecmwf-ifs-ens"
 )
@@ -61,13 +66,21 @@ class OpenDataSourceFileCoord(SourceFileCoord):
         init_hour_str = self.init_time.strftime("%H")  # pads 0 to be "00", as desired
         lead_time_hour_str = whole_hours(self.lead_time)
 
+        use_oper_control = (
+            self.init_time >= IFS_CYCLE_50R1_CUTOVER and self.ensemble_member == 0
+        )
+        stream_dir = "oper" if use_oper_control else "enfo"
+        file_kind = "oper-fc" if use_oper_control else "enfo-ef"
+
         # On 2024-02-29 and onward, the /ifs/ directory is included in the URL path.
         if self.init_time >= pd.Timestamp("2024-02-29T00:00"):
-            directory_path = f"{init_time_str}/{init_hour_str}z/ifs/0p25/enfo"
+            directory_path = f"{init_time_str}/{init_hour_str}z/ifs/0p25/{stream_dir}"
         else:
-            directory_path = f"{init_time_str}/{init_hour_str}z/0p25/enfo"
+            directory_path = f"{init_time_str}/{init_hour_str}z/0p25/{stream_dir}"
 
-        filename = f"{init_time_str}{init_hour_str}0000-{lead_time_hour_str}h-enfo-ef"
+        filename = (
+            f"{init_time_str}{init_hour_str}0000-{lead_time_hour_str}h-{file_kind}"
+        )
         return f"{base_url}/{directory_path}/{filename}"
 
     def get_url(self) -> str:

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord_test.py
@@ -84,6 +84,49 @@ def test_open_data_get_url_without_ifs_directory() -> None:
     )
 
 
+def test_open_data_get_url_control_uses_oper_after_50r1_cutover() -> None:
+    coord = OpenDataSourceFileCoord(
+        init_time=pd.Timestamp("2026-05-12T06:00"),
+        lead_time=pd.Timedelta("78h"),
+        data_var_group=[],
+        ensemble_member=0,
+    )
+    assert (
+        coord.get_url()
+        == "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20260512/06z/ifs/0p25/oper/20260512060000-78h-oper-fc.grib2"
+    )
+    assert (
+        coord.get_index_url()
+        == "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20260512/06z/ifs/0p25/oper/20260512060000-78h-oper-fc.index"
+    )
+
+
+def test_open_data_get_url_control_uses_enfo_before_50r1_cutover() -> None:
+    coord = OpenDataSourceFileCoord(
+        init_time=pd.Timestamp("2026-05-12T00:00"),
+        lead_time=pd.Timedelta("78h"),
+        data_var_group=[],
+        ensemble_member=0,
+    )
+    assert (
+        coord.get_url()
+        == "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20260512/00z/ifs/0p25/enfo/20260512000000-78h-enfo-ef.grib2"
+    )
+
+
+def test_open_data_get_url_perturbed_stays_in_enfo_after_50r1_cutover() -> None:
+    coord = OpenDataSourceFileCoord(
+        init_time=pd.Timestamp("2026-05-12T06:00"),
+        lead_time=pd.Timedelta("78h"),
+        data_var_group=[],
+        ensemble_member=1,
+    )
+    assert (
+        coord.get_url()
+        == "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20260512/06z/ifs/0p25/enfo/20260512060000-78h-enfo-ef.grib2"
+    )
+
+
 def test_open_data_index_step_is_none() -> None:
     coord = OpenDataSourceFileCoord(
         init_time=pd.Timestamp("2025-01-01"),

--- a/tests/ecmwf/test_ecmwf_grib_index.py
+++ b/tests/ecmwf/test_ecmwf_grib_index.py
@@ -33,6 +33,13 @@ _EXAMPLE_INDEX_JSONL = """\
 {"domain": "g", "date": "20240201", "time": "0000", "expver": "0001", "class": "od", "type": "pf", "stream": "enfo", "step": "3", "levtype": "pl", "levelist": "500", "number": "2", "param": "gh", "_offset": 674936844, "_length": 393429}
 """
 
+# Post-IFS-50r1 oper-fc index: no "number" column, type=fc, stream=oper.
+# The parser should fill number=0 for every row (the merged ex-HRES/ENS control).
+_OPER_FC_INDEX_JSONL = """\
+{"domain": "g", "date": "20260513", "time": "0000", "expver": "0001", "class": "od", "type": "fc", "stream": "oper", "step": "78", "levtype": "sfc", "param": "2t", "_offset": 0, "_length": 1000000}
+{"domain": "g", "date": "20260513", "time": "0000", "expver": "0001", "class": "od", "type": "fc", "stream": "oper", "step": "78", "levtype": "pl", "levelist": "500", "param": "gh", "_offset": 1000000, "_length": 500000}
+"""
+
 
 @pytest.fixture
 def index_file(tmp_path: Path) -> Path:
@@ -243,6 +250,45 @@ def test_get_byte_ranges_mars_pf_sfc_with_step() -> None:
     )
     assert starts == [2076642]
     assert ends == [2076642 + 2076642]
+
+
+# ---------------------------------------------------------------------------
+# Post-50r1 oper-fc index tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def oper_fc_index_file(tmp_path: Path) -> Path:
+    path = tmp_path / "oper-fc.index"
+    path.write_text(_OPER_FC_INDEX_JSONL)
+    return path
+
+
+def test_parse_oper_fc_index_fills_number_with_0(oper_fc_index_file: Path) -> None:
+    df = _parse_index_file(oper_fc_index_file, ensemble=True)
+    df_reset = df.reset_index()
+    assert (df_reset["number"] == 0).all()
+    assert (df_reset["type"] == "fc").all()
+
+
+def test_get_byte_ranges_oper_fc_surface_var(oper_fc_index_file: Path) -> None:
+    var = _make_ecmwf_var("temperature_2m", "2t", "sfc")
+    starts, ends = get_message_byte_ranges_from_index(
+        oper_fc_index_file, [var], ensemble_member=0
+    )
+    assert starts == [0]
+    assert ends == [1000000]
+
+
+def test_get_byte_ranges_oper_fc_pressure_level_var(oper_fc_index_file: Path) -> None:
+    var = _make_ecmwf_var(
+        "geopotential_height_500hpa", "gh", "pl", grib_index_level_value=500.0
+    )
+    starts, ends = get_message_byte_ranges_from_index(
+        oper_fc_index_file, [var], ensemble_member=0
+    )
+    assert starts == [1000000]
+    assert ends == [1500000]
 
 
 def test_get_byte_ranges_mars_multiple_vars_single_step() -> None:


### PR DESCRIPTION
## Summary

- ECMWF IFS Cycle 50r1 (implemented from 2026-05-12 06z) merged ex-HRES and the ENS control into a single forecast disseminated as `stream=oper, type=fc` instead of `stream=enfo, type=cf`. Today's `enfo-ef.index` files no longer contain any `cf` rows, so every `ensemble_member=0` download fails with `KeyError: (0, <param>, <levtype>, <level>)` (Sentry [REFORMATTERS-E6](https://dynamical.sentry.io/issues/7477904213/), [REFORMATTERS-E7](https://dynamical.sentry.io/issues/7477915723/)).
- Route `ensemble_member=0` to `/0p25/oper/...-oper-fc.{grib2,index}` when `init_time >= 2026-05-12T06:00`. Perturbed members and pre-cutover initializations continue using `/0p25/enfo/...-enfo-ef`.
- Relax the control-row assertion in `_parse_index_file` to accept `type ∈ {cf, fc}` so the oper-fc index (no `number` column, `type=fc`) parses cleanly.

Verified before this change:
- Today's `oper-fc.index` covers a strict superset of yesterday's `enfo-ef` `cf` rows (161 in both, 23 new in oper-fc, 0 missing).
- Sampled a `gh/pl/500` message from `oper-fc.grib2` via byte-range: same 1440×721 0.25° grid, identical bounds, lead time and GRIB tags consistent with what `_validate_grib_metadata` already accepts.

References:
- [Implementation of IFS Cycle 50r1 — ECMWF Confluence](https://confluence.ecmwf.int/display/FCST/Implementation+of+IFS+Cycle+50r1) — "ENS Control forecasts will be disseminated and archived in MARS with class=od, stream=oper, type=fc rather than class=od, stream=enfo, type=cf"
- [Confirmation: IFS Cycle 50r1 and AIFS v2 — 12 May 2026](https://forum.ecmwf.int/t/confirmation-ifs-cycle-50r1-and-aifs-v2-joint-implementation-on-12-may-2026/14937)

## Test plan

- [x] `uv run pytest tests/ecmwf/` (123 passed)
- [x] `uv run ruff format && uv run ruff check && uv run ty check`
- [ ] Confirm next operational update cron run produces `ensemble_member=0` data from oper-fc without errors (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)