### PR TITLE
Validation: scan full ensemble for nulls

### DIFF
--- a/src/scripts/validation/compare_spatial.py
+++ b/src/scripts/validation/compare_spatial.py
@@ -14,13 +14,13 @@ from scripts.validation.utils import (
     RunContext,
     VariableStats,
     end_date_option,
-    ensure_ensemble_member_selected,
     get_two_random_points,
     is_forecast_dataset,
     load_zarr_dataset,
     output_dir_option,
     resolve_output_dir,
     scope_time_period,
+    select_random_ensemble_member,
     select_variables_for_plotting,
     start_date_option,
     variables_option,
@@ -245,26 +245,34 @@ def run_compare_spatial(
     """Produce per-variable + combined spatial comparison plots in ctx.output_dir."""
     assert ctx.reference_ds is not None, "compare-spatial requires a reference dataset"
 
-    ensure_ensemble_member_selected(ctx)
+    # Spatial plots are over a single member; ctx.validation_ds keeps the full
+    # ensemble dim so report_nulls can scan every member.
+    validation_ds = ctx.validation_ds
+    if "ensemble_member" in validation_ds.dims:
+        if ctx.ensemble_member is None:
+            validation_ds, ctx.ensemble_member = select_random_ensemble_member(
+                validation_ds
+            )
+            log.info(f"Ensemble member (random): {ctx.ensemble_member}")
+        else:
+            validation_ds = validation_ds.sel(ensemble_member=ctx.ensemble_member)
 
-    is_forecast = is_forecast_dataset(ctx.validation_ds)
-    spatially_aligned_ref = align_reference_spatially(
-        ctx.validation_ds, ctx.reference_ds
-    )
+    is_forecast = is_forecast_dataset(validation_ds)
+    spatially_aligned_ref = align_reference_spatially(validation_ds, ctx.reference_ds)
 
     if is_forecast:
         ds, ref_ds = align_to_valid_time_forecast(
-            ctx.validation_ds, spatially_aligned_ref, init_time, lead_time
+            validation_ds, spatially_aligned_ref, init_time, lead_time
         )
     else:
         ds, ref_ds = align_to_valid_time_analysis(
-            ctx.validation_ds, spatially_aligned_ref, time
+            validation_ds, spatially_aligned_ref, time
         )
     ds = _downsample_for_plot(ds)
 
     val_time_label = _format_spatial_time_label(ds, is_forecast)
     ref_time_label = pd.Timestamp(ref_ds.time.item()).strftime("%Y-%m-%dT%H:%M")
-    val_label = ctx.validation_ds.attrs.get("name", "validation")
+    val_label = validation_ds.attrs.get("name", "validation")
     ref_label = ctx.reference_ds.attrs.get("name", "reference")
     ctx.spatial_time_label = val_time_label
     ctx.ref_spatial_time_label = ref_time_label

--- a/src/scripts/validation/compare_spatial.py
+++ b/src/scripts/validation/compare_spatial.py
@@ -14,13 +14,13 @@ from scripts.validation.utils import (
     RunContext,
     VariableStats,
     end_date_option,
+    ensure_ensemble_member_selected,
     get_two_random_points,
     is_forecast_dataset,
     load_zarr_dataset,
     output_dir_option,
     resolve_output_dir,
     scope_time_period,
-    select_random_ensemble_member,
     select_variables_for_plotting,
     start_date_option,
     variables_option,
@@ -245,6 +245,8 @@ def run_compare_spatial(
     """Produce per-variable + combined spatial comparison plots in ctx.output_dir."""
     assert ctx.reference_ds is not None, "compare-spatial requires a reference dataset"
 
+    ensure_ensemble_member_selected(ctx)
+
     is_forecast = is_forecast_dataset(ctx.validation_ds)
     spatially_aligned_ref = align_reference_spatially(
         ctx.validation_ds, ctx.reference_ds
@@ -387,7 +389,6 @@ def compare_spatial(
     else:
         selected_vars = select_variables_for_plotting(validation_ds, None)
 
-    validation_ds, ensemble_member = select_random_ensemble_member(validation_ds)
     point1_sel, point2_sel, (lat1, lon1), (lat2, lon2) = get_two_random_points(
         validation_ds
     )
@@ -408,7 +409,7 @@ def compare_spatial(
         point1_lon=lon1,
         point2_lat=lat2,
         point2_lon=lon2,
-        ensemble_member=ensemble_member,
+        ensemble_member=None,
         variables=selected_vars,
     )
     run_compare_spatial(ctx, init_time=init_time, lead_time=lead_time, time=time)

--- a/src/scripts/validation/compare_timeseries.py
+++ b/src/scripts/validation/compare_timeseries.py
@@ -12,13 +12,13 @@ from scripts.validation.utils import (
     RunContext,
     VariableStats,
     end_date_option,
-    ensure_ensemble_member_selected,
     get_two_random_points,
     is_forecast_dataset,
     load_zarr_dataset,
     output_dir_option,
     resolve_output_dir,
     scope_time_period,
+    select_random_ensemble_member,
     select_variables_for_plotting,
     start_date_option,
     variables_option,
@@ -194,7 +194,17 @@ def run_compare_timeseries(ctx: RunContext) -> None:
         "compare-timeseries requires a reference dataset"
     )
 
-    ensure_ensemble_member_selected(ctx)
+    # Temporal plots are over a single member; ctx.validation_ds keeps the full
+    # ensemble dim so report_nulls can scan every member.
+    validation_ds = ctx.validation_ds
+    if "ensemble_member" in validation_ds.dims:
+        if ctx.ensemble_member is None:
+            validation_ds, ctx.ensemble_member = select_random_ensemble_member(
+                validation_ds
+            )
+            log.info(f"Ensemble member (random): {ctx.ensemble_member}")
+        else:
+            validation_ds = validation_ds.sel(ensemble_member=ctx.ensemble_member)
 
     (
         validation_subset,
@@ -202,9 +212,9 @@ def run_compare_timeseries(ctx: RunContext) -> None:
         title_suffix,
         time_coord,
         ref_time_coord,
-    ) = select_time_period_for_comparison(ctx.validation_ds, ctx.reference_ds)
+    ) = select_time_period_for_comparison(validation_ds, ctx.reference_ds)
 
-    val_label = ctx.validation_ds.attrs.get("name", "validation")
+    val_label = validation_ds.attrs.get("name", "validation")
     ref_label = ctx.reference_ds.attrs.get("name", "reference")
     ctx.temporal_period_label = title_suffix
 

--- a/src/scripts/validation/compare_timeseries.py
+++ b/src/scripts/validation/compare_timeseries.py
@@ -12,13 +12,13 @@ from scripts.validation.utils import (
     RunContext,
     VariableStats,
     end_date_option,
+    ensure_ensemble_member_selected,
     get_two_random_points,
     is_forecast_dataset,
     load_zarr_dataset,
     output_dir_option,
     resolve_output_dir,
     scope_time_period,
-    select_random_ensemble_member,
     select_variables_for_plotting,
     start_date_option,
     variables_option,
@@ -194,6 +194,8 @@ def run_compare_timeseries(ctx: RunContext) -> None:
         "compare-timeseries requires a reference dataset"
     )
 
+    ensure_ensemble_member_selected(ctx)
+
     (
         validation_subset,
         reference_subset,
@@ -314,7 +316,6 @@ def compare_timeseries(
     reference_ds = load_zarr_dataset(reference_url)
 
     selected_vars = select_variables_for_plotting(validation_ds, variables)
-    validation_ds, ensemble_member = select_random_ensemble_member(validation_ds)
     point1_sel, point2_sel, (lat1, lon1), (lat2, lon2) = get_two_random_points(
         validation_ds
     )
@@ -335,7 +336,7 @@ def compare_timeseries(
         point1_lon=lon1,
         point2_lat=lat2,
         point2_lon=lon2,
-        ensemble_member=ensemble_member,
+        ensemble_member=None,
         variables=selected_vars,
     )
     run_compare_timeseries(ctx)

--- a/src/scripts/validation/plots.py
+++ b/src/scripts/validation/plots.py
@@ -26,7 +26,6 @@ from scripts.validation.utils import (
     load_zarr_dataset,
     output_dir_option,
     scope_time_period,
-    select_random_ensemble_member,
     select_variables_for_plotting,
     start_date_option,
     variables_option,
@@ -99,10 +98,6 @@ def run_all(
     selected_vars = select_variables_for_plotting(validation_ds, variables)
     log.info(f"Variables ({len(selected_vars)}): {', '.join(selected_vars)}")
 
-    validation_ds, ensemble_member = select_random_ensemble_member(validation_ds)
-    if ensemble_member is not None:
-        log.info(f"Ensemble member (random): {ensemble_member}")
-
     point1_sel, point2_sel, (lat1, lon1), (lat2, lon2) = get_two_random_points(
         validation_ds
     )
@@ -115,6 +110,9 @@ def run_all(
     out.mkdir(parents=True, exist_ok=True)
     log.info(f"Output dir: {out}")
 
+    # ctx.validation_ds keeps the full ensemble dim; run_compare_spatial and
+    # run_compare_timeseries reduce it to a random member lazily so the null
+    # analysis sees every member.
     ctx = RunContext(
         output_dir=out,
         validation_url=dataset_url,
@@ -128,7 +126,7 @@ def run_all(
         point1_lon=lon1,
         point2_lat=lat2,
         point2_lon=lon2,
-        ensemble_member=ensemble_member,
+        ensemble_member=None,
         variables=selected_vars,
         start_date=start_date,
         end_date=end_date,

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -11,10 +11,6 @@ import typer
 import xarray as xr
 from zarr.storage import ObjectStore, StoreLike
 
-from reformatters.common.logging import get_logger
-
-log = get_logger(__name__)
-
 OUTPUT_DIR = "data/output"
 
 variables_option = typer.Option(
@@ -253,23 +249,6 @@ def select_random_ensemble_member(ds: xr.Dataset) -> tuple[xr.Dataset, int | Non
         ds.sel(ensemble_member=ensemble_member),
         ensemble_member,
     )
-
-
-def ensure_ensemble_member_selected(ctx: RunContext) -> None:
-    """Reduce ctx.validation_ds to a single random ensemble member (idempotent).
-
-    Spatial and temporal plots are over a single member; the null analysis is over
-    the full ensemble so silent NaN cells at any member are visible. This helper
-    is called from the spatial/temporal entry points and skipped by the null path.
-    """
-    if "ensemble_member" not in ctx.validation_ds.dims:
-        return
-    if ctx.ensemble_member is not None:
-        return
-    ctx.validation_ds, ctx.ensemble_member = select_random_ensemble_member(
-        ctx.validation_ds
-    )
-    log.info(f"Ensemble member (random): {ctx.ensemble_member}")
 
 
 def extract_variable_metadata(ds: xr.Dataset, var: str) -> dict[str, Any]:

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -11,6 +11,10 @@ import typer
 import xarray as xr
 from zarr.storage import ObjectStore, StoreLike
 
+from reformatters.common.logging import get_logger
+
+log = get_logger(__name__)
+
 OUTPUT_DIR = "data/output"
 
 variables_option = typer.Option(
@@ -249,6 +253,23 @@ def select_random_ensemble_member(ds: xr.Dataset) -> tuple[xr.Dataset, int | Non
         ds.sel(ensemble_member=ensemble_member),
         ensemble_member,
     )
+
+
+def ensure_ensemble_member_selected(ctx: RunContext) -> None:
+    """Reduce ctx.validation_ds to a single random ensemble member (idempotent).
+
+    Spatial and temporal plots are over a single member; the null analysis is over
+    the full ensemble so silent NaN cells at any member are visible. This helper
+    is called from the spatial/temporal entry points and skipped by the null path.
+    """
+    if "ensemble_member" not in ctx.validation_ds.dims:
+        return
+    if ctx.ensemble_member is not None:
+        return
+    ctx.validation_ds, ctx.ensemble_member = select_random_ensemble_member(
+        ctx.validation_ds
+    )
+    log.info(f"Ensemble member (random): {ctx.ensemble_member}")
 
 
 def extract_variable_metadata(ds: xr.Dataset, var: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

`run-all` was selecting a single random `ensemble_member` up front and passing the reduced dataset to all three plot steps. As a result, `report_nulls` only saw one member's worth of cells and missed silent NaN dropouts on the other 50 members of an ENS forecast — even though `report_nulls` itself never samples in non-spatial dims.

Concretely, on the AIFS ENS forecast, two consecutive `run-all` invocations produced almost entirely disjoint "missing init_times" lists because each pass happened to randomly select a different member — masking the fact that some NaN cells affected most members at specific (init_time, lead_time) tuples but were just not co-sampled.

This PR keeps the full ensemble for the null path and only reduces to a single member for the spatial and temporal plots, which legitimately need one member.

## Changes

- New idempotent helper `utils.ensure_ensemble_member_selected(ctx)` that mutates `ctx.validation_ds` and sets `ctx.ensemble_member` on first call, no-ops afterwards.
- `plots.run_all`: drops the `select_random_ensemble_member` call. `ctx.validation_ds` carries the full ensemble dim.
- `compare_spatial.run_compare_spatial` and `compare_timeseries.run_compare_timeseries`: call the helper at the top, so they share the same randomly-chosen member when invoked back-to-back through `run-all`.
- Standalone `compare-spatial` / `compare-timeseries` CLIs: stop selecting in the entry point — the `run_compare_*` functions do it via the helper.
- `report_nulls`: unchanged; it now sees every member at the two sampled spatial points, so a null at any (init_time, lead_time, member) is reflected in `missing_timestamps.txt`.

## Test plan

- [ ] `uv run ruff format && uv run ruff check && uv run ty check` clean
- [ ] `uv run pytest tests/scripts/validation/` passes
- [ ] Re-run `plots.py run-all` against the AIFS ENS dataset and confirm the null analysis now surfaces missing (lead_time, ensemble_member) cells regardless of which member happens to be chosen for spatial/temporal plots.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRPEYp3bwyX2ib5fZr4g9U)_