### PR TITLE
Extract MaterializedRegionJob from RegionJob (virtual datasets PR 1/6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Use ECMWF variable name for `long_name` and ECMWF short name for `short_name`.  
 ### RegionJob
 Base class: `src/reformatters/common/region_job.py`, commented example subclass: `src/reformatters/example/region_job.py`.
 
-Defines the **process** for reformatting a region of the dataset: downloading, reading, and writing data. Key responsibilities:
+Defines the **process** for reformatting a region of the dataset: downloading, reading, and writing data. `RegionJob` is the shared base (partitioning via `get_jobs()`, `generate_source_file_coords()`, `operational_update_jobs()`, `update_template_with_results()`, and an abstract `process()`); `MaterializedRegionJob(RegionJob)` adds the concrete download → read → write pipeline (`download_file()`, `read_data()`, `apply_data_transformations()`, `process()` and the parallelism tunables). Materialized (rechunked) datasets subclass `MaterializedRegionJob`, as the example does. Key responsibilities:
 - Implement `generate_source_file_coords()` - list source files needed for a region
 - Implement `download_file()` - retrieve a source file to local disk
 - Implement `read_data()` - load data from a local file into a numpy array

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Use ECMWF variable name for `long_name` and ECMWF short name for `short_name`.  
 ### RegionJob
 Base class: `src/reformatters/common/region_job.py`, commented example subclass: `src/reformatters/example/region_job.py`.
 
-Defines the **process** for reformatting a region of the dataset: downloading, reading, and writing data. `RegionJob` is the shared base (partitioning via `get_jobs()`, `generate_source_file_coords()`, `operational_update_jobs()`, `update_template_with_results()`, and an abstract `process()`); `MaterializedRegionJob(RegionJob)` adds the concrete download → read → write pipeline (`download_file()`, `read_data()`, `apply_data_transformations()`, `process()` and the parallelism tunables). Materialized (rechunked) datasets subclass `MaterializedRegionJob`, as the example does. Key responsibilities:
+Defines the **process** for reformatting a region of the dataset: downloading, reading, and writing data. `RegionJob` is the shared base (partitioning via `get_jobs()`, `generate_source_file_coords()`, `operational_update_jobs()`, `update_template_with_results()`, and an abstract `process()`); `MaterializedRegionJob(RegionJob)` adds the concrete download → read → write pipeline (`download_file()`, `read_data()`, `apply_data_transformations()`, `process()` and the parallelism tunables). Materialized (rechunked) datasets subclass `MaterializedRegionJob`. Key responsibilities:
 - Implement `generate_source_file_coords()` - list source files needed for a region
 - Implement `download_file()` - retrieve a source file to local disk
 - Implement `read_data()` - load data from a local file into a numpy array

--- a/docs/dataset_integration_guide.md
+++ b/docs/dataset_integration_guide.md
@@ -79,7 +79,7 @@ uv run pytest tests/$DATASET_PATH/template_config_test.py
 
 ### 4. Implement `RegionJob` subclass
 
-Work through `src/reformatters/$DATASET_PATH/region_job.py`, implementing the attributes and method definitions based on the unique structure and processing required for your dataset.
+Work through `src/reformatters/$DATASET_PATH/region_job.py`, implementing the attributes and method definitions based on the unique structure and processing required for your dataset. A materialized (rechunked) dataset subclasses `MaterializedRegionJob` (the download → read → write pipeline); the scaffolded example already does this.
 
 There are four required methods:
 

--- a/docs/dataset_integration_guide.md
+++ b/docs/dataset_integration_guide.md
@@ -79,7 +79,7 @@ uv run pytest tests/$DATASET_PATH/template_config_test.py
 
 ### 4. Implement `RegionJob` subclass
 
-Work through `src/reformatters/$DATASET_PATH/region_job.py`, implementing the attributes and method definitions based on the unique structure and processing required for your dataset. A materialized (rechunked) dataset subclasses `MaterializedRegionJob` (the download → read → write pipeline); the scaffolded example already does this.
+Work through `src/reformatters/$DATASET_PATH/region_job.py`, implementing the attributes and method definitions based on the unique structure and processing required for your dataset. This guide walks through implementing a `MaterializedRegionJob`, the `RegionJob` subclass used for rechunked Icechunk Zarr data (as opposed to `VirtualRegionJob` for virtual Icechunk datasets).
 
 There are four required methods:
 

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -9,7 +9,7 @@ from http import HTTPStatus
 from itertools import chain, pairwise
 from multiprocessing.shared_memory import SharedMemory
 from pathlib import Path
-from typing import Annotated, Any, ClassVar, Generic, TypeVar, get_args
+from typing import Annotated, Any, ClassVar, Generic, Self, TypeVar, get_args
 
 import httpx
 import numpy as np
@@ -128,20 +128,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     # Rule of thumb: leave unset unless a job takes > 15 minutes.
     max_vars_per_job: ClassVar[int | None] = None
 
-    # Limit the number of variables processed in each download group if set.
-    # If value is less than len(data_vars), downloading, reading/recompressing, and writing steps
-    # will be pipelined within a region job.
-    max_vars_per_download_group: ClassVar[int | None] = None
-
-    # Subclasses can override this to control download parallelism
-    # This particularly useful of the data source cannot handle a large number of concurrent requests
-    download_parallelism: int = (os.cpu_count() or 1) * 2
-
-    # Subclasses can override this to control read parallelism.
-    # This is useful in cases where many threads reading data into shared memory
-    # causes deadlocks or resource contention.
-    read_parallelism: int = os.cpu_count() or 1
-
     @classmethod
     def source_groups(
         cls,
@@ -177,67 +163,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         raise NotImplementedError(
             "Return a sequence of SourceFileCoord objects, one for each source file required to process the data covered by processing_region_ds."
         )
-
-    def download_file(self, coord: SOURCE_FILE_COORD) -> Path:
-        """Download the file for the given coordinate and return the local path."""
-        raise NotImplementedError(
-            "Download the file for the given coordinate and return the local path."
-        )
-
-    def read_data(
-        self,
-        coord: SOURCE_FILE_COORD,
-        data_var: DATA_VAR,
-    ) -> ArrayND[np.generic]:
-        """
-        Read and return the data chunk for the given variable and source file coordinate.
-
-        Subclasses must implement this to load the data (e.g., from a file or remote source)
-        for the specified coord and data_var. The returned array will be written into the shared
-        output array by the base class.
-
-        Parameters
-        ----------
-        coord : SOURCE_FILE_COORD
-            The coordinate specifying which file and region to read.
-        data_var : DATA_VAR
-            The data variable metadata.
-
-        Returns
-        -------
-        ArrayFloat32 | ArrayInt16
-            The loaded data.
-        """
-        raise NotImplementedError(
-            "Read and return data for the given variable and source file coordinate."
-        )
-
-    def apply_data_transformations(
-        self, data_array: xr.DataArray, data_var: DATA_VAR
-    ) -> None:
-        """
-        Apply in-place data transformations to the output data array for a given data variable.
-
-        This method is called after reading all data for a variable into the shared-memory array,
-        and before writing shards to the output store. The default implementation applies binary
-        rounding to float32 arrays if `data_var.internal_attrs.keep_mantissa_bits` is set.
-
-        Subclasses may override this method to implement additional transformations such as
-        deaccumulation, interpolation or other custom logic. All transformations should be
-        performed in-place (don't copy `data_array`, it's large).
-
-        Parameters
-        ----------
-        data_array : xr.DataArray
-            The output data array to be transformed in-place.
-        data_var : DATA_VAR
-            The data variable metadata object, which may contain transformation parameters.
-        """
-        keep_mantissa_bits = data_var.internal_attrs.keep_mantissa_bits
-        if isinstance(keep_mantissa_bits, int):
-            round_float32_inplace(
-                data_array.values, keep_mantissa_bits=keep_mantissa_bits
-            )
 
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[SourceFileResult]]
@@ -360,7 +285,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         filter_end: Timestamp | None = None,
         filter_contains: list[Timestamp] | None = None,
         filter_variable_names: list[str] | None = None,
-    ) -> Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]]:
+    ) -> Sequence[Self]:
         """
         Return a sequence of RegionJob instances to process.
 
@@ -395,7 +320,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         Returns
         -------
-        Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]]
+        Sequence[Self]
             All RegionJob instances matching the filters. Worker partitioning
             is handled by the caller via get_worker_jobs.
         """
