### PR TITLE
Update precipitation type flag comment to include -3=no data

### DIFF
--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
@@ -309,7 +309,7 @@ class NoaaMrmsConusAnalysisHourlyTemplateConfig(TemplateConfig[NoaaMrmsDataVar])
                     long_name="Precipitation type",
                     units="1",
                     step_type="instant",
-                    comment="Precipitation type flag. 0=no precipitation, 1=warm stratiform rain, 3=snow, 6=convective, 7=hail, 10=cold stratiform rain, 91=tropical.",
+                    comment="Precipitation type flag. 0=no precipitation, 1=warm stratiform rain, 3=snow, 6=convective, 7=hail, 10=cold stratiform rain, 91=tropical, -3=no data.",
                 ),
                 internal_attrs=NoaaMrmsInternalAttrs(
                     mrms_product="PrecipFlag",

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/categorical_precipitation_type_surface/zarr.json
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/categorical_precipitation_type_surface/zarr.json
@@ -68,7 +68,7 @@
     "long_name": "Precipitation type",
     "short_name": "ptype",
     "units": "1",
-    "comment": "Precipitation type flag. 0=no precipitation, 1=warm stratiform rain, 3=snow, 6=convective, 7=hail, 10=cold stratiform rain, 91=tropical.",
+    "comment": "Precipitation type flag. 0=no precipitation, 1=warm stratiform rain, 3=snow, 6=convective, 7=hail, 10=cold stratiform rain, 91=tropical, -3=no data.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/zarr.json
@@ -86,7 +86,7 @@
           "long_name": "Precipitation type",
           "short_name": "ptype",
           "units": "1",
-          "comment": "Precipitation type flag. 0=no precipitation, 1=warm stratiform rain, 3=snow, 6=convective, 7=hail, 10=cold stratiform rain, 91=tropical.",
+          "comment": "Precipitation type flag. 0=no precipitation, 1=warm stratiform rain, 3=snow, 6=convective, 7=hail, 10=cold stratiform rain, 91=tropical, -3=no data.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="


### PR DESCRIPTION
## Summary
Updated the precipitation type flag metadata comment across the NOAA MRMS CONUS analysis hourly dataset to document the -3 value representing "no data".

## Changes
- Updated the `comment` attribute for the `categorical_precipitation_type_surface` variable in `template_config.py` to include `-3=no data` in the precipitation type flag documentation
- Regenerated zarr metadata templates to reflect this comment change:
  - `templates/latest.zarr/categorical_precipitation_type_surface/zarr.json`
  - `templates/latest.zarr/zarr.json`

## Details
The precipitation type flag now documents all valid values:
- 0=no precipitation
- 1=warm stratiform rain
- 3=snow
- 6=convective
- 7=hail
- 10=cold stratiform rain
- 91=tropical
- -3=no data (newly documented)

This improves data documentation and helps users understand the complete set of possible values in the dataset.

https://claude.ai/code/session_01LzZgB86eC4qiUfSroo5V2b