### PR TITLE
Prep for virtual icechunk datasets (virtual datasets PR 2/6)

### DIFF
--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -216,58 +216,84 @@ region jobs change base class here and nothing else.
 ## Storage configuration
 
 Virtual datasets carry one new declarative, per-dataset config object on the
-`DynamicalDataset`:
+`DynamicalDataset`, holding the **real icechunk objects** directly:
 
 ```python
 class IcechunkVirtualConfig(FrozenBaseModel):
-    # Source buckets the refs point into. Registered as icechunk virtual chunk
-    # containers at every repo open (writer AND reader).
-    containers: Sequence[icechunk.VirtualChunkContainer]
+    # Hold icechunk's own objects. `InstanceOf` relaxes ONLY these fields to an
+    # isinstance check — no model-level `arbitrary_types_allowed`, and the
+    # DynamicalDataset that holds this config is untouched.
+    containers: tuple[InstanceOf[icechunk.VirtualChunkContainer], ...]
     # Manifest splitting policy (see "Manifest splitting").
-    manifest_split: icechunk.ManifestSplittingConfig
+    manifest_split: InstanceOf[icechunk.ManifestSplittingConfig]
+    # No credentials field: every source we point at is public/anonymous-read, so
+    # StoreFactory derives anonymous credentials per container. Add an optional
+    # per-container credentials field here if a private source ever appears.
 ```
 
-**Measured: the icechunk types do not round-trip declaratively, so the thin-shim
-path is the one we take** (not "use them as-is"). A `VirtualChunkContainer`
-exposes `.name` / `.url_prefix` as plain fields, but its `.store` is an opaque
-`ObjectStoreConfig` that does not surface `region` / `anonymous` for read-back;
-`ManifestSplittingConfig.to_dict()` is keyed by condition *objects* with no value
-equality, so `from_dict(to_dict(...))` reconstructs structurally but is not a
-clean JSON round-trip. `IcechunkVirtualConfig` is therefore a thin pydantic model
-holding exactly `prefix` / `region` / `anonymous` per container and the split
-`dim` / `size`, which *constructs* the icechunk objects (`VirtualChunkContainer`,
-`s3_store(...)`, `ManifestSplittingConfig.from_dict(...)`) at repo-open — a
-serialization shim, not a reimplementation.
+**Why hold the icechunk objects, not plain fields.** Plain
+`prefix`/`region`/`anonymous` + `split_dim`/`split_size` fields are a *lossy
+subset*, and the lost pieces are ones we target: a Source Coop container needs
+`endpoint_url` + `s3_compatible` (an `s3_store(...)` that resolves to an
+S3-compatible store, not plain region); an en-masse repoint to a GCP mirror needs
+`gcs_store`; and `ManifestSplittingConfig` supports per-array rules
+(`name_matches("temperature.*"): 7` vs `AnyArray(): 30`) and multi-dim splits a
+single `split_dim`/`split_size` can't express. Holding the real objects avoids
+re-extending a shim the day a non-AWS source appears. `InstanceOf` keeps this
+clean under `FrozenBaseModel` (verified: builds with no model-wide
+`arbitrary_types_allowed`, still isinstance-validated, survives
+`revalidate_instances="always"`). The split verbosity has a terse escape hatch
+that still returns the full object — e.g. a helper
+`append_dim_split(size, dim="init_time") -> ManifestSplittingConfig` for the
+common case, dropping to `from_dict(...)` only when a dataset needs more.
 
-**Persistence shrinks the reader's job.** `repo.save_config()` writes the
-container set and split policy into the repo itself; both `Repository.open(storage)`
-(no config passed) and `Repository.fetch_config(storage)` recover them. Credentials
-are *not* persisted: reading a virtual chunk requires
-`authorize_virtual_chunk_access={prefix: credential}` at every open — a read
-without it raises, and `authorized_virtual_container_prefixes` is empty. So a
-reader can `fetch_config` to recover the container prefixes and only needs to
-supply the anonymous-credentials map; the minimal reader-facing config is the
-credential policy, not the full container definition.
+**Nothing serializes this config; `StoreFactory` consumes it directly.** It is
+in-code config like `StorageConfig` — k8s workers rebuild the whole dataset
+(this included) from the in-code registry by `dataset_id`, never from a
+serialized copy. `StoreFactory` holds the whole `IcechunkVirtualConfig`, so at
+repo open/create it just uses what's there: register each container with
+`set_virtual_chunk_container(c)`, assemble the `RepositoryConfig` (containers +
+`manifest_split`), and authorize each container anonymously —
+`authorize_virtual_chunk_access=icechunk.containers_credentials({c.url_prefix:
+icechunk.s3_anonymous_credentials() for c in cfg.containers})`. No round-trip,
+and no introspecting the (opaque) container `.store`.
+
+**Credentials are derived, not configured.** Every source we target is public,
+anonymous-read (NOAA NODD, ECMWF, Source Coop), so there is no credentials field —
+`StoreFactory` builds an anonymous authorize map straight from the container set.
+If a private / requester-pays source ever appears, add an optional per-container
+credentials field (held the same way, via `InstanceOf`) and have `StoreFactory`
+prefer it; nothing else changes.
+
+**Reader-facing exposure is a separate concern.** External public readers still
+need to know which containers to register and authorize (anonymously); that is
+surfaced through our STAC catalog + example dataset-open code, not by serializing
+`IcechunkVirtualConfig`. icechunk helps: it persists the container set into the
+repo (`save_config` → recovered by `Repository.open` / `fetch_config`), so the
+published surface can be minimal. Credentials are *not* persisted — a read
+without `authorize_virtual_chunk_access` raises, and
+`authorized_virtual_container_prefixes` is empty — so the example open code always
+supplies the anonymous-credentials map.
 
 This config is held on `DynamicalDataset` (not on the region job, not on the
 template) for three reasons:
 
 1. **Cardinality.** Containers and split policy are *per-dataset* and identical
-   across the primary store and every replica. A per-store home
-   (`StorageConfig`) would force duplicating the container set on each store and
-   risk drift; a per-region-job home is invisible to readers.
-2. **Readers need it.** Opening a virtual store requires registering the same
-   containers and wiring `authorize_virtual_chunk_access` to anonymous
-   credentials. Readers (and the `dynamical_catalog` / STAC path) have no
-   `RegionJob`, so the container set must live in a declarative model they can
-   serialize and reconstruct.
+   across the primary store and every replica. A per-store home (`StorageConfig`)
+   would force duplicating them on each store and risk drift; a per-region-job
+   home is invisible to the reader/STAC path.
+2. **One declarative home, writer and reader.** Opening a virtual store needs the
+   same containers + authorize map whether writing or reading. Keeping them in one
+   per-dataset object gives the writer a single source and lets the STAC /
+   example-open path mirror it (it can also recover the container set from the repo
+   via `fetch_config`).
 3. **It is the unit of repointing.** See below.
 
 `StoreFactory` takes `icechunk_virtual_config` as a single field and applies it
-uniformly to every repo it opens, building the `icechunk.RepositoryConfig`
-(registered containers + manifest-split policy) and the
-`authorize_virtual_chunk_access` credentials map. `__main__.py` registration is
-identical to materialized.
+uniformly to every repo it opens (primary + replicas), building the
+`icechunk.RepositoryConfig` (registered containers + manifest-split policy) and an
+anonymous `authorize_virtual_chunk_access` map (one `s3_anonymous_credentials()`
+per container). `__main__.py` registration is identical to materialized.
 
 ### Containers as indirection, not just auth
 
@@ -844,12 +870,11 @@ manifest size (once measured) is worth monitoring. Co-location is still fine.
 ### Reader experience
 
 All targeted source archives have anonymous read access. A reader needs the
