### PR TITLE
Fix/silence harmless warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,10 +137,3 @@ markers = [
     "slow: slow running tests.",
     "skip_set_local_zarr_store_base_path: opt out of automatically writing zarrs to a tmp directory during tests",
 ]
-filterwarnings = [
-    # GRIB2 files carry their own georeferencing rather than a GDAL geotransform, so rasterio emits
-    # NotGeoreferencedWarning when we reproject in read_rasterio. read_rasterio suppresses it per-call,
-    # but warnings.catch_warnings is process-global and not thread-safe, so the suppression leaks under
-    # the ThreadPoolExecutor concurrency in the download/read tests. The warning is expected and harmless.
-    "ignore::rasterio.errors.NotGeoreferencedWarning",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,3 +137,10 @@ markers = [
     "slow: slow running tests.",
     "skip_set_local_zarr_store_base_path: opt out of automatically writing zarrs to a tmp directory during tests",
 ]
+filterwarnings = [
+    # GRIB2 files carry their own georeferencing rather than a GDAL geotransform, so rasterio emits
+    # NotGeoreferencedWarning when we reproject in read_rasterio. read_rasterio suppresses it per-call,
+    # but warnings.catch_warnings is process-global and not thread-safe, so the suppression leaks under
+    # the ThreadPoolExecutor concurrency in the download/read tests. The warning is expected and harmless.
+    "ignore::rasterio.errors.NotGeoreferencedWarning",
+]

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -499,7 +499,6 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                         xr.open_zarr(
                             replica_store,
                             chunks=None,
-                            # Icechunk ignores consolidated metadata; see validation.validate_dataset.
                             consolidated=not isinstance(replica_store, IcechunkStore),
                         ),
                     )

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -14,6 +14,7 @@ import sentry_sdk
 import sentry_sdk.crons
 import typer
 import xarray as xr
+from icechunk.store import IcechunkStore
 from pydantic import Field, computed_field
 
 from reformatters.common import (
@@ -495,7 +496,12 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                     partial(
                         validation.compare_replica_and_primary,
                         self.template_config.append_dim,
-                        xr.open_zarr(replica_store, chunks=None),
+                        xr.open_zarr(
+                            replica_store,
+                            chunks=None,
+                            # Icechunk ignores consolidated metadata; see validation.validate_dataset.
+                            consolidated=not isinstance(replica_store, IcechunkStore),
+                        ),
                     )
                 )
 

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -12,6 +12,7 @@ import xarray as xr
 import zarr
 import zarr.core.sync
 import zarr.storage
+from icechunk.store import IcechunkStore
 from zarr.abc.store import Store
 
 from reformatters.common import iterating
