### PR TITLE
Fix multi-dimensional coordinate summarization in validation

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -260,9 +260,6 @@ def _format_coord_value(value: object) -> str:
 def _summarize_coords(ds: xr.Dataset) -> str:
     parts = []
     for name in ds.coords:
-        # ravel so multi-dimensional coords (e.g. valid_time over init_time x
-        # lead_time) summarize as a concise first..last range instead of
-        # indexing whole sub-arrays and dumping the full nested array.
         values = ds.coords[name].values.ravel()
         if values.size == 0:
             parts.append(f"{name}=<empty>")

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -260,7 +260,10 @@ def _format_coord_value(value: object) -> str:
 def _summarize_coords(ds: xr.Dataset) -> str:
     parts = []
     for name in ds.coords:
-        values = np.atleast_1d(ds.coords[name].values)
+        # ravel so multi-dimensional coords (e.g. valid_time over init_time x
+        # lead_time) summarize as a concise first..last range instead of
+        # indexing whole sub-arrays and dumping the full nested array.
+        values = ds.coords[name].values.ravel()
         if values.size == 0:
             parts.append(f"{name}=<empty>")
         elif values.size == 1:

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -525,6 +525,31 @@ def test_truncate_shards_truncation() -> None:
     assert out == "[0, 1, 2, ..., 7, 8, 9]"
 
 
+def test_summarize_coords_multidimensional() -> None:
+    """Multi-dimensional coords (e.g. valid_time) collapse to a first..last range."""
+    init_times = pd.date_range("2026-06-05T12:00", periods=1, freq="6h")
+    lead_times = pd.timedelta_range(start="0h", periods=209, freq="1h")
+    valid_time = xr.DataArray(
+        init_times.values[:, None] + lead_times.values[None, :],
+        dims=("init_time", "lead_time"),
+    )
+    ds = xr.Dataset(
+        coords={
+            "init_time": ("init_time", init_times),
+            "lead_time": ("lead_time", lead_times),
+            "valid_time": valid_time,
+        }
+    )
+
+    summary = validation._summarize_coords(ds)
+
+    assert "valid_time=[2026-06-05T12:00:00..2026-06-14T04:00:00] (n=209)" in summary
+    # The full nested array must not be dumped.
+    assert "\n" not in summary
+    assert "init_time=2026-06-05T12:00:00" in summary
+    assert "lead_time=[0 days 00:00:00..8 days 16:00:00] (n=209)" in summary
+
+
 def test_check_for_expected_shards_skips_hrrr_categorical(
     rng: np.random.Generator,
 ) -> None:


### PR DESCRIPTION
## Summary
Fixed coordinate summarization in dataset validation to properly handle multi-dimensional coordinates (e.g., `valid_time` spanning `init_time × lead_time` dimensions) by flattening them before generating summary strings.

## Changes
- **`src/reformatters/common/validation.py`**: Modified `_summarize_coords()` to call `.ravel()` on coordinate values instead of `np.atleast_1d()`. This ensures multi-dimensional coordinates are flattened to 1D before summarization, producing concise "first..last" range summaries instead of attempting to index and dump entire nested arrays.

- **`tests/common/validation_test.py`**: Added `test_summarize_coords_multidimensional()` test case that verifies:
  - Multi-dimensional coordinates (e.g., `valid_time` over `init_time × lead_time`) are summarized as a range with element count
  - The summary output remains single-line (no newlines from nested array dumps)
  - Other coordinates in the dataset are still properly summarized

## Implementation Details
The change from `np.atleast_1d()` to `.ravel()` handles the case where a coordinate is defined over multiple dimensions. Previously, `np.atleast_1d()` would preserve the multi-dimensional structure, causing the summarization logic to fail when trying to format the nested array. The `.ravel()` method flattens the array to 1D while preserving all values, allowing the existing min/max range logic to work correctly.

https://claude.ai/code/session_01SDuw5TV65SzF3qVBPHefUe