### PR TITLE
Dynamically resolve GEFS analysis reference URL from STAC catalog

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -23,7 +23,7 @@ When the run completes, stdout prints the path of `validation_summary.md` (relat
 
 ### Options
 
-- `--reference-url` Reference dataset for side-by-side comparison (default: NOAA GEFS analysis). Change if your dataset is outside the reference's temporal or spatial coverage. Variables not present in the reference still get validation-only plots and stats.
+- `--reference-url` Reference dataset for side-by-side comparison. Defaults to the NOAA GEFS analysis icechunk asset URL discovered from the STAC catalog at `https://stac.dynamical.org/catalog.json`. Change if your dataset is outside the reference's temporal or spatial coverage. Variables not present in the reference still get validation-only plots and stats.
 - `--variable <name>` (repeatable, alias `-v`) Restrict to specific variables. Especially useful while iterating on a single new variable — brings total runtime down to under a minute. To compare related variables side-by-side, pass `--variable` multiple times: `-v downward_short_wave_radiation_flux_surface -v total_cloud_cover_atmosphere`.
 - `--start-date <YYYY-MM-DD>` / `--end-date <YYYY-MM-DD>` Restrict the append dimension. Useful for reproducing an issue in a specific window.
 - `--init-time` / `--lead-time` (forecast) or `--time` (analysis) Pick the exact spatial snapshot instead of a random one. Use this to reproduce a spatial anomaly deterministically.

--- a/src/scripts/validation/compare_spatial.py
+++ b/src/scripts/validation/compare_spatial.py
@@ -18,7 +18,9 @@ from scripts.validation.utils import (
     is_forecast_dataset,
     load_zarr_dataset,
     output_dir_option,
+    reference_url_option,
     resolve_output_dir,
+    resolve_reference_url,
     scope_time_period,
     select_random_ensemble_member,
     select_variables_for_plotting,
@@ -29,8 +31,6 @@ from scripts.validation.utils import (
 log = get_logger(__name__)
 
 zarr.config.set({"async.concurrency": 32})
-
-GEFS_ANALYSIS_URL = "https://data.dynamical.org/noaa/gefs/analysis/latest.zarr"
 
 
 def align_reference_spatially(ds: xr.Dataset, reference_ds: xr.Dataset) -> xr.Dataset:
@@ -363,7 +363,7 @@ def run_compare_spatial(
 
 def compare_spatial(
     validation_url: str,
-    reference_url: str = GEFS_ANALYSIS_URL,
+    reference_url: str | None = reference_url_option,
     variables: list[str] | None = variables_option,
     show_plot: bool = False,
     init_time: str | None = None,
@@ -382,6 +382,7 @@ def compare_spatial(
     is_forecast = is_forecast_dataset(validation_ds)
     log.info(f"Detected {'forecast' if is_forecast else 'analysis'} dataset")
 
+    reference_url = resolve_reference_url(reference_url)
     log.info(f"Loading reference dataset: {reference_url}")
     reference_ds = load_zarr_dataset(reference_url)
 

--- a/src/scripts/validation/compare_timeseries.py
+++ b/src/scripts/validation/compare_timeseries.py
@@ -16,7 +16,9 @@ from scripts.validation.utils import (
     is_forecast_dataset,
     load_zarr_dataset,
     output_dir_option,
+    reference_url_option,
     resolve_output_dir,
+    resolve_reference_url,
     scope_time_period,
     select_random_ensemble_member,
     select_variables_for_plotting,
@@ -27,8 +29,6 @@ from scripts.validation.utils import (
 log = get_logger(__name__)
 
 zarr.config.set({"async.concurrency": 32})
-
-GEFS_ANALYSIS_URL = "https://data.dynamical.org/noaa/gefs/analysis/latest.zarr"
 
 
 def select_time_period_for_comparison(
@@ -312,7 +312,7 @@ def run_compare_timeseries(ctx: RunContext) -> None:
 
 def compare_timeseries(
     validation_url: str,
-    reference_url: str = GEFS_ANALYSIS_URL,
+    reference_url: str | None = reference_url_option,
     variables: list[str] | None = variables_option,
     show_plot: bool = False,
     start_date: str | None = start_date_option,
@@ -323,6 +323,7 @@ def compare_timeseries(
     validation_ds = load_zarr_dataset(validation_url)
     if start_date or end_date:
         validation_ds = scope_time_period(validation_ds, start_date, end_date)
+    reference_url = resolve_reference_url(reference_url)
     reference_ds = load_zarr_dataset(reference_url)
 
     selected_vars = select_variables_for_plotting(validation_ds, variables)

--- a/src/scripts/validation/plots.py
+++ b/src/scripts/validation/plots.py
@@ -5,7 +5,6 @@ import typer
 
 from reformatters.common.logging import get_logger
 from scripts.validation.compare_spatial import (
-    GEFS_ANALYSIS_URL,
     compare_spatial,
     run_compare_spatial,
 )
@@ -25,6 +24,8 @@ from scripts.validation.utils import (
     is_forecast_dataset,
     load_zarr_dataset,
     output_dir_option,
+    reference_url_option,
+    resolve_reference_url,
     scope_time_period,
     select_variables_for_plotting,
     start_date_option,
@@ -60,9 +61,7 @@ app.command(
 )
 def run_all(
     dataset_url: str,
-    reference_url: str = typer.Option(
-        GEFS_ANALYSIS_URL, "--reference-url", help="Reference dataset URL"
-    ),
+    reference_url: str | None = reference_url_option,
     variables: list[str] | None = variables_option,
     start_date: str | None = start_date_option,
     end_date: str | None = end_date_option,
@@ -89,6 +88,7 @@ def run_all(
     if start_date or end_date:
         validation_ds = scope_time_period(validation_ds, start_date, end_date)
 
+    reference_url = resolve_reference_url(reference_url)
     log.info(f"Loading reference dataset:  {reference_url}")
     reference_ds = load_zarr_dataset(reference_url)
 

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -1,8 +1,10 @@
+import functools
 from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
+import httpx
 import icechunk
 import numpy as np
 import obstore
@@ -12,6 +14,40 @@ import xarray as xr
 from zarr.storage import ObjectStore, StoreLike
 
 OUTPUT_DIR = "data/output"
+
+STAC_CATALOG_URL = "https://stac.dynamical.org/catalog.json"
+GEFS_ANALYSIS_COLLECTION_ID = "noaa-gefs-analysis"
+
+
+@functools.cache
+def get_gefs_analysis_reference_url() -> str:
+    """Look up the GEFS analysis icechunk asset URL from the STAC catalog."""
+    with httpx.Client(follow_redirects=True, timeout=30.0) as client:
+        catalog = client.get(STAC_CATALOG_URL).raise_for_status().json()
+        for link in catalog["links"]:
+            if link["rel"] != "child":
+                continue
+            collection = client.get(link["href"]).raise_for_status().json()
+            if collection["id"] == GEFS_ANALYSIS_COLLECTION_ID:
+                return collection["assets"]["icechunk"]["href"]
+    raise ValueError(
+        f"Collection {GEFS_ANALYSIS_COLLECTION_ID!r} not found in STAC catalog at {STAC_CATALOG_URL}"
+    )
+
+
+def resolve_reference_url(reference_url: str | None) -> str:
+    if reference_url is not None:
+        return reference_url
+    return get_gefs_analysis_reference_url()
+
+
+reference_url_option = typer.Option(
+    None,
+    "--reference-url",
+    help="Reference dataset URL "
+    "(default: GEFS analysis icechunk asset looked up from the STAC catalog)",
+)
+
 
 variables_option = typer.Option(
     None,


### PR DESCRIPTION
## Summary
Refactors the validation scripts to dynamically discover the GEFS analysis reference dataset URL from the STAC catalog instead of using a hardcoded URL. This makes the validation system more resilient to URL changes and allows the reference dataset to be updated without code changes.

## Key Changes
- Added `get_gefs_analysis_reference_url()` function in `utils.py` that queries the STAC catalog at `https://stac.dynamical.org/catalog.json` to discover the GEFS analysis icechunk asset URL
  - Uses `@functools.cache` decorator to avoid repeated catalog lookups
  - Includes proper error handling if the collection is not found
- Added `resolve_reference_url()` helper function to handle optional reference URLs, falling back to dynamic discovery when not provided
- Created reusable `reference_url_option` typer Option definition in `utils.py` for consistent CLI interface across scripts
- Updated `plots.py`, `compare_spatial.py`, and `compare_timeseries.py` to:
  - Import and use the new `reference_url_option` and `resolve_reference_url` from utils
  - Remove hardcoded `GEFS_ANALYSIS_URL` constants
  - Call `resolve_reference_url()` before loading the reference dataset
- Updated documentation in `validation.md` to reflect the new dynamic discovery behavior

## Implementation Details
- The STAC catalog lookup is cached to avoid repeated HTTP requests during a single validation run
- The reference URL parameter is now optional (`str | None`) with a default of `None`, triggering dynamic discovery
- All three validation scripts (`plots.py`, `compare_spatial.py`, `compare_timeseries.py`) now use the same pattern for reference URL resolution, improving consistency and maintainability

https://claude.ai/code/session_014NiXGcM3kFPdvFManZM7oK