@@ -481,6 +406,107 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             for data_var_group in data_var_groups
         ]
         return all_jobs
+
+    def process(
+        self,
+        primary_store: Store,
+        replica_stores: list[Store],
+    ) -> Mapping[str, Sequence[SOURCE_FILE_COORD]]:
+        """
+        Process this region, writing chunk data to primary_store (and replica_stores)
+        and returning the per-variable source file coordinates with their final status.
+
+        Implemented by the MaterializedRegionJob and VirtualRegionJob subclasses.
+        """
+        raise NotImplementedError(
+            "Subclasses implement process() with variant-specific logic"
+        )
+
+    def __repr__(self) -> str:
+        return f"RegionJob(region=({self.region.start}, {self.region.stop}), data_vars={[v.name for v in self.data_vars]})"
+
+
+class MaterializedRegionJob(
+    RegionJob[DATA_VAR, SOURCE_FILE_COORD], Generic[DATA_VAR, SOURCE_FILE_COORD]
+):
+    # Reformats source data into rechunked (materialized) chunk data: download
+    # source files, read them into shared-memory arrays, write output shards.
+    # Base class for all existing rechunked datasets.
+
+    # Limit the number of variables processed in each download group if set.
+    # If value is less than len(data_vars), downloading, reading/recompressing, and writing steps
+    # will be pipelined within a region job.
+    max_vars_per_download_group: ClassVar[int | None] = None
+
+    # Subclasses can override this to control download parallelism
+    # This particularly useful of the data source cannot handle a large number of concurrent requests
+    download_parallelism: int = (os.cpu_count() or 1) * 2
+
+    # Subclasses can override this to control read parallelism.
+    # This is useful in cases where many threads reading data into shared memory
+    # causes deadlocks or resource contention.
+    read_parallelism: int = os.cpu_count() or 1
+
+    def download_file(self, coord: SOURCE_FILE_COORD) -> Path:
+        """Download the file for the given coordinate and return the local path."""
+        raise NotImplementedError(
+            "Download the file for the given coordinate and return the local path."
+        )
+
+    def read_data(
+        self,
+        coord: SOURCE_FILE_COORD,
+        data_var: DATA_VAR,
+    ) -> ArrayND[np.generic]:
+        """
+        Read and return the data chunk for the given variable and source file coordinate.
+
+        Subclasses must implement this to load the data (e.g., from a file or remote source)
+        for the specified coord and data_var. The returned array will be written into the shared
+        output array by the base class.
+
+        Parameters
+        ----------
+        coord : SOURCE_FILE_COORD
+            The coordinate specifying which file and region to read.
+        data_var : DATA_VAR
+            The data variable metadata.
+
+        Returns
+        -------
+        ArrayFloat32 | ArrayInt16
+            The loaded data.
+        """
+        raise NotImplementedError(
+            "Read and return data for the given variable and source file coordinate."
+        )
+
+    def apply_data_transformations(
+        self, data_array: xr.DataArray, data_var: DATA_VAR
+    ) -> None:
+        """
+        Apply in-place data transformations to the output data array for a given data variable.
+
+        This method is called after reading all data for a variable into the shared-memory array,
+        and before writing shards to the output store. The default implementation applies binary
+        rounding to float32 arrays if `data_var.internal_attrs.keep_mantissa_bits` is set.
+
+        Subclasses may override this method to implement additional transformations such as
+        deaccumulation, interpolation or other custom logic. All transformations should be
+        performed in-place (don't copy `data_array`, it's large).
+
+        Parameters
+        ----------
+        data_array : xr.DataArray
+            The output data array to be transformed in-place.
+        data_var : DATA_VAR
+            The data variable metadata object, which may contain transformation parameters.
+        """
+        keep_mantissa_bits = data_var.internal_attrs.keep_mantissa_bits
+        if isinstance(keep_mantissa_bits, int):
+            round_float32_inplace(
+                data_array.values, keep_mantissa_bits=keep_mantissa_bits
+            )
 
     def process(
         self,
@@ -718,9 +744,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             if coord.downloaded_path:
                 with suppress(FileNotFoundError):
                     coord.downloaded_path.unlink()
-
-    def __repr__(self) -> str:
-        return f"RegionJob(region=({self.region.start}, {self.region.stop}), data_vars={[v.name for v in self.data_vars]})"
 
 
 class SourceFileResult(FrozenBaseModel):

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -423,7 +423,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         )
 
     def __repr__(self) -> str:
