### PR TITLE
fix(aifs-ens): correct cron schedules to run 4x/day

### DIFF
--- a/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
@@ -30,7 +30,7 @@ class EcmwfAifsEnsForecastDataset(
             # AIFS-ENS publishes the last file ~H+6h00m to H+6h40m after init across
             # normal cycles (sample of 11 v2 cycles 2026-05-12 through 05-14).
             # Run at H+6h43m for a 3 min margin past the worst-observed last-file lag.
-            schedule="43 6/6 * * *",
+            schedule="43 */6 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -45,7 +45,7 @@ class EcmwfAifsEnsForecastDataset(
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
             # Validation runs 30 minutes after each update run: 01:13, 07:13, 13:13, and 19:13.
-            schedule="13 7/6 * * *",
+            schedule="13 1-23/6 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,


### PR DESCRIPTION
## Summary

The AIFS ENS update and validation crons were running 3x/day instead of 4x — the 00:43 UTC update and 01:13 UTC validation cycles were silently skipped.

Root cause: the schedules used the `start/step` cron form (`6/6` and `7/6`), which Vixie cron reads as "starting at hour 6 (or 7), every 6 hours". That expands to hours `6,12,18` and `7,13,19` respectively — the lowest hour never matches because it's below the start. The intent (documented in the code comment at line 47: "01:13, 07:13, 13:13, and 19:13") was 4x/day.

Fix:
- Update: `"43 6/6 * * *"` → `"43 */6 * * *"` (00:43, 06:43, 12:43, 18:43)
- Validation: `"13 7/6 * * *"` → `"13 1-23/6 * * *"` (01:13, 07:13, 13:13, 19:13)

These conventions match sibling datasets (`aifs_single` uses `*/6`, `hrrr/analysis` uses `1-23/3`).

## Data gap check

Ran `report-nulls` over the last 3 weeks (2026-05-05 → 2026-05-26):

- All 17 variables: 0 unavailable timestamps at both random points
- 85 init_times present, evenly distributed: **22 × 00z, 21 × 06z, 21 × 12z, 21 × 18z**
- Every consecutive gap between init_times is exactly 6 hours — no missing cycles

The bug delayed the 00z forecasts but did not drop them: `operational_update_jobs` reads from `max(existing_init_time)` through `now - 5.5h`, so the 06:43 UTC cron caught both the 00z and 06z init_times whenever the (missing) 00:43 UTC cron should have run. The 00z cycle landed in the archive ~6h later than intended, but is fully present.

## Test plan
- [x] `uv run ruff format && uv run ruff check && uv run ty check` pass
- [x] `uv run pytest tests/ecmwf/aifs_ens/forecast/dynamical_dataset_test.py` passes
- [x] `report-nulls` over 3 weeks shows no gaps in archive
- [ ] After deploy, confirm the 01:13 UTC validation run appears in the next day's check-in history