### PR TITLE
Use deployed CronJob image for backfill-kubernetes

### DIFF
--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -17,7 +17,6 @@ import xarray as xr
 from pydantic import Field, computed_field
 
 from reformatters.common import (
-    docker,
     parallel_coordination,
     storage,
     template_utils,
@@ -31,6 +30,7 @@ from reformatters.common.kubernetes import (
     Job,
     ReformatCronJob,
     ValidationCronJob,
+    get_deployed_cronjob_image,
 )
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
@@ -194,7 +194,22 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             "backfill_kubernetes is only supported in prod environment"
         )
 
-        image_tag = docker_image or docker.build_and_push_image()
+        # In an attempt to keep the subclassing API simpler, we are keeping
+        # all resource needs defined right in `operational_kubernetes_resources`.
+        # If for some reason there are _multiple_ ReformatCronJobs returned from
+        # that we'll need to revisit the logic below or this approach.
+        reformat_jobs = [
+            r
+            for r in self.operational_kubernetes_resources(image_tag="placeholder")
+            if isinstance(r, ReformatCronJob)
+        ]
+        assert len(reformat_jobs) == 1, (
+            f"Can't infer kubernetes resources for backfill job from {reformat_jobs}."
+        )
+        reformat_job = reformat_jobs[0]
+
+        image_tag = docker_image or get_deployed_cronjob_image(reformat_job.name)
+        log.info(f"Using image {image_tag}")
 
         template_ds = self._get_template(append_dim_end)
 
@@ -247,20 +262,6 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 f"--filter-variable-names={variable_name}"
                 for variable_name in filter_variable_names
             )
-
-        # In an attempt to keep the subclassing API simpler, we are keeping
-        # all resource needs defined right in `operational_kubernetes_resources`.
-        # If for some reason there are _multiple_ ReformatCronJobs returned from
-        # that we'll need to revisit the logic below or this approach.
-        reformat_jobs = [
-            r
-            for r in self.operational_kubernetes_resources(image_tag)
-            if isinstance(r, ReformatCronJob)
-        ]
-        assert len(reformat_jobs) == 1, (
-            f"Can't infer kubernetes resources for backfill job from {reformat_jobs}."
-        )
-        reformat_job = reformat_jobs[0]
 
         kubernetes_job = Job(
             command=command,

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -299,3 +299,14 @@ def _load_secret_from_kubernetes_api(
     contents = json.loads(contents_json)
     assert isinstance(contents, dict)
     return contents
+
+
+def get_deployed_cronjob_image(cronjob_name: str) -> str:
+    """Read the container image of a deployed CronJob from the cluster."""
+    config.load_kube_config()
+    batch_v1 = client.BatchV1Api()
+    cronjob = batch_v1.read_namespaced_cron_job(cronjob_name, "default")
+    image = cronjob.spec.job_template.spec.template.spec.containers[0].image
+    assert isinstance(image, str), f"CronJob {cronjob_name} image is not a string"
+    assert len(image) > 0, f"CronJob {cronjob_name} has no container image"
+    return image

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -16,7 +16,7 @@ import zarr
 import zarr.errors
 from pydantic import computed_field
 
-from reformatters.common import docker, storage, template_utils, validation
+from reformatters.common import dynamical_dataset, storage, template_utils, validation
 from reformatters.common.config import Config, Env
 from reformatters.common.config_models import (
     BaseInternalAttrs,
@@ -572,7 +572,9 @@ def test_backfill_kubernetes_overwrite_existing_flag(
     monkeypatch.setattr(xr, "open_zarr", Mock())
 
     monkeypatch.setattr(
-        docker, "build_and_push_image", Mock(return_value="test-image-tag")
+        dynamical_dataset,
+        "get_deployed_cronjob_image",
+        Mock(return_value="test-image-tag"),
     )
     monkeypatch.setattr(subprocess, "run", Mock())
     monkeypatch.setattr(ExampleConfig, "get_template", lambda self, end: xr.Dataset())
@@ -619,7 +621,9 @@ def test_backfill_kubernetes_overwrite_existing_flag_fails_if_not_all_stores_exi
     monkeypatch.setattr(ExampleConfig, "get_template", lambda self, end: xr.Dataset())
 
     monkeypatch.setattr(
-        docker, "build_and_push_image", Mock(return_value="test-image-tag")
+        dynamical_dataset,
+        "get_deployed_cronjob_image",
+        Mock(return_value="test-image-tag"),
     )
     monkeypatch.setattr(subprocess, "run", Mock())
 


### PR DESCRIPTION
## Summary
- `backfill-kubernetes` no longer builds and pushes a fresh image each invocation. By default it reads the container image from the dataset's deployed operational `ReformatCronJob` in the cluster, so backfills run the same code that's currently running ops.
- Adds `get_deployed_cronjob_image()` helper in `common/kubernetes.py`.
- `--docker-image` override is preserved for first-time backfills (no deployed CronJob yet) and ad-hoc testing.
- `deploy_staging` is intentionally untouched — it exists to run code that isn't on main.

## Test plan
- [x] `uv run ruff format && uv run ruff check && uv run ty check` all pass
- [x] `uv run pytest -m "not slow"` — all 1259 tests pass
- [ ] Run a real `backfill-kubernetes` against a dataset that already has a deployed CronJob and confirm the indexed Job picks up the deployed image tag
- [ ] Run a `backfill-kubernetes` with `--docker-image=...` and confirm the override still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)