### PR TITLE
Add GCS, fallback to S3 access pattern for IFS-ENS and AIFS-single downloads

### DIFF
--- a/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
@@ -29,7 +29,10 @@ from reformatters.common.types import (
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, vars_available
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
-from reformatters.ecmwf.ecmwf_utils import EcmwfSource, ecmwf_download_with_fallback
+from reformatters.ecmwf.ecmwf_utils import (
+    EcmwfOpenDataSource,
+    ecmwf_download_with_fallback,
+)
 
 log = get_logger(__name__)
 
@@ -61,7 +64,7 @@ class EcmwfAifsEnsForecastSourceFileCoord(SourceFileCoord):
         # ensemble_member 0 is the control forecast (cf), 1-50 are perturbed members (pf).
         return "cf" if self.ensemble_member == 0 else "pf"
 
-    def _get_base_url(self, source: EcmwfSource) -> str:
+    def _get_base_url(self, source: EcmwfOpenDataSource) -> str:
         match source:
             case "s3":
                 root_url = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
@@ -78,10 +81,10 @@ class EcmwfAifsEnsForecastSourceFileCoord(SourceFileCoord):
         filename = f"{init_time_str}{init_hour_str}0000-{lead_time_hour_str}h-enfo-{self.file_type}"
         return f"{root_url}/{directory_path}/{filename}"
 
-    def get_url(self, source: EcmwfSource = "s3") -> str:
+    def get_url(self, source: EcmwfOpenDataSource = "s3") -> str:
         return self._get_base_url(source) + ".grib2"
 
-    def get_index_url(self, source: EcmwfSource = "s3") -> str:
+    def get_index_url(self, source: EcmwfOpenDataSource = "s3") -> str:
         return self._get_base_url(source) + ".index"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValue]:
