### PR TITLE
Fix zero-filled easternmost longitude column in GEFS a/b GRIB upsampling

### DIFF
--- a/src/reformatters/noaa/gefs/read_data.py
+++ b/src/reformatters/noaa/gefs/read_data.py
@@ -114,14 +114,13 @@ def read_rasterio(
                         assert reader.transform == out_transform
                         assert reader.crs.to_dict() == out_crs
                         return raw
-                    result, _ = rasterio.warp.reproject(
+                    result = _reproject_bilinear_longitude_wrap(
                         raw,
-                        np.full(out_spatial_shape, np.nan, dtype=np.float32),
-                        src_transform=reader.transform,
-                        src_crs=reader.crs,
-                        dst_transform=out_transform,
-                        dst_crs=out_crs,
-                        resampling=rasterio.warp.Resampling.bilinear,
+                        reader.transform,
+                        reader.crs,
+                        out_spatial_shape,
+                        out_transform,
+                        out_crs,
                     )
                     if not Config.is_prod:
                         # Because the pixel centers are aligned we exactly retain the source data
@@ -130,3 +129,33 @@ def read_rasterio(
                     return result
                 case _ as unreachable:
                     assert_never(unreachable)
+
+
+def _reproject_bilinear_longitude_wrap(
+    raw: Array2D[np.float32],
+    src_transform: rasterio.transform.Affine,
+    src_crs: rasterio.crs.CRS,
+    out_spatial_shape: tuple[int, int],
+    out_transform: rasterio.transform.Affine,
+    out_crs: rasterio.crs.CRS,
+) -> Array2D[np.float32]:
+    # The global source grid does not include a column for longitude 180°, so the
+    # easternmost 0.25° destination pixels sit just outside the source's eastern edge
+    # and bilinear resampling would leave them unset (NaN, later stored as the 0 fill
+    # value). Pad the source with a wrap-around column on each side (longitude 180° ==
+    # -180°) and shift the transform west by one source pixel so every destination pixel
+    # falls strictly inside the source extent and interpolates across the antimeridian.
+    assert abs(raw.shape[1] * src_transform.a - 360) < 1e-6, "Source must span the full globe"  # fmt: skip
+    wrapped = np.concatenate([raw[:, -1:], raw, raw[:, :1]], axis=1)
+    wrapped_transform = src_transform * rasterio.transform.Affine.translation(-1, 0)
+    result: Array2D[np.float32]
+    result, _ = rasterio.warp.reproject(
+        wrapped,
+        np.full(out_spatial_shape, np.nan, dtype=np.float32),
+        src_transform=wrapped_transform,
+        src_crs=src_crs,
+        dst_transform=out_transform,
+        dst_crs=out_crs,
+        resampling=rasterio.warp.Resampling.bilinear,
+    )
+    return result

--- a/tests/noaa/gefs/forecast_35_day/region_job_test.py
+++ b/tests/noaa/gefs/forecast_35_day/region_job_test.py
@@ -27,6 +27,7 @@ from reformatters.noaa.gefs.forecast_35_day.template_config import (
     GefsForecast35DayTemplateConfig,
 )
 from reformatters.noaa.gefs.gefs_config_models import (
+    GEFS_S_FILE_MAX,
     GEFSDataVar,
     GefsEnsembleSourceFileCoord,
     GEFSInternalAttrs,
@@ -749,6 +750,21 @@ def test_download_and_read_all_vars_current(lead_time: pd.Timedelta) -> None:
         for data_var in group:
             data = region_job.read_data(coord, data_var)
             assert np.all(np.isfinite(data)), f"Non-finite values for {data_var.name}"
+            if lead_time > GEFS_S_FILE_MAX:
+                # a/b files are 0.5° upsampled to 0.25°. The easternmost column (179.75°)
+                # must wrap across the antimeridian, interpolating halfway between the
+                # 179.5° column and the -180° column. A bug in longitude wrapping instead
+                # zero-filled this column (finite, so the isfinite check above misses it).
+                data = data.astype(np.float64)
+                east_column = data[..., -1]
+                wrap_interpolation = (data[..., -2] + data[..., 0]) / 2
+                np.testing.assert_allclose(
+                    east_column,
+                    wrap_interpolation,
+                    rtol=1e-4,
+                    atol=1e-2,
+                    err_msg=f"Eastern column not longitude-wrapped for {data_var.name}",
+                )
 
     groups = list(GefsForecast35DayRegionJob.source_groups(template_config.data_vars))
     with ThreadPoolExecutor() as pool:

--- a/tests/noaa/gefs/read_data_test.py
+++ b/tests/noaa/gefs/read_data_test.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import Affine
+
+from reformatters.noaa.gefs.read_data import _reproject_bilinear_longitude_wrap
+
+# Matches the source data's spherical-earth CRS (see common_gefs_template_config.py).
+_CRS = rasterio.crs.CRS.from_proj4("+proj=longlat +a=6371229 +b=6371229 +no_defs")
+
+# Destination 0.25° grid: longitude -180..179.75, latitude 90..-90.
+_OUT_SHAPE = (721, 1440)
+_OUT_TRANSFORM = Affine(0.25, 0, -180 - 0.125, 0, -0.25, 90 + 0.125)
+
+
+@pytest.mark.parametrize("src_deg", [0.5, 1.0])
+def test_reproject_bilinear_longitude_wrap_fills_eastern_edge(src_deg: float) -> None:
+    n_lon = round(360 / src_deg)
+    n_lat = round(180 / src_deg) + 1
+    src_transform = Affine(
+        src_deg, 0, -180 - src_deg / 2, 0, -src_deg, 90 + src_deg / 2
+    )
+
+    # Value encodes the source longitude so we can verify the antimeridian interpolation.
+    lons = -180 + np.arange(n_lon) * src_deg
+    raw = np.broadcast_to(lons.astype(np.float32), (n_lat, n_lon)).copy()
+
+    result = _reproject_bilinear_longitude_wrap(
+        raw, src_transform, _CRS, _OUT_SHAPE, _OUT_TRANSFORM, _CRS
+    )
+
+    assert np.all(np.isfinite(result)), "Reprojected data must not contain NaN"
+
+    # Destination pixels whose centers align with source centers exactly retain the source value.
+    step = round(src_deg / 0.25)
+    assert np.array_equal(raw, result[::step, ::step])
+
+    # The eastern edge column (longitude 179.75°) sits between the last source column
+    # (180° - src_deg) and the wrapped longitude 180° == -180°, interpolating linearly.
+    fraction = (179.75 - lons[-1]) / src_deg
+    expected_east = (1 - fraction) * lons[-1] + fraction * (-180)
+    np.testing.assert_allclose(result[:, -1], expected_east, rtol=0, atol=1e-4)


### PR DESCRIPTION
## Problem

When upsampling 0.5°/1.0° GEFS a/b GRIB data to the 0.25° grid, `rasterio.warp.reproject` (bilinear) has no longitude wraparound. The easternmost destination column (longitude 179.75°) falls just outside the source grid's eastern edge — the source has no column for longitude 180° — so `reproject` fills those pixels with `0.0`. That value coincides with the encoding `fill_value=0`, so the column reads back as a zeroed strip.

This affects every variable sourced from a/b files at lead times **> 240h** (where the higher-res s-files no longer apply), on every latitude row, for ~99/179 lead times of each 00Z init. For physically-positive variables (pressure, RH, longwave radiation, precipitable water, geopotential heights) it shows up directly as `val_spatial_min = 0`; for signed variables it's hidden below the real spatial min.

## Fix

`read_data._reproject_bilinear_longitude_wrap` pads the global source grid with a wrap-around column on each side (longitude 180° == −180°) and shifts the source transform west by one source pixel, so every destination pixel falls strictly inside the source extent and interpolates correctly across the antimeridian. The approach is longitude-convention-agnostic and asserts the source spans the full globe.

The existing pixel-center alignment invariant (`raw == result[::step, ::step]`) still holds — the wrap columns only affect the seam pixels that don't align with source centers.

## Why this slipped through

The slow integration test asserted only `np.all(np.isfinite(data))`. The buggy column is `0.0`, which is finite, so the check passed despite the corruption. This PR adds a wraparound assertion: the easternmost column must equal the antimeridian interpolation of its neighbors (`(data[..., -2] + data[..., 0]) / 2` for 0.5° source), which fails on the old behavior and passes on the fix.

## Tests

- New fast unit test `tests/noaa/gefs/read_data_test.py` covering 0.5° and 1.0° sources: no NaN, exact center alignment preserved, and correct antimeridian interpolation at the seam.
- Tightened slow test `test_download_and_read_all_vars_current` (lead 252h) with the wraparound assertion above.
- 84 fast GEFS tests pass; ruff/ty clean.

## Note on existing data

This fixes the read/processing path going forward. Data already written to the archive still has the zeroed column and needs a reprocess of the affected init/lead ranges to correct historically (being bundled with other edits separately).

https://claude.ai/code/session_01AP8RhtctgUqDKfyzsMTHtB

---
_Generated by [Claude Code](https://claude.ai/code/session_01AP8RhtctgUqDKfyzsMTHtB)_