### PR TITLE
Add GCS mirror fallback for AIFS-ENS downloads

### DIFF
--- a/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
@@ -29,8 +29,18 @@ from reformatters.common.types import (
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, vars_available
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
+from reformatters.ecmwf.ecmwf_utils import (
+    SOURCE_BASE_URLS,
+    EcmwfSource,
+    ecmwf_download_with_fallback,
+)
 
 log = get_logger(__name__)
+
+# aifs-ens files land on the GCS mirror ~40 min after S3. For recent forecasts
+# prefer S3 (freshness); for older forecasts prefer GCS (better availability under
+# S3 throttling). See https://forum.ecmwf.int/t/503-slowdown-errors-for-requests-to-s3-ecmwf-forecasts/14345
+_RECENT_CUTOFF = pd.Timedelta(hours=24)
 
 # GRIB master table version changes caused metadata differences for precipitation.
 # Early data (table v27): generic product template codes.
@@ -55,8 +65,8 @@ class EcmwfAifsEnsForecastSourceFileCoord(SourceFileCoord):
         # ensemble_member 0 is the control forecast (cf), 1-50 are perturbed members (pf).
         return "cf" if self.ensemble_member == 0 else "pf"
 
-    def _get_base_url(self) -> str:
-        root_url = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
+    def _get_base_url(self, source: EcmwfSource) -> str:
+        root_url = SOURCE_BASE_URLS[source]
 
         init_time_str = self.init_time.strftime("%Y%m%d")
         init_hour_str = self.init_time.strftime("%H")
@@ -66,11 +76,11 @@ class EcmwfAifsEnsForecastSourceFileCoord(SourceFileCoord):
         filename = f"{init_time_str}{init_hour_str}0000-{lead_time_hour_str}h-enfo-{self.file_type}"
         return f"{root_url}/{directory_path}/{filename}"
 
-    def get_url(self) -> str:
-        return self._get_base_url() + ".grib2"
+    def get_url(self, source: EcmwfSource = "s3") -> str:
+        return self._get_base_url(source) + ".grib2"
 
-    def get_index_url(self) -> str:
-        return self._get_base_url() + ".index"
+    def get_index_url(self, source: EcmwfSource = "s3") -> str:
+        return self._get_base_url(source) + ".index"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValue]:
         return {
@@ -117,10 +127,13 @@ class EcmwfAifsEnsForecastRegionJob(
             )
         return coords
 
-    def download_file(self, coord: EcmwfAifsEnsForecastSourceFileCoord) -> Path:
-        idx_url = coord.get_index_url()
+    def _download_from_source(
+        self,
+        coord: EcmwfAifsEnsForecastSourceFileCoord,
+        source: EcmwfSource,
+    ) -> Path:
         idx_local_path = http_download_to_disk(
-            idx_url, self.dataset_id, disk_cache=True
+            coord.get_index_url(source), self.dataset_id, disk_cache=True
         )
 
         # cf files have no "number" column (single member); pf files have a "number" column.
@@ -136,10 +149,19 @@ class EcmwfAifsEnsForecastRegionJob(
             f"{s}-{e}" for s, e in zip(byte_range_starts, byte_range_ends, strict=True)
         )
         return http_download_to_disk(
-            coord.get_url(),
+            coord.get_url(source),
             self.dataset_id,
             byte_ranges=(byte_range_starts, byte_range_ends),
             local_path_suffix=f"-{suffix}",
+        )
+
+    def download_file(self, coord: EcmwfAifsEnsForecastSourceFileCoord) -> Path:
+        if coord.init_time >= pd.Timestamp.now() - _RECENT_CUTOFF:
+            sources: tuple[EcmwfSource, ...] = ("s3", "gcs")
+        else:
+            sources = ("gcs", "s3")
+        return ecmwf_download_with_fallback(
+            sources, lambda source: self._download_from_source(coord, source)
         )
 
     def read_data(

--- a/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
@@ -1,7 +1,7 @@
 import itertools
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, assert_never
 
 import numpy as np
 import pandas as pd
@@ -29,11 +29,7 @@ from reformatters.common.types import (
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, vars_available
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
-from reformatters.ecmwf.ecmwf_utils import (
-    SOURCE_BASE_URLS,
-    EcmwfSource,
-    ecmwf_download_with_fallback,
-)
+from reformatters.ecmwf.ecmwf_utils import EcmwfSource, ecmwf_download_with_fallback
 
 log = get_logger(__name__)
 
@@ -66,7 +62,13 @@ class EcmwfAifsEnsForecastSourceFileCoord(SourceFileCoord):
         return "cf" if self.ensemble_member == 0 else "pf"
 
     def _get_base_url(self, source: EcmwfSource) -> str:
-        root_url = SOURCE_BASE_URLS[source]
+        match source:
+            case "s3":
+                root_url = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
+            case "gcs":
+                root_url = "https://storage.googleapis.com/ecmwf-open-data"
+            case _ as unreachable:
+                assert_never(unreachable)
 
         init_time_str = self.init_time.strftime("%Y%m%d")
         init_hour_str = self.init_time.strftime("%H")

--- a/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
@@ -129,6 +129,15 @@ class EcmwfAifsEnsForecastRegionJob(
             )
         return coords
 
+    def download_file(self, coord: EcmwfAifsEnsForecastSourceFileCoord) -> Path:
+        if coord.init_time >= pd.Timestamp.now() - _RECENT_CUTOFF:
+            sources: tuple[EcmwfSource, ...] = ("s3", "gcs")
+        else:
+            sources = ("gcs", "s3")
+        return ecmwf_download_with_fallback(
+            sources, lambda source: self._download_from_source(coord, source)
+        )
+
     def _download_from_source(
         self,
         coord: EcmwfAifsEnsForecastSourceFileCoord,
@@ -155,15 +164,6 @@ class EcmwfAifsEnsForecastRegionJob(
             self.dataset_id,
             byte_ranges=(byte_range_starts, byte_range_ends),
             local_path_suffix=f"-{suffix}",
-        )
-
-    def download_file(self, coord: EcmwfAifsEnsForecastSourceFileCoord) -> Path:
-        if coord.init_time >= pd.Timestamp.now() - _RECENT_CUTOFF:
-            sources: tuple[EcmwfSource, ...] = ("s3", "gcs")
-        else:
-            sources = ("gcs", "s3")
-        return ecmwf_download_with_fallback(
-            sources, lambda source: self._download_from_source(coord, source)
         )
 
     def read_data(

--- a/src/reformatters/ecmwf/ecmwf_utils.py
+++ b/src/reformatters/ecmwf/ecmwf_utils.py
@@ -1,0 +1,37 @@
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Literal
+
+from obstore.exceptions import GenericError, PermissionDeniedError
+
+from reformatters.common.logging import get_logger
+
+log = get_logger(__name__)
+
+type EcmwfSource = Literal["s3", "gcs"]
+
+SOURCE_BASE_URLS: dict[EcmwfSource, str] = {
+    "s3": "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com",
+    "gcs": "https://storage.googleapis.com/ecmwf-open-data",
+}
+
+# Triggers fallback to the next source: missing files, AWS 503 Slow Down translated
+# by obstore to GenericError, and AWS 403s which obstore raises as PermissionDeniedError.
+_FALLBACK_EXCEPTIONS = (FileNotFoundError, GenericError, PermissionDeniedError)
+
+
+def ecmwf_download_with_fallback(
+    sources: Sequence[EcmwfSource],
+    download_one: Callable[[EcmwfSource], Path],
+) -> Path:
+    """Try each source in order, falling back on missing-file / transient errors."""
+    assert len(sources) > 0
+    last_exc: Exception | None = None
+    for source in sources:
+        try:
+            return download_one(source)
+        except _FALLBACK_EXCEPTIONS as e:
+            log.warning(f"ECMWF download from {source!r} failed, will fall back: {e}")
+            last_exc = e
+    assert last_exc is not None
+    raise last_exc

--- a/src/reformatters/ecmwf/ecmwf_utils.py
+++ b/src/reformatters/ecmwf/ecmwf_utils.py
@@ -10,11 +10,6 @@ log = get_logger(__name__)
 
 type EcmwfSource = Literal["s3", "gcs"]
 
-SOURCE_BASE_URLS: dict[EcmwfSource, str] = {
-    "s3": "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com",
-    "gcs": "https://storage.googleapis.com/ecmwf-open-data",
-}
-
 # Triggers fallback to the next source: missing files, AWS 503 Slow Down translated
 # by obstore to GenericError, and AWS 403s which obstore raises as PermissionDeniedError.
 _FALLBACK_EXCEPTIONS = (FileNotFoundError, GenericError, PermissionDeniedError)

--- a/tests/ecmwf/aifs_ens/forecast/region_job_test.py
+++ b/tests/ecmwf/aifs_ens/forecast/region_job_test.py
@@ -31,12 +31,20 @@ def test_source_file_coord_url_cf() -> None:
         data_var_group=list(config.data_vars[:1]),
     )
     assert coord.file_type == "cf"
-    assert coord.get_url() == (
+    assert coord.get_url("s3") == (
         "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
         "/20250702/12z/aifs-ens/0p25/enfo/20250702120000-6h-enfo-cf.grib2"
     )
-    assert coord.get_index_url() == (
+    assert coord.get_index_url("s3") == (
         "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
+        "/20250702/12z/aifs-ens/0p25/enfo/20250702120000-6h-enfo-cf.index"
+    )
+    assert coord.get_url("gcs") == (
+        "https://storage.googleapis.com/ecmwf-open-data"
+        "/20250702/12z/aifs-ens/0p25/enfo/20250702120000-6h-enfo-cf.grib2"
+    )
+    assert coord.get_index_url("gcs") == (
+        "https://storage.googleapis.com/ecmwf-open-data"
         "/20250702/12z/aifs-ens/0p25/enfo/20250702120000-6h-enfo-cf.index"
     )
 
@@ -50,12 +58,20 @@ def test_source_file_coord_url_pf() -> None:
         data_var_group=list(config.data_vars[:1]),
     )
     assert coord.file_type == "pf"
-    assert coord.get_url() == (
+    assert coord.get_url("s3") == (
         "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
         "/20250702/00z/aifs-ens/0p25/enfo/20250702000000-12h-enfo-pf.grib2"
     )
-    assert coord.get_index_url() == (
+    assert coord.get_index_url("s3") == (
         "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
+        "/20250702/00z/aifs-ens/0p25/enfo/20250702000000-12h-enfo-pf.index"
+    )
+    assert coord.get_url("gcs") == (
+        "https://storage.googleapis.com/ecmwf-open-data"
+        "/20250702/00z/aifs-ens/0p25/enfo/20250702000000-12h-enfo-pf.grib2"
+    )
+    assert coord.get_index_url("gcs") == (
+        "https://storage.googleapis.com/ecmwf-open-data"
         "/20250702/00z/aifs-ens/0p25/enfo/20250702000000-12h-enfo-pf.index"
     )
 
@@ -118,11 +134,22 @@ def test_generate_source_file_coords() -> None:
         assert isinstance(coord, EcmwfAifsEnsForecastSourceFileCoord)
 
 
-def test_download_file_cf(monkeypatch: pytest.MonkeyPatch) -> None:
+_CF_INDEX = """
+{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "cf", "stream": "enfo", "step": "6", "levtype": "sfc", "param": "2t", "model": "aifs-ens", "_offset": 0, "_length": 665525}
+{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "cf", "stream": "enfo", "step": "6", "levtype": "sfc", "param": "10u", "_offset": 665525, "_length": 700000}
+"""
+
+_PF_INDEX = """
+{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "pf", "stream": "enfo", "step": "6", "levtype": "sfc", "number": "1", "param": "2t", "model": "aifs-ens", "_offset": 0, "_length": 665525}
+{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "pf", "stream": "enfo", "step": "6", "levtype": "sfc", "number": "2", "param": "2t", "model": "aifs-ens", "_offset": 665525, "_length": 670000}
+{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "pf", "stream": "enfo", "step": "6", "levtype": "sfc", "number": "3", "param": "2t", "model": "aifs-ens", "_offset": 1335525, "_length": 660000}
+"""
+
+
+def _make_region_job() -> EcmwfAifsEnsForecastRegionJob:
     config = EcmwfAifsEnsForecastTemplateConfig()
     template_ds = config.get_template(pd.Timestamp("2025-07-02T06:00"))
-
-    region_job = EcmwfAifsEnsForecastRegionJob.model_construct(
+    return EcmwfAifsEnsForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=template_ds,
         data_vars=config.data_vars,
@@ -130,6 +157,20 @@ def test_download_file_cf(monkeypatch: pytest.MonkeyPatch) -> None:
         region=slice(0, 1),
         reformat_job_name="test",
     )
+
+
+def _patch_pd_now(monkeypatch: pytest.MonkeyPatch, now: pd.Timestamp) -> None:
+    monkeypatch.setattr(pd.Timestamp, "now", classmethod(lambda *args, **kwargs: now))
+
+
+def _patch_index(monkeypatch: pytest.MonkeyPatch, index_text: str) -> None:
+    mock_index_df = pd.read_json(StringIO(index_text), lines=True)
+    monkeypatch.setattr("pandas.read_json", lambda path, **kwargs: mock_index_df)
+
+
+def test_download_file_cf(monkeypatch: pytest.MonkeyPatch) -> None:
+    region_job = _make_region_job()
+    config = EcmwfAifsEnsForecastTemplateConfig()
     t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
     coord = EcmwfAifsEnsForecastSourceFileCoord(
         init_time=pd.Timestamp("2025-07-02T00:00"),
@@ -137,17 +178,9 @@ def test_download_file_cf(monkeypatch: pytest.MonkeyPatch) -> None:
         ensemble_member=0,
         data_var_group=[t2m_var],
     )
-
-    # cf index has no "number" or "type=pf" - all type=cf
-    example_grib_index = """
-{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "cf", "stream": "enfo", "step": "6", "levtype": "sfc", "param": "2t", "model": "aifs-ens", "_offset": 0, "_length": 665525}
-{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "cf", "stream": "enfo", "step": "6", "levtype": "sfc", "param": "10u", "_offset": 665525, "_length": 700000}
-"""
-    mock_index_df = pd.read_json(StringIO(example_grib_index), lines=True)
-    monkeypatch.setattr(
-        "pandas.read_json",
-        lambda path, **kwargs: mock_index_df,
-    )
+    # Recent: 12h after init_time, S3 should be tried first.
+    _patch_pd_now(monkeypatch, pd.Timestamp("2025-07-02T12:00"))
+    _patch_index(monkeypatch, _CF_INDEX)
 
     download_to_disk_mock = Mock()
     monkeypatch.setattr(
@@ -158,25 +191,19 @@ def test_download_file_cf(monkeypatch: pytest.MonkeyPatch) -> None:
     region_job.download_file(coord)
 
     assert download_to_disk_mock.call_count == 2
-    url, _dataset_id = download_to_disk_mock.call_args_list[1][0]
+    idx_url = download_to_disk_mock.call_args_list[0][0][0]
+    data_url, _dataset_id = download_to_disk_mock.call_args_list[1][0]
     kwargs = download_to_disk_mock.call_args_list[1][1]
 
-    assert "20250702000000-6h-enfo-cf.grib2" in url
+    assert "ecmwf-forecasts.s3" in idx_url
+    assert "ecmwf-forecasts.s3" in data_url
+    assert "20250702000000-6h-enfo-cf.grib2" in data_url
     assert kwargs["byte_ranges"] == ([0], [665525])
 
 
 def test_download_file_pf(monkeypatch: pytest.MonkeyPatch) -> None:
+    region_job = _make_region_job()
     config = EcmwfAifsEnsForecastTemplateConfig()
-    template_ds = config.get_template(pd.Timestamp("2025-07-02T06:00"))
-
-    region_job = EcmwfAifsEnsForecastRegionJob.model_construct(
-        tmp_store=Mock(),
-        template_ds=template_ds,
-        data_vars=config.data_vars,
-        append_dim=config.append_dim,
-        region=slice(0, 1),
-        reformat_job_name="test",
-    )
     t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
     coord = EcmwfAifsEnsForecastSourceFileCoord(
         init_time=pd.Timestamp("2025-07-02T00:00"),
@@ -184,18 +211,9 @@ def test_download_file_pf(monkeypatch: pytest.MonkeyPatch) -> None:
         ensemble_member=2,
         data_var_group=[t2m_var],
     )
-
-    # pf index has "number" column for each ensemble member, members interleaved
-    example_grib_index = """
-{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "pf", "stream": "enfo", "step": "6", "levtype": "sfc", "number": "1", "param": "2t", "model": "aifs-ens", "_offset": 0, "_length": 665525}
-{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "pf", "stream": "enfo", "step": "6", "levtype": "sfc", "number": "2", "param": "2t", "model": "aifs-ens", "_offset": 665525, "_length": 670000}
-{"domain": "g", "date": "20250702", "time": "0000", "expver": "0001", "class": "ai", "type": "pf", "stream": "enfo", "step": "6", "levtype": "sfc", "number": "3", "param": "2t", "model": "aifs-ens", "_offset": 1335525, "_length": 660000}
-"""
-    mock_index_df = pd.read_json(StringIO(example_grib_index), lines=True)
-    monkeypatch.setattr(
-        "pandas.read_json",
-        lambda path, **kwargs: mock_index_df,
-    )
+    # Recent: 12h after init_time, S3 should be tried first.
+    _patch_pd_now(monkeypatch, pd.Timestamp("2025-07-02T12:00"))
+    _patch_index(monkeypatch, _PF_INDEX)
 
     download_to_disk_mock = Mock()
     monkeypatch.setattr(
@@ -206,12 +224,107 @@ def test_download_file_pf(monkeypatch: pytest.MonkeyPatch) -> None:
     region_job.download_file(coord)
 
     assert download_to_disk_mock.call_count == 2
-    url, _dataset_id = download_to_disk_mock.call_args_list[1][0]
+    data_url, _dataset_id = download_to_disk_mock.call_args_list[1][0]
     kwargs = download_to_disk_mock.call_args_list[1][1]
 
-    assert "20250702000000-6h-enfo-pf.grib2" in url
+    assert "ecmwf-forecasts.s3" in data_url
+    assert "20250702000000-6h-enfo-pf.grib2" in data_url
     # member=2 selects offsets 665525..1335525
     assert kwargs["byte_ranges"] == ([665525], [665525 + 670000])
+
+
+def test_download_file_old_init_prefers_gcs(monkeypatch: pytest.MonkeyPatch) -> None:
+    region_job = _make_region_job()
+    config = EcmwfAifsEnsForecastTemplateConfig()
+    t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
+    coord = EcmwfAifsEnsForecastSourceFileCoord(
+        init_time=pd.Timestamp("2025-07-02T00:00"),
+        lead_time=pd.Timedelta("6h"),
+        ensemble_member=0,
+        data_var_group=[t2m_var],
+    )
+    # Old: more than 24h after init_time, GCS should be tried first.
+    _patch_pd_now(monkeypatch, pd.Timestamp("2025-07-04T00:00"))
+    _patch_index(monkeypatch, _CF_INDEX)
+
+    download_to_disk_mock = Mock()
+    monkeypatch.setattr(
+        "reformatters.ecmwf.aifs_ens.forecast.region_job.http_download_to_disk",
+        download_to_disk_mock,
+    )
+
+    region_job.download_file(coord)
+
+    assert download_to_disk_mock.call_count == 2
+    idx_url = download_to_disk_mock.call_args_list[0][0][0]
+    data_url = download_to_disk_mock.call_args_list[1][0][0]
+    assert "storage.googleapis.com/ecmwf-open-data" in idx_url
+    assert "storage.googleapis.com/ecmwf-open-data" in data_url
+
+
+def test_download_file_falls_back_to_gcs_on_s3_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    region_job = _make_region_job()
+    config = EcmwfAifsEnsForecastTemplateConfig()
+    t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
+    coord = EcmwfAifsEnsForecastSourceFileCoord(
+        init_time=pd.Timestamp("2025-07-02T00:00"),
+        lead_time=pd.Timedelta("6h"),
+        ensemble_member=0,
+        data_var_group=[t2m_var],
+    )
+    # Recent: S3 is primary, GCS is fallback.
+    _patch_pd_now(monkeypatch, pd.Timestamp("2025-07-02T12:00"))
+    _patch_index(monkeypatch, _CF_INDEX)
+
+    download_to_disk_mock = Mock()
+
+    def fake_download(url: str, *_args: object, **_kwargs: object) -> Mock:
+        if "ecmwf-forecasts.s3" in url:
+            raise FileNotFoundError(url)
+        return Mock()
+
+    download_to_disk_mock.side_effect = fake_download
+    monkeypatch.setattr(
+        "reformatters.ecmwf.aifs_ens.forecast.region_job.http_download_to_disk",
+        download_to_disk_mock,
+    )
+
+    region_job.download_file(coord)
+
+    # First attempt: S3 index (fails). Second attempt: GCS index + GCS data.
+    urls = [call[0][0] for call in download_to_disk_mock.call_args_list]
+    assert "ecmwf-forecasts.s3" in urls[0]
+    assert all("storage.googleapis.com" in u for u in urls[1:])
+    assert any("20250702000000-6h-enfo-cf.grib2" in u for u in urls)
+
+
+def test_download_file_raises_when_all_sources_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    region_job = _make_region_job()
+    config = EcmwfAifsEnsForecastTemplateConfig()
+    t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
+    coord = EcmwfAifsEnsForecastSourceFileCoord(
+        init_time=pd.Timestamp("2025-07-02T00:00"),
+        lead_time=pd.Timedelta("6h"),
+        ensemble_member=0,
+        data_var_group=[t2m_var],
+    )
+    _patch_pd_now(monkeypatch, pd.Timestamp("2025-07-02T12:00"))
+    _patch_index(monkeypatch, _CF_INDEX)
+
+    def always_404(url: str, *_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError(url)
+
+    monkeypatch.setattr(
+        "reformatters.ecmwf.aifs_ens.forecast.region_job.http_download_to_disk",
+        Mock(side_effect=always_404),
+    )
+
+    with pytest.raises(FileNotFoundError):
+        region_job.download_file(coord)
 
 
 def test_read_data(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
S3 (s3://ecmwf-forecasts) has been returning frequent 503s. GCS
(gs://ecmwf-open-data) is a complete byte-for-byte mirror but lags S3
by ~40 min for aifs-ens. For recent forecasts (< 24h) try S3 first and
fall back to GCS; for older forecasts try GCS first and fall back to S3.

Adds a small ecmwf_utils.ecmwf_download_with_fallback helper so the
same pattern can later be wired into ifs_ens and aifs_single.