### PR TITLE
Fix AIFS Single precipitation units for legacy-format era

### DIFF
--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -193,7 +193,7 @@ class EcmwfAifsSingleForecastRegionJob(
             # scaling the accumulation is equivalent to scaling the resulting rate).
             for factor in data_var.internal_attrs.init_time_scale_factors:
                 if factor.applies_to(coord.init_time):
-                    result = result * factor.scale_factor
+                    result *= factor.scale_factor
 
             return result
 

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -187,16 +187,13 @@ class EcmwfAifsSingleForecastRegionJob(
             )
             result: ArrayFloat32 = reader.read(matching_bands[0], out_dtype=np.float32)
 
-            # Apply the legacy-format scale factor here, per message, rather than in
-            # apply_data_transformations: a region can straddle the format change, and the
+            # Apply any init_time-ranged scale factors here, per message, rather than in
+            # apply_data_transformations: a region can straddle a format change, and the
             # scale must be applied before deaccumulation (deaccumulation is linear, so
             # scaling the accumulation is equivalent to scaling the resulting rate).
-            legacy_scale = data_var.internal_attrs.legacy_format_scale_factor
-            if (
-                legacy_scale is not None
-                and coord.init_time < AIFS_SINGLE_PATH_CHANGE_DATE
-            ):
-                result = result * legacy_scale
+            for factor in data_var.internal_attrs.init_time_scale_factors:
+                if factor.applies_to(coord.init_time):
+                    result = result * factor.scale_factor
 
             return result
 

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -186,6 +186,18 @@ class EcmwfAifsSingleForecastRegionJob(
                 f"{expected_comment=}, {expected_description=}, {coord.downloaded_path=}"
             )
             result: ArrayFloat32 = reader.read(matching_bands[0], out_dtype=np.float32)
+
+            # Apply the legacy-format scale factor here, per message, rather than in
+            # apply_data_transformations: a region can straddle the format change, and the
+            # scale must be applied before deaccumulation (deaccumulation is linear, so
+            # scaling the accumulation is equivalent to scaling the resulting rate).
+            legacy_scale = data_var.internal_attrs.legacy_format_scale_factor
+            if (
+                legacy_scale is not None
+                and coord.init_time < AIFS_SINGLE_PATH_CHANGE_DATE
+            ):
+                result = result * legacy_scale
+
             return result
 
     def apply_data_transformations(

--- a/src/reformatters/ecmwf/aifs_single/forecast/template_config.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/template_config.py
@@ -27,7 +27,11 @@ from reformatters.common.zarr import (
     BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE,
     BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE,
 )
-from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, EcmwfInternalAttrs
+from reformatters.ecmwf.ecmwf_config_models import (
+    EcmwfDataVar,
+    EcmwfInternalAttrs,
+    InitTimeScaleFactor,
+)
 
 
 class EcmwfAifsSingleForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
@@ -423,8 +427,9 @@ class EcmwfAifsSingleForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
                 # Early GRIB master tables (v27) encode tp with generic product template codes.
                 # Later versions (v34+) use "Total precipitation rate [kg/(m^2*s)]".
                 # We use the early form here; read_data handles both.
-                # The legacy "aifs" format also stored the accumulation in metres, whereas the
-                # current "aifs-single" format uses mm (kg m-2), so legacy data is scaled x1000.
+                # The legacy "aifs" format (init_time before expanded_vars_date) also stored
+                # the accumulation in metres, whereas the current "aifs-single" format uses
+                # mm (kg m-2), so that range is scaled x1000.
                 internal_attrs=EcmwfInternalAttrs(
                     grib_comment="(prodType 0, cat 1, subcat 193) [-]",
                     grib_description='2[-] SFC="Ground or water surface"',
@@ -432,7 +437,9 @@ class EcmwfAifsSingleForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
                     grib_index_param="tp",
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     deaccumulate_to_rate=True,
-                    legacy_format_scale_factor=1000,
+                    init_time_scale_factors=(
+                        InitTimeScaleFactor(scale_factor=1000, end=expanded_vars_date),
+                    ),
                     window_reset_frequency=pd.Timedelta.max,
                     deaccumulation_invalid_below_threshold_rate=PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD,
                 ),

--- a/src/reformatters/ecmwf/aifs_single/forecast/template_config.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/template_config.py
@@ -423,6 +423,8 @@ class EcmwfAifsSingleForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
                 # Early GRIB master tables (v27) encode tp with generic product template codes.
                 # Later versions (v34+) use "Total precipitation rate [kg/(m^2*s)]".
                 # We use the early form here; read_data handles both.
+                # The legacy "aifs" format also stored the accumulation in metres, whereas the
+                # current "aifs-single" format uses mm (kg m-2), so legacy data is scaled x1000.
                 internal_attrs=EcmwfInternalAttrs(
                     grib_comment="(prodType 0, cat 1, subcat 193) [-]",
                     grib_description='2[-] SFC="Ground or water surface"',
@@ -430,6 +432,7 @@ class EcmwfAifsSingleForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
                     grib_index_param="tp",
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     deaccumulate_to_rate=True,
+                    legacy_format_scale_factor=1000,
                     window_reset_frequency=pd.Timedelta.max,
                     deaccumulation_invalid_below_threshold_rate=PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD,
                 ),

--- a/src/reformatters/ecmwf/ecmwf_config_models.py
+++ b/src/reformatters/ecmwf/ecmwf_config_models.py
@@ -23,6 +23,25 @@ class MarsSourceOverrides(FrozenBaseModel):
     scale_factor: float | None = None
 
 
+class InitTimeScaleFactor(FrozenBaseModel):
+    """A scale factor applied only to source files whose init_time falls in [start, end).
+
+    Used when a source changes encoding/units over time. For example AIFS total
+    precipitation accumulation was stored in metres in the legacy "aifs" open-data format
+    and in mm (kg m-2) in the current "aifs-single" format (from 2025-02-26), so the legacy
+    range needs a x1000 conversion. `start` and `end` are open-ended when None.
+    """
+
+    scale_factor: float
+    start: Timestamp | None = None  # inclusive
+    end: Timestamp | None = None  # exclusive
+
+    def applies_to(self, init_time: Timestamp) -> bool:
+        return (self.start is None or init_time >= self.start) and (
+            self.end is None or init_time < self.end
+        )
+
+
 class EcmwfInternalAttrs(BaseInternalAttrs):
     """Variable specific attributes used internally to drive processing. Not written to the dataset."""
 
@@ -45,13 +64,11 @@ class EcmwfInternalAttrs(BaseInternalAttrs):
 
     scale_factor: float | None = None
 
-    # Scale factor applied only to source files in the dataset's legacy open-data
-    # format (those before the format-change date; the RegionJob decides which files
-    # are legacy). Used for AIFS total precipitation: the legacy "aifs" format encoded
-    # accumulation in metres while the current "aifs-single" format uses mm (kg m-2),
-    # so legacy precip needs a x1000 conversion before deaccumulation and current
-    # precip needs none.
-    legacy_format_scale_factor: float | None = None
+    # Scale factors applied only to source files whose init_time falls in each entry's
+    # [start, end) range, before deaccumulation. Use this for sources that changed encoding
+    # or units over time (e.g. AIFS total precipitation, stored in metres in the legacy
+    # "aifs" format and mm in the current "aifs-single" format). Ranges should be disjoint.
+    init_time_scale_factors: tuple[InitTimeScaleFactor, ...] = ()
 
     # Date when this variable became available for the time period being processed.
     # Source-specific overrides (e.g. _resolve_mars_data_var) may clear this when

--- a/src/reformatters/ecmwf/ecmwf_config_models.py
+++ b/src/reformatters/ecmwf/ecmwf_config_models.py
@@ -45,6 +45,14 @@ class EcmwfInternalAttrs(BaseInternalAttrs):
 
     scale_factor: float | None = None
 
+    # Scale factor applied only to source files in the dataset's legacy open-data
+    # format (those before the format-change date; the RegionJob decides which files
+    # are legacy). Used for AIFS total precipitation: the legacy "aifs" format encoded
+    # accumulation in metres while the current "aifs-single" format uses mm (kg m-2),
+    # so legacy precip needs a x1000 conversion before deaccumulation and current
+    # precip needs none.
+    legacy_format_scale_factor: float | None = None
+
     # Date when this variable became available for the time period being processed.
     # Source-specific overrides (e.g. _resolve_mars_data_var) may clear this when
     # the source has the variable regardless of the original availability date.

--- a/tests/ecmwf/aifs_single/forecast/dynamical_dataset_test.py
+++ b/tests/ecmwf/aifs_single/forecast/dynamical_dataset_test.py
@@ -58,9 +58,8 @@ def test_backfill_local_and_operational_update(
         init_time="2024-04-01T00:00:00", latitude=0, longitude=0, lead_time="6h"
     )
     assert float(point_6h["temperature_2m"]) == 28.75
-    assert float(point_6h["precipitation_surface"]) == pytest.approx(
-        7.59027898311615e-08
-    )
+    # Legacy "aifs" precip is stored in metres and scaled x1000 to mm (kg m-2).
+    assert float(point_6h["precipitation_surface"]) == pytest.approx(7.62939453125e-05)
 
     # Operational update
     monkeypatch.setattr(
@@ -99,12 +98,13 @@ def test_backfill_local_and_operational_update(
     )
     np.testing.assert_array_equal(t2m_updated, t2m_expected)
 
+    # Legacy "aifs" precip is stored in metres and scaled x1000 to mm (kg m-2).
     precip_expected = np.array(
         [
             # init_time=2024-04-01T00, lead_time=[0h, 6h]
-            [np.nan, 7.590279e-08],
+            [np.nan, 7.629395e-05],
             # init_time=2024-04-01T06, lead_time=[0h, 6h]
-            [np.nan, 9.371433e-09],
+            [np.nan, 9.357929e-06],
         ],
         dtype=np.float32,
     )

--- a/tests/ecmwf/aifs_single/forecast/region_job_test.py
+++ b/tests/ecmwf/aifs_single/forecast/region_job_test.py
@@ -12,6 +12,7 @@ from reformatters.common import template_utils
 from reformatters.common.iterating import item
 from reformatters.common.pydantic import replace
 from reformatters.common.storage import DatasetFormat, StorageConfig, StoreFactory
+from reformatters.common.types import ArrayFloat32
 from reformatters.ecmwf.aifs_single.forecast.region_job import (
     AIFS_SINGLE_PATH_CHANGE_DATE,
     EcmwfAifsSingleForecastRegionJob,
@@ -411,7 +412,8 @@ def test_read_data_alt_precip_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
 
     precip_var = item(v for v in config.data_vars if v.name == "precipitation_surface")
     coord = EcmwfAifsSingleForecastSourceFileCoord(
-        init_time=pd.Timestamp("2024-04-01"),
+        # v34+ alt metadata is the current "aifs-single" format, so use a current-era init.
+        init_time=AIFS_SINGLE_PATH_CHANGE_DATE,
         lead_time=pd.Timedelta("6h"),
         data_var_group=[precip_var],
         downloaded_path=Path("fake/path.grib2"),
@@ -436,6 +438,59 @@ def test_read_data_alt_precip_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     result = region_job.read_data(coord, precip_var)
     assert np.array_equal(result, test_data)
     rasterio_reader.read.assert_called_once_with(1, out_dtype=np.float32)
+
+
+def _precip_read_data_mock(
+    monkeypatch: pytest.MonkeyPatch, init_time: pd.Timestamp
+) -> ArrayFloat32:
+    """Read precipitation_surface for the given init_time, returning the raw-scaled array."""
+    config = EcmwfAifsSingleForecastTemplateConfig()
+    region_job = EcmwfAifsSingleForecastRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=Mock(),
+        data_vars=config.data_vars,
+        append_dim=config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+    precip_var = item(v for v in config.data_vars if v.name == "precipitation_surface")
+    coord = EcmwfAifsSingleForecastSourceFileCoord(
+        init_time=init_time,
+        lead_time=pd.Timedelta("6h"),
+        data_var_group=[precip_var],
+        downloaded_path=Path("fake/path.grib2"),
+    )
+
+    rasterio_reader = Mock()
+    rasterio_reader.__enter__ = Mock(return_value=rasterio_reader)
+    rasterio_reader.__exit__ = Mock(return_value=False)
+    rasterio_reader.count = 1
+    rasterio_reader.descriptions = ['2[-] SFC="Ground or water surface"']
+    rasterio_reader.tags = Mock(
+        return_value={"GRIB_COMMENT": "(prodType 0, cat 1, subcat 193) [-]"}
+    )
+    rasterio_reader.read = Mock(
+        return_value=np.full((721, 1440), 0.001, dtype=np.float32)
+    )
+    monkeypatch.setattr(
+        "reformatters.ecmwf.aifs_single.forecast.region_job.rasterio.open",
+        Mock(return_value=rasterio_reader),
+    )
+    return region_job.read_data(coord, precip_var)
+
+
+def test_read_data_legacy_precip_scaled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy 'aifs' precip is stored in metres and scaled x1000 to mm (kg m-2)."""
+    result = _precip_read_data_mock(
+        monkeypatch, AIFS_SINGLE_PATH_CHANGE_DATE - pd.Timedelta("6h")
+    )
+    np.testing.assert_array_equal(result, 1.0)  # 0.001 m * 1000
+
+
+def test_read_data_current_precip_not_scaled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Current 'aifs-single' precip is already in mm (kg m-2) and is not rescaled."""
+    result = _precip_read_data_mock(monkeypatch, AIFS_SINGLE_PATH_CHANGE_DATE)
+    np.testing.assert_allclose(result, 0.001, rtol=1e-6)
 
 
 def test_operational_update_jobs(

--- a/tests/ecmwf/test_ecmwf_config_models.py
+++ b/tests/ecmwf/test_ecmwf_config_models.py
@@ -8,6 +8,7 @@ from reformatters.common.zarr import BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE
 from reformatters.ecmwf.ecmwf_config_models import (
     EcmwfDataVar,
     EcmwfInternalAttrs,
+    InitTimeScaleFactor,
     has_hour_0_values,
     vars_available,
 )
@@ -104,3 +105,25 @@ def test_has_hour_0_values_override_false_overrides_step_type() -> None:
         has_hour_0_values(_make_data_var("instant", hour_0_values_override=False))
         is False
     )
+
+
+def test_init_time_scale_factor_applies_to_half_open_range() -> None:
+    factor = InitTimeScaleFactor(
+        scale_factor=1000, end=pd.Timestamp("2025-02-26T00:00")
+    )
+    assert factor.applies_to(pd.Timestamp("2025-02-25T18:00")) is True
+    # end is exclusive
+    assert factor.applies_to(pd.Timestamp("2025-02-26T00:00")) is False
+    assert factor.applies_to(pd.Timestamp("2025-03-01T00:00")) is False
+
+
+def test_init_time_scale_factor_bounded_range() -> None:
+    factor = InitTimeScaleFactor(
+        scale_factor=2,
+        start=pd.Timestamp("2024-01-01"),
+        end=pd.Timestamp("2024-02-01"),
+    )
+    assert factor.applies_to(pd.Timestamp("2023-12-31")) is False
+    assert factor.applies_to(pd.Timestamp("2024-01-01")) is True  # start inclusive
+    assert factor.applies_to(pd.Timestamp("2024-01-15")) is True
+    assert factor.applies_to(pd.Timestamp("2024-02-01")) is False  # end exclusive


### PR DESCRIPTION
## Problem

Validation of `ecmwf-aifs-single-forecast` v0.1.0 surfaced that `precipitation_surface` is **1000× too small for the entire legacy-format era** (`init_time` 2024-04-01 → 2025-02-25) and correct from 2025-02-26 onward.

The two AIFS open-data eras encode total precipitation differently:

| Era | Path | `tp` encoding |
|---|---|---|
| Legacy (2024-04-01 → 2025-02-25) | `aifs/` | accumulated **metres** |
| Current (2025-02-26+) | `aifs-single/` | accumulated **mm (kg m⁻²)** |

The reformatter applied no scale factor, so deaccumulation produced **m s⁻¹** for legacy data (1000× too small) while labeling it `kg m⁻² s⁻¹`. Current-era data was already correct.

### Evidence
- **Raw GRIB** at step 24h: legacy `20241014/06z/aifs` `tp` mean `0.00237` (units `[-]`, i.e. metres) vs current `20250301/00z/aifs-single` mean `2.36` (mm).
- **Published archive** global-max precip rate at lead 24h: 2024-10-14 = **0.012 mm/hr** (impossible as a global maximum) vs 2025-03-01 = **12.8 mm/hr** (correct).
- Visually, the legacy-era spatial/temporal plots show precip pinned at ~0 against the GEFS reference; the current era matches.

## Fix

Mirrors the IFS ENS source-aware scaling pattern (`MarsSourceOverrides` applied per-message in `read_data`), but keyed by **date** rather than source since the AIFS distinction is temporal:

- Add `legacy_format_scale_factor: float | None` to `EcmwfInternalAttrs`.
- Apply it per-message in AIFS `read_data` when `coord.init_time < AIFS_SINGLE_PATH_CHANGE_DATE` (2025-02-26). Applied here, before deaccumulation — a region can straddle the format change, and because deaccumulation is linear, scaling the accumulation is equivalent to scaling the resulting rate.
- Set `legacy_format_scale_factor=1000` on `precipitation_surface`. Current-era precip is unaffected.

No template metadata change (internal attr only).

## Tests
- New: legacy-era precip is scaled ×1000; current-era precip is not.
- Updated: the existing `read_data` alt-metadata test now uses a current-era init (the v34+ `TPRATE` metadata is the current format); the slow backfill snapshot test's legacy-era precip expectations are ×1000 (re-quantized under `keep_mantissa_bits`).
- `ruff format`, `ruff check`, `ty check`, and the AIFS + common template/CF-compliance + ECMWF (non-slow) suites all pass.

## Follow-up (not in this PR)
A **backfill of the legacy era** (`init_time` 2024-04-01 → 2025-02-25) is required to correct existing data in the published archive.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBt8Fxa8hcjgSJ5UmYyDvt)_