### PR TITLE
Enforce zero NaN tolerance in forecast dataset validators

### DIFF
--- a/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import timedelta
+from functools import partial
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
@@ -60,5 +61,5 @@ class EcmwfAifsEnsForecastDataset(
     def validators(self) -> Sequence[validation.DataValidator]:
         return (
             validation.check_forecast_current_data,
-            validation.check_forecast_recent_nans,
+            partial(validation.check_forecast_recent_nans, max_nan_percentage=0),
         )

--- a/src/reformatters/ecmwf/aifs_single/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/dynamical_dataset.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import timedelta
+from functools import partial
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
@@ -55,5 +56,5 @@ class EcmwfAifsSingleForecastDataset(
     def validators(self) -> Sequence[validation.DataValidator]:
         return (
             validation.check_forecast_current_data,
-            validation.check_forecast_recent_nans,
+            partial(validation.check_forecast_recent_nans, max_nan_percentage=0),
         )

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import timedelta
+from functools import partial
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
@@ -62,5 +63,5 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
         """Return a sequence of DataValidators to run on this dataset."""
         return (
             validation.check_forecast_current_data,
-            validation.check_forecast_recent_nans,
+            partial(validation.check_forecast_recent_nans, max_nan_percentage=0),
         )


### PR DESCRIPTION
## Summary
Updates forecast dataset validators across three ECMWF datasets to enforce strict zero-tolerance for NaN values by explicitly setting `max_nan_percentage=0` when calling the `check_forecast_recent_nans` validator.

## Changes
- Modified `validators()` method in three forecast dataset classes:
  - `src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py`
  - `src/reformatters/ecmwf/aifs_single/forecast/dynamical_dataset.py`
  - `src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py`
- Wrapped `validation.check_forecast_recent_nans` with `functools.partial` to explicitly pass `max_nan_percentage=0`
- Added `from functools import partial` import to each modified file

## Implementation Details
The change uses `functools.partial` to create a validator function with the `max_nan_percentage` parameter pre-configured to 0, ensuring these datasets will fail validation if any NaN values are detected in recent forecast data. This is more explicit than relying on a default parameter value and makes the strict validation requirement clear in the code.

https://claude.ai/code/session_01VF7rqGkp8UbENNsM1p8RkQ