### PR TITLE
AIFS-ENS enable updates and don't attemp to process cycles that haven't started

### DIFF
--- a/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
@@ -27,9 +27,10 @@ class EcmwfAifsEnsForecastDataset(
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            # AIFS-ENS publishes the last file (step 360h) at ~H+5h44m after init.
-            # Run 3 minutes later at H+5h47m.
-            schedule="47 5/6 * * *",
+            # AIFS-ENS publishes the last file ~H+6h00m to H+6h40m after init across
+            # normal cycles (sample of 11 v2 cycles 2026-05-12 through 05-14).
+            # Run at H+6h43m for a 3 min margin past the worst-observed last-file lag.
+            schedule="43 6/6 * * *",
             suspend=True,
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -44,8 +45,8 @@ class EcmwfAifsEnsForecastDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            # Validation runs 30 minutes after each update run: 00:17, 06:17, 12:17, and 18:17.
-            schedule="17 */6 * * *",
+            # Validation runs 30 minutes after each update run: 01:13, 07:13, 13:13, and 19:13.
+            schedule="13 7/6 * * *",
             suspend=True,
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
@@ -31,7 +31,6 @@ class EcmwfAifsEnsForecastDataset(
             # normal cycles (sample of 11 v2 cycles 2026-05-12 through 05-14).
             # Run at H+6h43m for a 3 min margin past the worst-observed last-file lag.
             schedule="43 6/6 * * *",
-            suspend=True,
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -47,7 +46,6 @@ class EcmwfAifsEnsForecastDataset(
             name=f"{self.dataset_id}-validate",
             # Validation runs 30 minutes after each update run: 01:13, 07:13, 13:13, and 19:13.
             schedule="13 7/6 * * *",
-            suspend=True,
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
@@ -246,7 +246,9 @@ class EcmwfAifsEnsForecastRegionJob(
     ]:
         existing_ds = xr.open_zarr(primary_store, chunks=None)
         append_dim_start = existing_ds[append_dim].max()
-        append_dim_end = pd.Timestamp.now()
+        # Subtracting 5.5h here keeps a not-yet-published
+        # cycle out of scope so pods don't waste time trying files that won't exist.
+        append_dim_end = pd.Timestamp.now() - pd.Timedelta(hours=5.5)
         template_ds = get_template_fn(append_dim_end)
 
         jobs = cls.get_jobs(


### PR DESCRIPTION
## Summary
- unsuspend operational updates and validation
- `operational_update_jobs` was using `pd.Timestamp.now()` for `append_dim_end`, which dragged the in-progress next init cycle into scope. Workers stuck retrying not-yet-published files never wrote their `results/*.json`, so the last worker's `wait_for_workers` loop never returned, `finalize` never ran, and the temp `_job_*` branch was never merged to main.
- Subtracts 5.5h from `now` so `pd.date_range(..., inclusive="left", freq="6h")` in `template_config.py` snaps to the prior 6h boundary, keeping any in-progress cycle out of scope.
- Dialled the cron schedules from H+5h47m / H+6h17m to H+6h43m / H+7h13m to match the new timing.

## Background
Spot-checked 11 AIFS-ENS v2 cycles (2026-05-12 through 05-14):

| Cycle | First-file lag | Last-file lag |
|---|---|---|
| 05-12T06 (v2 launch) | 7.65h | 7.96h (outlier) |
| 05-12T18 | 5.71h | 5.95h |
| 05-13T00 | 6.43h | 6.64h |
| 05-13T06 | 5.87h | 6.10h |
| 05-13T12 | 5.88h | 6.13h |
| 05-13T18 | 5.75h | 6.00h |
| 05-14T00 | 5.76h | 6.05h |
| 05-14T06 | 5.76h | 6.00h |
| 05-14T12 | 6.41h | 6.65h |
| 05-14T18 | 5.77h | 6.01h |

Excluding the v2 launch day, last-file lag is consistently 5.95h–6.65h. Previous comment claimed ~H+5h44m — the cron has been firing before any cycle finishes uploading, every single cycle since v2 launch, which is why operational updates have been silently producing nothing.

## Test plan
- [ ] After merge + redeploy, watch the next scheduled update at H+6h43m and confirm a finalize commit lands on main with new init_time(s).
- [ ] Confirm the validate cron at H+7h13m runs and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)