-        return f"RegionJob(region=({self.region.start}, {self.region.stop}), data_vars={[v.name for v in self.data_vars]})"
+        return f"{type(self).__name__}(region=({self.region.start}, {self.region.stop}), data_vars={[v.name for v in self.data_vars]})"
 
 
 class MaterializedRegionJob(
@@ -474,7 +474,7 @@ class MaterializedRegionJob(
 
         Returns
         -------
-        ArrayFloat32 | ArrayInt16
+        ArrayND[np.generic]
             The loaded data.
         """
         raise NotImplementedError(

--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/region_job.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/region_job.py
@@ -11,6 +11,7 @@ from zarr.abc.store import Store
 from reformatters.common.download import get_local_path
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -43,7 +44,7 @@ class NasaSmapLevel336KmV9SourceFileCoord(SourceFileCoord):
 
 
 class NasaSmapLevel336KmV9RegionJob(
-    RegionJob[NasaSmapDataVar, NasaSmapLevel336KmV9SourceFileCoord]
+    MaterializedRegionJob[NasaSmapDataVar, NasaSmapLevel336KmV9SourceFileCoord]
 ):
     def generate_source_file_coords(
         self,

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/region_job.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/region_job.py
@@ -22,6 +22,7 @@ from reformatters.common.iterating import item
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -67,7 +68,7 @@ class NoaaNdviCdrAnalysisSourceFileCoord(SourceFileCoord):
 
 
 class NoaaNdviCdrAnalysisRegionJob(
-    RegionJob[NoaaNdviCdrDataVar, NoaaNdviCdrAnalysisSourceFileCoord]
+    MaterializedRegionJob[NoaaNdviCdrDataVar, NoaaNdviCdrAnalysisSourceFileCoord]
 ):
     # Set lower than would be needed for fetching exclusively from S3
     # to accomodate the cases where we are downloading from NCEI.

--- a/src/reformatters/contrib/uarizona/swann/analysis/region_job.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/region_job.py
@@ -12,6 +12,7 @@ from zarr.abc.store import Store
 from reformatters.common.download import http_download_to_disk
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -79,7 +80,7 @@ class UarizonaSwannAnalysisSourceFileCoord(SourceFileCoord):
 
 
 class UarizonaSwannAnalysisRegionJob(
-    RegionJob[UarizonaSwannDataVar, UarizonaSwannAnalysisSourceFileCoord]
+    MaterializedRegionJob[UarizonaSwannDataVar, UarizonaSwannAnalysisSourceFileCoord]
 ):
     # Be gentle to UA HTTP servers
     download_parallelism: int = 2

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
@@ -16,6 +16,7 @@ from reformatters.common.iterating import item
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -87,7 +88,7 @@ class DwdIconEuForecast5DaySourceFileCoord(SourceFileCoord):
 
 
 class DwdIconEuForecast5DayRegionJob(
-    RegionJob[DwdIconEuDataVar, DwdIconEuForecast5DaySourceFileCoord]
+    MaterializedRegionJob[DwdIconEuDataVar, DwdIconEuForecast5DaySourceFileCoord]
 ):
     @classmethod
     def source_groups(

--- a/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
@@ -15,6 +15,7 @@ from reformatters.common.iterating import digest, group_by
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -96,7 +97,7 @@ class EcmwfAifsEnsForecastSourceFileCoord(SourceFileCoord):
 
 
 class EcmwfAifsEnsForecastRegionJob(
-    RegionJob[EcmwfDataVar, EcmwfAifsEnsForecastSourceFileCoord]
+    MaterializedRegionJob[EcmwfDataVar, EcmwfAifsEnsForecastSourceFileCoord]
 ):
     max_vars_per_download_group: ClassVar[int] = 2
     max_vars_per_job: ClassVar[int] = 4

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -15,6 +15,7 @@ from reformatters.common.iterating import digest, group_by
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -92,7 +93,7 @@ class EcmwfAifsSingleForecastSourceFileCoord(SourceFileCoord):
 
 
 class EcmwfAifsSingleForecastRegionJob(
-    RegionJob[EcmwfDataVar, EcmwfAifsSingleForecastSourceFileCoord]
+    MaterializedRegionJob[EcmwfDataVar, EcmwfAifsSingleForecastSourceFileCoord]
 ):
     max_vars_per_download_group: ClassVar[int] = 10
 

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -14,7 +14,7 @@ from reformatters.common.deaccumulation import deaccumulate_to_rates_inplace
 from reformatters.common.download import http_download_to_disk
 from reformatters.common.iterating import digest, item
 from reformatters.common.logging import get_logger
-from reformatters.common.region_job import RegionJob
+from reformatters.common.region_job import MaterializedRegionJob, RegionJob
 from reformatters.common.types import (
     AppendDim,
     ArrayFloat32,
@@ -43,7 +43,7 @@ log = get_logger(__name__)
 
 
 class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
-    RegionJob[EcmwfDataVar, IfsEnsSourceFileCoord]
+    MaterializedRegionJob[EcmwfDataVar, IfsEnsSourceFileCoord]
 ):
     # Limits the number of variables downloaded together.
     # All variables are scattered throughout the grib file without any organization,

--- a/src/reformatters/example/region_job.py
+++ b/src/reformatters/example/region_job.py
@@ -7,6 +7,7 @@ from zarr.abc.store import Store
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
     SourceFileResult,
@@ -47,7 +48,7 @@ class ExampleSourceFileCoord(SourceFileCoord):
         return super().out_loc()
 
 
-class ExampleRegionJob(RegionJob[ExampleDataVar, ExampleSourceFileCoord]):
+class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCoord]):
     # Optionally, limit the number of variables downloaded together.
     # If set to a value less than len(data_vars), downloading, reading/recompressing,
     # and uploading steps will be pipelined within a region job.

--- a/src/reformatters/noaa/gefs/analysis/region_job.py
+++ b/src/reformatters/noaa/gefs/analysis/region_job.py
@@ -13,6 +13,7 @@ from reformatters.common.iterating import item
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileResult,
 )
@@ -60,7 +61,9 @@ class GefsAnalysisSourceFileCoord(GefsEnsembleSourceFileCoord):
         }
 
 
-class GefsAnalysisRegionJob(RegionJob[GEFSDataVar, GefsAnalysisSourceFileCoord]):
+class GefsAnalysisRegionJob(
+    MaterializedRegionJob[GEFSDataVar, GefsAnalysisSourceFileCoord]
+):
     """RegionJob for GEFS Analysis dataset processing."""
 
     # 1 makes logic simpler when accessing GEFSv12 reforecast which has a file per variable

--- a/src/reformatters/noaa/gefs/forecast_35_day/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/region_job.py
@@ -11,7 +11,7 @@ from reformatters.common.binary_rounding import round_float32_inplace
 from reformatters.common.deaccumulation import deaccumulate_to_rates_inplace
 from reformatters.common.iterating import item
 from reformatters.common.logging import get_logger
-from reformatters.common.region_job import RegionJob
+from reformatters.common.region_job import MaterializedRegionJob, RegionJob
 from reformatters.common.types import AppendDim, ArrayND, DatetimeLike
 from reformatters.noaa.gefs.gefs_config_models import (
     GEFSDataVar,
@@ -34,7 +34,7 @@ class GefsForecast35DaySourceFileCoord(GefsEnsembleSourceFileCoord):
 
 
 class GefsForecast35DayRegionJob(
-    RegionJob[GEFSDataVar, GefsForecast35DaySourceFileCoord]
+    MaterializedRegionJob[GEFSDataVar, GefsForecast35DaySourceFileCoord]
 ):
     """RegionJob for GEFS Forecast 35-Day dataset processing."""
 

--- a/src/reformatters/noaa/gfs/region_job.py
+++ b/src/reformatters/noaa/gfs/region_job.py
@@ -20,6 +20,7 @@ from reformatters.common.iterating import digest, group_by
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -74,7 +75,9 @@ class NoaaGfsSourceFileCoord(SourceFileCoord):
         raise NotImplementedError("Subclasses must implement out_loc()")
 
 
-class NoaaGfsCommonRegionJob(RegionJob[NoaaDataVar, NoaaGfsSourceFileCoord]):
+class NoaaGfsCommonRegionJob(
+    MaterializedRegionJob[NoaaDataVar, NoaaGfsSourceFileCoord]
+):
     """Common RegionJob for GFS datasets."""
 
     @classmethod

--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -16,6 +16,7 @@ from reformatters.common.iterating import digest, group_by, item
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -78,7 +79,9 @@ class NoaaHrrrSourceFileCoord(SourceFileCoord):
         raise NotImplementedError  # depends on if the dataset is a forecast or analysis
 
 
-class NoaaHrrrRegionJob(RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]):
+class NoaaHrrrRegionJob(
+    MaterializedRegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]
+):
     """Base RegionJob for HRRR based datasets.  Subclassed by specific HRRR datasets."""
 
     max_vars_per_download_group = 5

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -18,6 +18,7 @@ from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import replace
 from reformatters.common.region_job import (
     CoordinateValue,
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
 )
@@ -78,7 +79,9 @@ class NoaaMrmsSourceFileCoord(SourceFileCoord):
         return {"time": self.time}
 
 
-class NoaaMrmsRegionJob(RegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]):
+class NoaaMrmsRegionJob(
+    MaterializedRegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]
+):
     def get_processing_region(self) -> slice:
         """Buffer start by one step to allow deaccumulation without gaps in resulting output."""
         return slice(max(0, self.region.start - 1), self.region.stop)

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -26,7 +26,7 @@ from reformatters.common.config_models import (
 )
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
-from reformatters.common.region_job import RegionJob, SourceFileCoord
+from reformatters.common.region_job import MaterializedRegionJob, SourceFileCoord
 from reformatters.common.storage import _NO_SECRET_NAME, DatasetFormat, StorageConfig
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
@@ -66,7 +66,7 @@ class ExampleSourceFileCoord(SourceFileCoord):
     pass
 
 
-class ExampleRegionJob(RegionJob[ExampleDataVar, ExampleSourceFileCoord]):
+class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCoord]):
     max_vars_per_job: ClassVar[int] = 2
 
 

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -22,7 +22,7 @@ from reformatters.common.config_models import (
 )
 from reformatters.common.iterating import get_worker_jobs
 from reformatters.common.region_job import (
-    RegionJob,
+    MaterializedRegionJob,
     SourceFileCoord,
     SourceFileResult,
     SourceFileStatus,
@@ -62,7 +62,7 @@ class ExampleSourceFileCoords(SourceFileCoord):
         return f"https://test.org/testfile{self.time.strftime('%Y%m%d%H%M')}"
 
 
-class ExampleRegionJob(RegionJob[ExampleDataVar, ExampleSourceFileCoords]):
+class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCoords]):
     max_vars_per_job: ClassVar[int] = 2
 
     @classmethod

--- a/tests/common/test_parallel_writes.py
+++ b/tests/common/test_parallel_writes.py
@@ -34,7 +34,7 @@ from reformatters.common.config_models import (
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 from reformatters.common.region_job import (
-    RegionJob,
+    MaterializedRegionJob,
     SourceFileCoord,
 )
 from reformatters.common.storage import DatasetFormat, StorageConfig
@@ -80,7 +80,9 @@ class ParallelSourceFileCoord(SourceFileCoord):
         return f"https://test.org/{self.time.isoformat()}"
 
 
-class ParallelRegionJob(RegionJob[ParallelDataVar, ParallelSourceFileCoord]):
+class ParallelRegionJob(
+    MaterializedRegionJob[ParallelDataVar, ParallelSourceFileCoord]
+):
     max_vars_per_job: ClassVar[int] = 2
 
     def generate_source_file_coords(


### PR DESCRIPTION
## What

Extract the materialized download → read → write pipeline out of the shared `RegionJob` base in `common/region_job.py` into a new sibling subclass `MaterializedRegionJob`. This is **PR 1 of 6** implementing [`docs/plans/virtual_icechunk_datasets.md`](https://github.com/dynamical-org/reformatters/blob/main/docs/plans/virtual_icechunk_datasets.md) — it creates the seam so a future `VirtualRegionJob` can be a sibling under the same base.

## The split

**`RegionJob` (shared base) keeps:**
- model fields, `max_vars_per_job`
- `get_jobs()` partitioning, `source_groups()`, `num_variable_groups()`, `get_processing_region()`
- `generate_source_file_coords()` (abstract), `operational_update_jobs()` (abstract), `update_template_with_results()`
- `dataset_id`, `__repr__`, and a now-abstract `process()`

**`MaterializedRegionJob(RegionJob)` gets:**
- the concrete `process()` body
- the `download_file` / `read_data` / `apply_data_transformations` hooks
- `download_parallelism`, `read_parallelism`, `max_vars_per_download_group`
- the shared-memory helpers (`_get_region_datasets`, `_download_processing_group`, `_read_into_data_array`, `_write_shards`, `_cleanup_local_files`)

Every concrete dataset region job (13, incl. `example/`) plus the 3 common test fixtures swap their base from `RegionJob[...]` to `MaterializedRegionJob[...]`. The 4 intermediate HRRR/GFS subclasses ride their parent's swap.

The one non-mechanical line: `get_jobs()` now returns `Sequence[Self]` instead of `Sequence[RegionJob[...]]`, so subclass call sites (e.g. `ExampleRegionJob.get_jobs(...)`) keep their concrete type and can reach the now-relocated helpers. More precise, no behavior change.

## Mechanical — behavior unchanged

The moved code is byte-identical in logic; no dataset overrides `process()` or the materialized helpers, and nothing calls `super().process()`. Docs (`AGENTS.md`/`CLAUDE.md` RegionJob section, dataset integration guide) updated to describe the base/`MaterializedRegionJob` split.

## Test plan

- `uv run ruff format && uv run ruff check && uv run ty check` — all pass
- `uv run pytest -m "not slow"` — 1273 passed
- `tests/common/{region_job_test,test_parallel_writes,dynamical_dataset_test}.py` — 93 passed
- all per-dataset `region_job_test.py` across providers — 280 passed

Part of #513