-container registration + anonymous credentials map — the same
-`IcechunkVirtualConfig` the writer uses, reconstructed from the declarative
-model (today via the `dynamical_catalog` library wrapping our STAC catalog;
-bare-path code is in [Appendix A](#appendix-a-prototype-pr-511)). Confirmed: the
-container *definitions* are recoverable straight from the store via
-`Repository.fetch_config`, so the only thing a reader must supply is the
+container registration + anonymous credentials map. It does **not** reconstruct
+our in-code `IcechunkVirtualConfig`: the container *definitions* are recoverable
+straight from the store via `Repository.fetch_config` (confirmed), so the reader
+path (today the `dynamical_catalog` library wrapping our STAC catalog; bare-path
+code is in [Appendix A](#appendix-a-prototype-pr-511)) only has to supply the
 anonymous credentials map passed to `authorize_virtual_chunk_access` at open — a
 virtual read without it raises with a "you need to authorize the virtual chunk
 container" error.
@@ -909,15 +934,16 @@ Mechanical; tests pass unchanged.
   so it installs cleanly on the project's Python 3.14; the decode path is already
   smoke-tested against `icechunk 2.0.5` / `zarr 3.1.3` (see
   [Spike results](#spike-results)).
-- Add `IcechunkVirtualConfig` to `common/storage.py` as a **thin serialization
-  shim** — confirmed required, since icechunk's `VirtualChunkContainer` /
-  `ManifestSplittingConfig` don't round-trip declaratively (see
-  [Storage configuration](#storage-configuration)). Hold `prefix` / `region` /
-  `anonymous` per container + split `dim` / `size`, and construct the icechunk
-  objects at repo-open. Thread `icechunk_virtual_config` through `StoreFactory`
-  and repo open/create (register containers, set split policy, wire anonymous
-  credentials via `authorize_virtual_chunk_access`). Add the `DynamicalDataset`
-  validator (virtual ⇒ all stores ICECHUNK ∧ non-empty containers).
+- Add `IcechunkVirtualConfig` to `common/storage.py` holding the **real icechunk
+  objects** directly via `InstanceOf` (containers + split policy) — plain fields
+  would be a lossy subset (no Source Coop `s3_compatible`, no GCS mirror, no
+  per-array/multi-dim splits; see [Storage configuration](#storage-configuration)).
+  No credentials field (all sources public/anonymous). Nothing serializes it:
+  `StoreFactory` consumes the config directly to register containers and build an
+  anonymous `authorize_virtual_chunk_access` map (one `s3_anonymous_credentials()`
+  per container). Thread `icechunk_virtual_config` through `StoreFactory` and repo
+  open/create. Add the `DynamicalDataset` validator (virtual ⇒ all stores ICECHUNK
+  ∧ non-empty containers).
 
 ### PR #3 — `VirtualRegionJob` + driver
 
@@ -1052,12 +1078,18 @@ landed; none forced a design change except #3 (empty commits raise).
    lengths_u64, *, validate_containers, arr_offset, checksum)` (zero-copy;
    empty-string locations silently skipped; `arr_offset` writes a sub-block for
    appends). Both return `None` on success or a list of validation-failed indices.
-8. **`IcechunkVirtualConfig` serialization → thin shim required.** icechunk's
-   types don't round-trip (opaque `.store` on `VirtualChunkContainer`; object-keyed
-   `ManifestSplittingConfig.to_dict()`). But `save_config` persists containers +
-   split policy into the repo (recovered by `Repository.open` / `fetch_config`),
-   so the shim is small and readers recover containers from the store, supplying
-   only the credentials map. (See [Storage configuration](#storage-configuration).)
+8. **`IcechunkVirtualConfig` → hold the real icechunk objects in-code; nothing
+   serializes it.** The icechunk types don't round-trip declaratively (opaque
+   `.store` on `VirtualChunkContainer`; object-keyed `ManifestSplittingConfig.to_dict()`)
+   — but that's moot, because nothing needs to: k8s workers rebuild the config
+   from the in-code registry by `dataset_id`, and `StoreFactory` uses the config
+   directly. So hold the real objects via pydantic `InstanceOf` (verified: works
+   under `FrozenBaseModel` with no model-wide `arbitrary_types_allowed`, scoped to
+   the field, isinstance-validated) — plain fields would be a lossy subset.
+   Separately, `save_config` persists containers + split into the repo (recovered
+   by `Repository.open` / `fetch_config`), so the reader/STAC exposure can be
+   minimal; credentials are never persisted (a read without
+   `authorize_virtual_chunk_access` raises). (See [Storage configuration](#storage-configuration).)
 
 Spike scripts live under `/tmp/spike/` for the run that produced these numbers;
 they are throwaway (local-FS repos, synthetic refs, gribberish via `uv run --with`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "icechunk~=2.0",
     "google-crc32c>=1.8.0",
     "httpx>=0.28.1",
+    "gribberish~=0.30",
 ]
 
 [build-system]

--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -156,6 +156,10 @@ class Encoding(pydantic.BaseModel):
         pydantic.BeforeValidator(codecs_to_dicts),
     ] = None
     compressors: Sequence[dict[str, Any]] | None = None
+    # zarr v3 ArrayBytesCodec serializer (the single slot between filters and
+    # compressors). None means zarr's default BytesCodec. Virtual datasets set
+    # this to a per-variable GribberishCodec dict.
+    serializer: dict[str, Any] | None = None
 
     calendar: Literal["proleptic_gregorian"] | None = None  # For timestamps only
     # The _encoded_ units, for timestamps and timedeltas only

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Annotated, Any, Generic, Literal, TypeVar
+from typing import Annotated, Any, Generic, Literal, Self, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -15,7 +15,7 @@ import sentry_sdk.crons
 import typer
 import xarray as xr
 from icechunk.store import IcechunkStore
-from pydantic import Field, computed_field
+from pydantic import Field, computed_field, model_validator
 
 from reformatters.common import (
     parallel_coordination,
@@ -40,7 +40,13 @@ from reformatters.common.region_job import (
     SourceFileCoord,
     SourceFileResult,
 )
-from reformatters.common.storage import StorageConfig, StoreFactory, get_local_tmp_store
+from reformatters.common.storage import (
+    DatasetFormat,
+    IcechunkVirtualConfig,
+    StorageConfig,
+    StoreFactory,
+    get_local_tmp_store,
+)
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import DatetimeLike
 
@@ -58,6 +64,30 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     primary_storage_config: StorageConfig
     replica_storage_configs: Sequence[StorageConfig] = Field(default_factory=tuple)
+    # Set for virtual datasets only; threaded through to every store this dataset opens.
+    icechunk_virtual_config: IcechunkVirtualConfig | None = None
+
+    @model_validator(mode="after")
+    def _validate_virtual_storage(self) -> Self:
+        # Virtual datasets store icechunk metadata + virtual chunk refs, so every
+        # store must be icechunk. The complementary direction (a virtual
+        # region_job_class requires icechunk_virtual_config) lands with
+        # VirtualRegionJob in PR #3.
+        if self.icechunk_virtual_config is not None:
+            non_icechunk = [
+                config
+                for config in (
+                    self.primary_storage_config,
+                    *self.replica_storage_configs,
+                )
+                if config.format != DatasetFormat.ICECHUNK
+            ]
+            if non_icechunk:
+                raise ValueError(
+                    "icechunk_virtual_config requires every storage config to use "
+                    f"the ICECHUNK format, but found: {non_icechunk}"
+                )
+        return self
 
     @computed_field
     @property
@@ -67,6 +97,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             replica_storage_configs=self.replica_storage_configs,
             dataset_id=self.dataset_id,
             template_config_version=self.template_config.version,
+            icechunk_virtual_config=self.icechunk_virtual_config,
         )
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -64,15 +64,11 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     primary_storage_config: StorageConfig
     replica_storage_configs: Sequence[StorageConfig] = Field(default_factory=tuple)
-    # Set for virtual datasets only; threaded through to every store this dataset opens.
     icechunk_virtual_config: IcechunkVirtualConfig | None = None
 
     @model_validator(mode="after")
     def _validate_virtual_storage(self) -> Self:
-        # Virtual datasets store icechunk metadata + virtual chunk refs, so every
-        # store must be icechunk. The complementary direction (a virtual
-        # region_job_class requires icechunk_virtual_config) lands with
-        # VirtualRegionJob in PR #3.
+        # Virtual datasets store icechunk metadata + virtual chunk refs, so every store must be icechunk.
         if self.icechunk_virtual_config is not None:
             non_icechunk = [
                 config

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -15,7 +15,7 @@ import zarr
 import zarr.abc.store
 import zarr.storage
 from icechunk.store import IcechunkStore
-from pydantic import Field, computed_field
+from pydantic import Field, InstanceOf, computed_field
 from zarr.abc.store import Store
 
 from reformatters.common import kubernetes
@@ -53,11 +53,73 @@ class StorageConfig(FrozenBaseModel):
         return kubernetes.load_secret(self.k8s_secret_name)
 
 
+def append_dim_split(
+    size: int, dim: str = "init_time"
+) -> icechunk.ManifestSplittingConfig:
+    """Split every array's manifest along `dim` every `size` indices.
+
+    The common-case terse constructor for `IcechunkVirtualConfig.manifest_split`;
+    drop to `icechunk.ManifestSplittingConfig.from_dict` for per-array or
+    multi-dimensional split policies.
+    """
+    return icechunk.ManifestSplittingConfig.from_dict(
+        {
+            icechunk.ManifestSplitCondition.AnyArray(): {
+                icechunk.ManifestSplitDimCondition.DimensionName(dim): size
+            }
+        }
+    )
+
+
+class IcechunkVirtualConfig(FrozenBaseModel):
+    """Per-dataset configuration for an icechunk virtual-chunk store.
+
+    Holds icechunk's own objects directly. `InstanceOf` relaxes only these fields to
+    an isinstance check, so the surrounding `FrozenBaseModel` keeps strict validation
+    and nothing model-wide opts into `arbitrary_types_allowed`. Nothing serializes
+    this config; `StoreFactory` consumes it directly at every repo open to register
+    the virtual chunk containers and build an anonymous `authorize_virtual_chunk_access`
+    map (every source we target is public, anonymous-read).
+    """
+
+    # Source buckets the refs point into, registered as virtual chunk containers.
+    containers: tuple[InstanceOf[icechunk.VirtualChunkContainer], ...] = Field(
+        min_length=1
+    )
+    # Per-array manifest splitting policy (see append_dim_split).
+    manifest_split: InstanceOf[icechunk.ManifestSplittingConfig]
+
+
+def _virtual_repository_overrides(
+    virtual_config: IcechunkVirtualConfig | None,
+) -> tuple[icechunk.RepositoryConfig | None, dict[str, Any] | None]:
+    """Build the icechunk `RepositoryConfig` override and anonymous authorize map for a
+    virtual dataset, or `(None, None)` for a materialized one (icechunk uses defaults)."""
+    if virtual_config is None:
+        return None, None
+
+    config = icechunk.RepositoryConfig.default()
+    for container in virtual_config.containers:
+        config.set_virtual_chunk_container(container)
+    config.manifest = icechunk.ManifestConfig(splitting=virtual_config.manifest_split)
+
+    credentials = icechunk.containers_credentials(
+        {
+            container.url_prefix: icechunk.s3_anonymous_credentials()
+            for container in virtual_config.containers
+        }
+    )
+    return config, credentials
+
+
 class StoreFactory(FrozenBaseModel):
     primary_storage_config: StorageConfig
     replica_storage_configs: Sequence[StorageConfig] = Field(default_factory=tuple)
     dataset_id: str
     template_config_version: str
+    # Set for virtual datasets; threaded into every repo this factory opens
+    # (primary + replicas). None for materialized datasets.
+    icechunk_virtual_config: IcechunkVirtualConfig | None = None
 
     @computed_field
     @property
@@ -96,7 +158,13 @@ class StoreFactory(FrozenBaseModel):
             self.primary_storage_config,
         )
 
-        return _get_store(store_path, self.primary_storage_config, writable, branch)
+        return _get_store(
+            store_path,
+            self.primary_storage_config,
+            writable,
+            branch,
+            self.icechunk_virtual_config,
+        )
 
     def replica_stores(
         self, writable: bool = False, branch: str = "main"
@@ -108,7 +176,9 @@ class StoreFactory(FrozenBaseModel):
         stores = []
         for config in self.replica_storage_configs:
             store_path = _get_store_path(self.dataset_id, self.version, config)
-            store = _get_store(store_path, config, writable, branch)
+            store = _get_store(
+                store_path, config, writable, branch, self.icechunk_virtual_config
+            )
             stores.append(store)
 
         return stores
@@ -151,7 +221,14 @@ class StoreFactory(FrozenBaseModel):
                 continue
             store_path = _get_store_path(self.dataset_id, self.version, config)
             ic_storage = _get_icechunk_storage(store_path, config)
-            repo = icechunk.Repository.open_or_create(ic_storage)
+            repo_config, credentials = _virtual_repository_overrides(
+                self.icechunk_virtual_config
+            )
+            repo = icechunk.Repository.open_or_create(
+                ic_storage,
+                config=repo_config,
+                authorize_virtual_chunk_access=credentials,
+            )
             repos.append((role, repo))
 
         match sort:
@@ -288,12 +365,18 @@ def _build_dataset_url(
 
 
 def _get_store(
-    store_path: str, storage_config: StorageConfig, writable: bool, branch: str = "main"
+    store_path: str,
+    storage_config: StorageConfig,
+    writable: bool,
+    branch: str = "main",
+    virtual_config: IcechunkVirtualConfig | None = None,
 ) -> Store:
     match storage_config.format:
         case DatasetFormat.ICECHUNK:
             assert store_path.endswith(".icechunk")
-            return _get_icechunk_store(store_path, storage_config, writable, branch)
+            return _get_icechunk_store(
+                store_path, storage_config, writable, branch, virtual_config
+            )
         case DatasetFormat.ZARR3:
             assert store_path.endswith(".zarr")
             return _get_zarr3_store(store_path, storage_config, writable)
@@ -351,21 +434,27 @@ def _get_icechunk_store(
     storage_config: StorageConfig,
     writable: bool,
     branch: str = "main",
+    virtual_config: IcechunkVirtualConfig | None = None,
 ) -> IcechunkStore:
     storage = _get_icechunk_storage(store_path, storage_config)
+    repo_config, credentials = _virtual_repository_overrides(virtual_config)
 
     if writable:
         log.info(
             f"Opening icechunk store {store_path} on branch {branch} in writable mode"
         )
-        repo = icechunk.Repository.open_or_create(storage)
+        repo = icechunk.Repository.open_or_create(
+            storage, config=repo_config, authorize_virtual_chunk_access=credentials
+        )
         session = repo.writable_session(branch)
         return session.store
     else:
         log.info(
             f"Opening icechunk store {store_path} on branch {branch} in readonly mode"
         )
-        repo = icechunk.Repository.open(storage)
+        repo = icechunk.Repository.open(
+            storage, config=repo_config, authorize_virtual_chunk_access=credentials
+        )
         session = repo.readonly_session(branch)
         return session.store
 

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -23,6 +23,7 @@ from reformatters.common.config import Config, Env
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.retry import retry
+from reformatters.common.types import AppendDim
 
 log = get_logger(__name__)
 
@@ -53,73 +54,14 @@ class StorageConfig(FrozenBaseModel):
         return kubernetes.load_secret(self.k8s_secret_name)
 
 
-def append_dim_split(
-    size: int, dim: str = "init_time"
-) -> icechunk.ManifestSplittingConfig:
-    """Split every array's manifest along `dim` every `size` indices.
-
-    The common-case terse constructor for `IcechunkVirtualConfig.manifest_split`;
-    drop to `icechunk.ManifestSplittingConfig.from_dict` for per-array or
-    multi-dimensional split policies.
-    """
-    return icechunk.ManifestSplittingConfig.from_dict(
-        {
-            icechunk.ManifestSplitCondition.AnyArray(): {
-                icechunk.ManifestSplitDimCondition.DimensionName(dim): size
-            }
-        }
-    )
-
-
-class IcechunkVirtualConfig(FrozenBaseModel):
-    """Per-dataset configuration for an icechunk virtual-chunk store.
-
-    Holds icechunk's own objects directly. `InstanceOf` relaxes only these fields to
-    an isinstance check, so the surrounding `FrozenBaseModel` keeps strict validation
-    and nothing model-wide opts into `arbitrary_types_allowed`. Nothing serializes
-    this config; `StoreFactory` consumes it directly at every repo open to register
-    the virtual chunk containers and build an anonymous `authorize_virtual_chunk_access`
-    map (every source we target is public, anonymous-read).
-    """
-
-    # Source buckets the refs point into, registered as virtual chunk containers.
-    containers: tuple[InstanceOf[icechunk.VirtualChunkContainer], ...] = Field(
-        min_length=1
-    )
-    # Per-array manifest splitting policy (see append_dim_split).
-    manifest_split: InstanceOf[icechunk.ManifestSplittingConfig]
-
-
-def _virtual_repository_overrides(
-    virtual_config: IcechunkVirtualConfig | None,
-) -> tuple[icechunk.RepositoryConfig | None, dict[str, Any] | None]:
-    """Build the icechunk `RepositoryConfig` override and anonymous authorize map for a
-    virtual dataset, or `(None, None)` for a materialized one (icechunk uses defaults)."""
-    if virtual_config is None:
-        return None, None
-
-    config = icechunk.RepositoryConfig.default()
-    for container in virtual_config.containers:
-        config.set_virtual_chunk_container(container)
-    config.manifest = icechunk.ManifestConfig(splitting=virtual_config.manifest_split)
-
-    credentials = icechunk.containers_credentials(
-        {
-            container.url_prefix: icechunk.s3_anonymous_credentials()
-            for container in virtual_config.containers
-        }
-    )
-    return config, credentials
-
-
 class StoreFactory(FrozenBaseModel):
     primary_storage_config: StorageConfig
     replica_storage_configs: Sequence[StorageConfig] = Field(default_factory=tuple)
     dataset_id: str
     template_config_version: str
-    # Set for virtual datasets; threaded into every repo this factory opens
-    # (primary + replicas). None for materialized datasets.
-    icechunk_virtual_config: IcechunkVirtualConfig | None = None
+    icechunk_virtual_config: IcechunkVirtualConfig | None = (
+        None  # None for materialized datasets
+    )
 
     @computed_field
     @property
@@ -221,7 +163,7 @@ class StoreFactory(FrozenBaseModel):
                 continue
             store_path = _get_store_path(self.dataset_id, self.version, config)
             ic_storage = _get_icechunk_storage(store_path, config)
-            repo_config, credentials = _virtual_repository_overrides(
+            repo_config, credentials = _virtual_repository_config_and_credentials(
                 self.icechunk_virtual_config
             )
             repo = icechunk.Repository.open_or_create(
@@ -437,7 +379,9 @@ def _get_icechunk_store(
     virtual_config: IcechunkVirtualConfig | None = None,
 ) -> IcechunkStore:
     storage = _get_icechunk_storage(store_path, storage_config)
-    repo_config, credentials = _virtual_repository_overrides(virtual_config)
+    repo_config, credentials = _virtual_repository_config_and_credentials(
+        virtual_config
+    )
 
     if writable:
         log.info(
@@ -499,3 +443,77 @@ def commit_if_icechunk(
             functools.partial(_commit, primary_store),
             max_attempts=10,
         )
+
+
+def manifest_append_dim_split(
+    *, split_size: int, dim: AppendDim
+) -> icechunk.ManifestSplittingConfig:
+    """Split every array's manifest along `dim` every `split_size` indices.
+
+    The common-case terse constructor for `IcechunkVirtualConfig.manifest_split`;
+    drop to `icechunk.ManifestSplittingConfig.from_dict` for per-array or
+    multi-dimensional split policies.
+    """
+    return icechunk.ManifestSplittingConfig.from_dict(
+        {
+            icechunk.ManifestSplitCondition.AnyArray(): {
+                icechunk.ManifestSplitDimCondition.DimensionName(dim): split_size
+            }
+        }
+    )
+
+
+class IcechunkVirtualConfig(FrozenBaseModel):
+    """Per-dataset configuration for an icechunk virtual-chunk store."""
+
+    # Source buckets the refs point into, registered as virtual chunk containers.
+    containers: tuple[InstanceOf[icechunk.VirtualChunkContainer], ...] = Field(
+        min_length=1
+    )
+    # Per-array manifest splitting policy (see manifest_append_dim_split).
+    manifest_split: InstanceOf[icechunk.ManifestSplittingConfig]
+
+
+def _virtual_repository_config_and_credentials(
+    virtual_config: IcechunkVirtualConfig | None,
+) -> tuple[icechunk.RepositoryConfig | None, dict[str, Any] | None]:
+    """Build the icechunk `RepositoryConfig` override and anonymous authorize map for a
+    virtual dataset, or `(None, None)` for a materialized one (icechunk uses defaults)."""
+    if virtual_config is None:
+        return None, None
+
+    config = icechunk.RepositoryConfig.default()
+    for container in virtual_config.containers:
+        config.set_virtual_chunk_container(container)
+    config.manifest = icechunk.ManifestConfig(splitting=virtual_config.manifest_split)
+
+    # Every source we target today is S3 or S3-compatible (NOAA NODD, ECMWF,
+    # Source Coop) and anonymous-read, and icechunk only ships an S3 anonymous
+    # credential constructor. Assert that here rather than silently handing an S3
+    # credential to a GCS/Azure container. To support a non-S3 or private /
+    # requester-pays source, add an optional per-container credentials field to
+    # IcechunkVirtualConfig and prefer it over this anonymous default.
+    s3_compatible_stores = (
+        icechunk.ObjectStoreConfig.S3,
+        icechunk.ObjectStoreConfig.S3Compatible,
+        icechunk.ObjectStoreConfig.Tigris,
+    )
+    for container in virtual_config.containers:
+        assert isinstance(container.store, s3_compatible_stores), (
+            f"Virtual chunk container {container.url_prefix} uses a non-S3 store "
+            f"({type(container.store).__name__}); only S3-compatible anonymous "
+            "sources are supported. Add explicit credentials to IcechunkVirtualConfig."
+        )
+
+    credentials = icechunk.containers_credentials(
+        {
+            container.url_prefix: icechunk.s3_anonymous_credentials()
+            for container in virtual_config.containers
+        }
+    )
+    return config, credentials
+
+
+# IcechunkVirtualConfig is defined below StoreFactory (which references it), so
+# resolve the forward reference now that the name exists.
+StoreFactory.model_rebuild()

--- a/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
@@ -29,7 +29,7 @@ from reformatters.common.types import (
     Timestamp,
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, vars_available
-from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
+from reformatters.ecmwf.ecmwf_grib_index import grib_message_byte_ranges_from_index
 from reformatters.ecmwf.ecmwf_utils import (
     EcmwfOpenDataSource,
     ecmwf_download_with_fallback,
@@ -155,7 +155,7 @@ class EcmwfAifsEnsForecastRegionJob(
         index_ensemble_member = (
             None if coord.file_type == "cf" else coord.ensemble_member
         )
-        byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(
+        byte_range_starts, byte_range_ends = grib_message_byte_ranges_from_index(
             idx_local_path,
             coord.data_var_group,
             ensemble_member=index_ensemble_member,

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -29,7 +29,7 @@ from reformatters.common.types import (
     Timestamp,
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, vars_available
-from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
+from reformatters.ecmwf.ecmwf_grib_index import grib_message_byte_ranges_from_index
 from reformatters.ecmwf.ecmwf_utils import (
     EcmwfOpenDataSource,
     ecmwf_download_with_fallback,
@@ -141,7 +141,7 @@ class EcmwfAifsSingleForecastRegionJob(
             coord.get_index_url(source), self.dataset_id, disk_cache=True
         )
 
-        byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(
+        byte_range_starts, byte_range_ends = grib_message_byte_ranges_from_index(
             idx_local_path,
             coord.data_var_group,
         )

--- a/src/reformatters/ecmwf/ecmwf_grib_index.py
+++ b/src/reformatters/ecmwf/ecmwf_grib_index.py
@@ -10,7 +10,7 @@ from reformatters.ecmwf.ecmwf_config_models import (
 )
 
 
-def get_message_byte_ranges_from_index(
+def grib_message_byte_ranges_from_index(
     index_local_path: PathLike[str],
     data_vars: Sequence[DataVar[EcmwfInternalAttrs]],
     ensemble_member: int | None = None,

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -25,7 +25,7 @@ from reformatters.ecmwf.ecmwf_config_models import (
     has_hour_0_values,
     vars_available,
 )
-from reformatters.ecmwf.ecmwf_grib_index import get_message_byte_ranges_from_index
+from reformatters.ecmwf.ecmwf_grib_index import grib_message_byte_ranges_from_index
 from reformatters.ecmwf.ecmwf_utils import (
     EcmwfOpenDataSource,
     ecmwf_download_with_fallback,
@@ -144,7 +144,7 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
             idx_url, self.dataset_id, disk_cache=True
         )
 
-        byte_range_starts, byte_range_ends = get_message_byte_ranges_from_index(
+        byte_range_starts, byte_range_ends = grib_message_byte_ranges_from_index(
             idx_local_path,
             coord.data_var_group,
             coord.ensemble_member,

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -33,7 +33,7 @@ from reformatters.common.storage import (
     DatasetFormat,
     IcechunkVirtualConfig,
     StorageConfig,
-    append_dim_split,
+    manifest_append_dim_split,
 )
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
@@ -162,7 +162,8 @@ class TestIcechunkVirtualConfigValidation:
             icechunk.s3_store(region="us-east-1", anonymous=True),
         )
         return IcechunkVirtualConfig(
-            containers=(container,), manifest_split=append_dim_split(1000, dim="time")
+            containers=(container,),
+            manifest_split=manifest_append_dim_split(split_size=1000, dim="time"),
         )
 
     def test_rejects_non_icechunk_primary(self) -> None:

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import ClassVar
 from unittest.mock import Mock
 
+import icechunk
 import numpy as np
 import pandas as pd
 import pytest
@@ -14,7 +15,7 @@ import sentry_sdk.crons
 import xarray as xr
 import zarr
 import zarr.errors
-from pydantic import computed_field
+from pydantic import ValidationError, computed_field
 
 from reformatters.common import dynamical_dataset, storage, template_utils, validation
 from reformatters.common.config import Config, Env
@@ -27,7 +28,13 @@ from reformatters.common.config_models import (
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 from reformatters.common.region_job import MaterializedRegionJob, SourceFileCoord
-from reformatters.common.storage import _NO_SECRET_NAME, DatasetFormat, StorageConfig
+from reformatters.common.storage import (
+    _NO_SECRET_NAME,
+    DatasetFormat,
+    IcechunkVirtualConfig,
+    StorageConfig,
+    append_dim_split,
+)
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
 
@@ -145,6 +152,51 @@ def test_dynamical_dataset_init() -> None:
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,
     )
+
+
+class TestIcechunkVirtualConfigValidation:
+    @staticmethod
+    def _virtual_config() -> IcechunkVirtualConfig:
+        container = icechunk.VirtualChunkContainer(
+            "s3://noaa-gfs-bdp-pds/",
+            icechunk.s3_store(region="us-east-1", anonymous=True),
+        )
+        return IcechunkVirtualConfig(
+            containers=(container,), manifest_split=append_dim_split(1000, dim="time")
+        )
+
+    def test_rejects_non_icechunk_primary(self) -> None:
+        # ExampleDataset's default primary_storage_config uses the ZARR3 format.
+        with pytest.raises(ValidationError, match="ICECHUNK"):
+            ExampleDataset(icechunk_virtual_config=self._virtual_config())
+
+    def test_rejects_non_icechunk_replica(self) -> None:
+        with pytest.raises(ValidationError, match="ICECHUNK"):
+            ExampleDataset(
+                primary_storage_config=ExampleDatasetStorageConfig(
+                    format=DatasetFormat.ICECHUNK
+                ),
+                replica_storage_configs=[
+                    StorageConfig(
+                        base_path="s3://bucket/replica", format=DatasetFormat.ZARR3
+                    )
+                ],
+                icechunk_virtual_config=self._virtual_config(),
+            )
+
+    def test_accepts_all_icechunk_stores(self) -> None:
+        dataset = ExampleDataset(
+            primary_storage_config=ExampleDatasetStorageConfig(
+                format=DatasetFormat.ICECHUNK
+            ),
+            icechunk_virtual_config=self._virtual_config(),
+        )
+        assert dataset.store_factory.icechunk_virtual_config is not None
+
+    def test_materialized_dataset_needs_no_virtual_config(self) -> None:
+        dataset = ExampleDataset()
+        assert dataset.icechunk_virtual_config is None
+        assert dataset.store_factory.icechunk_virtual_config is None
 
 
 def test_update_template(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/common/test_config_models.py
+++ b/tests/common/test_config_models.py
@@ -78,6 +78,21 @@ class TestEncodingValidation:
                 fill_value=-1,
             )
 
+    def test_serializer_defaults_to_none(self) -> None:
+        enc = Encoding(dtype="float64", chunks=(1, 1), shards=None, fill_value=0.0)
+        assert enc.serializer is None
+
+    def test_serializer_dict_is_retained(self) -> None:
+        serializer = {"name": "gribberish", "configuration": {"var": "TMP"}}
+        enc = Encoding(
+            dtype="float64",
+            chunks=(1, 1),
+            shards=None,
+            fill_value=0.0,
+            serializer=serializer,
+        )
+        assert enc.serializer == serializer
+
 
 class TestDatasetAttributes:
     def test_valid_attributes(self) -> None:

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -18,8 +18,8 @@ from reformatters.common.storage import (
     StoreFactory,
     _get_store_path,
     _icechunk_to_s3fs_storage_options,
-    append_dim_split,
     commit_if_icechunk,
+    manifest_append_dim_split,
 )
 
 
@@ -28,7 +28,8 @@ def _example_virtual_config() -> IcechunkVirtualConfig:
         "s3://noaa-gfs-bdp-pds/", icechunk.s3_store(region="us-east-1", anonymous=True)
     )
     return IcechunkVirtualConfig(
-        containers=(container,), manifest_split=append_dim_split(1000)
+        containers=(container,),
+        manifest_split=manifest_append_dim_split(split_size=1000, dim="init_time"),
     )
 
 
@@ -388,13 +389,22 @@ class TestIcechunkRepos:
 
 
 class TestIcechunkVirtualConfig:
-    def test_append_dim_split_returns_splitting_config(self) -> None:
-        split = append_dim_split(500, dim="init_time")
+    def test_manifest_append_dim_split_structure(self) -> None:
+        split = manifest_append_dim_split(split_size=500, dim="init_time")
         assert isinstance(split, icechunk.ManifestSplittingConfig)
+        # One AnyArray rule splitting the named dim every `split_size` indices.
+        [(condition, dim_splits)] = split.split_sizes
+        assert condition == icechunk.ManifestSplitCondition.AnyArray()
+        [(dim_condition, size)] = dim_splits
+        assert "init_time" in repr(dim_condition)
+        assert size == 500
 
     def test_requires_at_least_one_container(self) -> None:
         with pytest.raises(ValidationError):
-            IcechunkVirtualConfig(containers=(), manifest_split=append_dim_split(1))
+            IcechunkVirtualConfig(
+                containers=(),
+                manifest_split=manifest_append_dim_split(split_size=1, dim="init_time"),
+            )
 
     def test_store_factory_registers_containers_and_split(self) -> None:
         factory = StoreFactory(
@@ -414,6 +424,24 @@ class TestIcechunkVirtualConfig:
         assert manifest is not None
         assert manifest.splitting is not None
         assert manifest.splitting.split_sizes
+
+    def test_non_s3_container_rejected(self) -> None:
+        gcs_container = icechunk.VirtualChunkContainer(
+            "gs://bucket/", icechunk.gcs_store()
+        )
+        factory = StoreFactory(
+            primary_storage_config=StorageConfig(
+                base_path="s3://bucket/data", format=DatasetFormat.ICECHUNK
+            ),
+            dataset_id="test-dataset",
+            template_config_version="v1.0",
+            icechunk_virtual_config=IcechunkVirtualConfig(
+                containers=(gcs_container,),
+                manifest_split=manifest_append_dim_split(split_size=1, dim="init_time"),
+            ),
+        )
+        with pytest.raises(AssertionError, match="non-S3 store"):
+            factory.icechunk_repos(sort="primary-first")
 
     def test_materialized_factory_registers_no_containers(self) -> None:
         factory = StoreFactory(

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -7,17 +7,29 @@ import pytest
 import zarr
 import zarr.storage
 from icechunk.store import IcechunkStore
+from pydantic import ValidationError
 
 from reformatters.common import retry as retry_module
 from reformatters.common.config import Config, Env
 from reformatters.common.storage import (
     DatasetFormat,
+    IcechunkVirtualConfig,
     StorageConfig,
     StoreFactory,
     _get_store_path,
     _icechunk_to_s3fs_storage_options,
+    append_dim_split,
     commit_if_icechunk,
 )
+
+
+def _example_virtual_config() -> IcechunkVirtualConfig:
+    container = icechunk.VirtualChunkContainer(
+        "s3://noaa-gfs-bdp-pds/", icechunk.s3_store(region="us-east-1", anonymous=True)
+    )
+    return IcechunkVirtualConfig(
+        containers=(container,), manifest_split=append_dim_split(1000)
+    )
 
 
 @pytest.mark.parametrize(
@@ -373,6 +385,46 @@ class TestIcechunkRepos:
         assert len(repos) == 2
         assert repos[0][0] == "primary"
         assert repos[1][0] == "replica-0"
+
+
+class TestIcechunkVirtualConfig:
+    def test_append_dim_split_returns_splitting_config(self) -> None:
+        split = append_dim_split(500, dim="init_time")
+        assert isinstance(split, icechunk.ManifestSplittingConfig)
+
+    def test_requires_at_least_one_container(self) -> None:
+        with pytest.raises(ValidationError):
+            IcechunkVirtualConfig(containers=(), manifest_split=append_dim_split(1))
+
+    def test_store_factory_registers_containers_and_split(self) -> None:
+        factory = StoreFactory(
+            primary_storage_config=StorageConfig(
+                base_path="s3://bucket/data", format=DatasetFormat.ICECHUNK
+            ),
+            dataset_id="test-dataset",
+            template_config_version="v1.0",
+            icechunk_virtual_config=_example_virtual_config(),
+        )
+        # icechunk_repos opens (and so creates) the repo with our override config.
+        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        containers = repo.config.virtual_chunk_containers
+        assert containers is not None
+        assert "s3://noaa-gfs-bdp-pds/" in containers
+        manifest = repo.config.manifest
+        assert manifest is not None
+        assert manifest.splitting is not None
+        assert manifest.splitting.split_sizes
+
+    def test_materialized_factory_registers_no_containers(self) -> None:
+        factory = StoreFactory(
+            primary_storage_config=StorageConfig(
+                base_path="s3://bucket/data", format=DatasetFormat.ICECHUNK
+            ),
+            dataset_id="test-dataset",
+            template_config_version="v1.0",
+        )
+        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        assert not repo.config.virtual_chunk_containers
 
 
 class TestBranchSupport:

--- a/tests/common/test_template_utils.py
+++ b/tests/common/test_template_utils.py
@@ -170,13 +170,15 @@ def test_assign_var_metadata_units_not_duplicated_when_in_encoding() -> None:
 
 
 def test_assign_var_metadata_includes_serializer_when_set() -> None:
+    codec = GribberishCodec(var="TMP")
+
     class SerializerVar(DataVar[BaseInternalAttrs]):
         encoding: Encoding = Encoding(
             dtype="float64",
             fill_value=np.nan,
             chunks=(1,),
             shards=None,
-            serializer=GribberishCodec(var="TMP").to_dict(),
+            serializer=codec.to_dict(),
         )
         attrs: DataVarAttrs = DataVarAttrs(
             units="K",
@@ -191,11 +193,7 @@ def test_assign_var_metadata_includes_serializer_when_set() -> None:
     da = xr.DataArray([1.0, 2.0], name="temperature_2m")
     result = assign_var_metadata(da, SerializerVar(name="temperature_2m"))
 
-    assert result.encoding["serializer"] == GribberishCodec(var="TMP").to_dict()
-    assert result.encoding["serializer"] == {
-        "name": "gribberish",
-        "configuration": {"var": "TMP"},
-    }
+    assert result.encoding["serializer"] == codec.to_dict()
 
 
 def test_assign_var_metadata_omits_serializer_when_none() -> None:

--- a/tests/common/test_template_utils.py
+++ b/tests/common/test_template_utils.py
@@ -168,6 +168,45 @@ def test_assign_var_metadata_units_not_duplicated_when_in_encoding() -> None:
     assert "units" in result.encoding
 
 
+def test_assign_var_metadata_includes_serializer_when_set() -> None:
+    class SerializerVar(DataVar[BaseInternalAttrs]):
+        encoding: Encoding = Encoding(
+            dtype="float64",
+            fill_value=np.nan,
+            chunks=(1,),
+            shards=None,
+            serializer={"name": "gribberish", "configuration": {"var": "TMP"}},
+        )
+        attrs: DataVarAttrs = DataVarAttrs(
+            units="K",
+            long_name="Temperature 2m",
+            short_name="2t",
+            step_type="instant",
+        )
+        internal_attrs: BaseInternalAttrs = BaseInternalAttrs(
+            keep_mantissa_bits="no-rounding"
+        )
+
+    da = xr.DataArray([1.0, 2.0], name="temperature_2m")
+    result = assign_var_metadata(da, SerializerVar(name="temperature_2m"))
+
+    assert result.encoding["serializer"] == {
+        "name": "gribberish",
+        "configuration": {"var": "TMP"},
+    }
+
+
+def test_assign_var_metadata_omits_serializer_when_none() -> None:
+    # Materialized vars don't declare a serializer; model_dump(exclude_none=True)
+    # drops it so zarr falls back to its default BytesCodec.
+    var_config = _TestDataVar(name="temperature_2m")
+    da = xr.DataArray([1.0, 2.0], name="temperature_2m")
+
+    result = assign_var_metadata(da, var_config)
+
+    assert "serializer" not in result.encoding
+
+
 # --- empty_copy_with_reindex tests ---
 
 

--- a/tests/common/test_template_utils.py
+++ b/tests/common/test_template_utils.py
@@ -5,6 +5,7 @@ import dask.array
 import numpy as np
 import pytest
 import xarray as xr
+from gribberish.zarr import GribberishCodec
 
 from reformatters.common.config_models import (
     BaseInternalAttrs,
@@ -175,7 +176,7 @@ def test_assign_var_metadata_includes_serializer_when_set() -> None:
             fill_value=np.nan,
             chunks=(1,),
             shards=None,
-            serializer={"name": "gribberish", "configuration": {"var": "TMP"}},
+            serializer=GribberishCodec(var="TMP").to_dict(),
         )
         attrs: DataVarAttrs = DataVarAttrs(
             units="K",
@@ -190,6 +191,7 @@ def test_assign_var_metadata_includes_serializer_when_set() -> None:
     da = xr.DataArray([1.0, 2.0], name="temperature_2m")
     result = assign_var_metadata(da, SerializerVar(name="temperature_2m"))
 
+    assert result.encoding["serializer"] == GribberishCodec(var="TMP").to_dict()
     assert result.encoding["serializer"] == {
         "name": "gribberish",
         "configuration": {"var": "TMP"},

--- a/tests/ecmwf/test_ecmwf_grib_index.py
+++ b/tests/ecmwf/test_ecmwf_grib_index.py
@@ -14,7 +14,7 @@ from reformatters.common.config_models import (
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, EcmwfInternalAttrs
 from reformatters.ecmwf.ecmwf_grib_index import (
     _parse_index_file,
-    get_message_byte_ranges_from_index,
+    grib_message_byte_ranges_from_index,
 )
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -97,7 +97,7 @@ def test_parse_index_file_correct_perturbed_member_offset(index_file: Path) -> N
 
 
 # ---------------------------------------------------------------------------
-# get_message_byte_ranges_from_index tests
+# grib_message_byte_ranges_from_index tests
 # ---------------------------------------------------------------------------
 
 
@@ -135,7 +135,7 @@ def _make_ecmwf_var(
 
 def test_get_byte_ranges_control_member_surface_var(index_file: Path) -> None:
     var = _make_ecmwf_var("temperature_2m", "2t", "sfc")
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         index_file, [var], ensemble_member=0
     )
     assert len(starts) == 1
@@ -146,7 +146,7 @@ def test_get_byte_ranges_control_member_surface_var(index_file: Path) -> None:
 
 def test_get_byte_ranges_perturbed_member(index_file: Path) -> None:
     var = _make_ecmwf_var("temperature_2m", "2t", "sfc")
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         index_file, [var], ensemble_member=1
     )
     assert starts[0] == 1554442
@@ -157,7 +157,7 @@ def test_get_byte_ranges_pressure_level_var(index_file: Path) -> None:
     var = _make_ecmwf_var(
         "geopotential_500hpa", "gh", "pl", grib_index_level_value=500.0
     )
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         index_file, [var], ensemble_member=2
     )
     assert starts[0] == 674936844
@@ -166,7 +166,7 @@ def test_get_byte_ranges_pressure_level_var(index_file: Path) -> None:
 
 def test_get_byte_ranges_returns_ints(index_file: Path) -> None:
     var = _make_ecmwf_var("temperature_2m", "2t", "sfc")
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         index_file, [var], ensemble_member=0
     )
     assert all(isinstance(s, int) for s in starts)
@@ -176,7 +176,9 @@ def test_get_byte_ranges_returns_ints(index_file: Path) -> None:
 def test_get_byte_ranges_raises_for_missing_var(index_file: Path) -> None:
     missing_var = _make_ecmwf_var("missing", "nonexistent_param", "sfc")
     with pytest.raises((KeyError, AssertionError)):
-        get_message_byte_ranges_from_index(index_file, [missing_var], ensemble_member=0)
+        grib_message_byte_ranges_from_index(
+            index_file, [missing_var], ensemble_member=0
+        )
 
 
 def test_get_byte_ranges_multiple_vars(index_file: Path) -> None:
@@ -187,10 +189,10 @@ def test_get_byte_ranges_multiple_vars(index_file: Path) -> None:
     )
 
     # Test each independently since they require different ensemble members
-    starts1, ends1 = get_message_byte_ranges_from_index(
+    starts1, ends1 = grib_message_byte_ranges_from_index(
         index_file, [var1], ensemble_member=0
     )
-    starts2, ends2 = get_message_byte_ranges_from_index(
+    starts2, ends2 = grib_message_byte_ranges_from_index(
         index_file, [var2], ensemble_member=2
     )
 
@@ -223,7 +225,7 @@ def test_parse_mars_index_with_step_filter() -> None:
 def test_get_byte_ranges_mars_cf_sfc_with_step() -> None:
     """Extract byte ranges for 2t from a MARS control sfc index, filtering by step."""
     var = _make_ecmwf_var("temperature_2m", "2t", "sfc")
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         FIXTURES_DIR / "mars_cf_sfc.idx", [var], ensemble_member=0, step=3
     )
     assert starts == [30071109]
@@ -235,7 +237,7 @@ def test_get_byte_ranges_mars_cf_pl_with_step() -> None:
     var = _make_ecmwf_var(
         "geopotential_500hpa", "z", "pl", grib_index_level_value=500.0
     )
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         FIXTURES_DIR / "mars_cf_pl.idx", [var], ensemble_member=0, step=0
     )
     assert starts == [0]
@@ -245,7 +247,7 @@ def test_get_byte_ranges_mars_cf_pl_with_step() -> None:
 def test_get_byte_ranges_mars_pf_sfc_with_step() -> None:
     """Extract byte ranges for perturbed member 1 from MARS pf_sfc index."""
     var = _make_ecmwf_var("temperature_2m", "2t", "sfc")
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         FIXTURES_DIR / "mars_pf_sfc.idx", [var], ensemble_member=1, step=0
     )
     assert starts == [2076642]
@@ -273,7 +275,7 @@ def test_parse_oper_fc_index_fills_number_with_0(oper_fc_index_file: Path) -> No
 
 def test_get_byte_ranges_oper_fc_surface_var(oper_fc_index_file: Path) -> None:
     var = _make_ecmwf_var("temperature_2m", "2t", "sfc")
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         oper_fc_index_file, [var], ensemble_member=0
     )
     assert starts == [0]
@@ -284,7 +286,7 @@ def test_get_byte_ranges_oper_fc_pressure_level_var(oper_fc_index_file: Path) ->
     var = _make_ecmwf_var(
         "geopotential_height_500hpa", "gh", "pl", grib_index_level_value=500.0
     )
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         oper_fc_index_file, [var], ensemble_member=0
     )
     assert starts == [1000000]
@@ -296,7 +298,7 @@ def test_get_byte_ranges_mars_multiple_vars_single_step() -> None:
     var_2t = _make_ecmwf_var("temperature_2m", "2t", "sfc")
     var_tp = _make_ecmwf_var("total_precipitation", "tp", "sfc")
 
-    starts, ends = get_message_byte_ranges_from_index(
+    starts, ends = grib_message_byte_ranges_from_index(
         FIXTURES_DIR / "mars_cf_sfc.idx", [var_2t, var_tp], ensemble_member=0, step=6
     )
     assert starts == [58065503, 68448713]

--- a/uv.lock
+++ b/uv.lock
@@ -507,6 +507,26 @@ wheels = [
 ]
 
 [[package]]
+name = "gribberish"
+version = "0.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/ad/9b61e2c24eae0827c3b7eb9a46197a0a831b1b62fcff349ac69852fe2f48/gribberish-0.30.3.tar.gz", hash = "sha256:38740e9e4e0e68069a1c7600d8700473f317bf9678714ab260ce86b38392f022", size = 3732116, upload-time = "2026-05-21T18:25:53.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/86/70a3f845ec4033538e25241807f82e41a5bed394415308ced5e376ef5451/gribberish-0.30.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6ca26b572ca4c2523d6606442cc703282a79fb8a84a8288db5a509fb254d0a46", size = 670687, upload-time = "2026-05-21T18:25:29.315Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fe/c5dbd2f4483772a6b1d91b3678314713021442f2ac22bc0533b94e399552/gribberish-0.30.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4bde0c6f3cbb4d82daa989dd600e0456cd283f95c2abf9b5baed94beb0cef0e3", size = 623823, upload-time = "2026-05-21T18:25:22.417Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/55/63e7acca372588120e433e93d8b0e7fd2390374a1ba2bb41b72e94a509f5/gribberish-0.30.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc1a4648c4c93cb7d8ffb39ad955e648c60493b5ce1e6fcfba8ad7a5a7fd6541", size = 657889, upload-time = "2026-05-21T18:25:00.445Z" },
+    { url = "https://files.pythonhosted.org/packages/10/80/91b501b29dbc8261fc8d047b0a195097b1b1f823cb19654369cbe3d0d47d/gribberish-0.30.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7a16a9d876a2ff3742b18b0af9e9e855eaf9ef31c23f1f79b368706c086dbdcf", size = 677882, upload-time = "2026-05-21T18:25:08.02Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/97/55bc761f1e4f5baedead846015d0bddab2962e1e9896a2dca387371e93e3/gribberish-0.30.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5780834acb02eb6e50ed7c9e7070b95f9a618ce95b5836e264a57aba67fc135f", size = 697737, upload-time = "2026-05-21T18:25:14.715Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/46/940f1ab44ac4f4b918336154c660c154ceb2ab561b2f8fdb560437a8f96b/gribberish-0.30.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:51457481208dc3c07b44217ce56babac08ee5ece36fcfc3ad03f2925c27ddf36", size = 842609, upload-time = "2026-05-21T18:25:36.482Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cf/aa2d5126b65702a0eb69f9888523db67b3c46315d1e4d7f765fd03c8f06e/gribberish-0.30.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:18fefd287c643a376d82af50cf5f2c613c31d98395fb37863767562a264e3d4a", size = 955347, upload-time = "2026-05-21T18:25:43.699Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f5/cfcda5e15e8c4b9155e4f6182f8dc15198907e308b2fe466b7af8c5066c9/gribberish-0.30.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc0ce27f0b7f761cb8333d369d3a2ef8fb43777d35546fc0276889ad881419b2", size = 910744, upload-time = "2026-05-21T18:25:50.901Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/258efac20f9d553d5a2c09754fb4fdd3df54d1153cf843f943427d303cdc/gribberish-0.30.3-cp314-cp314-win_amd64.whl", hash = "sha256:ecf0bf42b8ab818529bf147b6230e6e7a7dbe06ca4d1abf01647bcd443180a79", size = 591502, upload-time = "2026-05-21T18:25:59.995Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1330,6 +1350,7 @@ source = { editable = "." }
 dependencies = [
     { name = "dask" },
     { name = "google-crc32c" },
+    { name = "gribberish" },
     { name = "httpx" },
     { name = "icechunk" },
     { name = "kubernetes" },
@@ -1371,6 +1392,7 @@ dev = [
 requires-dist = [
     { name = "dask", specifier = "~=2026.0" },
     { name = "google-crc32c", specifier = ">=1.8.0" },
+    { name = "gribberish", specifier = "~=0.30" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "icechunk", specifier = "~=2.0" },
     { name = "kubernetes", specifier = ">=36.0.1,<37" },


### PR DESCRIPTION
Plumbing PR for [virtual Icechunk datasets](https://github.com/dynamical-org/reformatters/blob/main/docs/plans/virtual_icechunk_datasets.md#pr-2--prep). No behavior change for existing materialized datasets — every new field is optional and defaults to the current behavior, and the checked-in templates are unchanged.

## Changes

- **Rename the ECMWF index parser** `get_message_byte_ranges_from_index` → `grib_message_byte_ranges_from_index`, matching NOAA's `noaa/noaa_grib_index.py::grib_message_byte_ranges_from_index`. Updates the 3 ECMWF region jobs and the parser's tests.
- **`Encoding.serializer`** — a new optional `dict | None` for the zarr v3 `ArrayBytesCodec` slot. Threads through `assign_var_metadata` automatically via `model_dump(exclude_none=True)`; `None` for materialized vars, so it serializes to nothing and templates are byte-for-byte unchanged. Virtual datasets (PR #4) will set it to a per-variable `GribberishCodec`.
- **`gribberish` dependency** (`~=0.30`). Its zarr codec resolves by name `gribberish` via entry point and `GribberishCodec` lives at `gribberish.zarr`.
- **`IcechunkVirtualConfig`** in `common/storage.py`, holding the real icechunk objects (`VirtualChunkContainer`s + `ManifestSplittingConfig`) directly via pydantic `InstanceOf` — scoped to those fields, so `FrozenBaseModel` keeps strict validation with no model-wide `arbitrary_types_allowed`. Plain fields would be a lossy subset (no Source Coop `s3_compatible`, no GCS mirror, no per-array/multi-dim splits). Requires ≥1 container. Plus an `append_dim_split(size, dim)` terse helper for the common split policy.
  - Threaded through `StoreFactory` (one optional field, applied uniformly to primary + replicas) and every repo open/create: register each container, set the manifest-split policy, and authorize each container with anonymous S3 credentials. Nothing serializes the config — `StoreFactory` consumes it directly.
  - `DynamicalDataset` gains the `icechunk_virtual_config` field and a validator: when set, every storage config must use the `ICECHUNK` format. (The complementary direction — a virtual `region_job_class` *requires* the config — lands with `VirtualRegionJob` in PR #3.)
- **Plan doc**: fold in the `IcechunkVirtualConfig` design refinement (hold real icechunk objects via `InstanceOf` rather than a thin serialization shim).

## Tests

- `Encoding.serializer` defaults/retention and threading through `assign_var_metadata` (set ⇒ present, `None` ⇒ absent).
- `IcechunkVirtualConfig` requires ≥1 container; `append_dim_split` returns a `ManifestSplittingConfig`; `StoreFactory` registers the containers + split policy on the opened repo, and a materialized factory registers none.
- `DynamicalDataset` validator rejects a non-icechunk primary or replica when `icechunk_virtual_config` is set, and accepts an all-icechunk config.

`ruff format` / `ruff check` / `ty check` clean; `tests/ecmwf` + `tests/common` (708 tests) green.

Part of #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)