### PR TITLE
WIP: tolerate transient S3 errors in validation script

### DIFF
--- a/src/scripts/validation/compare_spatial.py
+++ b/src/scripts/validation/compare_spatial.py
@@ -285,11 +285,25 @@ def run_compare_spatial(
 
     fig_c, axes_c = plt.subplots(n_vars, 3, figsize=(15, 3.375 * n_vars), squeeze=False)
 
+    import time as _time
+
+    def _load(da):
+        last = None
+        for attempt in range(6):
+            try:
+                return da.load()
+            except Exception as e:
+                last = e
+                wait = min(2 ** attempt, 30)
+                log.warning(f"  load retry attempt {attempt + 1}: {e!r}; sleeping {wait}s")
+                _time.sleep(wait)
+        raise last
+
     for i, var in enumerate(ctx.variables):
         stats = ctx.stats_for(var)
 
-        data = ds[var].load()
-        ref_data = ref_ds[var].load() if var in ref_ds.data_vars else None
+        data = _load(ds[var])
+        ref_data = _load(ref_ds[var]) if var in ref_ds.data_vars else None
         data_clean, ref_clean = _compute_spatial_stats(data, ref_data, stats)
 
         stats.spatial_time_label = val_time_label

--- a/src/scripts/validation/compare_timeseries.py
+++ b/src/scripts/validation/compare_timeseries.py
@@ -228,11 +228,26 @@ def run_compare_timeseries(ctx: RunContext) -> None:
     p1_title_suffix = f"(lat={ctx.point1_lat:.2f}, lon={ctx.point1_lon:.2f})"
     p2_title_suffix = f"(lat={ctx.point2_lat:.2f}, lon={ctx.point2_lon:.2f})"
 
+    import time as _time
+
     for i, var in enumerate(ctx.variables):
         stats = ctx.stats_for(var)
-        val_p1, ref_p1, val_p2, ref_p2 = _load_timeseries_for_var(
-            var, ctx, validation_subset, reference_subset
-        )
+        last = None
+        loaded = None
+        for attempt in range(6):
+            try:
+                loaded = _load_timeseries_for_var(
+                    var, ctx, validation_subset, reference_subset
+                )
+                break
+            except Exception as e:
+                last = e
+                wait = min(2 ** attempt, 30)
+                log.warning(f"  temporal {var}: attempt {attempt + 1} failed: {e!r}; sleeping {wait}s")
+                _time.sleep(wait)
+        if loaded is None:
+            raise last  # type: ignore[misc]
+        val_p1, ref_p1, val_p2, ref_p2 = loaded
         _store_temporal_stats(stats, val_p1, val_p2, ref_p1, ref_p2)
         units = stats.units or ""
 

--- a/src/scripts/validation/report_nulls.py
+++ b/src/scripts/validation/report_nulls.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -151,11 +152,27 @@ def run_report_nulls(ctx: RunContext) -> None:
 
     fig_c, axes_c = plt.subplots(n_vars, 2, figsize=(12, 2.625 * n_vars), squeeze=False)
 
+    def _retry(fn, label):
+        last = None
+        for attempt in range(6):
+            try:
+                return fn()
+            except Exception as e:
+                last = e
+                wait = min(2 ** attempt, 30)
+                log.warning(f"  {label}: attempt {attempt + 1} failed: {e!r}; sleeping {wait}s")
+                time.sleep(wait)
+        raise last
+
     for i, var in enumerate(ctx.variables):
         stats = ctx.stats_for(var)
 
-        null_p1, unavailable_p1, n_p1, total_p1 = _compute_nulls_for_point(ds_p1, var)
-        null_p2, unavailable_p2, n_p2, total_p2 = _compute_nulls_for_point(ds_p2, var)
+        null_p1, unavailable_p1, n_p1, total_p1 = _retry(
+            lambda: _compute_nulls_for_point(ds_p1, var), f"nulls {var} P1"
+        )
+        null_p2, unavailable_p2, n_p2, total_p2 = _retry(
+            lambda: _compute_nulls_for_point(ds_p2, var), f"nulls {var} P2"
+        )
 
         stats.unavailable_timestamps_p1 = unavailable_p1
         stats.unavailable_timestamps_p2 = unavailable_p2


### PR DESCRIPTION
Sandbox environment intermittently fails on S3 chunk reads with
"Host resolves to a private/reserved IP" (zarr) and "service error /
error parsing XML" (icechunk). Wrap per-variable data loads in
report-nulls, compare-spatial, and compare-timeseries with a small
retry+backoff so the long validation run completes despite transient
infra hiccups.

https://claude.ai/code/session_01GWvzvcdGys8xKxGwLpmhzY