### PR TITLE
Move ensemble member info to spatial/time series sections

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -61,7 +61,7 @@ The directory path itself is dense enough to identify the run: dataset id + vers
 The entry point for every run. It contains, in order:
 
 - Validation and reference dataset identity (name, id, version, URL), time ranges, and scope.
-- Run parameters (ensemble member, spatial points, chosen init/lead/time for the spatial plot, timeseries period).
+- Run parameters: spatial points used by the null analysis (all ensemble members), and for each of the spatial and time series sections the picked ensemble member plus the chosen init/lead/time (spatial) or timeseries period.
 - Links to the three `combined_*.png` images.
 - Unavailable-timestamp summary (count, earliest/latest unavailable per (variable, point), pointer to `unavailable_timestamps.txt` if any were detected).
 - A variables table with nulls at the two points and links to the three per-variable images.
@@ -76,7 +76,7 @@ Work in this order.
 Open `validation_summary.md` first. It provides text-based information which can help identify issues that are harder to view in plots.
 
 - [ ] **Datasets block**: confirm the validation dataset id + version match what you intend to review. Note the reference dataset and its time range — if the reference doesn't cover your validation window, temporal + spatial comparisons will be empty (expected, not a bug).
-- [ ] **Run parameters**: confirm the ensemble member (if any), the chosen spatial time (init/lead for forecasts), and the timeseries period. The spatial plot is a single snapshot — if you see something weird, you can pass `--init-time`/`--lead-time`/`--time` to reproduce deterministically.
+- [ ] **Run parameters**: confirm the ensemble member recorded under each of the spatial and time series subsections (if the dataset has ensembles — the same member is used for both, and the null analysis intentionally runs over all members), the chosen spatial time (init/lead for forecasts), and the timeseries period. The spatial plot is a single snapshot — if you see something weird, you can pass `--init-time`/`--lead-time`/`--time` to reproduce deterministically.
 - [ ] **Unavailable timestamps**: if any, open `unavailable_timestamps.txt`. The file lists exact timestamps by (variable, point) and provides a ready-to-paste `--filter-contains` argument string for a targeted backfill retry. The summary table in `validation_summary.md` also shows the earliest and latest unavailable timestamp per (variable, point), making it easy to spot common patterns across variables about when data is (un)available.
 - [ ] **Variables overview table**: scan the null counts. Unexpected non-zero values are your first lead.
 - [ ] **Per-variable details**: for each variable, compare validation stats to reference stats. Validation min/max that is orders of magnitude off from the reference is a near-certain unit mismatch.

--- a/src/scripts/validation/summary.py
+++ b/src/scripts/validation/summary.py
@@ -233,11 +233,10 @@ def write_summary_md(ctx: RunContext) -> Path:  # noqa: PLR0915
     lines.append(f"- Validation time range: {_dataset_time_range(ctx)}")
     lines.append(f"- Reference time range:  {_reference_time_range(ctx)}")
     lines.append(f"- Time scope: {scope_line}")
-    lines.append(
-        f"- Ensemble member: "
-        f"{ctx.ensemble_member if ctx.ensemble_member is not None else 'n/a'}"
-    )
     lines.append("")
+    ensemble_member_label = (
+        str(ctx.ensemble_member) if ctx.ensemble_member is not None else "n/a"
+    )
     lines.append("### Unavailable values")
     lines.append("")
     lines.append(f"- Point 1: lat={ctx.point1_lat:.4f}, lon={ctx.point1_lon:.4f}")
@@ -245,6 +244,7 @@ def write_summary_md(ctx: RunContext) -> Path:  # noqa: PLR0915
     lines.append("")
     lines.append("### Spatial and distribution")
     lines.append("")