@@ -131,7 +134,7 @@ class EcmwfAifsEnsForecastRegionJob(
 
     def download_file(self, coord: EcmwfAifsEnsForecastSourceFileCoord) -> Path:
         if coord.init_time >= pd.Timestamp.now() - _RECENT_CUTOFF:
-            sources: tuple[EcmwfSource, ...] = ("s3", "gcs")
+            sources: tuple[EcmwfOpenDataSource, ...] = ("s3", "gcs")
         else:
             sources = ("gcs", "s3")
         return ecmwf_download_with_fallback(
@@ -141,7 +144,7 @@ class EcmwfAifsEnsForecastRegionJob(
     def _download_from_source(
         self,
         coord: EcmwfAifsEnsForecastSourceFileCoord,
-        source: EcmwfSource,
+        source: EcmwfOpenDataSource,
     ) -> Path:
         idx_local_path = http_download_to_disk(
             coord.get_index_url(source), self.dataset_id, disk_cache=True

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -1,7 +1,7 @@
 import itertools
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, assert_never
 
 import numpy as np
 import pandas as pd
@@ -29,6 +29,7 @@ from reformatters.common.types import (
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, vars_available
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
+from reformatters.ecmwf.ecmwf_utils import EcmwfSource, ecmwf_download_with_fallback
 
 log = get_logger(__name__)
 
@@ -52,8 +53,14 @@ class EcmwfAifsSingleForecastSourceFileCoord(SourceFileCoord):
     lead_time: Timedelta
     data_var_group: Sequence[EcmwfDataVar]
 
-    def _get_base_url(self) -> str:
-        root_url = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
+    def _get_base_url(self, source: EcmwfSource) -> str:
+        match source:
+            case "s3":
+                root_url = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
+            case "gcs":
+                root_url = "https://storage.googleapis.com/ecmwf-open-data"
+            case _ as unreachable:
+                assert_never(unreachable)
 
         init_time_str = self.init_time.strftime("%Y%m%d")
         init_hour_str = self.init_time.strftime("%H")
@@ -68,11 +75,11 @@ class EcmwfAifsSingleForecastSourceFileCoord(SourceFileCoord):
         filename = f"{init_time_str}{init_hour_str}0000-{lead_time_hour_str}h-oper-fc"
         return f"{root_url}/{directory_path}/{filename}"
 
-    def get_url(self) -> str:
-        return self._get_base_url() + ".grib2"
+    def get_url(self, source: EcmwfSource = "s3") -> str:
+        return self._get_base_url(source) + ".grib2"
 
-    def get_index_url(self) -> str:
-        return self._get_base_url() + ".index"
+    def get_index_url(self, source: EcmwfSource = "s3") -> str:
+        return self._get_base_url(source) + ".index"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValue]:
         return {
@@ -116,9 +123,18 @@ class EcmwfAifsSingleForecastRegionJob(
         return coords
 
     def download_file(self, coord: EcmwfAifsSingleForecastSourceFileCoord) -> Path:
-        idx_url = coord.get_index_url()
+        return ecmwf_download_with_fallback(
+            ("gcs", "s3"),
+            lambda source: self._download_from_source(coord, source),
+        )
+
+    def _download_from_source(
+        self,
+        coord: EcmwfAifsSingleForecastSourceFileCoord,
+        source: EcmwfSource,
+    ) -> Path:
         idx_local_path = http_download_to_disk(
-            idx_url, self.dataset_id, disk_cache=True
+            coord.get_index_url(source), self.dataset_id, disk_cache=True
         )
 
         byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(
@@ -129,7 +145,7 @@ class EcmwfAifsSingleForecastRegionJob(
             f"{s}-{e}" for s, e in zip(byte_range_starts, byte_range_ends, strict=True)
         )
         return http_download_to_disk(
-            coord.get_url(),
+            coord.get_url(source),
             self.dataset_id,
             byte_ranges=(byte_range_starts, byte_range_ends),
             local_path_suffix=f"-{suffix}",

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -29,7 +29,10 @@ from reformatters.common.types import (
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, vars_available
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
-from reformatters.ecmwf.ecmwf_utils import EcmwfSource, ecmwf_download_with_fallback
+from reformatters.ecmwf.ecmwf_utils import (
+    EcmwfOpenDataSource,
+    ecmwf_download_with_fallback,
+)
 
 log = get_logger(__name__)
 
@@ -53,7 +56,7 @@ class EcmwfAifsSingleForecastSourceFileCoord(SourceFileCoord):
     lead_time: Timedelta
     data_var_group: Sequence[EcmwfDataVar]
 
-    def _get_base_url(self, source: EcmwfSource) -> str:
+    def _get_base_url(self, source: EcmwfOpenDataSource) -> str:
         match source:
             case "s3":
                 root_url = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
@@ -75,10 +78,10 @@ class EcmwfAifsSingleForecastSourceFileCoord(SourceFileCoord):
         filename = f"{init_time_str}{init_hour_str}0000-{lead_time_hour_str}h-oper-fc"
         return f"{root_url}/{directory_path}/{filename}"
 
-    def get_url(self, source: EcmwfSource = "s3") -> str:
+    def get_url(self, source: EcmwfOpenDataSource = "s3") -> str:
         return self._get_base_url(source) + ".grib2"
 
-    def get_index_url(self, source: EcmwfSource = "s3") -> str:
+    def get_index_url(self, source: EcmwfOpenDataSource = "s3") -> str:
         return self._get_base_url(source) + ".index"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValue]:
@@ -131,7 +134,7 @@ class EcmwfAifsSingleForecastRegionJob(
     def _download_from_source(
         self,
         coord: EcmwfAifsSingleForecastSourceFileCoord,
-        source: EcmwfSource,
+        source: EcmwfOpenDataSource,
     ) -> Path:
         idx_local_path = http_download_to_disk(
             coord.get_index_url(source), self.dataset_id, disk_cache=True

--- a/src/reformatters/ecmwf/ecmwf_utils.py
+++ b/src/reformatters/ecmwf/ecmwf_utils.py
@@ -8,7 +8,7 @@ from reformatters.common.logging import get_logger
 
 log = get_logger(__name__)
 
-type EcmwfSource = Literal["s3", "gcs"]
+type EcmwfOpenDataSource = Literal["s3", "gcs"]
 
 # Triggers fallback to the next source: missing files, AWS 503 Slow Down translated
 # by obstore to GenericError, and AWS 403s which obstore raises as PermissionDeniedError.
@@ -16,8 +16,8 @@ _FALLBACK_EXCEPTIONS = (FileNotFoundError, GenericError, PermissionDeniedError)
 
 
 def ecmwf_download_with_fallback(
-    sources: Sequence[EcmwfSource],
-    download_one: Callable[[EcmwfSource], Path],
+    sources: Sequence[EcmwfOpenDataSource],
+    download_one: Callable[[EcmwfOpenDataSource], Path],
 ) -> Path:
     """Try each source in order, falling back on missing-file / transient errors."""
     assert len(sources) > 0

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -2,7 +2,7 @@ import itertools
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, assert_never
 
 import numpy as np
 import pandas as pd
@@ -128,15 +128,13 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
         coord: IfsEnsSourceFileCoord,
         source: EcmwfOpenDataSource | MarsSource,
     ) -> Path:
-        match coord, source:
-            case (OpenDataSourceFileCoord(), "s3" | "gcs"):
-                pass
-            case (MarsSourceFileCoord(), "s3-source-coop"):
-                pass
-            case _:
-                raise AssertionError(
-                    f"Unsupported pairing: {type(coord).__name__} with {source=!r}"
-                )
+        match source:
+            case "s3-source-coop":
+                assert isinstance(coord, MarsSourceFileCoord)
+            case "s3" | "gcs":
+                assert isinstance(coord, OpenDataSourceFileCoord)
+            case _ as unreachable:
+                assert_never(unreachable)
 
         # The match above guarantees this pair is supported; ty cannot narrow
         # both coord and source together to a compatible call signature.

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -2,7 +2,7 @@ import itertools
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, assert_never
 
 import numpy as np
 import pandas as pd
@@ -26,11 +26,12 @@ from reformatters.ecmwf.ecmwf_config_models import (
     vars_available,
 )
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
-from reformatters.ecmwf.ecmwf_utils import ecmwf_download_with_fallback
+from reformatters.ecmwf.ecmwf_utils import EcmwfSource, ecmwf_download_with_fallback
 
 from .source_file_coord import (
     MARS_OPEN_DATA_CUTOVER,
     IfsEnsSourceFileCoord,
+    MarsSource,
     MarsSourceFileCoord,
     OpenDataSourceFileCoord,
 )
@@ -114,19 +115,28 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
         if isinstance(coord, OpenDataSourceFileCoord):
             return ecmwf_download_with_fallback(
                 ("gcs", "s3"),
-                lambda source: self._download(
-                    coord.get_index_url(source), coord.get_url(source), coord
-                ),
+                lambda source: self._download_from_source(coord, source),
             )
         # MARS lives on Dynamical's source.coop archive; no mirror to fall back to.
-        return self._download(coord.get_index_url(), coord.get_url(), coord)
+        return self._download_from_source(coord, "s3-source-coop")
 
-    def _download(
+    def _download_from_source(
         self,
-        idx_url: str,
-        data_url: str,
         coord: IfsEnsSourceFileCoord,
+        source: EcmwfSource | MarsSource,
     ) -> Path:
+        match source:
+            case "s3-source-coop":
+                assert isinstance(coord, MarsSourceFileCoord)
+                idx_url = coord.get_index_url("s3-source-coop")
+                data_url = coord.get_url("s3-source-coop")
+            case "s3" | "gcs":
+                assert isinstance(coord, OpenDataSourceFileCoord)
+                idx_url = coord.get_index_url(source)
+                data_url = coord.get_url(source)
+            case _ as unreachable:
+                assert_never(unreachable)
+
         idx_local_path = http_download_to_disk(
             idx_url, self.dataset_id, disk_cache=True
         )

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -26,6 +26,7 @@ from reformatters.ecmwf.ecmwf_config_models import (
     vars_available,
 )
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
+from reformatters.ecmwf.ecmwf_utils import ecmwf_download_with_fallback
 
 from .source_file_coord import (
     MARS_OPEN_DATA_CUTOVER,
@@ -110,8 +111,24 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
 
     def download_file(self, coord: IfsEnsSourceFileCoord) -> Path:
         """Download the file for the given coordinate and return the local path."""
+        if isinstance(coord, OpenDataSourceFileCoord):
+            return ecmwf_download_with_fallback(
+                ("gcs", "s3"),
+                lambda source: self._download(
+                    coord.get_index_url(source), coord.get_url(source), coord
+                ),
+            )
+        # MARS lives on Dynamical's source.coop archive; no mirror to fall back to.
+        return self._download(coord.get_index_url(), coord.get_url(), coord)
+
+    def _download(
+        self,
+        idx_url: str,
+        data_url: str,
+        coord: IfsEnsSourceFileCoord,
+    ) -> Path:
         idx_local_path = http_download_to_disk(
-            coord.get_index_url(), self.dataset_id, disk_cache=True
+            idx_url, self.dataset_id, disk_cache=True
         )
 
         byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(
@@ -124,7 +141,7 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
             f"{s}-{e}" for s, e in zip(byte_range_starts, byte_range_ends, strict=True)
         )
         return http_download_to_disk(
-            coord.get_url(),
+            data_url,
             self.dataset_id,
             byte_ranges=(byte_range_starts, byte_range_ends),
             local_path_suffix=f"-{suffix}",

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -26,7 +26,10 @@ from reformatters.ecmwf.ecmwf_config_models import (
     vars_available,
 )
 from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
-from reformatters.ecmwf.ecmwf_utils import EcmwfSource, ecmwf_download_with_fallback
+from reformatters.ecmwf.ecmwf_utils import (
+    EcmwfOpenDataSource,
+    ecmwf_download_with_fallback,
+)
 
 from .source_file_coord import (
     MARS_OPEN_DATA_CUTOVER,
@@ -123,7 +126,7 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
     def _download_from_source(
         self,
         coord: IfsEnsSourceFileCoord,
-        source: EcmwfSource | MarsSource,
+        source: EcmwfOpenDataSource | MarsSource,
     ) -> Path:
         match source:
             case "s3-source-coop":

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -2,7 +2,7 @@ import itertools
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import ClassVar, assert_never
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -128,17 +128,20 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
         coord: IfsEnsSourceFileCoord,
         source: EcmwfOpenDataSource | MarsSource,
     ) -> Path:
-        match source:
-            case "s3-source-coop":
-                assert isinstance(coord, MarsSourceFileCoord)
-                idx_url = coord.get_index_url("s3-source-coop")
-                data_url = coord.get_url("s3-source-coop")
-            case "s3" | "gcs":
-                assert isinstance(coord, OpenDataSourceFileCoord)
-                idx_url = coord.get_index_url(source)
-                data_url = coord.get_url(source)
-            case _ as unreachable:
-                assert_never(unreachable)
+        match coord, source:
+            case (OpenDataSourceFileCoord(), "s3" | "gcs"):
+                pass
+            case (MarsSourceFileCoord(), "s3-source-coop"):
+                pass
+            case _:
+                raise AssertionError(
+                    f"Unsupported pairing: {type(coord).__name__} with {source=!r}"
+                )
+
+        # The match above guarantees this pair is supported; ty cannot narrow
+        # both coord and source together to a compatible call signature.
+        idx_url = coord.get_index_url(source)  # ty: ignore[invalid-argument-type]
+        data_url = coord.get_url(source)  # ty: ignore[invalid-argument-type]
 
         idx_local_path = http_download_to_disk(
             idx_url, self.dataset_id, disk_cache=True

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -131,15 +131,14 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
         match source:
             case "s3-source-coop":
                 assert isinstance(coord, MarsSourceFileCoord)
+                idx_url = coord.get_index_url("s3-source-coop")
+                data_url = coord.get_url("s3-source-coop")
             case "s3" | "gcs":
                 assert isinstance(coord, OpenDataSourceFileCoord)
+                idx_url = coord.get_index_url(source)
+                data_url = coord.get_url(source)
             case _ as unreachable:
                 assert_never(unreachable)
-
-        # The match above guarantees this pair is supported; ty cannot narrow
-        # both coord and source together to a compatible call signature.
-        idx_url = coord.get_index_url(source)  # ty: ignore[invalid-argument-type]
-        data_url = coord.get_url(source)  # ty: ignore[invalid-argument-type]
 
         idx_local_path = http_download_to_disk(
             idx_url, self.dataset_id, disk_cache=True

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-from typing import ClassVar
+from typing import ClassVar, assert_never
 
 import pandas as pd
 
@@ -18,6 +18,7 @@ from reformatters.ecmwf.ecmwf_config_models import (
     EcmwfDataVar,
     _resolve_grib_index_param,
 )
+from reformatters.ecmwf.ecmwf_utils import EcmwfSource
 
 MARS_OPEN_DATA_CUTOVER = pd.Timestamp("2024-04-01T00:00")
 
@@ -59,8 +60,16 @@ class OpenDataSourceFileCoord(SourceFileCoord):
     def validate_grib_comment_unit_only(self) -> bool:
         return False
 
-    def _get_base_url(self) -> str:
-        base_url = f"https://{self.s3_bucket_url}.s3.{self.s3_region}.amazonaws.com"
+    def _get_base_url(self, source: EcmwfSource) -> str:
+        match source:
+            case "s3":
+                base_url = (
+                    f"https://{self.s3_bucket_url}.s3.{self.s3_region}.amazonaws.com"
+                )
+            case "gcs":
+                base_url = "https://storage.googleapis.com/ecmwf-open-data"
+            case _ as unreachable:
+                assert_never(unreachable)
 
         init_time_str = self.init_time.strftime("%Y%m%d")
         init_hour_str = self.init_time.strftime("%H")  # pads 0 to be "00", as desired
@@ -83,11 +92,11 @@ class OpenDataSourceFileCoord(SourceFileCoord):
         )
         return f"{base_url}/{directory_path}/{filename}"
 
-    def get_url(self) -> str:
-        return self._get_base_url() + ".grib2"
+    def get_url(self, source: EcmwfSource = "s3") -> str:
+        return self._get_base_url(source) + ".grib2"
 
-    def get_index_url(self) -> str:
-        return self._get_base_url() + ".index"
+    def get_index_url(self, source: EcmwfSource = "s3") -> str:
+        return self._get_base_url(source) + ".index"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValue]:
         return {

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
@@ -18,7 +18,7 @@ from reformatters.ecmwf.ecmwf_config_models import (
     EcmwfDataVar,
     _resolve_grib_index_param,
 )
-from reformatters.ecmwf.ecmwf_utils import EcmwfSource
+from reformatters.ecmwf.ecmwf_utils import EcmwfOpenDataSource
 
 type MarsSource = Literal["s3-source-coop"]
 
@@ -62,7 +62,7 @@ class OpenDataSourceFileCoord(SourceFileCoord):
     def validate_grib_comment_unit_only(self) -> bool:
         return False
 
-    def _get_base_url(self, source: EcmwfSource) -> str:
+    def _get_base_url(self, source: EcmwfOpenDataSource) -> str:
         match source:
             case "s3":
                 base_url = (
@@ -94,10 +94,10 @@ class OpenDataSourceFileCoord(SourceFileCoord):
         )
         return f"{base_url}/{directory_path}/{filename}"
 
-    def get_url(self, source: EcmwfSource = "s3") -> str:
+    def get_url(self, source: EcmwfOpenDataSource = "s3") -> str:
         return self._get_base_url(source) + ".grib2"
 
-    def get_index_url(self, source: EcmwfSource = "s3") -> str:
+    def get_index_url(self, source: EcmwfOpenDataSource = "s3") -> str:
         return self._get_base_url(source) + ".index"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValue]:

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-from typing import ClassVar, assert_never
+from typing import ClassVar, Literal, assert_never
 
 import pandas as pd
 
@@ -19,6 +19,8 @@ from reformatters.ecmwf.ecmwf_config_models import (
     _resolve_grib_index_param,
 )
 from reformatters.ecmwf.ecmwf_utils import EcmwfSource
+
+type MarsSource = Literal["s3-source-coop"]
 
 MARS_OPEN_DATA_CUTOVER = pd.Timestamp("2024-04-01T00:00")
 
@@ -165,11 +167,21 @@ class MarsSourceFileCoord(SourceFileCoord):
     def _date_str(self) -> str:
         return self.init_time.strftime("%Y-%m-%d")
 
-    def get_url(self) -> str:
-        return f"{DYNAMICAL_MARS_GRIB_BASE_URL}/{self._date_str()}/{self.request_type}.grib"
+    def get_url(self, source: MarsSource = "s3-source-coop") -> str:
+        match source:
+            case "s3-source-coop":
+                base_url = DYNAMICAL_MARS_GRIB_BASE_URL
+            case _ as unreachable:
+                assert_never(unreachable)
+        return f"{base_url}/{self._date_str()}/{self.request_type}.grib"
 
-    def get_index_url(self) -> str:
-        return f"{DYNAMICAL_MARS_GRIB_BASE_URL}/{self._date_str()}/{self.request_type}.grib.idx"
+    def get_index_url(self, source: MarsSource = "s3-source-coop") -> str:
+        match source:
+            case "s3-source-coop":
+                base_url = DYNAMICAL_MARS_GRIB_BASE_URL
+            case _ as unreachable:
+                assert_never(unreachable)
+        return f"{base_url}/{self._date_str()}/{self.request_type}.grib.idx"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValue]:
         return {

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-from typing import ClassVar, Literal, assert_never
+from typing import Literal, assert_never
 
 import pandas as pd
 
@@ -42,9 +42,6 @@ class OpenDataSourceFileCoord(SourceFileCoord):
     ensemble_member: int
     data_var_group: Sequence[EcmwfDataVar]
 
-    s3_bucket_url: ClassVar[str] = "ecmwf-forecasts"
-    s3_region: ClassVar[str] = "eu-central-1"
-
     def resolve_data_vars(self) -> OpenDataSourceFileCoord:
         return replace(
             self,
@@ -65,9 +62,7 @@ class OpenDataSourceFileCoord(SourceFileCoord):
     def _get_base_url(self, source: EcmwfOpenDataSource) -> str:
         match source:
             case "s3":
-                base_url = (
-                    f"https://{self.s3_bucket_url}.s3.{self.s3_region}.amazonaws.com"
-                )
+                base_url = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
             case "gcs":
                 base_url = "https://storage.googleapis.com/ecmwf-open-data"
             case _ as unreachable:

--- a/tests/ecmwf/aifs_single/forecast/region_job_test.py
+++ b/tests/ecmwf/aifs_single/forecast/region_job_test.py
@@ -55,6 +55,14 @@ def test_source_file_coord_url_after_path_change() -> None:
         "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
         "/20250226/00z/aifs-single/0p25/oper/20250226000000-12h-oper-fc.index"
     )
+    assert coord.get_url("gcs") == (
+        "https://storage.googleapis.com/ecmwf-open-data"
+        "/20250226/00z/aifs-single/0p25/oper/20250226000000-12h-oper-fc.grib2"
+    )
+    assert coord.get_index_url("gcs") == (
+        "https://storage.googleapis.com/ecmwf-open-data"
+        "/20250226/00z/aifs-single/0p25/oper/20250226000000-12h-oper-fc.index"
+    )
 
 
 def test_source_file_coord_url_00z_init() -> None:
@@ -143,11 +151,16 @@ def test_generate_source_file_coords() -> None:
         assert isinstance(coord, EcmwfAifsSingleForecastSourceFileCoord)
 
 
-def test_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
+_EXAMPLE_GRIB_INDEX = """
+{"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "stream": "oper", "step": "6", "levtype": "sfc", "param": "2t", "_offset": 0, "_length": 665525}
+{"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "stream": "oper", "step": "6", "levtype": "sfc", "param": "10u", "_offset": 665525, "_length": 700000}
+"""
+
+
+def _make_download_test_region_job() -> EcmwfAifsSingleForecastRegionJob:
     config = EcmwfAifsSingleForecastTemplateConfig()
     template_ds = config.get_template(pd.Timestamp("2024-04-02"))
-
-    region_job = EcmwfAifsSingleForecastRegionJob.model_construct(
+    return EcmwfAifsSingleForecastRegionJob.model_construct(
         tmp_store=Mock(),
         template_ds=template_ds,
         data_vars=config.data_vars,
@@ -155,23 +168,22 @@ def test_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
         region=slice(0, 1),
         reformat_job_name="test",
     )
+
+
+def _t2m_coord() -> EcmwfAifsSingleForecastSourceFileCoord:
+    config = EcmwfAifsSingleForecastTemplateConfig()
     t2m_var = item(v for v in config.data_vars if v.name == "temperature_2m")
-    source_file_coord = EcmwfAifsSingleForecastSourceFileCoord(
+    return EcmwfAifsSingleForecastSourceFileCoord(
         init_time=pd.Timestamp("2024-04-01"),
         lead_time=pd.Timedelta("6h"),
         data_var_group=[t2m_var],
     )
 
-    # Deterministic AIFS index has no "number" or "type" fields
-    example_grib_index = """
-{"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "stream": "oper", "step": "6", "levtype": "sfc", "param": "2t", "_offset": 0, "_length": 665525}
-{"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "stream": "oper", "step": "6", "levtype": "sfc", "param": "10u", "_offset": 665525, "_length": 700000}
-"""
-    mock_index_df = pd.read_json(StringIO(example_grib_index), lines=True)
-    monkeypatch.setattr(
-        "pandas.read_json",
-        lambda path, **kwargs: mock_index_df,
-    )
+
+def test_download_file_prefers_gcs(monkeypatch: pytest.MonkeyPatch) -> None:
+    region_job = _make_download_test_region_job()
+    mock_index_df = pd.read_json(StringIO(_EXAMPLE_GRIB_INDEX), lines=True)
+    monkeypatch.setattr("pandas.read_json", lambda path, **kwargs: mock_index_df)
 
     download_to_disk_mock = Mock()
     monkeypatch.setattr(
@@ -179,15 +191,63 @@ def test_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
         download_to_disk_mock,
     )
 
-    region_job.download_file(source_file_coord)
+    region_job.download_file(_t2m_coord())
 
-    # First call is for the index file, second for the GRIB data
+    # First call is the index file, second the GRIB data; both on GCS.
     assert download_to_disk_mock.call_count == 2
-    url, _dataset_id = download_to_disk_mock.call_args_list[1][0]
+    idx_url = download_to_disk_mock.call_args_list[0][0][0]
+    data_url, _dataset_id = download_to_disk_mock.call_args_list[1][0]
     kwargs = download_to_disk_mock.call_args_list[1][1]
 
-    assert "20240401000000-6h-oper-fc.grib2" in url
+    assert "storage.googleapis.com/ecmwf-open-data" in idx_url
+    assert "storage.googleapis.com/ecmwf-open-data" in data_url
+    assert "20240401000000-6h-oper-fc.grib2" in data_url
     assert kwargs["byte_ranges"] == ([0], [665525])
+
+
+def test_download_file_falls_back_to_s3_on_gcs_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    region_job = _make_download_test_region_job()
+    mock_index_df = pd.read_json(StringIO(_EXAMPLE_GRIB_INDEX), lines=True)
+    monkeypatch.setattr("pandas.read_json", lambda path, **kwargs: mock_index_df)
+
+    def fake_download(url: str, *_args: object, **_kwargs: object) -> Mock:
+        if "storage.googleapis.com" in url:
+            raise FileNotFoundError(url)
+        return Mock()
+
+    download_to_disk_mock = Mock(side_effect=fake_download)
+    monkeypatch.setattr(
+        "reformatters.ecmwf.aifs_single.forecast.region_job.http_download_to_disk",
+        download_to_disk_mock,
+    )
+
+    region_job.download_file(_t2m_coord())
+
+    urls = [call[0][0] for call in download_to_disk_mock.call_args_list]
+    assert "storage.googleapis.com" in urls[0]
+    assert all("ecmwf-forecasts.s3" in u for u in urls[1:])
+    assert any("20240401000000-6h-oper-fc.grib2" in u for u in urls)
+
+
+def test_download_file_raises_when_all_sources_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    region_job = _make_download_test_region_job()
+    mock_index_df = pd.read_json(StringIO(_EXAMPLE_GRIB_INDEX), lines=True)
+    monkeypatch.setattr("pandas.read_json", lambda path, **kwargs: mock_index_df)
+
+    def always_404(url: str, *_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError(url)
+
+    monkeypatch.setattr(
+        "reformatters.ecmwf.aifs_single.forecast.region_job.http_download_to_disk",
+        Mock(side_effect=always_404),
+    )
+
+    with pytest.raises(FileNotFoundError):
+        region_job.download_file(_t2m_coord())
 
 
 def test_read_data(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job_test.py
@@ -177,28 +177,7 @@ def test_region_job_generate_source_file_coords_mars_date_available_vars() -> No
     assert all(isinstance(c, MarsSourceFileCoord) for c in tcc_coords)
 
 
-def test_region_job_download_file_open_data(monkeypatch: pytest.MonkeyPatch) -> None:
-    template_config = EcmwfIfsEnsForecast15Day025DegreeTemplateConfig()
-    template_ds = template_config.get_template(pd.Timestamp("2024-04-02"))
-
-    region_job = EcmwfIfsEnsForecast15Day025DegreeRegionJob.model_construct(
-        tmp_store=Mock(),
-        template_ds=template_ds,
-        data_vars=template_config.data_vars,
-        append_dim=template_config.append_dim,
-        region=slice(0, 1),
-        reformat_job_name="test",
-    )
-    source_file_coord = OpenDataSourceFileCoord(
-        init_time=pd.Timestamp("2024-04-01"),
-        lead_time=pd.Timedelta("3h"),
-        data_var_group=[
-            var for var in template_config.data_vars if var.name == "temperature_2m"
-        ],
-        ensemble_member=0,
-    )
-
-    example_grib_index = """
+_EXAMPLE_OPEN_DATA_INDEX = """
 {"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "type": "pf", "stream": "enfo", "step": "3", "levelist": "500", "levtype": "pl", "number": "2", "param": "gh", "_offset": 674936844, "_length": 393429}
 {"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "type": "cf", "stream": "enfo", "step": "3", "levtype": "sfc", "param": "2t", "_offset": 0, "_length": 665525}
 {"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "type": "cf", "stream": "enfo", "step": "3", "levtype": "sfc", "param": "10u", "_offset": 3773626, "_length": 665525}
@@ -207,11 +186,39 @@ def test_region_job_download_file_open_data(monkeypatch: pytest.MonkeyPatch) -> 
 {"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "type": "pf", "stream": "enfo", "step": "3", "levtype": "sfc", "number": "2", "param": "2t", "_offset": 2219364, "_length": 664716}
 {"domain": "g", "date": "20240401", "time": "0000", "expver": "0001", "class": "od", "type": "pf", "stream": "enfo", "step": "3", "levtype": "sfc", "number": "1", "param": "10u", "_offset": 2884080, "_length": 889546}
 """
-    mock_index_df = pd.read_json(StringIO(example_grib_index), lines=True)
-    monkeypatch.setattr(
-        "pandas.read_json",
-        lambda path, **kwargs: mock_index_df,
+
+
+def _make_ifs_ens_region_job() -> EcmwfIfsEnsForecast15Day025DegreeRegionJob:
+    template_config = EcmwfIfsEnsForecast15Day025DegreeTemplateConfig()
+    template_ds = template_config.get_template(pd.Timestamp("2024-04-02"))
+    return EcmwfIfsEnsForecast15Day025DegreeRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=template_ds,
+        data_vars=template_config.data_vars,
+        append_dim=template_config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
     )
+
+
+def _t2m_open_data_coord() -> OpenDataSourceFileCoord:
+    template_config = EcmwfIfsEnsForecast15Day025DegreeTemplateConfig()
+    return OpenDataSourceFileCoord(
+        init_time=pd.Timestamp("2024-04-01"),
+        lead_time=pd.Timedelta("3h"),
+        data_var_group=[
+            var for var in template_config.data_vars if var.name == "temperature_2m"
+        ],
+        ensemble_member=0,
+    )
+
+
+def test_region_job_download_file_open_data_prefers_gcs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    region_job = _make_ifs_ens_region_job()
+    mock_index_df = pd.read_json(StringIO(_EXAMPLE_OPEN_DATA_INDEX), lines=True)
+    monkeypatch.setattr("pandas.read_json", lambda path, **kwargs: mock_index_df)
 
     download_to_disk_mock = Mock()
     monkeypatch.setattr(
@@ -219,23 +226,78 @@ def test_region_job_download_file_open_data(monkeypatch: pytest.MonkeyPatch) -> 
         download_to_disk_mock,
     )
 
-    region_job.download_file(source_file_coord)
+    region_job.download_file(_t2m_open_data_coord())
 
     url, dataset_id = download_to_disk_mock.call_args[0]
     kwargs = download_to_disk_mock.call_args[1]
 
-    byte_ranges = kwargs["byte_ranges"]
-    local_path_suffix = kwargs["local_path_suffix"]
-
     assert (
         url
-        == "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20240401/00z/ifs/0p25/enfo/20240401000000-3h-enfo-ef.grib2"
+        == "https://storage.googleapis.com/ecmwf-open-data/20240401/00z/ifs/0p25/enfo/20240401000000-3h-enfo-ef.grib2"
     )
     assert dataset_id == "ecmwf-ifs-ens-forecast-15-day-0-25-degree"
-    assert (
-        local_path_suffix == "-4f434771"
-    )  # result of calling digest on the byte ranges
-    assert byte_ranges == ([0], [665525])
+    assert kwargs["local_path_suffix"] == "-4f434771"
+    assert kwargs["byte_ranges"] == ([0], [665525])
+
+
+def test_region_job_download_file_open_data_falls_back_to_s3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    region_job = _make_ifs_ens_region_job()
+    mock_index_df = pd.read_json(StringIO(_EXAMPLE_OPEN_DATA_INDEX), lines=True)
+    monkeypatch.setattr("pandas.read_json", lambda path, **kwargs: mock_index_df)
+
+    def fake_download(url: str, *_args: object, **_kwargs: object) -> Mock:
+        if "storage.googleapis.com" in url:
+            raise FileNotFoundError(url)
+        return Mock()
+
+    download_to_disk_mock = Mock(side_effect=fake_download)
+    monkeypatch.setattr(
+        "reformatters.ecmwf.ifs_ens.forecast_15_day_0_25_degree.region_job.http_download_to_disk",
+        download_to_disk_mock,
+    )
+
+    region_job.download_file(_t2m_open_data_coord())
+
+    urls = [call[0][0] for call in download_to_disk_mock.call_args_list]
+    assert "storage.googleapis.com" in urls[0]
+    assert all("ecmwf-forecasts.s3" in u for u in urls[1:])
+
+
+def test_region_job_download_file_mars_no_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MARS coords download directly from source.coop without a fallback."""
+    template_config = EcmwfIfsEnsForecast15Day025DegreeTemplateConfig()
+    region_job = _make_ifs_ens_region_job()
+    t2m = item(v for v in template_config.data_vars if v.name == "temperature_2m")
+    coord = MarsSourceFileCoord(
+        init_time=pd.Timestamp("2024-01-01"),
+        lead_time=pd.Timedelta("3h"),
+        ensemble_member=0,
+        data_var_group=[t2m],
+        request_type="cf_sfc",
+    ).resolve_data_vars()
+
+    mars_index = (
+        '{"domain": "g", "date": "20240101", "time": "0000", "expver": "0001", '
+        '"class": "od", "type": "cf", "stream": "enfo", "step": "3", '
+        '"levtype": "sfc", "param": "2t", "_offset": 0, "_length": 665525}\n'
+    )
+    mock_index_df = pd.read_json(StringIO(mars_index), lines=True)
+    monkeypatch.setattr("pandas.read_json", lambda path, **kwargs: mock_index_df)
+
+    download_to_disk_mock = Mock()
+    monkeypatch.setattr(
+        "reformatters.ecmwf.ifs_ens.forecast_15_day_0_25_degree.region_job.http_download_to_disk",
+        download_to_disk_mock,
+    )
+
+    region_job.download_file(coord)
+
+    urls = [call[0][0] for call in download_to_disk_mock.call_args_list]
+    assert all("data.source.coop" in u for u in urls)
 
 
 def test_region_job_read_data_open_data(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/source_file_coord_test.py
@@ -69,6 +69,14 @@ def test_open_data_get_url_with_ifs_directory() -> None:
         coord.get_url()
         == "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20250101/00z/ifs/0p25/enfo/20250101000000-0h-enfo-ef.grib2"
     )
+    assert (
+        coord.get_url("gcs")
+        == "https://storage.googleapis.com/ecmwf-open-data/20250101/00z/ifs/0p25/enfo/20250101000000-0h-enfo-ef.grib2"
+    )
+    assert (
+        coord.get_index_url("gcs")
+        == "https://storage.googleapis.com/ecmwf-open-data/20250101/00z/ifs/0p25/enfo/20250101000000-0h-enfo-ef.index"
+    )
 
 
 def test_open_data_get_url_without_ifs_directory() -> None:


### PR DESCRIPTION
## Summary

Reduce our request rate to `s3://ecmwf-forecasts` which frequently 503s by also reading from GCS mirror.

Extends the ECMWF GCS-mirror fallback added in #600 (AIFS-ENS) to the remaining two ECMWF Open Data datasets:

- **`ecmwf/aifs_single/forecast`** — try GCS first, fall back to S3 on transient errors.
- **`ecmwf/ifs_ens/forecast_15_day_0_25_degree`** — for `OpenDataSourceFileCoord`s try GCS first, fall back to S3. `MarsSourceFileCoord`s keep their existing single-source path (the MARS archive lives on Dynamical's source.coop bucket; no ECMWF mirror to fall back to).

Both reuse `ecmwf_utils.ecmwf_download_with_fallback`. Unlike AIFS-ENS, neither dataset needs an age-based source ordering — empirically GCS lag is small enough for both that GCS-primary is fine regardless of init_time age (`aifs-single` ~30 s; `ifs/oper` ~4 min median).

## Changes

- `aifs_single/forecast/region_job.py`: `_get_base_url` / `get_url` / `get_index_url` now take a source param (default `"s3"` so the base class' no-arg `get_url()` callers keep working). Split `download_file` into a thin wrapper and `_download_from_source(coord, source)`.
- `ifs_ens/.../source_file_coord.py`: same source-parameterization on `OpenDataSourceFileCoord` only.
- `ifs_ens/.../region_job.py`: `download_file` branches on coord type — fallback helper for OpenData, direct download for MARS. Shared core extracted to `_download(idx_url, data_url, coord)`.

## Test plan

- [x] `uv run ruff format && uv run ruff check && uv run ty check` all green.
- [x] `uv run pytest -m "not slow"` — 1263 tests pass.
- [x] New unit tests cover: GCS-first ordering, fallback to S3 on `FileNotFoundError`, raise-when-both-fail, and MARS-coord no-fallback path.
- [ ] Validate operationally — bake on real backfill / op-update once merged.

Built on top of merged PR #600.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXyzuabP4BFbuiRUfarLmC)_