### PR TITLE
Improve NaN fraction validation logging with coordinate summary

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -244,6 +244,34 @@ def _apply_spatial_sampling(
     assert_never(sampling_strategy)
 
 
+def _format_coord_value(value: object) -> str:
+    if isinstance(value, np.datetime64):
+        return pd.Timestamp(value).isoformat()
+    if isinstance(value, np.timedelta64):
+        return str(pd.Timedelta(value))
+    if isinstance(value, float | np.floating):
+        return f"{float(value):.4f}"
+    return str(value)
+
+
+def _summarize_coords(ds: xr.Dataset) -> str:
+    parts = []
+    for name in ds.coords:
+        values = np.atleast_1d(ds.coords[name].values)
+        if values.size == 0:
+            parts.append(f"{name}=<empty>")
+        elif values.size == 1:
+            parts.append(f"{name}={_format_coord_value(values[0])}")
+        elif values.size <= 4:
+            joined = ", ".join(_format_coord_value(v) for v in values)
+            parts.append(f"{name}=[{joined}]")
+        else:
+            parts.append(
+                f"{name}=[{_format_coord_value(values[0])}..{_format_coord_value(values[-1])}] (n={values.size})"
+            )
+    return ", ".join(parts)
+
+
 def _check_nan_fractions(
     sample_ds: xr.Dataset,
     *,
@@ -261,7 +289,8 @@ def _check_nan_fractions(
     ]
 
     log.info(
-        f"Computing NaN fraction for {len(var_names)} variables: {sorted(var_names)}"
+        f"Computing NaN fraction for {len(var_names)} variables: {sorted(var_names)} "
+        f"over coordinates: {_summarize_coords(sample_ds)}"
     )
 
     skip_lead_time_0_vars = set(additional_skip_lead_time_0_vars)


### PR DESCRIPTION
## Summary
Enhanced the NaN fraction validation logging to include a human-readable summary of the dataset coordinates being validated. This provides better context when reviewing validation logs.

## Key Changes
- Added `_format_coord_value()` helper function to format coordinate values consistently:
  - Converts `np.datetime64` to ISO format timestamps
  - Converts `np.timedelta64` to string representation
  - Formats floats to 4 decimal places
  - Falls back to string representation for other types

- Added `_summarize_coords()` function to generate a compact coordinate summary:
  - Shows individual values for empty or single-value coordinates
  - Shows all values for coordinates with 2-4 values
  - Shows first and last values with count for larger coordinates (e.g., `time=[2024-01-01T00:00:00..2024-01-31T23:00:00] (n=744)`)

- Updated `_check_nan_fractions()` logging to include the coordinate summary in the info message, providing better context about what data is being validated

## Implementation Details
The coordinate summary is generated on-demand during logging and handles various numpy data types appropriately, making validation logs more informative for debugging and monitoring purposes.

https://claude.ai/code/session_017aa2LrCunNboodMSAEQHeM