@@ -63,10 +64,15 @@ def validate_dataset(
     """
     log.info(f"Validating zarr {store}")
 
+    # Icechunk ignores consolidated metadata, so reading it always falls back to
+    # the (slower) unconsolidated path with a warning; pass consolidated=False.
+    # Our zarr3 stores always carry consolidated metadata, so require it there.
+    consolidated = not isinstance(store, IcechunkStore)
+
     # Run all validators
     failed_validations = []
     for validator in validators:
-        ds = xr.open_zarr(store, chunks=None)
+        ds = xr.open_zarr(store, chunks=None, consolidated=consolidated)
 
         result = validator(ds)
         if not result.passed:

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -64,9 +64,6 @@ def validate_dataset(
     """
     log.info(f"Validating zarr {store}")
 
-    # Icechunk ignores consolidated metadata, so reading it always falls back to
-    # the (slower) unconsolidated path with a warning; pass consolidated=False.
-    # Our zarr3 stores always carry consolidated metadata, so require it there.
     consolidated = not isinstance(store, IcechunkStore)
 
     # Run all validators

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -350,7 +350,9 @@ def test_validate_dataset_calls_validators(
 
     mock_replica_store_ds = Mock()
     monkeypatch.setattr(
-        xr, "open_zarr", lambda store, chunks=None: mock_replica_store_ds
+        xr,
+        "open_zarr",
+        lambda store, chunks=None, consolidated=None: mock_replica_store_ds,
     )
 
     dataset.validate_dataset("example-job-name")

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import timedelta
 
 import icechunk
@@ -577,7 +578,16 @@ def test_validate_dataset_raises_on_failed_validator(
         coords={"time": times, "y": np.arange(4), "x": np.arange(4)},
     )
     store = zarr.storage.MemoryStore()
-    ds.to_zarr(store, mode="w", consolidated=False)
+    # Match production stores, which carry consolidated metadata (see template_utils.write_metadata),
+    # so validate_dataset opens them without the consolidated-fallback warning. Writing it emits a
+    # spec-compatibility UserWarning that production suppresses too.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Consolidated metadata is currently not part in the Zarr format 3 specification",
+            category=UserWarning,
+        )
+        ds.to_zarr(store, mode="w")
 
     def passing(ds: xr.Dataset) -> validation.ValidationResult:
         return validation.ValidationResult(passed=True, message="ok")

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -810,6 +810,9 @@ _PRE_V12_MISSING_VARS = frozenset(
 )
 
 
+# read_rasterio's per-call NotGeoreferencedWarning suppression leaks under the ThreadPoolExecutor
+# below because warnings.catch_warnings is not thread-safe; the warning is expected for GEFS GRIB.
+@pytest.mark.filterwarnings("ignore::rasterio.errors.NotGeoreferencedWarning")
 @pytest.mark.slow
 def test_download_and_read_all_vars_reforecast() -> None:
     """Download and read all vars from GEFS v12 reforecast (2000-2019), one var per file.
@@ -841,6 +844,7 @@ def test_download_and_read_all_vars_reforecast() -> None:
         list(pool.map(_download_and_check, data_vars))
 
 
+@pytest.mark.filterwarnings("ignore::rasterio.errors.NotGeoreferencedWarning")
 @pytest.mark.slow
 def test_download_and_read_all_vars_pre_v12() -> None:
     """Download and read all vars from pre-GEFS v12 period (2020-01-01 to 2020-09-23).
@@ -870,6 +874,7 @@ def test_download_and_read_all_vars_pre_v12() -> None:
         list(pool.map(_download_and_check, data_vars))
 
 
+@pytest.mark.filterwarnings("ignore::rasterio.errors.NotGeoreferencedWarning")
 @pytest.mark.slow
 def test_download_and_read_all_vars_current_early_lead() -> None:
     """Download and read all vars from current GEFS analysis archive (s-files, lead = 6h).

--- a/tests/noaa/gefs/forecast_35_day/region_job_test.py
+++ b/tests/noaa/gefs/forecast_35_day/region_job_test.py
@@ -721,6 +721,9 @@ def _make_forecast_region_job() -> GefsForecast35DayRegionJob:
     )
 
 
+# read_rasterio reprojects GEFS GRIB and suppresses the expected NotGeoreferencedWarning per-call,
+# but warnings.catch_warnings is not thread-safe so it leaks under the ThreadPoolExecutor below.
+@pytest.mark.filterwarnings("ignore::rasterio.errors.NotGeoreferencedWarning")
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "lead_time",


### PR DESCRIPTION
## Summary
This PR silences open_zarr efficiency warnings during validation of Icechunk stores by using consolidated=False. Icechunk ignores consolidated metadata, so we now conditionally pass `consolidated=False` when opening Icechunk stores to avoid unnecessary warnings and fallback behavior.

## Key Changes

- **validation.py**: Added logic to detect Icechunk stores and pass `consolidated=False` to `xr.open_zarr()` since Icechunk ignores consolidated metadata. Zarr v3 stores always carry consolidated metadata, so we require it there.

- **dynamical_dataset.py**: Updated the replica store opening in `validate_dataset()` to use the same consolidated metadata handling as the primary validation path, ensuring consistent behavior across replica and primary stores.

- **validation_test.py**: Updated test to write consolidated metadata (matching production stores) and suppress the expected Zarr format 3 spec-compatibility warning that production also suppresses.

- **dynamical_dataset_test.py**: Updated mock to accept the new `consolidated` parameter in `xr.open_zarr()` calls.

- **region_job_test.py (GEFS analysis & forecast)**: Added `@pytest.mark.filterwarnings` decorators to suppress expected `NotGeoreferencedWarning` from rasterio that leaks under ThreadPoolExecutor (warnings.catch_warnings is not thread-safe).

## Implementation Details

The key insight is that Icechunk and Zarr v3 handle consolidated metadata differently:
- Icechunk ignores consolidated metadata and always reads unconsolidated, triggering a warning if `consolidated=True` is passed
- Zarr v3 stores always carry consolidated metadata and should be opened with `consolidated=True`

By checking `isinstance(store, IcechunkStore)`, we can conditionally set the appropriate value and avoid spurious warnings during validation.

https://claude.ai/code/session_01JGZrrRJyKu8KUK2Ri4VrAn