+    lines.append(f"- Ensemble member: {ensemble_member_label}")
     lines.append(
         f"- Spatial comparison time: "
         f"{ctx.spatial_time_label or 'n/a'} (reference at {ctx.ref_spatial_time_label or 'n/a'})"
@@ -252,6 +252,7 @@ def write_summary_md(ctx: RunContext) -> Path:  # noqa: PLR0915
     lines.append("")
     lines.append("### Time series")
     lines.append("")
+    lines.append(f"- Ensemble member: {ensemble_member_label}")
     lines.append(f"- Point 1: lat={ctx.point1_lat:.4f}, lon={ctx.point1_lon:.4f}")
     lines.append(f"- Point 2: lat={ctx.point2_lat:.4f}, lon={ctx.point2_lon:.4f}")
     lines.append(f"- Timeseries period: {ctx.temporal_period_label or 'n/a'}")

--- a/src/scripts/validation/summary.py
+++ b/src/scripts/validation/summary.py
@@ -234,9 +234,6 @@ def write_summary_md(ctx: RunContext) -> Path:  # noqa: PLR0915
     lines.append(f"- Reference time range:  {_reference_time_range(ctx)}")
     lines.append(f"- Time scope: {scope_line}")
     lines.append("")
-    ensemble_member_label = (
-        str(ctx.ensemble_member) if ctx.ensemble_member is not None else "n/a"
-    )
     lines.append("### Unavailable values")
     lines.append("")
     lines.append(f"- Point 1: lat={ctx.point1_lat:.4f}, lon={ctx.point1_lon:.4f}")
@@ -244,7 +241,8 @@ def write_summary_md(ctx: RunContext) -> Path:  # noqa: PLR0915
     lines.append("")
     lines.append("### Spatial and distribution")
     lines.append("")
-    lines.append(f"- Ensemble member: {ensemble_member_label}")
+    if ctx.ensemble_member is not None:
+        lines.append(f"- Ensemble member: {ctx.ensemble_member}")
     lines.append(
         f"- Spatial comparison time: "
         f"{ctx.spatial_time_label or 'n/a'} (reference at {ctx.ref_spatial_time_label or 'n/a'})"
@@ -252,7 +250,8 @@ def write_summary_md(ctx: RunContext) -> Path:  # noqa: PLR0915
     lines.append("")
     lines.append("### Time series")
     lines.append("")
-    lines.append(f"- Ensemble member: {ensemble_member_label}")
+    if ctx.ensemble_member is not None:
+        lines.append(f"- Ensemble member: {ctx.ensemble_member}")
     lines.append(f"- Point 1: lat={ctx.point1_lat:.4f}, lon={ctx.point1_lon:.4f}")
     lines.append(f"- Point 2: lat={ctx.point2_lat:.4f}, lon={ctx.point2_lon:.4f}")
     lines.append(f"- Timeseries period: {ctx.temporal_period_label or 'n/a'}")


### PR DESCRIPTION
## Summary
Reorganized the validation summary markdown output to move ensemble member information from the general "Run parameters" section to the specific subsections where it's actually used (spatial and time series analysis). This better reflects how the ensemble member is applied in practice.

## Changes
- **Removed** ensemble member line from the top-level run parameters section in `write_summary_md()`
- **Added** conditional ensemble member display in both the "Spatial and distribution" and "Time series" subsections (only shown if `ctx.ensemble_member is not None`)
- **Updated** documentation in `docs/validation.md` to clarify that:
  - The null analysis intentionally runs over all ensemble members
  - The same ensemble member is used for both spatial and time series sections
  - Ensemble member information is now documented under each respective subsection rather than globally

## Implementation Details
The ensemble member is now displayed contextually where it matters to the analysis:
- In the spatial comparison section, showing which ensemble member was selected for the spatial snapshot
- In the time series section, showing which ensemble member was selected for the point analysis

This change makes the validation summary more intuitive by grouping related parameters together, while the documentation clarifies the distinction between the null analysis (all members) and the specific analyses (single member per section).

https://claude.ai/code/session_01Trce55YAiDtz8F4Syp4A2H