### PR TITLE
VirtualRegionJob + virtual driver fork (virtual datasets PR 3/6)

### DIFF
--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -149,8 +149,8 @@ DynamicalDataset                          # unchanged single base
 
 RegionJob                                 # shared base: fields, get_jobs,
 │                                         #   source_groups, generate_source_file_coords,
-│                                         #   operational_update_jobs (abstract), process (abstract)
-├── MaterializedRegionJob                 # existing process() pipeline + hooks + tunables
+│                                         #   operational_update_jobs (abstract)
+├── MaterializedRegionJob                 # process() pipeline + hooks + tunables
 │   ├── NoaaGfsCommonRegionJob → NoaaGfsForecastRegionJob   (base swap only)
 │   ├── NoaaHrrrRegionJob → …                                (base swap only)
 │   └── …
@@ -193,18 +193,25 @@ ride their parent's swap. Tests pass unchanged. This is PR #1 on its own.
 - `get_jobs()` — region × variable-group fan-out (see
   [Partitioning](#partitioning)).
 - `source_groups()`, `get_processing_region()`, `generate_source_file_coords()`
-  (abstract), `operational_update_jobs()` (abstract), `process()` (abstract).
+  (abstract), `operational_update_jobs()` (abstract). The per-region write entry
+  point lives on each subclass, not the base — `process()` on
+  `MaterializedRegionJob`, `process_virtual()` on `VirtualRegionJob` — so neither
+  carries a stub for the other variant's method.
 
-**`MaterializedRegionJob` (subclass):** today's `process()` body, the
-`download_file` / `read_data` / `apply_data_transformations` hooks, the
-parallelism tunables, and the shared-memory helpers. The existing datasets'
-region jobs change base class here and nothing else.
+**`MaterializedRegionJob` (subclass):** today's `process(primary_store,
+replica_stores)` body, the `download_file` / `read_data` /
+`apply_data_transformations` hooks, the parallelism tunables, and the
+shared-memory helpers. The existing datasets' region jobs change base class here
+and nothing else.
 
 **`VirtualRegionJob` (subclass):**
 
-- `process()` — runs [the one virtual write loop](#the-virtual-write-loop).
-- `process_virtual_refs(remaining, deadline)` — abstract generator: discover
-  available source files and yield one file's refs at a time.
+- `process_virtual(primary_repo, replica_repos, branch)` — runs
+  [the one virtual write loop](#the-virtual-write-loop).
+- `process_virtual_refs(remaining)` — abstract generator: discover available
+  source files and yield whole files' refs a batch at a time. The generator owns
+  its own stopping (backfill exhausts `remaining`; an operational generator polls
+  and the pod's k8s active-deadline bounds the run).
 - `filter_already_present(candidates, store, ds)` — default impl
   (see [Filtering](#filtering-already-present-coordinates)); overridable.
 - `sync_dims_to(store, extent)` — idempotent dim/coord/derived-coord expansion
@@ -385,7 +392,7 @@ yields*:
 candidates = self.generate_source_file_coords(scope)          # shared w/ materialized
 remaining  = self.filter_already_present(candidates, store, ds)
 
-for batch in self.process_virtual_refs(remaining, deadline):  # batch == 1+ whole files
+for batch in self.process_virtual_refs(remaining):           # batch == 1+ whole files
     assert batch.refs                                         # contract: never an empty yield
     self.sync_dims_to(stores, batch.extent)                  # idempotent; no-op if already covered
     self.set_virtual_refs(stores, batch.refs)                # per array path, all stores
@@ -495,16 +502,17 @@ in one poll iteration can ride one yield if the generator chooses.
 1. **CronJob fires** ~5 min before a publication window opens (per dataset).
    `concurrencyPolicy: Forbid` prevents overlapping fires.
 2. **A single worker runs `update()`**, which calls `operational_update_jobs()`
-   (→ one active-window job) and `_process_region_jobs()`.
-3. **The driver detects virtual + operational** and takes the
-   single-writer-to-`main` path: no temp branch, no shared setup, no
-   coordination files. It opens one writable session on `main` and runs
+   (→ one active-window job).
+3. **`update()` detects a virtual dataset** and routes to
+   `_run_virtual_operational_update` — the single-writer-to-`main` path: no temp
+   branch, no shared setup, no coordination files, no `_process_region_jobs`. It
+   opens one writable session on `main` per batch and runs
    [the virtual write loop](#the-virtual-write-loop).
 4. **The loop** filters to what's still missing, drives
-   `process_virtual_refs(..., deadline)`, lazily expands via `sync_dims_to`,
+   `process_virtual_refs(remaining)`, lazily expands via `sync_dims_to`,
    batches refs, and commits on the ~1 s cadence.
-5. **The generator exits** when the window is complete or the pod deadline
-   approaches.
+5. **The generator exits** when the window is complete; the pod's k8s
+   active-deadline bounds the run.
 6. **The pod exits.** The next fire starts fresh and resumes via the filter.
 
 ### No NaN-padded future

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -386,10 +386,10 @@ candidates = self.generate_source_file_coords(scope)          # shared w/ materi
 remaining  = self.filter_already_present(candidates, store, ds)
 
 for batch in self.process_virtual_refs(remaining, deadline):  # batch == 1+ whole files
-    self.sync_dims_to(store, batch.extent)                    # idempotent; no-op if already covered
-    store.set_virtual_refs(path, batch.refs)                  # plural API, per array path
-    if store.session.has_uncommitted_changes:                 # guard: empty commit raises
-        commit(store)                                         # one commit per yield
+    assert batch.refs                                         # contract: never an empty yield
+    self.sync_dims_to(stores, batch.extent)                  # idempotent; no-op if already covered
+    self.set_virtual_refs(stores, batch.refs)                # per array path, all stores
+    commit(stores)                                           # one commit per yield (never empty)
 ```
 
 `sync_dims_to(store, extent)` is the single primitive that unifies pre-sizing
@@ -415,16 +415,18 @@ yield-immediately. The atomicity invariant (see
 [Reader safety](#reader-safety)) says each yield is **whole files** — never
 splitting a file across yields — but a yield can contain one file or many.
 
-> **Empty commits raise — guard them.** icechunk's `session.commit` raises
-> `IcechunkError` ("no changes made to the session") rather than no-opping, and
-> the shared `storage.commit_if_icechunk` helper commits unconditionally. A
-> well-behaved generator never yields an empty batch, but the driver still guards
-> on `session.has_uncommitted_changes` before committing (the alternative,
-> `allow_empty=True`, would litter the history with empty snapshots). This pairs
-> with the idempotency story: **setting refs always dirties the session — even
-> re-emitting byte-identical refs** — so the guard fires only on a genuinely
-> empty poll, never on idempotent replay (a filter false-negative just rewrites
-> an identical, content-addressed manifest and commits a no-content snapshot).
+> **Empty commits raise — so the contract forbids empty yields.** icechunk's
+> `session.commit` raises `IcechunkError` ("no changes made to the session")
+> rather than no-opping. Rather than guard each commit on
+> `session.has_uncommitted_changes`, the loop relies on the generator contract:
+> each yield is one commit's worth of **whole files**, so a batch always has refs,
+> and **setting refs always dirties the session — even re-emitting byte-identical
+> refs** — so the commit is never empty. The loop **asserts** `batch.refs` (a
+> loud, early failure if a generator ever violates the contract) and leaves
+> `commit_if_icechunk` committing unconditionally. The empty-poll and
+> everything-already-present cases never reach the commit at all — they yield no
+> batch, so the loop body simply doesn't run (a filter false-negative still
+> re-emits and commits an idempotent, content-addressed no-content snapshot).
 
 The two flows fall out naturally:
 
@@ -950,24 +952,46 @@ Mechanical; tests pass unchanged.
 The spike is already done (run ahead of this PR — see
 [Spike results](#spike-results)), so PR #3 is just the implementation it derisked.
 
-- Add `VirtualRegionJob` (the virtual write loop, `process_virtual_refs`
+- Add `VirtualRegionJob` (the `process_virtual` write loop, `process_virtual_refs`
   abstract generator, `filter_already_present` default, `sync_dims_to`,
-  `chunk_key`). Use `set_virtual_refs_arr` (columnar, zero-copy) for the emit
-  batches; `array.metadata.chunk_key_encoding.encode_chunk_key` + `store.exists`
-  for the filter.
-- Extend `_process_region_jobs` with the single fork (virtual + operational →
-  single-writer-to-`main`; else existing path). **Guard commits on
-  `session.has_uncommitted_changes`** — empty commits raise, and the shared
-  `storage.commit_if_icechunk` currently commits unconditionally, so either teach
-  it the guard or wrap the call.
+  `chunk_key`). Emit with `set_virtual_refs` (explicit `VirtualChunkSpec` per ref)
+  — it handles arbitrary sparse cell sets directly, which the common
+  one-message-per-`(var, cell)` packing produces; `set_virtual_refs_arr`'s dense
+  columnar block is a later optimization for contiguous backfill ranges. The
+  filter builds keys from `array.metadata.chunk_key_encoding.encode_chunk_key` +
+  `store.exists`.
+- `process_virtual` is driven from the `icechunk.Repository` objects (not a
+  pre-opened store): a committed icechunk session is read-only, so each yielded
+  batch opens a **fresh writable session** on the branch, emits, and commits.
+- Extend `_process_region_jobs` with the virtual fork: virtual + operational →
+  single-writer-to-`main` (no temp branch / `parallel_setup` / `finalize`);
+  virtual backfill → the existing temp-branch flow, but route the per-job middle
+  through `process_virtual` (fresh sessions) rather than the materialized
+  per-job-store loop. **No commit guard** — the generator contract forbids empty
+  yields, so the loop `assert`s `batch.refs` and `commit_if_icechunk` stays
+  unconditional (see [the write loop](#the-virtual-write-loop)).
+- Partitioning: `get_jobs` partitions by `encoding["shards"]` if present, else by
+  `encoding["chunks"]` (virtual arrays have no shards). Materialized behavior is
+  unchanged.
+- `sync_dims_to` appends the new slice of the (already-derived) template via
+  `to_zarr(append_dim=…, compute=False)`, keeping data vars dask-lazy so the
+  decode-only serializer is never invoked; `chunk_key` derives indices from the
+  full-size template, so it never re-reads the growing store.
+- Storage: `_virtual_repository_config_and_credentials` also accepts
+  local-filesystem containers (no credentials) so dev/test virtual datasets can
+  point at local files.
 - Document the `process_virtual_refs` generator contract: each yield is one
   commit's worth of whole files; operational yields ~1 file at a time for
   per-file visibility, backfill yields batches of ~N files to amortize commit
   overhead. No timer, no `max_seconds_between_commits` knob — the driver commits
   on every yield.
-- Integration tests: yield-count/grouping; concurrent disjoint-chunk backfill on
-  a branch; emit → commit → reopen → read-back round-trip (the spike already
-  proves this round-trip works on 2.0.5; the test pins it in CI).
+- Tests: a synthetic virtual dataset (local-filesystem container, raw-float64
+  "messages" file, default `BytesCodec`) drives unit tests (`chunk_key`,
+  sizing) and integration tests — yield-count/grouping, two-worker disjoint
+  backfill on a branch, operational single-writer expansion + idempotent second
+  fire, and an emit → commit → reopen → **value** read-back round-trip (catches
+  bad chunk keys *and* byte ranges in CI). A separate test pins that a
+  `GribberishCodec` serializer threads through expansion without being invoked.
 
 ### PR #4 — First concrete virtual dataset (end to end)
 
@@ -1050,10 +1074,12 @@ landed; none forced a design change except #3 (empty commits raise).
    repo config. (See [Manifest splitting](#manifest-splitting).)
 3. **Empty commit → RAISES (design change).** `session.commit` on an unchanged
    session raises `IcechunkError` ("no changes made to the session"), *not* a
-   no-op. Guard with the `session.has_uncommitted_changes` bool property (or
-   `allow_empty=True`). Re-emitting byte-identical refs *does* dirty the session,
-   so idempotent replay still commits (harmless, content-addressed); the guard
-   only fires on an empty poll. (See [the write loop](#the-virtual-write-loop).)
+   no-op. The implementation avoids this not by guarding the commit but by the
+   generator contract: every yield is a non-empty batch and re-emitting
+   byte-identical refs *does* dirty the session, so the commit is never empty
+   (idempotent replay still commits a harmless, content-addressed snapshot). The
+   loop `assert`s `batch.refs`; the empty-poll / all-present cases yield no batch
+   and never reach the commit. (See [the write loop](#the-virtual-write-loop).)
 4. **Chunk-key encoding API → `array.metadata.chunk_key_encoding`.**
    `.encode_chunk_key((i,j,k,l)) → "c/i/j/k/l"`; full key `f"{array.path}/{…}"`;
    `await store.exists(key)` True/False against the manifest, no decode. Emit uses

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -85,7 +85,8 @@ for source_file in source_files:                       # see "what a file covers
 
     refs = [
         VirtualRef(
-            key=chunk_key(msg.out_loc, msg.var, ds),    # msg.out_loc: the cell this message fills
+            data_var=msg.var,                           # which array this message fills
+            out_loc=msg.out_loc,                        # the cell this message fills
             location=source_file.get_url(),             # s3://noaa-gefs-pds/...
             offset=msg.start,
             length=msg.end - msg.start,
@@ -212,7 +213,7 @@ and nothing else.
   source files and yield whole files' refs a batch at a time. The generator owns
   its own stopping (backfill exhausts `remaining`; an operational generator polls
   and the pod's k8s active-deadline bounds the run).
-- `filter_already_present(candidates, store, ds)` — default impl
+- `filter_already_present(candidates, store)` — default impl
   (see [Filtering](#filtering-already-present-coordinates)); overridable.
 - `sync_dims_to(store, extent)` — idempotent dim/coord/derived-coord expansion
   (see [The virtual write loop](#the-virtual-write-loop)).
@@ -390,12 +391,12 @@ yields*:
 
 ```python
 candidates = self.generate_source_file_coords(scope)          # shared w/ materialized
-remaining  = self.filter_already_present(candidates, store, ds)
+remaining  = self.filter_already_present(candidates, store)
 
-for batch in self.process_virtual_refs(remaining):           # batch == 1+ whole files
-    assert batch.refs                                         # contract: never an empty yield
-    self.sync_dims_to(stores, batch.extent)                  # idempotent; no-op if already covered
-    self.set_virtual_refs(stores, batch.refs)                # per array path, all stores
+for refs in self.process_virtual_refs(remaining):            # refs == 1+ whole files' refs
+    assert refs                                              # contract: never an empty yield
+    self.sync_dims_to(stores, needed_size(refs))            # idempotent; no-op if already covered
+    self.set_virtual_refs(stores, refs)                     # per array path, all stores
     commit(stores)                                           # one commit per yield (never empty)
 ```
 
@@ -428,7 +429,7 @@ splitting a file across yields — but a yield can contain one file or many.
 > `session.has_uncommitted_changes`, the loop relies on the generator contract:
 > each yield is one commit's worth of **whole files**, so a batch always has refs,
 > and **setting refs always dirties the session — even re-emitting byte-identical
-> refs** — so the commit is never empty. The loop **asserts** `batch.refs` (a
+> refs** — so the commit is never empty. The loop **asserts** `refs` (a
 > loud, early failure if a generator ever violates the contract) and leaves
 > `commit_if_icechunk` committing unconditionally. The empty-poll and
 > everything-already-present cases never reach the commit at all — they yield no
@@ -962,15 +963,27 @@ The spike is already done (run ahead of this PR — see
 
 - Add `VirtualRegionJob` (the `process_virtual` write loop, `process_virtual_refs`
   abstract generator, `filter_already_present` default, `sync_dims_to`,
-  `chunk_key`). Emit with `set_virtual_refs` (explicit `VirtualChunkSpec` per ref)
-  — it handles arbitrary sparse cell sets directly, which the common
-  one-message-per-`(var, cell)` packing produces; `set_virtual_refs_arr`'s dense
-  columnar block is a later optimization for contiguous backfill ranges. The
-  filter builds keys from `array.metadata.chunk_key_encoding.encode_chunk_key` +
-  `store.exists`.
+  `chunk_key`). `process_virtual_refs` yields `Sequence[VirtualRef]` — one commit's
+  worth of refs; a `VirtualRef` is `(data_var, out_loc, location, offset, length)`,
+  carrying its `DataVar` so `chunk_key` reads the array geometry straight off it.
+  The whole-file atomicity invariant (all of a file's refs in one yield) is a
+  generator discipline checked by tests, not encoded in a batch type. Emit with
+  `set_virtual_refs` (explicit `VirtualChunkSpec` per ref) — it handles arbitrary
+  sparse cell sets directly, which the common one-message-per-`(var, cell)`
+  packing produces; `set_virtual_refs_arr`'s dense columnar block is a later
+  optimization for contiguous backfill ranges. The filter builds keys from
+  `array.metadata.chunk_key_encoding.encode_chunk_key` + `store.exists`.
+- The per-region write entry point lives on each subclass: `process()` on
+  `MaterializedRegionJob`, `process_virtual()` on `VirtualRegionJob` — the
+  `RegionJob` base carries neither, so neither subclass needs a raising stub for
+  the other's method.
 - `process_virtual` is driven from the `icechunk.Repository` objects (not a
   pre-opened store): a committed icechunk session is read-only, so each yielded
-  batch opens a **fresh writable session** on the branch, emits, and commits.
+  batch opens a **fresh writable session** on the branch, emits, and commits. The
+  driver gets `(primary_repo, replica_repos)` from `StoreFactory.icechunk_repos()`;
+  the role-tagged, sort-ordered list (for `parallel_setup`/`finalize`) is
+  `all_icechunk_repos(sort=…)`. `process_virtual` returns nothing — virtual refs
+  live in the manifest, so no per-file result tracking is threaded back.
 - Two coordination lifecycles, forked at the entry points (not deep in one
   method): **single-writer streaming** (virtual operational) forks in `update()`
   → `_run_virtual_operational_update`, committing whole files straight to `main`
@@ -979,7 +992,7 @@ The spike is already done (run ahead of this PR — see
   materialized operational, and virtual backfill) routes its per-job middle
   through `process_virtual` (fresh sessions) for virtual, else the materialized
   per-job-store loop. **No commit guard** — the generator contract forbids empty
-  yields, so the loop `assert`s `batch.refs` and `commit_if_icechunk` stays
+  yields, so the loop `assert`s `refs` and `commit_if_icechunk` stays
   unconditional (see [the write loop](#the-virtual-write-loop)).
 - Partitioning: `get_jobs` partitions by `encoding["shards"]` if present, else by
   `encoding["chunks"]` (virtual arrays have no shards). Materialized behavior is
@@ -1089,7 +1102,7 @@ landed; none forced a design change except #3 (empty commits raise).
    generator contract: every yield is a non-empty batch and re-emitting
    byte-identical refs *does* dirty the session, so the commit is never empty
    (idempotent replay still commits a harmless, content-addressed snapshot). The
-   loop `assert`s `batch.refs`; the empty-poll / all-present cases yield no batch
+   loop `assert`s `refs`; the empty-poll / all-present cases yield no batch
    and never reach the commit. (See [the write loop](#the-virtual-write-loop).)
 4. **Chunk-key encoding API → `array.metadata.chunk_key_encoding`.**
    `.encode_chunk_key((i,j,k,l)) → "c/i/j/k/l"`; full key `f"{array.path}/{…}"`;

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -963,10 +963,13 @@ The spike is already done (run ahead of this PR — see
 - `process_virtual` is driven from the `icechunk.Repository` objects (not a
   pre-opened store): a committed icechunk session is read-only, so each yielded
   batch opens a **fresh writable session** on the branch, emits, and commits.
-- Extend `_process_region_jobs` with the virtual fork: virtual + operational →
-  single-writer-to-`main` (no temp branch / `parallel_setup` / `finalize`);
-  virtual backfill → the existing temp-branch flow, but route the per-job middle
-  through `process_virtual` (fresh sessions) rather than the materialized
+- Two coordination lifecycles, forked at the entry points (not deep in one
+  method): **single-writer streaming** (virtual operational) forks in `update()`
+  → `_run_virtual_operational_update`, committing whole files straight to `main`
+  with no temp branch / `parallel_setup` / `finalize`; the **parallel temp-branch
+  coordinator** (`_process_region_jobs`, shared by materialized backfill,
+  materialized operational, and virtual backfill) routes its per-job middle
+  through `process_virtual` (fresh sessions) for virtual, else the materialized
   per-job-store loop. **No commit guard** — the generator contract forbids empty
   yields, so the loop `assert`s `batch.refs` and `commit_if_icechunk` stays
   unconditional (see [the write loop](#the-virtual-write-loop)).

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -400,11 +400,16 @@ for refs in self.process_virtual_refs(remaining):            # refs == 1+ whole 
     commit(stores)                                           # one commit per yield (never empty)
 ```
 
-`sync_dims_to(store, extent)` is the single primitive that unifies pre-sizing
+`sync_dims_to(stores, extent)` is the single primitive that unifies pre-sizing
 and lazy expansion. It grows the append-dim coord, the data-var arrays, and the
 derived coords (via the template config's `derive_coordinates`) to cover
 `extent`, **writing only the new positions** and leaving existing positions
-untouched. It is a **no-op when the extent is already covered**.
+untouched. It is a **no-op for any store already covering the extent**, and it
+computes each store's missing slice from **that store's own committed size** —
+not the primary's. That per-store sizing is what makes the
+[replica replay](#replica-writes) safe: replicas commit before the primary, so a
+partial commit can leave a replica ahead, and appending the primary's slice to an
+already-grown replica would duplicate positions.
 
 That single primitive is why the two flows don't need separate write paths:
 
@@ -1000,7 +1005,17 @@ The spike is already done (run ahead of this PR — see
 - `sync_dims_to` appends the new slice of the (already-derived) template via
   `to_zarr(append_dim=…, compute=False)`, keeping data vars dask-lazy so the
   decode-only serializer is never invoked; `chunk_key` derives indices from the
-  full-size template, so it never re-reads the growing store.
+  full-size template, so it never re-reads the growing store. It sizes each store
+  from that store's own committed size (not the primary's) so an ahead-of-primary
+  replica after a partial commit is never double-appended (see
+  [Replica writes](#replica-writes)).
+- The `DynamicalDataset` validator gains the virtual-region-job direction of the
+  invariant: a `VirtualRegionJob` `region_job_class` requires a non-null
+  `icechunk_virtual_config` (the container set is already `min_length=1`), so a
+  misconfigured virtual dataset fails at construction rather than at first emit.
+- `VirtualRegionJob._processing_region_ds` asserts `get_processing_region() ==
+  self.region`: buffering is meaningless for virtual refs (they point at raw
+  bytes) and would make adjacent backfill workers emit into each other's regions.
 - Storage: `_virtual_repository_config_and_credentials` also accepts
   local-filesystem containers (no credentials) so dev/test virtual datasets can
   point at local files.
@@ -1016,6 +1031,11 @@ The spike is already done (run ahead of this PR — see
   fire, and an emit → commit → reopen → **value** read-back round-trip (catches
   bad chunk keys *and* byte ranges in CI). A separate test pins that a
   `GribberishCodec` serializer threads through expansion without being invoked.
+  Edge-case coverage: `sync_dims_to` sizing each store from its own committed
+  size (a second independent repo stands in for an ahead replica, since the test
+  harness maps every store of one dataset to one path), the
+  virtual-region-job-needs-config validator, and the buffered-processing-region
+  assertion.
 
 ### PR #4 — First concrete virtual dataset (end to end)
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Annotated, Any, Generic, Literal, Self, TypeVar
+from typing import Annotated, Any, Generic, Literal, Self, TypeVar, cast
 
 import icechunk
 import numpy as np
@@ -37,6 +37,7 @@ from reformatters.common.kubernetes import (
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.region_job import (
+    MaterializedRegionJob,
     RegionJob,
     SourceFileCoord,
     SourceFileResult,
@@ -466,6 +467,11 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 worker_jobs, icechunk_repos, branch_name
             )
         elif worker_jobs:
+            # Not virtual (handled above), so process() is defined on these jobs.
+            materialized_jobs = cast(
+                "Sequence[MaterializedRegionJob[DATA_VAR, SOURCE_FILE_COORD]]",
+                worker_jobs,
+            )
             primary_store = self.store_factory.primary_store(
                 writable=True, branch=branch_name
             )
@@ -473,7 +479,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 writable=True, branch=branch_name
             )
 
-            for job in worker_jobs:
+            for job in materialized_jobs:
                 template_utils.write_metadata(job.template_ds, job.tmp_store)
                 results = job.process(
                     primary_store=primary_store, replica_stores=replica_stores

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -202,15 +202,23 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 reformat_job_name=reformat_job_name,
             )
 
-            self._process_region_jobs(
-                all_jobs=all_jobs,
-                worker_index=worker_index,
-                workers_total=workers_total,
-                reformat_job_name=reformat_job_name,
-                template_ds=template_ds,
-                tmp_store=tmp_store,
-                update_template_with_results=True,
-            )
+            is_virtual = issubclass(self.region_job_class, VirtualRegionJob)
+            if is_virtual:
+                # Virtual operational updates are single-writer streaming (whole
+                # files committed straight to main as they arrive) — a different
+                # lifecycle from the parallel temp-branch coordinator, so they
+                # don't go through _process_region_jobs.
+                self._run_virtual_operational_update(all_jobs, workers_total)
+            else:
+                self._process_region_jobs(
+                    all_jobs=all_jobs,
+                    worker_index=worker_index,
+                    workers_total=workers_total,
+                    reformat_job_name=reformat_job_name,
+                    template_ds=template_ds,
+                    tmp_store=tmp_store,
+                    update_template_with_results=True,
+                )
 
         log.info(
             f"Operational update complete. Wrote to primary store: {self.store_factory.primary_store()} and replicas {self.store_factory.replica_stores()} replicas"
@@ -409,24 +417,20 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         *,
         update_template_with_results: bool,
     ) -> None:
-        """Shared processing loop for both updates and backfills.
+        """Parallel temp-branch coordinator: worker 0 sets up, all workers
+        process, the last worker finalizes (resets main / writes deferred metadata).
 
         Coordinates parallel writes across multiple workers:
         - Icechunk stores: uses a temp branch so readers on "main" never see partial data
         - Zarr v3 stores: defers metadata write until all workers finish
 
-        Virtual datasets fork here: a virtual *operational* update commits whole
-        source files straight to "main" (single writer, no temp branch) for ~5 s
-        visibility; a virtual *backfill* reuses the temp-branch flow but routes job
+        Shared by materialized backfill, materialized operational, and virtual
+        backfill. A virtual *backfill* reuses the temp-branch flow but routes job
         processing through process_virtual (per-batch sessions) instead of the
-        materialized per-job-store loop.
+        materialized per-job-store loop. Virtual *operational* updates are
+        single-writer streaming and run via update(), not here.
         """
         is_virtual = issubclass(self.region_job_class, VirtualRegionJob)
-
-        if is_virtual and update_template_with_results:
-            self._process_virtual_operational_jobs(all_jobs, workers_total)
-            return
-
         is_first = worker_index == 0
         is_last = worker_index == workers_total - 1
         worker_jobs = get_worker_jobs(all_jobs, worker_index, workers_total)
@@ -525,7 +529,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 update_template_with_results=update_template_with_results,
             )
 
-    def _process_virtual_operational_jobs(
+    def _run_virtual_operational_update(
         self,
         all_jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
         workers_total: int,

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -8,6 +8,7 @@ from functools import partial
 from pathlib import Path
 from typing import Annotated, Any, Generic, Literal, Self, TypeVar
 
+import icechunk
 import numpy as np
 import pandas as pd
 import sentry_sdk
@@ -39,6 +40,7 @@ from reformatters.common.region_job import (
     RegionJob,
     SourceFileCoord,
     SourceFileResult,
+    VirtualRegionJob,
 )
 from reformatters.common.storage import (
     DatasetFormat,
@@ -54,6 +56,15 @@ DATA_VAR = TypeVar("DATA_VAR", bound=DataVar[Any])
 SOURCE_FILE_COORD = TypeVar("SOURCE_FILE_COORD", bound=SourceFileCoord)
 
 log = get_logger(__name__)
+
+
+def _split_primary_repo(
+    repos: list[tuple[str, icechunk.Repository]],
+) -> tuple[icechunk.Repository, list[icechunk.Repository]]:
+    """Split the (role, repo) list (sorted primary-first) into (primary, replicas)."""
+    primary = next(repo for role, repo in repos if role == "primary")
+    replicas = [repo for role, repo in repos if role != "primary"]
+    return primary, replicas
 
 
 class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
@@ -403,7 +414,19 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         Coordinates parallel writes across multiple workers:
         - Icechunk stores: uses a temp branch so readers on "main" never see partial data
         - Zarr v3 stores: defers metadata write until all workers finish
+
+        Virtual datasets fork here: a virtual *operational* update commits whole
+        source files straight to "main" (single writer, no temp branch) for ~5 s
+        visibility; a virtual *backfill* reuses the temp-branch flow but routes job
+        processing through process_virtual (per-batch sessions) instead of the
+        materialized per-job-store loop.
         """
+        is_virtual = issubclass(self.region_job_class, VirtualRegionJob)
+
+        if is_virtual and update_template_with_results:
+            self._process_virtual_operational_jobs(all_jobs, workers_total)
+            return
+
         is_first = worker_index == 0
         is_last = worker_index == workers_total - 1
         worker_jobs = get_worker_jobs(all_jobs, worker_index, workers_total)
@@ -432,7 +455,13 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         # 2. Get stores and process jobs
         worker_results: dict[str, list[SourceFileResult]] = {}
-        if worker_jobs:
+        if worker_jobs and is_virtual:
+            # Virtual backfill: pre-sized branch (parallel_setup), per-batch commits
+            # via fresh sessions, then finalize resets main (existing temp-branch flow).
+            worker_results = self._process_virtual_backfill_jobs(
+                worker_jobs, icechunk_repos, branch_name
+            )
+        elif worker_jobs:
             primary_store = self.store_factory.primary_store(
                 writable=True, branch=branch_name
             )
@@ -495,6 +524,45 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 workers_total=workers_total,
                 update_template_with_results=update_template_with_results,
             )
+
+    def _process_virtual_operational_jobs(
+        self,
+        all_jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
+        workers_total: int,
+    ) -> None:
+        """Single-writer virtual operational update: commit whole source files
+        straight to "main" as they arrive (no temp branch, no parallel_setup, no
+        finalize), so readers see each file within seconds."""
+        assert workers_total == 1, "Virtual operational updates run single-writer"
+        repos = self.store_factory.icechunk_repos(sort="primary-first")
+        primary_repo, replica_repos = _split_primary_repo(repos)
+        for job in all_jobs:
+            assert isinstance(job, VirtualRegionJob)
+            job.process_virtual(primary_repo, replica_repos, branch="main")
+
+    def _process_virtual_backfill_jobs(
+        self,
+        worker_jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
+        icechunk_repos: list[tuple[str, icechunk.Repository]],
+        branch_name: str,
+    ) -> dict[str, list[SourceFileResult]]:
+        """Process a worker's virtual backfill jobs on the pre-sized temp branch,
+        each committing its batches via fresh sessions on the repos."""
+        primary_repo, replica_repos = _split_primary_repo(icechunk_repos)
+        worker_results: dict[str, list[SourceFileResult]] = {}
+        for job in worker_jobs:
+            assert isinstance(job, VirtualRegionJob)
+            results = job.process_virtual(primary_repo, replica_repos, branch_name)
+            for var_name, coords in results.items():
+                worker_results.setdefault(var_name, []).extend(
+                    SourceFileResult(
+                        status=c.status,
+                        out_loc={**c.out_loc()},
+                        url=c.get_url(),
+                    )
+                    for c in coords
+                )
+        return worker_results
 
     def validate_dataset(
         self,

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -6,9 +6,8 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Annotated, Any, Generic, Literal, Self, TypeVar, cast
+from typing import Annotated, Any, Generic, Literal, Self, TypeVar
 
-import icechunk
 import numpy as np
 import pandas as pd
 import sentry_sdk
@@ -59,13 +58,15 @@ SOURCE_FILE_COORD = TypeVar("SOURCE_FILE_COORD", bound=SourceFileCoord)
 log = get_logger(__name__)
 
 
-def _split_primary_repo(
-    repos: list[tuple[str, icechunk.Repository]],
-) -> tuple[icechunk.Repository, list[icechunk.Repository]]:
-    """Split the (role, repo) list (sorted primary-first) into (primary, replicas)."""
-    primary = next(repo for role, repo in repos if role == "primary")
-    replicas = [repo for role, repo in repos if role != "primary"]
-    return primary, replicas
+def _virtual_jobs(
+    jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
+) -> list[VirtualRegionJob[DATA_VAR, SOURCE_FILE_COORD]]:
+    """Narrow a sequence of region jobs to virtual ones (asserting each is)."""
+    virtual_jobs: list[VirtualRegionJob[DATA_VAR, SOURCE_FILE_COORD]] = []
+    for job in jobs:
+        assert isinstance(job, VirtualRegionJob)
+        virtual_jobs.append(job)
+    return virtual_jobs
 
 
 class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
@@ -209,7 +210,9 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 # files committed straight to main as they arrive) — a different
                 # lifecycle from the parallel temp-branch coordinator, so they
                 # don't go through _process_region_jobs.
-                self._run_virtual_operational_update(all_jobs, workers_total)
+                self._run_virtual_operational_update(
+                    _virtual_jobs(all_jobs), workers_total
+                )
             else:
                 self._process_region_jobs(
                     all_jobs=all_jobs,
@@ -442,7 +445,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             f"{len(worker_jobs)} of {len(all_jobs)} total jobs, {jobs_summary}"
         )
 
-        icechunk_repos = self.store_factory.icechunk_repos(sort="primary-first")
+        icechunk_repos = self.store_factory.all_icechunk_repos(sort="primary-first")
         has_icechunk = len(icechunk_repos) > 0
         branch_name = f"_job_{reformat_job_name}" if has_icechunk else "main"
 
@@ -462,16 +465,11 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         worker_results: dict[str, list[SourceFileResult]] = {}
         if worker_jobs and is_virtual:
             # Virtual backfill: pre-sized branch (parallel_setup), per-batch commits
-            # via fresh sessions, then finalize resets main (existing temp-branch flow).
-            worker_results = self._process_virtual_backfill_jobs(
-                worker_jobs, icechunk_repos, branch_name
-            )
+            # via fresh sessions, then finalize resets main (existing temp-branch
+            # flow). worker_results stays empty — virtual refs live in the manifest,
+            # not result files.
+            self._process_virtual_backfill_jobs(_virtual_jobs(worker_jobs), branch_name)
         elif worker_jobs:
-            # Not virtual (handled above), so process() is defined on these jobs.
-            materialized_jobs = cast(
-                "Sequence[MaterializedRegionJob[DATA_VAR, SOURCE_FILE_COORD]]",
-                worker_jobs,
-            )
             primary_store = self.store_factory.primary_store(
                 writable=True, branch=branch_name
             )
@@ -479,7 +477,9 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 writable=True, branch=branch_name
             )
 
-            for job in materialized_jobs:
+            for job in worker_jobs:
+                # Not virtual (handled above), so process() is defined here.
+                assert isinstance(job, MaterializedRegionJob)
                 template_utils.write_metadata(job.template_ds, job.tmp_store)
                 results = job.process(
                     primary_store=primary_store, replica_stores=replica_stores
@@ -537,42 +537,27 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     def _run_virtual_operational_update(
         self,
-        all_jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
+        all_jobs: Sequence[VirtualRegionJob[DATA_VAR, SOURCE_FILE_COORD]],
         workers_total: int,
     ) -> None:
         """Single-writer virtual operational update: commit whole source files
         straight to "main" as they arrive (no temp branch, no parallel_setup, no
         finalize), so readers see each file within seconds."""
         assert workers_total == 1, "Virtual operational updates run single-writer"
-        repos = self.store_factory.icechunk_repos(sort="primary-first")
-        primary_repo, replica_repos = _split_primary_repo(repos)
+        primary_repo, replica_repos = self.store_factory.icechunk_repos()
         for job in all_jobs:
-            assert isinstance(job, VirtualRegionJob)
             job.process_virtual(primary_repo, replica_repos, branch="main")
 
     def _process_virtual_backfill_jobs(
         self,
-        worker_jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
-        icechunk_repos: list[tuple[str, icechunk.Repository]],
+        worker_jobs: Sequence[VirtualRegionJob[DATA_VAR, SOURCE_FILE_COORD]],
         branch_name: str,
-    ) -> dict[str, list[SourceFileResult]]:
+    ) -> None:
         """Process a worker's virtual backfill jobs on the pre-sized temp branch,
         each committing its batches via fresh sessions on the repos."""
-        primary_repo, replica_repos = _split_primary_repo(icechunk_repos)
-        worker_results: dict[str, list[SourceFileResult]] = {}
+        primary_repo, replica_repos = self.store_factory.icechunk_repos()
         for job in worker_jobs:
-            assert isinstance(job, VirtualRegionJob)
-            results = job.process_virtual(primary_repo, replica_repos, branch_name)
-            for var_name, coords in results.items():
-                worker_results.setdefault(var_name, []).extend(
-                    SourceFileResult(
-                        status=c.status,
-                        out_loc={**c.out_loc()},
-                        url=c.get_url(),
-                    )
-                    for c in coords
-                )
-        return worker_results
+            job.process_virtual(primary_repo, replica_repos, branch_name)
 
     def validate_dataset(
         self,

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -81,6 +81,16 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     @model_validator(mode="after")
     def _validate_virtual_storage(self) -> Self:
+        # A virtual region job emits chunk refs into icechunk and needs the source
+        # containers registered, so the virtual config is mandatory for it.
+        if (
+            issubclass(self.region_job_class, VirtualRegionJob)
+            and self.icechunk_virtual_config is None
+        ):
+            raise ValueError(
+                f"{self.region_job_class.__name__} is a VirtualRegionJob but no "
+                "icechunk_virtual_config was provided; virtual datasets require it."
+            )
         # Virtual datasets store icechunk metadata + virtual chunk refs, so every store must be icechunk.
         if self.icechunk_virtual_config is not None:
             non_icechunk = [

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -172,7 +172,7 @@ def finalize(
     # on the temp branch from parallel_setup — we only need to update the metadata files.
     # Process replicas before primary so primary (which drives future work) is last to update.
     if branch_name != "main":
-        replicas_first = store_factory.icechunk_repos(sort="primary-last")
+        replicas_first = store_factory.all_icechunk_repos(sort="primary-last")
         # First pass: commit final metadata and reset main on each repo.
         # If a previous attempt already reset main for a repo, skip it.
         for role, repo in replicas_first:

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -1,6 +1,7 @@
+import asyncio
 import concurrent.futures
 import os
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import suppress
 from copy import deepcopy
@@ -9,13 +10,26 @@ from http import HTTPStatus
 from itertools import chain, pairwise
 from multiprocessing.shared_memory import SharedMemory
 from pathlib import Path
-from typing import Annotated, Any, ClassVar, Generic, Self, TypeVar, get_args
+from typing import (
+    Annotated,
+    Any,
+    ClassVar,
+    Generic,
+    NamedTuple,
+    Self,
+    TypeVar,
+    get_args,
+)
 
 import httpx
+import icechunk
 import numpy as np
 import pandas as pd
 import pydantic
 import xarray as xr
+import zarr
+from icechunk import VirtualChunkSpec
+from icechunk.store import IcechunkStore
 from pydantic import (
     AfterValidator,
     Field,
@@ -24,6 +38,7 @@ from pydantic import (
     field_validator,
 )
 from zarr.abc.store import Store
+from zarr.core.metadata import ArrayV3Metadata
 
 from reformatters.common.binary_rounding import round_float32_inplace
 from reformatters.common.config_models import DataVar
@@ -35,6 +50,7 @@ from reformatters.common.shared_memory_utils import (
     make_shared_buffer,
     write_shards,
 )
+from reformatters.common.storage import commit_if_icechunk
 from reformatters.common.types import (
     AppendDim,
     ArrayND,
@@ -342,8 +358,12 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         else:
             data_var_groups = [data_vars]
 
-        # Regions along append dimension
-        regions = dimension_slices(template_ds, append_dim, kind="shards")
+        # Regions along append dimension. Materialized arrays partition by physical
+        # shard; virtual arrays have no shards (one ref per GRIB message), so they
+        # fall back to chunks. dimension_slices stays strict about which key it reads.
+        sample_encoding = next(iter(template_ds.data_vars.values())).encoding
+        kind = "shards" if sample_encoding.get("shards") is not None else "chunks"
+        regions = dimension_slices(template_ds, append_dim, kind=kind)
 
         # Filter regions by time
         if (
@@ -744,6 +764,296 @@ class MaterializedRegionJob(
             if coord.downloaded_path:
                 with suppress(FileNotFoundError):
                     coord.downloaded_path.unlink()
+
+
+class VirtualRef(NamedTuple):
+    """A single virtual chunk reference: one GRIB message -> one zarr chunk.
+
+    `out_loc` is the output cell the message fills (e.g. {init_time, lead_time});
+    the chunk index it maps to is computed by VirtualRegionJob.chunk_key, so the
+    generator never reimplements zarr's chunk-key math.
+    """
+
+    var_name: str
+    out_loc: Mapping[Dim, CoordinateValue]
+    location: str
+    offset: int
+    length: int
+
+
+class VirtualRefBatch(NamedTuple):
+    """One commit's worth of *whole* source files.
+
+    `refs` are the messages to emit; `source_coords` are the source files they
+    came from (whole, never split across batches), carried for result tracking and
+    to make per-file atomicity structural.
+    """
+
+    source_coords: Sequence[SourceFileCoord]
+    refs: Sequence[VirtualRef]
+
+
+class VirtualRegionJob(
+    RegionJob[DATA_VAR, SOURCE_FILE_COORD], Generic[DATA_VAR, SOURCE_FILE_COORD]
+):
+    # Writes virtual chunk references (byte ranges into public GRIB files) into an
+    # icechunk store rather than materializing rechunked data. Base class for
+    # spatial/map-optimized virtual datasets. The driver routes virtual jobs to
+    # process_virtual() (not process()), because each yielded batch is committed
+    # on its own writable session - a committed icechunk session is read-only, so
+    # the per-batch commit loop must reopen a session from the repository.
+
+    # Operational poll deadline. None for backfills, which exhaust their candidate
+    # set and return; set by operational_update_jobs for operational updates, which
+    # poll for newly published files until the deadline approaches.
+    deadline: Timestamp | None = None
+
+    def process_virtual_refs(
+        self,
+        remaining: Sequence[SOURCE_FILE_COORD],
+        deadline: Timestamp | None,
+    ) -> Iterator[VirtualRefBatch]:
+        """Discover available source files among `remaining` and yield their refs.
+
+        Each yielded VirtualRefBatch holds one commit's worth of *whole* source
+        files (never a partial file - see "Reader safety" in the design doc); the
+        driver commits once per yield. The generator owns the batching policy:
+
+        - `deadline is None` (backfill): yield all of `remaining`, grouped into
+          batches of ~N whole files to amortize commit overhead, then return.
+        - `deadline` set (operational): poll for newly-available files, yielding
+          ~1 file per batch for per-file visibility, until the active window is
+          complete or `deadline` approaches; then return.
+        """
+        raise NotImplementedError(
+            "Yield VirtualRefBatch objects, each one commit's worth of whole source files."
+        )
+
+    def representative_var(self, coord: SOURCE_FILE_COORD) -> DATA_VAR:  # noqa: ARG002
+        """The variable whose chunk presence means `coord`'s file is fully ingested.
+
+        Used by filter_already_present to probe a single representative cell per
+        file. Default: the first data var, valid when every file contains every
+        variable. Override for one-variable-per-file packings (e.g. GEFS v12
+        reforecast) to return the candidate's own variable.
+        """
+        return self.data_vars[0]
+
+    def process(
+        self,
+        primary_store: Store,
+        replica_stores: list[Store],
+    ) -> Mapping[str, Sequence[SOURCE_FILE_COORD]]:
+        raise NotImplementedError(
+            "VirtualRegionJob is driven via process_virtual(); the dataset driver "
+            "routes virtual jobs there so each batch can commit on its own session."
+        )
+
+    def process_virtual(
+        self,
+        primary_repo: icechunk.Repository,
+        replica_repos: Sequence[icechunk.Repository],
+        branch: str,
+    ) -> Mapping[str, Sequence[SourceFileCoord]]:
+        """Run the virtual write loop, committing each yielded batch atomically.
+
+        Same loop for backfill and operational; the only differences are the
+        `branch` the driver opened (a temp branch for backfill, "main" for the
+        single-writer operational update) and whether `self.deadline` makes the
+        generator poll. sync_dims_to grows the store lazily (a no-op on the
+        pre-sized backfill branch). A fresh writable session is opened per batch
+        because committing an icechunk session makes it read-only.
+        """
+        readonly_store = primary_repo.readonly_session(branch).store
+        candidates = self.generate_source_file_coords(
+            self._processing_region_ds(), self.data_vars
+        )
+        remaining = self.filter_already_present(candidates, readonly_store)
+        current_size = self._append_dim_size(readonly_store)
+
+        results: dict[str, list[SourceFileCoord]] = {}
+        for batch in self.process_virtual_refs(remaining, self.deadline):
+            # The generator contract is one commit's worth of whole files per
+            # yield, so a batch always has refs; emitting them always dirties the
+            # session, so the commit below is never empty (an empty icechunk commit
+            # raises rather than no-ops).
+            assert batch.refs, "process_virtual_refs yielded an empty batch"
+            primary_session = primary_repo.writable_session(branch)
+            replica_sessions = [repo.writable_session(branch) for repo in replica_repos]
+            stores = [primary_session.store, *(s.store for s in replica_sessions)]
+
+            needed_size = self._needed_append_dim_size(batch.refs)
+            if needed_size > current_size:
+                self.sync_dims_to(stores, needed_size)
+                current_size = needed_size
+
+            self._emit_refs(stores, batch.refs)
+
+            now = pd.Timestamp.now(tz="UTC")
+            commit_if_icechunk(
+                f"Virtual refs at {now.strftime('%Y-%m-%dT%H:%M:%SZ')}",
+                primary_session.store,
+                [s.store for s in replica_sessions],
+            )
+
+            batch_var_names = {ref.var_name for ref in batch.refs}
+            for coord in batch.source_coords:
+                succeeded = replace(coord, status=SourceFileStatus.Succeeded)
+                for var_name in batch_var_names:
+                    results.setdefault(var_name, []).append(succeeded)
+        return results
+
+    def filter_already_present(
+        self,
+        candidates: Sequence[SOURCE_FILE_COORD],
+        store: IcechunkStore,
+    ) -> list[SOURCE_FILE_COORD]:
+        """Drop candidates whose representative chunk is already in the manifest.
+
+        Probes ref existence (store.exists) - never reads or decodes a chunk, which
+        would trigger an S3 fetch + GRIB decode. A false-negative (re-emitting done
+        work) is a harmless idempotent rewrite; the manifest probe has no
+        false-positives (a key is present iff we emitted it), so no work is ever
+        skipped undone.
+        """
+        group = zarr.open_group(store, mode="r")
+        keyed: list[tuple[SOURCE_FILE_COORD, str | None]] = []
+        for coord in candidates:
+            var = self.representative_var(coord)
+            index = self.chunk_key(coord.out_loc(), var)
+            if index is None:
+                keyed.append((coord, None))
+                continue
+            array = group[var.name]
+            assert isinstance(array, zarr.Array)
+            metadata = array.metadata
+            assert isinstance(metadata, ArrayV3Metadata)
+            key = f"{array.path}/{metadata.chunk_key_encoding.encode_chunk_key(index)}"
+            keyed.append((coord, key))
+
+        present = _exists_many(store, [key for _, key in keyed if key is not None])
+        return [coord for coord, key in keyed if key is None or not present[key]]
+
+    def chunk_key(
+        self, out_loc: Mapping[Dim, CoordinateValue], var: DATA_VAR
+    ) -> tuple[int, ...] | None:
+        """Map a source message's coordinate labels to its zarr chunk index.
+
+        Geometry (dim order, chunk sizes, coord positions) is read from the
+        full-size template, so the index matches what readers resolve and does not
+        depend on how far the store has been expanded. Shared by the filter and the
+        emitter so they cannot disagree. Returns None if a label is not in the
+        template's coords, which the filter treats as "remaining".
+
+        Asserts each label lands on an exact chunk boundary - a virtual chunk is
+        exactly one GRIB message, so any non-aligned position is a bug.
+        """
+        dims = tuple(str(d) for d in self.template_ds[var.name].dims)
+        chunks = var.encoding.chunks
+        chunks = (chunks,) if isinstance(chunks, int) else chunks
+        assert len(chunks) == len(dims)
+        labels = {str(dim): label for dim, label in out_loc.items()}
+
+        index: list[int] = []
+        for dim, chunk_size in zip(dims, chunks, strict=True):
+            if dim in labels:
+                position = int(
+                    self.template_ds.get_index(dim).get_indexer(
+                        pd.Index([labels[dim]])
+                    )[0]
+                )
+                if position < 0:
+                    return None  # label not in coords -> not yet a position in this dataset
+            else:
+                position = 0  # dims absent from out_loc (e.g. lat/lon) are one chunk
+            chunk_index, remainder = divmod(position, chunk_size)
+            assert remainder == 0, (
+                f"{dim}={labels.get(dim)} maps to position {position}, which is not "
+                f"on a chunk boundary (chunk size {chunk_size}); a virtual chunk must "
+                "be exactly one GRIB message."
+            )
+            index.append(chunk_index)
+        return tuple(index)
+
+    def sync_dims_to(
+        self, stores: Sequence[IcechunkStore], needed_append_dim_size: int
+    ) -> None:
+        """Grow the append dim (and its dependent coords) to `needed_append_dim_size`.
+
+        Writes only the new positions by appending the corresponding slice of the
+        already-derived template; existing positions are untouched. Data vars stay
+        dask-lazy under compute=False, so the decode-only serializer is never
+        invoked. A no-op when the store already covers the size (so backfill's
+        pre-sized branch never resizes, and parallel workers never conflict).
+        """
+        current_size = self._append_dim_size(stores[0])
+        if needed_append_dim_size <= current_size:
+            return
+        slice_ds = self.template_ds.isel(
+            {self.append_dim: slice(current_size, needed_append_dim_size)}
+        )
+        for store in stores:
+            slice_ds.to_zarr(
+                store, append_dim=self.append_dim, compute=False, consolidated=False
+            )
+
+    def _emit_refs(
+        self, stores: Sequence[IcechunkStore], refs: Sequence[VirtualRef]
+    ) -> None:
+        var_by_name = {v.name: v for v in self.data_vars}
+        specs_by_var: dict[str, list[VirtualChunkSpec]] = {}
+        for ref in refs:
+            index = self.chunk_key(ref.out_loc, var_by_name[ref.var_name])
+            assert index is not None, (
+                f"ref {ref.var_name} {dict(ref.out_loc)} did not resolve to a chunk "
+                "index after expansion"
+            )
+            specs_by_var.setdefault(ref.var_name, []).append(
+                VirtualChunkSpec(
+                    index=list(index),
+                    location=ref.location,
+                    offset=ref.offset,
+                    length=ref.length,
+                )
+            )
+        for store in stores:
+            for var_name, specs in specs_by_var.items():
+                failed = store.set_virtual_refs(
+                    var_name, specs, validate_containers=True
+                )
+                assert failed is None, (
+                    f"{len(failed)} virtual ref(s) for {var_name} did not match a "
+                    f"registered container, e.g. {failed[:3]}"
+                )
+
+    def _needed_append_dim_size(self, refs: Sequence[VirtualRef]) -> int:
+        positions = self.template_ds.get_index(self.append_dim).get_indexer(
+            pd.Index([ref.out_loc[self.append_dim] for ref in refs])
+        )
+        assert (positions >= 0).all(), (
+            "a ref's append-dim label is not present in the template"
+        )
+        return int(positions.max()) + 1
+
+    def _append_dim_size(self, store: IcechunkStore) -> int:
+        array = zarr.open_group(store, mode="r")[self.append_dim]
+        assert isinstance(array, zarr.Array)
+        return int(array.shape[0])
+
+    def _processing_region_ds(self) -> xr.Dataset:
+        ds: xr.Dataset = self.template_ds[[v.name for v in self.data_vars]]  # ty: ignore[invalid-assignment]
+        return ds.isel({self.append_dim: self.get_processing_region()})
+
+
+def _exists_many(store: IcechunkStore, keys: Sequence[str]) -> dict[str, bool]:
+    """Probe many chunk keys concurrently (store.exists is async)."""
+    if not keys:
+        return {}
+
+    async def _check() -> list[bool]:
+        return list(await asyncio.gather(*(store.exists(key) for key in keys)))
+
+    return dict(zip(keys, asyncio.run(_check()), strict=True))
 
 
 class SourceFileResult(FrozenBaseModel):

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -516,7 +516,7 @@ class MaterializedRegionJob(
         self,
         primary_store: Store,
         replica_stores: list[Store],
-    ) -> Mapping[str, Sequence[SOURCE_FILE_COORD]]:
+    ) -> Mapping[str, Sequence[SourceFileCoord]]:
         """
         Orchestrate the full region job processing pipeline.
 
@@ -755,26 +755,15 @@ class VirtualRef(NamedTuple):
 
     `out_loc` is the output cell the message fills (e.g. {init_time, lead_time});
     the chunk index it maps to is computed by VirtualRegionJob.chunk_key, so the
-    generator never reimplements zarr's chunk-key math.
+    generator never reimplements zarr's chunk-key math. `data_var` identifies the
+    array the ref belongs to (and supplies the chunk geometry for chunk_key).
     """
 
-    var_name: str
+    data_var: DataVar[Any]
     out_loc: Mapping[Dim, CoordinateValue]
     location: str
     offset: int
     length: int
-
-
-class VirtualRefBatch(NamedTuple):
-    """One commit's worth of *whole* source files.
-
-    `refs` are the messages to emit; `source_coords` are the source files they
-    came from (whole, never split across batches), carried for result tracking and
-    to make per-file atomicity structural.
-    """
-
-    source_coords: Sequence[SourceFileCoord]
-    refs: Sequence[VirtualRef]
 
 
 class VirtualRegionJob(
@@ -785,17 +774,20 @@ class VirtualRegionJob(
     def process_virtual_refs(
         self,
         remaining: Sequence[SOURCE_FILE_COORD],
-    ) -> Iterator[VirtualRefBatch]:
+    ) -> Iterator[Sequence[VirtualRef]]:
         """Discover available source files among `remaining` and yield their refs.
 
-        Each yielded VirtualRefBatch holds one commit's worth of *whole* source
-        files (never a partial file - see "Reader safety" in the design doc); the
-        driver commits once per yield. The generator owns the batching policy:
-        backfill yields batches of ~N whole files to amortize commit overhead;
-        operational yields ~1 file at a time for per-file visibility.
+        Each yield is one commit's worth of refs. The contract is that a yield
+        holds *whole* source files — every ref of a file is emitted in the same
+        batch, never split across yields — so a reader on `main` sees all of a
+        file's data or none of it (see "Reader safety" in the design doc). This is
+        a discipline the generator must keep (and tests check); it is not encoded
+        in the type. The generator owns the batching policy: backfill yields
+        batches of ~N whole files to amortize commit overhead; operational yields
+        ~1 file at a time for per-file visibility.
         """
         raise NotImplementedError(
-            "Yield VirtualRefBatch objects, each one commit's worth of whole source files."
+            "Yield batches of VirtualRefs, each one commit's worth of whole source files."
         )
 
     def representative_var(self, coord: SOURCE_FILE_COORD) -> DATA_VAR:  # noqa: ARG002
@@ -813,7 +805,7 @@ class VirtualRegionJob(
         primary_repo: icechunk.Repository,
         replica_repos: Sequence[icechunk.Repository],
         branch: str,
-    ) -> Mapping[str, Sequence[SourceFileCoord]]:
+    ) -> None:
         """Run the virtual write loop, committing each yielded batch atomically.
 
         Same loop for backfill and operational; the only difference is the
@@ -829,23 +821,21 @@ class VirtualRegionJob(
         remaining = self.filter_already_present(candidates, readonly_store)
         current_size = self._append_dim_size(readonly_store)
 
-        results: dict[str, list[SourceFileCoord]] = {}
-        for batch in self.process_virtual_refs(remaining):
-            # The generator contract is one commit's worth of whole files per
-            # yield, so a batch always has refs; emitting them always dirties the
-            # session, so the commit below is never empty (an empty icechunk commit
-            # raises rather than no-ops).
-            assert batch.refs, "process_virtual_refs yielded an empty batch"
+        for refs in self.process_virtual_refs(remaining):
+            # The generator yields whole files, so a batch always has refs; emitting
+            # them always dirties the session, so the commit below is never empty
+            # (an empty icechunk commit raises rather than no-ops).
+            assert refs, "process_virtual_refs yielded an empty batch"
             primary_session = primary_repo.writable_session(branch)
             replica_sessions = [repo.writable_session(branch) for repo in replica_repos]
             stores = [primary_session.store, *(s.store for s in replica_sessions)]
 
-            needed_size = self._needed_append_dim_size(batch.refs)
+            needed_size = self._needed_append_dim_size(refs)
             if needed_size > current_size:
                 self.sync_dims_to(stores, needed_size)
                 current_size = needed_size
 
-            self._emit_refs(stores, batch.refs)
+            self._emit_refs(stores, refs)
 
             now = pd.Timestamp.now(tz="UTC")
             commit_if_icechunk(
@@ -853,13 +843,6 @@ class VirtualRegionJob(
                 primary_session.store,
                 [s.store for s in replica_sessions],
             )
-
-            batch_var_names = {ref.var_name for ref in batch.refs}
-            for coord in batch.source_coords:
-                succeeded = replace(coord, status=SourceFileStatus.Succeeded)
-                for var_name in batch_var_names:
-                    results.setdefault(var_name, []).append(succeeded)
-        return results
 
     def filter_already_present(
         self,
@@ -893,7 +876,7 @@ class VirtualRegionJob(
         return [coord for coord, key in keyed if key is None or not present[key]]
 
     def chunk_key(
-        self, out_loc: Mapping[Dim, CoordinateValue], var: DATA_VAR
+        self, out_loc: Mapping[Dim, CoordinateValue], var: DataVar[Any]
     ) -> tuple[int, ...] | None:
         """Map a source message's coordinate labels to its zarr chunk index.
 
@@ -958,15 +941,14 @@ class VirtualRegionJob(
     def _emit_refs(
         self, stores: Sequence[IcechunkStore], refs: Sequence[VirtualRef]
     ) -> None:
-        var_by_name = {v.name: v for v in self.data_vars}
         specs_by_var: dict[str, list[VirtualChunkSpec]] = {}
         for ref in refs:
-            index = self.chunk_key(ref.out_loc, var_by_name[ref.var_name])
+            index = self.chunk_key(ref.out_loc, ref.data_var)
             assert index is not None, (
-                f"ref {ref.var_name} {dict(ref.out_loc)} did not resolve to a chunk "
-                "index after expansion"
+                f"ref {ref.data_var.name} {dict(ref.out_loc)} did not resolve to a "
+                "chunk index after expansion"
             )
-            specs_by_var.setdefault(ref.var_name, []).append(
+            specs_by_var.setdefault(ref.data_var.name, []).append(
                 VirtualChunkSpec(
                     index=list(index),
                     location=ref.location,

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -924,16 +924,19 @@ class VirtualRegionJob(
         Writes only the new positions by appending the corresponding slice of the
         already-derived template; existing positions are untouched. Data vars stay
         dask-lazy under compute=False, so the decode-only serializer is never
-        invoked. A no-op when the store already covers the size (so backfill's
-        pre-sized branch never resizes, and parallel workers never conflict).
+        invoked. A no-op for any store already covering the size (so backfill's
+        pre-sized branch never resizes, and parallel workers never conflict). Each
+        store's missing slice is computed from its own committed size: replicas
+        commit before the primary, so a partial commit can leave a replica ahead,
+        and appending the primary's slice to it would duplicate positions.
         """
-        current_size = self._append_dim_size(stores[0])
-        if needed_append_dim_size <= current_size:
-            return
-        slice_ds = self.template_ds.isel(
-            {self.append_dim: slice(current_size, needed_append_dim_size)}
-        )
         for store in stores:
+            current_size = self._append_dim_size(store)
+            if needed_append_dim_size <= current_size:
+                continue
+            slice_ds = self.template_ds.isel(
+                {self.append_dim: slice(current_size, needed_append_dim_size)}
+            )
             slice_ds.to_zarr(
                 store, append_dim=self.append_dim, compute=False, consolidated=False
             )
@@ -981,8 +984,15 @@ class VirtualRegionJob(
         return int(array.shape[0])
 
     def _processing_region_ds(self) -> xr.Dataset:
+        processing_region = self.get_processing_region()
+        # Virtual refs point at raw source bytes, so no surrounding buffer is ever
+        # needed; a buffered region would make adjacent backfill workers generate
+        # overlapping candidates and emit refs into each other's regions.
+        assert processing_region == self.region, (
+            "VirtualRegionJob.get_processing_region must equal self.region"
+        )
         ds: xr.Dataset = self.template_ds[[v.name for v in self.data_vars]]  # ty: ignore[invalid-assignment]
-        return ds.isel({self.append_dim: self.get_processing_region()})
+        return ds.isel({self.append_dim: processing_region})
 
 
 def _exists_many(store: IcechunkStore, keys: Sequence[str]) -> dict[str, bool]:

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -358,9 +358,8 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         else:
             data_var_groups = [data_vars]
 
-        # Regions along append dimension. Materialized arrays partition by physical
-        # shard; virtual arrays have no shards (one ref per GRIB message), so they
-        # fall back to chunks. dimension_slices stays strict about which key it reads.
+        # Regions along append dimension.
+        # Materialized arrays partition by shard; virtual arrays use chunks.
         sample_encoding = next(iter(template_ds.data_vars.values())).encoding
         kind = "shards" if sample_encoding.get("shards") is not None else "chunks"
         regions = dimension_slices(template_ds, append_dim, kind=kind)
@@ -426,21 +425,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             for data_var_group in data_var_groups
         ]
         return all_jobs
-
-    def process(
-        self,
-        primary_store: Store,
-        replica_stores: list[Store],
-    ) -> Mapping[str, Sequence[SOURCE_FILE_COORD]]:
-        """
-        Process this region, writing chunk data to primary_store (and replica_stores)
-        and returning the per-variable source file coordinates with their final status.
-
-        Implemented by the MaterializedRegionJob and VirtualRegionJob subclasses.
-        """
-        raise NotImplementedError(
-            "Subclasses implement process() with variant-specific logic"
-        )
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(region=({self.region.start}, {self.region.stop}), data_vars={[v.name for v in self.data_vars]})"
@@ -796,34 +780,19 @@ class VirtualRefBatch(NamedTuple):
 class VirtualRegionJob(
     RegionJob[DATA_VAR, SOURCE_FILE_COORD], Generic[DATA_VAR, SOURCE_FILE_COORD]
 ):
-    # Writes virtual chunk references (byte ranges into public GRIB files) into an
-    # icechunk store rather than materializing rechunked data. Base class for
-    # spatial/map-optimized virtual datasets. The driver routes virtual jobs to
-    # process_virtual() (not process()), because each yielded batch is committed
-    # on its own writable session - a committed icechunk session is read-only, so
-    # the per-batch commit loop must reopen a session from the repository.
-
-    # Operational poll deadline. None for backfills, which exhaust their candidate
-    # set and return; set by operational_update_jobs for operational updates, which
-    # poll for newly published files until the deadline approaches.
-    deadline: Timestamp | None = None
+    """Base class for processing a region of virtual Icechunk datasets that point to external files."""
 
     def process_virtual_refs(
         self,
         remaining: Sequence[SOURCE_FILE_COORD],
-        deadline: Timestamp | None,
     ) -> Iterator[VirtualRefBatch]:
         """Discover available source files among `remaining` and yield their refs.
 
         Each yielded VirtualRefBatch holds one commit's worth of *whole* source
         files (never a partial file - see "Reader safety" in the design doc); the
         driver commits once per yield. The generator owns the batching policy:
-
-        - `deadline is None` (backfill): yield all of `remaining`, grouped into
-          batches of ~N whole files to amortize commit overhead, then return.
-        - `deadline` set (operational): poll for newly-available files, yielding
-          ~1 file per batch for per-file visibility, until the active window is
-          complete or `deadline` approaches; then return.
+        backfill yields batches of ~N whole files to amortize commit overhead;
+        operational yields ~1 file at a time for per-file visibility.
         """
         raise NotImplementedError(
             "Yield VirtualRefBatch objects, each one commit's worth of whole source files."
@@ -839,16 +808,6 @@ class VirtualRegionJob(
         """
         return self.data_vars[0]
 
-    def process(
-        self,
-        primary_store: Store,
-        replica_stores: list[Store],
-    ) -> Mapping[str, Sequence[SOURCE_FILE_COORD]]:
-        raise NotImplementedError(
-            "VirtualRegionJob is driven via process_virtual(); the dataset driver "
-            "routes virtual jobs there so each batch can commit on its own session."
-        )
-
     def process_virtual(
         self,
         primary_repo: icechunk.Repository,
@@ -857,12 +816,11 @@ class VirtualRegionJob(
     ) -> Mapping[str, Sequence[SourceFileCoord]]:
         """Run the virtual write loop, committing each yielded batch atomically.
 
-        Same loop for backfill and operational; the only differences are the
+        Same loop for backfill and operational; the only difference is the
         `branch` the driver opened (a temp branch for backfill, "main" for the
-        single-writer operational update) and whether `self.deadline` makes the
-        generator poll. sync_dims_to grows the store lazily (a no-op on the
-        pre-sized backfill branch). A fresh writable session is opened per batch
-        because committing an icechunk session makes it read-only.
+        single-writer operational update). sync_dims_to grows the store lazily (a
+        no-op on the pre-sized backfill branch). A fresh writable session is opened
+        per batch because committing an icechunk session makes it read-only.
         """
         readonly_store = primary_repo.readonly_session(branch).store
         candidates = self.generate_source_file_coords(
@@ -872,7 +830,7 @@ class VirtualRegionJob(
         current_size = self._append_dim_size(readonly_store)
 
         results: dict[str, list[SourceFileCoord]] = {}
-        for batch in self.process_virtual_refs(remaining, self.deadline):
+        for batch in self.process_virtual_refs(remaining):
             # The generator contract is one commit's worth of whole files per
             # yield, so a batch always has refs; emitting them always dirties the
             # session, so the commit below is never empty (an empty icechunk commit

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -139,6 +139,17 @@ class StoreFactory(FrozenBaseModel):
         return True
 
     def icechunk_repos(
+        self,
+    ) -> tuple[icechunk.Repository, tuple[icechunk.Repository, ...]]:
+        """Returns (primary_repo, (replica_repos, ...)) for the common case where
+        the caller just wants the primary and its replicas. Use all_icechunk_repos
+        when you also need roles or a specific primary-first/last ordering."""
+        repos = self.all_icechunk_repos(sort="primary-first")
+        primary = next(repo for role, repo in repos if role == "primary")
+        replicas = tuple(repo for role, repo in repos if role != "primary")
+        return primary, replicas
+
+    def all_icechunk_repos(
         self, *, sort: Literal["primary-first", "primary-last"]
     ) -> list[tuple[str, icechunk.Repository]]:
         """Returns (role, Repository) for each icechunk store in the specified order.

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -487,30 +487,35 @@ def _virtual_repository_config_and_credentials(
         config.set_virtual_chunk_container(container)
     config.manifest = icechunk.ManifestConfig(splitting=virtual_config.manifest_split)
 
-    # Every source we target today is S3 or S3-compatible (NOAA NODD, ECMWF,
-    # Source Coop) and anonymous-read, and icechunk only ships an S3 anonymous
-    # credential constructor. Assert that here rather than silently handing an S3
-    # credential to a GCS/Azure container. To support a non-S3 or private /
+    # Every production source is S3 or S3-compatible (NOAA NODD, ECMWF, Source
+    # Coop) and anonymous-read, and icechunk only ships an S3 anonymous credential
+    # constructor; local-filesystem containers (dev/test) need no credentials. Map
+    # each container to the right credential explicitly rather than silently handing
+    # an S3 credential to a GCS/Azure container. To support a non-S3 or private /
     # requester-pays source, add an optional per-container credentials field to
-    # IcechunkVirtualConfig and prefer it over this anonymous default.
+    # IcechunkVirtualConfig and prefer it over these defaults.
     s3_compatible_stores = (
         icechunk.ObjectStoreConfig.S3,
         icechunk.ObjectStoreConfig.S3Compatible,
         icechunk.ObjectStoreConfig.Tigris,
     )
+    credentials_by_prefix: dict[str, Any] = {}
     for container in virtual_config.containers:
-        assert isinstance(container.store, s3_compatible_stores), (
-            f"Virtual chunk container {container.url_prefix} uses a non-S3 store "
-            f"({type(container.store).__name__}); only S3-compatible anonymous "
-            "sources are supported. Add explicit credentials to IcechunkVirtualConfig."
-        )
+        if isinstance(container.store, s3_compatible_stores):
+            credentials_by_prefix[container.url_prefix] = (
+                icechunk.s3_anonymous_credentials()
+            )
+        elif isinstance(container.store, icechunk.ObjectStoreConfig.LocalFileSystem):
+            credentials_by_prefix[container.url_prefix] = None  # local files: no creds
+        else:
+            raise AssertionError(
+                f"Virtual chunk container {container.url_prefix} uses an unsupported "
+                f"store ({type(container.store).__name__}); only S3-compatible "
+                "(anonymous) and local-filesystem sources are supported. Add explicit "
+                "credentials to IcechunkVirtualConfig."
+            )
 
-    credentials = icechunk.containers_credentials(
-        {
-            container.url_prefix: icechunk.s3_anonymous_credentials()
-            for container in virtual_config.containers
-        }
-    )
+    credentials = icechunk.containers_credentials(credentials_by_prefix)
     return config, credentials
 
 

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -215,9 +215,13 @@ def test_update_template(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_backfill(monkeypatch: pytest.MonkeyPatch) -> None:
+    # __class__ spoof so the driver's isinstance(job, MaterializedRegionJob) passes
+    # while keeping auto-mocked attributes.
     mock_job0 = Mock()
+    mock_job0.__class__ = ExampleRegionJob
     mock_job0.summary = lambda: "job0-summary"
     mock_job1 = Mock()
+    mock_job1.__class__ = ExampleRegionJob
     mock_job1.summary = lambda: "job1-summary"
     monkeypatch.setattr(
         ExampleRegionJob,

--- a/tests/common/test_parallel_coordination.py
+++ b/tests/common/test_parallel_coordination.py
@@ -48,7 +48,7 @@ class FakeStoreFactory:
     def clear_coordination_files(self, job_name: str) -> None:
         self.files.pop(job_name, None)
 
-    def icechunk_repos(self, *, sort: str) -> list[tuple[str, FakeRepo]]:
+    def all_icechunk_repos(self, *, sort: str) -> list[tuple[str, FakeRepo]]:
         return list(self._icechunk_repos_by_sort[sort])
 
     def primary_store(self, writable: bool = False) -> object:  # noqa: ARG002
@@ -467,7 +467,7 @@ class TestFinalize:
         # No metadata copies, no commits, and no replicas/primary stores queried.
         stub_io["copy_zarr_metadata"].assert_not_called()
         # One primary + one replica repo configured; none should have been touched.
-        for _role, repo in factory.icechunk_repos(sort="primary-first"):
+        for _role, repo in factory.all_icechunk_repos(sort="primary-first"):
             assert repo.sessions == []
             assert repo.reset_calls == []
             assert repo.delete_branch_calls == []

--- a/tests/common/test_parallel_writes.py
+++ b/tests/common/test_parallel_writes.py
@@ -464,7 +464,7 @@ class TestIcechunkParallelWrites:
             )
 
         # Temp branch should be cleaned up
-        repos = dataset.store_factory.icechunk_repos(sort="primary-first")
+        repos = dataset.store_factory.all_icechunk_repos(sort="primary-first")
         assert len(repos) == 1
         _, repo = repos[0]
         branches = list(repo.list_branches())
@@ -529,7 +529,9 @@ class TestReplicaParallelWrites:
                 assert np.all(result[var].values == 1.0)
 
         # Temp branches cleaned up on both repos
-        for _role, repo in dataset.store_factory.icechunk_repos(sort="primary-first"):
+        for _role, repo in dataset.store_factory.all_icechunk_repos(
+            sort="primary-first"
+        ):
             assert list(repo.list_branches()) == ["main"]
 
 
@@ -772,7 +774,7 @@ class TestWorkerRestart:
             assert np.all(result[var].values == 1.0)
 
         # Temp branch cleaned up
-        _, repo = dataset.store_factory.icechunk_repos(sort="primary-first")[0]
+        _, repo = dataset.store_factory.all_icechunk_repos(sort="primary-first")[0]
         assert list(repo.list_branches()) == ["main"]
 
 
@@ -884,8 +886,12 @@ class TestLastWorkerRetryAfterPartialFinalize:
             )
 
         # Replica was reset; primary was not.
-        primary_repo = dataset.store_factory.icechunk_repos(sort="primary-first")[0][1]
-        replica_repo = dataset.store_factory.icechunk_repos(sort="primary-last")[0][1]
+        primary_repo = dataset.store_factory.all_icechunk_repos(sort="primary-first")[
+            0
+        ][1]
+        replica_repo = dataset.store_factory.all_icechunk_repos(sort="primary-last")[0][
+            1
+        ]
         primary_pre_retry = primary_repo.lookup_branch("main")
         replica_pre_retry = replica_repo.lookup_branch("main")
 
@@ -910,7 +916,9 @@ class TestLastWorkerRetryAfterPartialFinalize:
                 assert np.all(result[var].values == 1.0)
 
         # Temp branches cleaned up on both repos.
-        for _role, repo in dataset.store_factory.icechunk_repos(sort="primary-first"):
+        for _role, repo in dataset.store_factory.all_icechunk_repos(
+            sort="primary-first"
+        ):
             assert list(repo.list_branches()) == ["main"]
 
     def test_retry_before_any_reset_completes_all(
@@ -948,8 +956,12 @@ class TestLastWorkerRetryAfterPartialFinalize:
             reformat_job_name="test",
         )
 
-        primary_repo = dataset.store_factory.icechunk_repos(sort="primary-first")[0][1]
-        replica_repo = dataset.store_factory.icechunk_repos(sort="primary-last")[0][1]
+        primary_repo = dataset.store_factory.all_icechunk_repos(sort="primary-first")[
+            0
+        ][1]
+        replica_repo = dataset.store_factory.all_icechunk_repos(sort="primary-last")[0][
+            1
+        ]
         initial_primary = primary_repo.lookup_branch("main")
         initial_replica = replica_repo.lookup_branch("main")
 
@@ -999,7 +1011,9 @@ class TestLastWorkerRetryAfterPartialFinalize:
             for var in ["var0", "var1", "var2", "var3"]:
                 assert np.all(result[var].values == 1.0)
 
-        for _role, repo in dataset.store_factory.icechunk_repos(sort="primary-first"):
+        for _role, repo in dataset.store_factory.all_icechunk_repos(
+            sort="primary-first"
+        ):
             assert list(repo.list_branches()) == ["main"]
 
 
@@ -1041,11 +1055,13 @@ class TestReplicaOrdering:
         # labels here, which are unaffected.
         roles_first = [
             role
-            for role, _ in dataset.store_factory.icechunk_repos(sort="primary-first")
+            for role, _ in dataset.store_factory.all_icechunk_repos(
+                sort="primary-first"
+            )
         ]
         roles_last = [
             role
-            for role, _ in dataset.store_factory.icechunk_repos(sort="primary-last")
+            for role, _ in dataset.store_factory.all_icechunk_repos(sort="primary-last")
         ]
         assert roles_first[0] == "primary"
         assert roles_last[-1] == "primary"
@@ -1127,7 +1143,9 @@ class TestConcurrentJobs:
         template_ds = _create_template_ds()
         template_utils.write_metadata(template_ds, dataset.store_factory)
 
-        primary_repo = dataset.store_factory.icechunk_repos(sort="primary-first")[0][1]
+        primary_repo = dataset.store_factory.all_icechunk_repos(sort="primary-first")[
+            0
+        ][1]
         initial_snapshot = primary_repo.lookup_branch("main")
 
         jobs_a = ParallelRegionJob.get_jobs(

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -425,7 +425,7 @@ class TestIcechunkVirtualConfig:
         assert manifest.splitting is not None
         assert manifest.splitting.split_sizes
 
-    def test_non_s3_container_rejected(self) -> None:
+    def test_unsupported_container_rejected(self) -> None:
         gcs_container = icechunk.VirtualChunkContainer(
             "gs://bucket/", icechunk.gcs_store()
         )
@@ -440,8 +440,29 @@ class TestIcechunkVirtualConfig:
                 manifest_split=manifest_append_dim_split(split_size=1, dim="init_time"),
             ),
         )
-        with pytest.raises(AssertionError, match="non-S3 store"):
+        with pytest.raises(AssertionError, match="unsupported store"):
             factory.icechunk_repos(sort="primary-first")
+
+    def test_local_filesystem_container_accepted(self) -> None:
+        # Local-filesystem containers (dev/test sources) need no credentials.
+        local_container = icechunk.VirtualChunkContainer(
+            "file:///data/", icechunk.local_filesystem_store("/data/")
+        )
+        factory = StoreFactory(
+            primary_storage_config=StorageConfig(
+                base_path="s3://bucket/data", format=DatasetFormat.ICECHUNK
+            ),
+            dataset_id="test-dataset",
+            template_config_version="v1.0",
+            icechunk_virtual_config=IcechunkVirtualConfig(
+                containers=(local_container,),
+                manifest_split=manifest_append_dim_split(split_size=1, dim="init_time"),
+            ),
+        )
+        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        containers = repo.config.virtual_chunk_containers
+        assert containers is not None
+        assert "file:///data/" in containers
 
     def test_materialized_factory_registers_no_containers(self) -> None:
         factory = StoreFactory(

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -355,7 +355,7 @@ class TestIcechunkRepos:
             dataset_id="test-dataset",
             template_config_version="v1.0",
         )
-        repos = factory.icechunk_repos(sort="primary-first")
+        repos = factory.all_icechunk_repos(sort="primary-first")
         assert len(repos) == 1
         assert repos[0][0] == "replica-0"
 
@@ -367,7 +367,7 @@ class TestIcechunkRepos:
             dataset_id="test-dataset",
             template_config_version="v1.0",
         )
-        assert factory.icechunk_repos(sort="primary-first") == []
+        assert factory.all_icechunk_repos(sort="primary-first") == []
 
     def test_primary_comes_first(self) -> None:
         factory = StoreFactory(
@@ -382,7 +382,7 @@ class TestIcechunkRepos:
             dataset_id="test-dataset",
             template_config_version="v1.0",
         )
-        repos = factory.icechunk_repos(sort="primary-first")
+        repos = factory.all_icechunk_repos(sort="primary-first")
         assert len(repos) == 2
         assert repos[0][0] == "primary"
         assert repos[1][0] == "replica-0"
@@ -416,7 +416,7 @@ class TestIcechunkVirtualConfig:
             icechunk_virtual_config=_example_virtual_config(),
         )
         # icechunk_repos opens (and so creates) the repo with our override config.
-        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        repo = factory.all_icechunk_repos(sort="primary-first")[0][1]
         containers = repo.config.virtual_chunk_containers
         assert containers is not None
         assert "s3://noaa-gfs-bdp-pds/" in containers
@@ -441,7 +441,7 @@ class TestIcechunkVirtualConfig:
             ),
         )
         with pytest.raises(AssertionError, match="unsupported store"):
-            factory.icechunk_repos(sort="primary-first")
+            factory.all_icechunk_repos(sort="primary-first")
 
     def test_local_filesystem_container_accepted(self) -> None:
         # Local-filesystem containers (dev/test sources) need no credentials.
@@ -459,7 +459,7 @@ class TestIcechunkVirtualConfig:
                 manifest_split=manifest_append_dim_split(split_size=1, dim="init_time"),
             ),
         )
-        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        repo = factory.all_icechunk_repos(sort="primary-first")[0][1]
         containers = repo.config.virtual_chunk_containers
         assert containers is not None
         assert "file:///data/" in containers
@@ -472,7 +472,7 @@ class TestIcechunkVirtualConfig:
             dataset_id="test-dataset",
             template_config_version="v1.0",
         )
-        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        repo = factory.all_icechunk_repos(sort="primary-first")[0][1]
         assert not repo.config.virtual_chunk_containers
 
 
@@ -492,7 +492,7 @@ class TestBranchSupport:
         snapshot = store.session.commit(message="init")
 
         # Create a branch at the current snapshot
-        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        repo = factory.all_icechunk_repos(sort="primary-first")[0][1]
         repo.create_branch("test-branch", snapshot)
 
         # Open on the new branch
@@ -579,7 +579,7 @@ class TestIcechunkPrimaryWithZarr3Replica:
             dataset_id="test-dataset",
             template_config_version="v1.0",
         )
-        repos = factory.icechunk_repos(sort="primary-first")
+        repos = factory.all_icechunk_repos(sort="primary-first")
         assert len(repos) == 1
         assert repos[0][0] == "primary"
 
@@ -594,8 +594,31 @@ class TestIcechunkPrimaryWithZarr3Replica:
             dataset_id="test-dataset",
             template_config_version="v1.0",
         )
-        repos = factory.icechunk_repos(sort="primary-last")
+        repos = factory.all_icechunk_repos(sort="primary-last")
         assert [role for role, _repo in repos] == ["primary"]
+
+    def test_icechunk_repos_returns_primary_and_replicas(self) -> None:
+        """The no-arg icechunk_repos returns (primary_repo, (replica_repos, ...))."""
+        factory = StoreFactory(
+            primary_storage_config=StorageConfig(
+                base_path="s3://bucket/primary", format=DatasetFormat.ICECHUNK
+            ),
+            replica_storage_configs=[
+                StorageConfig(
+                    base_path="s3://bucket/replica-0", format=DatasetFormat.ICECHUNK
+                ),
+            ],
+            dataset_id="test-dataset",
+            template_config_version="v1.0",
+        )
+        primary_repo, replica_repos = factory.icechunk_repos()
+        assert isinstance(primary_repo, icechunk.Repository)
+        assert len(replica_repos) == 1
+        assert isinstance(replica_repos[0], icechunk.Repository)
+        # primary + replicas accounts for every repo the role-based accessor returns.
+        assert 1 + len(replica_repos) == len(
+            factory.all_icechunk_repos(sort="primary-first")
+        )
 
 
 class TestCommitIfIcechunkFailureIsolation:
@@ -668,7 +691,7 @@ class TestPrimaryStoreReadonly:
         # Create a branch so we can open readonly on something other than main.
         # Point it at the initial snapshot so we can distinguish it from main
         # after a subsequent commit on main.
-        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        repo = factory.all_icechunk_repos(sort="primary-first")[0][1]
         repo.create_branch("ro-branch", branch_snapshot)
         # Advance main past the branch point.
         writable_again = factory.primary_store(writable=True)

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -24,7 +24,7 @@ import pytest
 import xarray as xr
 import zarr
 from gribberish.zarr import GribberishCodec
-from pydantic import computed_field
+from pydantic import ValidationError, computed_field
 from zarr.core.metadata import ArrayV3Metadata
 
 from reformatters.common import template_utils, validation
@@ -400,6 +400,25 @@ def test_needed_append_dim_size() -> None:
     assert job._needed_append_dim_size(refs) == 3  # init index 2 -> size 3
 
 
+def test_processing_region_rejects_buffered_region() -> None:
+    # Buffering is meaningless for virtual datasets and would make adjacent
+    # backfill workers emit refs into each other's regions.
+    class BufferedJob(VirtualTestRegionJob):
+        def get_processing_region(self) -> slice:
+            return slice(self.region.start - 1, self.region.stop + 1)
+
+    job = BufferedJob(
+        tmp_store=Path("unused-tmp.zarr"),
+        template_ds=_create_template_ds(4),
+        data_vars=[VirtualTestDataVar(name="temperature_2m")],
+        append_dim="init_time",
+        region=slice(1, 3),
+        reformat_job_name="test",
+    )
+    with pytest.raises(AssertionError, match="get_processing_region must equal"):
+        job._processing_region_ds()
+
+
 def test_process_virtual_rejects_empty_batch(tmp_path: Path) -> None:
     # The generator contract is one commit's worth of whole files per yield, so an
     # empty batch is a bug (and an empty icechunk commit would raise). The loop
@@ -496,6 +515,48 @@ def test_sync_dims_to_grows_then_is_noop(tmp_path: Path) -> None:
     assert not session.has_uncommitted_changes
 
 
+def test_sync_dims_to_resizes_each_store_from_its_own_size(tmp_path: Path) -> None:
+    """Replicas commit before the primary, so a partial commit can leave a replica
+    ahead. sync_dims_to must append each store's own missing slice; appending the
+    primary's slice to an already-grown store would duplicate positions.
+
+    The test harness maps every store of one dataset to a single path, so we stand
+    in for the ahead replica with a second, independent repo.
+    """
+    dataset = _make_dataset(tmp_path)
+    template_utils.write_metadata(_create_template_ds(0), dataset.store_factory)
+    primary_repo = _primary_repo(dataset.store_factory)
+
+    ahead_repo = icechunk.Repository.create(
+        icechunk.local_filesystem_storage(str(tmp_path / "ahead.icechunk"))
+    )
+    template_utils.write_metadata(
+        _create_template_ds(0), ahead_repo.writable_session("main").store, mode="w-"
+    )
+
+    full_template = _create_template_ds(4)
+    job = _make_region_job(full_template, region=slice(0, 4))
+
+    # The ahead store committed a grow to 3 while the primary stayed at 0.
+    ahead_session = ahead_repo.writable_session("main")
+    job.sync_dims_to([ahead_session.store], 3)
+    ahead_session.commit("ahead store grew before a partial commit")
+
+    primary_session = primary_repo.writable_session("main")
+    ahead_session = ahead_repo.writable_session("main")
+    job.sync_dims_to([primary_session.store, ahead_session.store], 3)
+    # The ahead store already covers 3 -> untouched; only the primary grows.
+    assert not ahead_session.has_uncommitted_changes
+    primary_session.commit("primary catches up")
+
+    for repo in (primary_repo, ahead_repo):
+        ds = xr.open_zarr(repo.readonly_session("main").store, decode_timedelta=True)
+        assert ds.sizes["init_time"] == 3
+        np.testing.assert_array_equal(
+            ds["init_time"].values, full_template["init_time"].values[:3]
+        )
+
+
 def test_yield_is_the_commit_unit(tmp_path: Path) -> None:
     dataset = _make_dataset(tmp_path)
     template_ds = _create_template_ds(4)
@@ -511,6 +572,15 @@ def test_yield_is_the_commit_unit(tmp_path: Path) -> None:
 
 
 # --- driver fork integration (operational + backfill routing) ---
+
+
+def test_virtual_region_job_requires_virtual_config(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="icechunk_virtual_config"):
+        VirtualTestDataset(
+            primary_storage_config=StorageConfig(
+                base_path=str(tmp_path), format=DatasetFormat.ICECHUNK
+            ),
+        )
 
 
 def test_two_worker_backfill_disjoint(tmp_path: Path) -> None:

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -560,15 +560,7 @@ def test_virtual_operational_single_writer_expands_main(tmp_path: Path) -> None:
         full_template, region=slice(0, 4), deadline=pd.Timestamp("2100-01-01")
     )
 
-    dataset._process_region_jobs(
-        all_jobs=[job],
-        worker_index=0,
-        workers_total=1,
-        reformat_job_name="test",
-        template_ds=full_template,
-        tmp_store=dataset._tmp_store(),
-        update_template_with_results=True,
-    )
+    dataset._run_virtual_operational_update([job], workers_total=1)
 
     # Single writer committed straight to main (no temp branch ever created).
     assert list(_primary_repo(dataset.store_factory).list_branches()) == ["main"]
@@ -584,15 +576,7 @@ def test_virtual_operational_second_fire_sees_no_new_work(tmp_path: Path) -> Non
         job = _make_region_job(
             full_template, region=slice(0, 4), deadline=pd.Timestamp("2100-01-01")
         )
-        dataset._process_region_jobs(
-            all_jobs=[job],
-            worker_index=0,
-            workers_total=1,
-            reformat_job_name="test",
-            template_ds=full_template,
-            tmp_store=dataset._tmp_store(),
-            update_template_with_results=True,
-        )
+        dataset._run_virtual_operational_update([job], workers_total=1)
 
     fire()
     repo = _primary_repo(dataset.store_factory)

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -40,7 +40,6 @@ from reformatters.common.region_job import (
     CoordinateValue,
     SourceFileCoord,
     VirtualRef,
-    VirtualRefBatch,
     VirtualRegionJob,
 )
 from reformatters.common.storage import (
@@ -196,11 +195,11 @@ class VirtualTestRegionJob(
     def process_virtual_refs(
         self,
         remaining: Sequence[VirtualTestSourceFileCoord],
-    ) -> Iterator[VirtualRefBatch]:
-        batch_files = self.backfill_batch_files
+    ) -> Iterator[Sequence[VirtualRef]]:
+        data_var = self.data_vars[0]
         init_index = self.template_ds.get_index("init_time")
         lead_index = self.template_ds.get_index("lead_time")
-        for group in batched(remaining, batch_files, strict=False):
+        for group in batched(remaining, self.backfill_batch_files, strict=False):
             refs: list[VirtualRef] = []
             for coord in group:
                 init_idx = int(init_index.get_indexer(pd.Index([coord.init_time]))[0])
@@ -208,14 +207,14 @@ class VirtualTestRegionJob(
                 offset, length = _message_offset_length(init_idx, lead_idx)
                 refs.append(
                     VirtualRef(
-                        var_name="temperature_2m",
+                        data_var=data_var,
                         out_loc=coord.out_loc(),
                         location=self.messages_url,
                         offset=offset,
                         length=length,
                     )
                 )
-            yield VirtualRefBatch(source_coords=list(group), refs=refs)
+            yield refs
 
 
 class VirtualTestTemplateConfig(TemplateConfig[VirtualTestDataVar]):
@@ -319,7 +318,7 @@ def _make_region_job(
 
 
 def _primary_repo(factory: StoreFactory) -> icechunk.Repository:
-    return factory.icechunk_repos(sort="primary-first")[0][1]
+    return factory.all_icechunk_repos(sort="primary-first")[0][1]
 
 
 def _snapshot_count(repo: icechunk.Repository, branch: str = "main") -> int:
@@ -388,7 +387,7 @@ def test_needed_append_dim_size() -> None:
     job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
     refs = [
         VirtualRef(
-            "temperature_2m",
+            VirtualTestDataVar(name="temperature_2m"),
             {
                 "init_time": APPEND_DIM_START + 2 * APPEND_DIM_FREQ,
                 "lead_time": LEAD_TIMES[0],
@@ -414,8 +413,8 @@ def test_process_virtual_rejects_empty_batch(tmp_path: Path) -> None:
         def process_virtual_refs(
             self,
             remaining: Sequence[VirtualTestSourceFileCoord],  # noqa: ARG002
-        ) -> Iterator[VirtualRefBatch]:
-            yield VirtualRefBatch(source_coords=[], refs=[])
+        ) -> Iterator[Sequence[VirtualRef]]:
+            yield []
 
     job = EmptyBatchJob(
         tmp_store=Path("unused-tmp.zarr"),
@@ -440,8 +439,7 @@ def test_backfill_emits_refs_and_reads_back_values(tmp_path: Path) -> None:
 
     repo = _primary_repo(dataset.store_factory)
     job = _make_region_job(template_ds, region=slice(0, 4))
-    results = job.process_virtual(repo, [], "main")
-    assert set(results) == {"temperature_2m"}
+    job.process_virtual(repo, [], "main")
 
     _assert_all_values(dataset, n_inits=4)
 
@@ -458,8 +456,7 @@ def test_filter_skips_already_present_refs(tmp_path: Path) -> None:
 
     # Second run: every candidate is already present, so the filter drops them
     # all, the generator yields nothing, and no new commit is made.
-    results = job.process_virtual(repo, [], "main")
-    assert results == {}
+    job.process_virtual(repo, [], "main")
     assert _snapshot_count(repo) == snapshots_after_first
 
     candidates = job.generate_source_file_coords(
@@ -599,7 +596,7 @@ def test_serializer_threads_through_expansion_without_decoding(tmp_path: Path) -
         [session.store],
         [
             VirtualRef(
-                "temperature_2m",
+                job.data_vars[0],
                 {"init_time": new_init, "lead_time": LEAD_TIMES[0]},
                 VirtualTestRegionJob.messages_url,
                 *_message_offset_length(1, 0),

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -1,0 +1,644 @@
+"""Tests for VirtualRegionJob and the virtual fork in _process_region_jobs.
+
+The synthetic dataset below stores its "GRIB messages" as raw little-endian
+float64 blocks in a local file and points virtual refs at byte ranges within it,
+using a local-filesystem virtual chunk container. The data var uses zarr's
+default BytesCodec (no GribberishCodec), so a real value read-back round-trip
+catches bad chunk keys *and* bad byte ranges without needing real GRIB. A
+separate test pins that a GribberishCodec serializer threads through dimension
+expansion without the decode-only codec ever being invoked.
+"""
+
+import asyncio
+from collections.abc import Iterator, Mapping, Sequence
+from datetime import timedelta
+from itertools import batched
+from pathlib import Path
+from typing import Any, ClassVar
+
+import dask.array
+import icechunk
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+import zarr
+from gribberish.zarr import GribberishCodec
+from pydantic import computed_field
+from zarr.core.metadata import ArrayV3Metadata
+
+from reformatters.common import template_utils, validation
+from reformatters.common.config_models import (
+    BaseInternalAttrs,
+    DataVar,
+    DataVarAttrs,
+    Encoding,
+)
+from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
+from reformatters.common.region_job import (
+    CoordinateValue,
+    SourceFileCoord,
+    VirtualRef,
+    VirtualRefBatch,
+    VirtualRegionJob,
+)
+from reformatters.common.storage import (
+    DatasetFormat,
+    IcechunkVirtualConfig,
+    StorageConfig,
+    StoreFactory,
+    manifest_append_dim_split,
+)
+from reformatters.common.template_config import TemplateConfig
+from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
+
+pytestmark = pytest.mark.slow
+
+N_LAT = 2
+N_LON = 3
+LEAD_TIMES = pd.timedelta_range("0h", periods=2, freq="6h")
+N_LEADS = len(LEAD_TIMES)
+BLOCK_NBYTES = N_LAT * N_LON * 8  # one float64 message
+APPEND_DIM_START = pd.Timestamp("2024-01-01")
+APPEND_DIM_FREQ = pd.Timedelta("6h")
+DATASET_ID = "test-virtual-dataset"
+
+
+def _block_values(init_idx: int, lead_idx: int) -> np.ndarray:
+    """Deterministic per-message values; distinct per (init, lead)."""
+    base = 1000.0 * init_idx + 10.0 * lead_idx
+    return (base + np.arange(N_LAT * N_LON)).reshape(N_LAT, N_LON).astype("<f8")
+
+
+def _message_offset_length(init_idx: int, lead_idx: int) -> tuple[int, int]:
+    order = init_idx * N_LEADS + lead_idx
+    return order * BLOCK_NBYTES, BLOCK_NBYTES
+
+
+def _write_messages_file(path: Path, n_inits: int) -> None:
+    blocks = [
+        _block_values(init_idx, lead_idx).tobytes()
+        for init_idx in range(n_inits)
+        for lead_idx in range(N_LEADS)
+    ]
+    path.write_bytes(b"".join(blocks))
+
+
+def _create_template_ds(
+    n_inits: int, *, serializer: dict[str, Any] | None = None
+) -> xr.Dataset:
+    """Forecast-shaped virtual template (no shards; one chunk per message)."""
+    init_times = pd.date_range(APPEND_DIM_START, periods=n_inits, freq=APPEND_DIM_FREQ)
+    encoding: dict[str, Any] = {
+        "dtype": "float64",
+        "chunks": (1, 1, N_LAT, N_LON),
+        "fill_value": np.nan,
+        "compressors": None,
+        "filters": None,
+    }
+    if serializer is not None:
+        encoding["serializer"] = serializer
+    ds = xr.Dataset(
+        {
+            "temperature_2m": xr.Variable(
+                ("init_time", "lead_time", "latitude", "longitude"),
+                dask.array.full(
+                    (n_inits, N_LEADS, N_LAT, N_LON),
+                    np.nan,
+                    dtype="float64",
+                    chunks=-1,
+                ),
+                encoding=encoding,
+            )
+        },
+        coords={
+            "init_time": ("init_time", init_times),
+            "lead_time": ("lead_time", LEAD_TIMES),
+            "latitude": ("latitude", np.arange(N_LAT, dtype="float64")),
+            "longitude": ("longitude", np.arange(N_LON, dtype="float64")),
+            "valid_time": (
+                ("init_time", "lead_time"),
+                init_times.values[:, None] + LEAD_TIMES.values[None, :],
+            ),
+        },
+        attrs={"dataset_id": DATASET_ID, "dataset_version": "v1.0"},
+    )
+    # Explicit time encodings so dimension-appends re-encode consistently.
+    time_encoding = {
+        "dtype": "int64",
+        "fill_value": -1,
+        "units": "seconds since 1970-01-01 00:00:00",
+        "calendar": "proleptic_gregorian",
+    }
+    ds["init_time"].encoding.update(time_encoding)
+    ds["valid_time"].encoding.update(time_encoding)
+    ds["lead_time"].encoding.update(
+        {"dtype": "int64", "fill_value": -1, "units": "seconds"}
+    )
+    ds["latitude"].encoding["fill_value"] = np.nan
+    ds["longitude"].encoding["fill_value"] = np.nan
+    return ds
+
+
+# --- synthetic virtual forecast dataset ---
+
+
+class VirtualTestDataVar(DataVar[BaseInternalAttrs]):
+    encoding: Encoding = Encoding(
+        dtype="float64",
+        fill_value=np.nan,
+        chunks=(1, 1, N_LAT, N_LON),  # one chunk per (init, lead) message
+        shards=None,
+        compressors=None,
+        filters=None,
+    )
+    attrs: DataVarAttrs = DataVarAttrs(
+        units="K",
+        long_name="Temperature 2m",
+        short_name="2t",
+        step_type="instant",
+    )
+    internal_attrs: BaseInternalAttrs = BaseInternalAttrs(
+        keep_mantissa_bits="no-rounding"
+    )
+
+
+class VirtualTestSourceFileCoord(SourceFileCoord):
+    init_time: Timestamp
+    lead_time: Timedelta
+
+    def get_url(self) -> str:
+        return VirtualTestRegionJob.messages_url
+
+
+class VirtualTestRegionJob(
+    VirtualRegionJob[VirtualTestDataVar, VirtualTestSourceFileCoord]
+):
+    # Set per test by _make_dataset; the generator points every ref at this file.
+    messages_url: ClassVar[str] = ""
+    # Whole files per yielded batch during backfill (operational yields 1 at a time).
+    backfill_batch_files: ClassVar[int] = 2
+
+    def generate_source_file_coords(
+        self,
+        processing_region_ds: xr.Dataset,
+        data_var_group: Sequence[VirtualTestDataVar],  # noqa: ARG002
+    ) -> Sequence[VirtualTestSourceFileCoord]:
+        return [
+            VirtualTestSourceFileCoord(
+                init_time=pd.Timestamp(init_time), lead_time=lead
+            )
+            for init_time in processing_region_ds["init_time"].values
+            for lead in LEAD_TIMES
+        ]
+
+    def process_virtual_refs(
+        self,
+        remaining: Sequence[VirtualTestSourceFileCoord],
+        deadline: Timestamp | None,
+    ) -> Iterator[VirtualRefBatch]:
+        batch_files = 1 if deadline is not None else self.backfill_batch_files
+        init_index = self.template_ds.get_index("init_time")
+        lead_index = self.template_ds.get_index("lead_time")
+        for group in batched(remaining, batch_files, strict=False):
+            refs: list[VirtualRef] = []
+            for coord in group:
+                init_idx = int(init_index.get_indexer(pd.Index([coord.init_time]))[0])
+                lead_idx = int(lead_index.get_indexer(pd.Index([coord.lead_time]))[0])
+                offset, length = _message_offset_length(init_idx, lead_idx)
+                refs.append(
+                    VirtualRef(
+                        var_name="temperature_2m",
+                        out_loc=coord.out_loc(),
+                        location=self.messages_url,
+                        offset=offset,
+                        length=length,
+                    )
+                )
+            yield VirtualRefBatch(source_coords=list(group), refs=refs)
+
+
+class VirtualTestTemplateConfig(TemplateConfig[VirtualTestDataVar]):
+    dims: tuple[Dim, ...] = ("init_time", "lead_time", "latitude", "longitude")
+    append_dim: AppendDim = "init_time"
+    append_dim_start: Timestamp = APPEND_DIM_START
+    append_dim_frequency: Timedelta = APPEND_DIM_FREQ
+
+    @computed_field
+    @property
+    def dataset_id(self) -> str:
+        return DATASET_ID
+
+    @computed_field
+    @property
+    def version(self) -> str:
+        return "v1.0"
+
+    @computed_field
+    @property
+    def data_vars(self) -> Sequence[VirtualTestDataVar]:
+        return [VirtualTestDataVar(name="temperature_2m")]
+
+
+class VirtualTestDataset(
+    DynamicalDataset[VirtualTestDataVar, VirtualTestSourceFileCoord]
+):
+    template_config: VirtualTestTemplateConfig = VirtualTestTemplateConfig()
+    region_job_class: type[VirtualTestRegionJob] = VirtualTestRegionJob
+
+    def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+        return [
+            ReformatCronJob(
+                name=f"{self.dataset_id}-update",
+                schedule="0 0 * * *",
+                pod_active_deadline=timedelta(minutes=5),
+                image=image_tag,
+                dataset_id=self.dataset_id,
+                cpu="1",
+                memory="1G",
+                shared_memory="1G",
+                ephemeral_storage="1G",
+                secret_names=self.store_factory.k8s_secret_names(),
+            ),
+            ValidationCronJob(
+                name=f"{self.dataset_id}-validate",
+                schedule="0 1 * * *",
+                pod_active_deadline=timedelta(minutes=5),
+                image=image_tag,
+                dataset_id=self.dataset_id,
+                cpu="1",
+                memory="1G",
+                shared_memory="1G",
+                ephemeral_storage="1G",
+                secret_names=self.store_factory.k8s_secret_names(),
+            ),
+        ]
+
+    def validators(self) -> Sequence[validation.DataValidator]:
+        return ()
+
+
+def _make_dataset(tmp_path: Path, *, n_inits: int = 4) -> VirtualTestDataset:
+    """Build the dataset, write the messages file, and point the region job at it.
+
+    The virtual chunk container is a local-filesystem store rooted at tmp_path;
+    refs point at tmp_path/messages.bin.
+    """
+    messages_path = tmp_path / "messages.bin"
+    _write_messages_file(messages_path, n_inits=max(n_inits, 4))
+    VirtualTestRegionJob.messages_url = f"file://{messages_path}"
+    VirtualTestRegionJob.backfill_batch_files = 2
+
+    container = icechunk.VirtualChunkContainer(
+        f"file://{tmp_path}/", icechunk.local_filesystem_store(str(tmp_path))
+    )
+    return VirtualTestDataset(
+        primary_storage_config=StorageConfig(
+            base_path=str(tmp_path), format=DatasetFormat.ICECHUNK
+        ),
+        icechunk_virtual_config=IcechunkVirtualConfig(
+            containers=(container,),
+            manifest_split=manifest_append_dim_split(split_size=2, dim="init_time"),
+        ),
+    )
+
+
+def _make_region_job(
+    template_ds: xr.Dataset,
+    *,
+    region: slice,
+    deadline: Timestamp | None = None,
+) -> VirtualTestRegionJob:
+    return VirtualTestRegionJob(
+        tmp_store=Path("unused-tmp.zarr"),
+        template_ds=template_ds,
+        data_vars=[VirtualTestDataVar(name="temperature_2m")],
+        append_dim="init_time",
+        region=region,
+        reformat_job_name="test",
+        deadline=deadline,
+    )
+
+
+def _primary_repo(factory: StoreFactory) -> icechunk.Repository:
+    return factory.icechunk_repos(sort="primary-first")[0][1]
+
+
+def _snapshot_count(repo: icechunk.Repository, branch: str = "main") -> int:
+    return sum(1 for _ in repo.ancestry(branch=branch))
+
+
+def _assert_all_values(dataset: VirtualTestDataset, n_inits: int) -> None:
+    result = xr.open_zarr(dataset.store_factory.primary_store(), decode_timedelta=True)
+    assert result.sizes["init_time"] == n_inits
+    for init_idx in range(n_inits):
+        for lead_idx in range(N_LEADS):
+            np.testing.assert_array_equal(
+                result["temperature_2m"]
+                .isel(init_time=init_idx, lead_time=lead_idx)
+                .values,
+                _block_values(init_idx, lead_idx),
+            )
+
+
+# --- unit tests (chunk_key, sizing, commit guard) ---
+
+
+def test_chunk_key_maps_labels_to_index() -> None:
+    job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
+    var = job.data_vars[0]
+    out_loc: Mapping[Dim, CoordinateValue] = {
+        "init_time": APPEND_DIM_START + 2 * APPEND_DIM_FREQ,
+        "lead_time": LEAD_TIMES[1],
+    }
+    # init index 2, lead index 1; lat/lon are single full-width chunks at 0.
+    assert job.chunk_key(out_loc, var) == (2, 1, 0, 0)
+
+
+def test_chunk_key_returns_none_for_unknown_label() -> None:
+    job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
+    out_loc: Mapping[Dim, CoordinateValue] = {
+        "init_time": pd.Timestamp("2030-01-01"),  # not in the template's coords
+        "lead_time": LEAD_TIMES[0],
+    }
+    assert job.chunk_key(out_loc, job.data_vars[0]) is None
+
+
+def test_chunk_key_asserts_on_unaligned_position() -> None:
+    job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
+    # A var whose lead_time chunk size is 2; lead index 1 falls mid-chunk.
+    var = VirtualTestDataVar(
+        name="temperature_2m",
+        encoding=Encoding(
+            dtype="float64",
+            fill_value=np.nan,
+            chunks=(1, 2, N_LAT, N_LON),
+            shards=None,
+            compressors=None,
+            filters=None,
+        ),
+    )
+    out_loc: Mapping[Dim, CoordinateValue] = {
+        "init_time": APPEND_DIM_START,
+        "lead_time": LEAD_TIMES[1],
+    }
+    with pytest.raises(AssertionError, match="chunk boundary"):
+        job.chunk_key(out_loc, var)
+
+
+def test_needed_append_dim_size() -> None:
+    job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
+    refs = [
+        VirtualRef(
+            "temperature_2m",
+            {
+                "init_time": APPEND_DIM_START + 2 * APPEND_DIM_FREQ,
+                "lead_time": LEAD_TIMES[0],
+            },
+            "file://x",
+            0,
+            BLOCK_NBYTES,
+        )
+    ]
+    assert job._needed_append_dim_size(refs) == 3  # init index 2 -> size 3
+
+
+def test_process_virtual_rejects_empty_batch(tmp_path: Path) -> None:
+    # The generator contract is one commit's worth of whole files per yield, so an
+    # empty batch is a bug (and an empty icechunk commit would raise). The loop
+    # asserts it loudly rather than silently no-opping.
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+
+    class EmptyBatchJob(VirtualTestRegionJob):
+        def process_virtual_refs(
+            self,
+            remaining: Sequence[VirtualTestSourceFileCoord],  # noqa: ARG002
+            deadline: Timestamp | None,  # noqa: ARG002
+        ) -> Iterator[VirtualRefBatch]:
+            yield VirtualRefBatch(source_coords=[], refs=[])
+
+    job = EmptyBatchJob(
+        tmp_store=Path("unused-tmp.zarr"),
+        template_ds=template_ds,
+        data_vars=[VirtualTestDataVar(name="temperature_2m")],
+        append_dim="init_time",
+        region=slice(0, 4),
+        reformat_job_name="test",
+    )
+    with pytest.raises(AssertionError, match="empty batch"):
+        job.process_virtual(repo, [], "main")
+
+
+# --- process_virtual integration (real value read-back) ---
+
+
+def test_backfill_emits_refs_and_reads_back_values(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    # Pre-size main with full metadata (as a backfill's parallel_setup would).
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+
+    repo = _primary_repo(dataset.store_factory)
+    job = _make_region_job(template_ds, region=slice(0, 4))
+    results = job.process_virtual(repo, [], "main")
+    assert set(results) == {"temperature_2m"}
+
+    _assert_all_values(dataset, n_inits=4)
+
+
+def test_filter_skips_already_present_refs(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+    job = _make_region_job(template_ds, region=slice(0, 4))
+
+    job.process_virtual(repo, [], "main")
+    snapshots_after_first = _snapshot_count(repo)
+
+    # Second run: every candidate is already present, so the filter drops them
+    # all, the generator yields nothing, and no new commit is made.
+    results = job.process_virtual(repo, [], "main")
+    assert results == {}
+    assert _snapshot_count(repo) == snapshots_after_first
+
+    candidates = job.generate_source_file_coords(
+        job._processing_region_ds(), job.data_vars
+    )
+    readonly = repo.readonly_session("main").store
+    assert job.filter_already_present(candidates, readonly) == []
+
+
+def test_sync_dims_to_grows_then_is_noop(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    # Initialize main empty (0 inits), as a virtual operational store starts.
+    template_utils.write_metadata(_create_template_ds(0), dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+    full_template = _create_template_ds(4)
+    job = _make_region_job(full_template, region=slice(0, 4))
+
+    session = repo.writable_session("main")
+    assert job._append_dim_size(session.store) == 0
+    job.sync_dims_to([session.store], 3)
+    session.commit("grow to 3")
+
+    grown = xr.open_zarr(dataset.store_factory.primary_store(), decode_timedelta=True)
+    assert grown.sizes["init_time"] == 3
+    # Derived coord (dims init_time x lead_time) expanded alongside the append dim.
+    assert grown["valid_time"].sizes["init_time"] == 3
+    np.testing.assert_array_equal(
+        grown["valid_time"].values, full_template["valid_time"].values[:3]
+    )
+    np.testing.assert_array_equal(
+        grown["init_time"].values, full_template["init_time"].values[:3]
+    )
+
+    # Already covered -> no-op (no write, session stays clean).
+    session = repo.writable_session("main")
+    job.sync_dims_to([session.store], 3)
+    assert not session.has_uncommitted_changes
+
+
+def test_yield_is_the_commit_unit(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+
+    # 4 inits x 2 leads = 8 candidate files, batched 2 at a time -> 4 yields.
+    VirtualTestRegionJob.backfill_batch_files = 2
+    job = _make_region_job(template_ds, region=slice(0, 4))
+    before = _snapshot_count(repo)
+    job.process_virtual(repo, [], "main")
+    assert _snapshot_count(repo) - before == 4
+
+
+# --- driver fork integration (operational + backfill routing) ---
+
+
+def test_two_worker_backfill_disjoint(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+
+    all_jobs = VirtualTestRegionJob.get_jobs(
+        tmp_store=dataset._tmp_store(),
+        template_ds=template_ds,
+        append_dim="init_time",
+        all_data_vars=dataset.template_config.data_vars,
+        reformat_job_name="test",
+    )
+    # shards=None -> partition by chunks -> one region (one init) per job.
+    assert len(all_jobs) == 4
+
+    for worker_index in range(2):
+        dataset._process_region_jobs(
+            all_jobs=all_jobs,
+            worker_index=worker_index,
+            workers_total=2,
+            reformat_job_name="test",
+            template_ds=template_ds,
+            tmp_store=dataset._tmp_store(),
+            update_template_with_results=False,
+        )
+
+    _assert_all_values(dataset, n_inits=4)
+    # Temp branch cleaned up after finalize.
+    assert list(_primary_repo(dataset.store_factory).list_branches()) == ["main"]
+
+
+def test_virtual_operational_single_writer_expands_main(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    # Start with an empty main (no future NaNs), then operationally expand it.
+    template_utils.write_metadata(_create_template_ds(0), dataset.store_factory)
+    full_template = _create_template_ds(4)
+    job = _make_region_job(
+        full_template, region=slice(0, 4), deadline=pd.Timestamp("2100-01-01")
+    )
+
+    dataset._process_region_jobs(
+        all_jobs=[job],
+        worker_index=0,
+        workers_total=1,
+        reformat_job_name="test",
+        template_ds=full_template,
+        tmp_store=dataset._tmp_store(),
+        update_template_with_results=True,
+    )
+
+    # Single writer committed straight to main (no temp branch ever created).
+    assert list(_primary_repo(dataset.store_factory).list_branches()) == ["main"]
+    _assert_all_values(dataset, n_inits=4)
+
+
+def test_virtual_operational_second_fire_sees_no_new_work(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    template_utils.write_metadata(_create_template_ds(0), dataset.store_factory)
+    full_template = _create_template_ds(4)
+
+    def fire() -> None:
+        job = _make_region_job(
+            full_template, region=slice(0, 4), deadline=pd.Timestamp("2100-01-01")
+        )
+        dataset._process_region_jobs(
+            all_jobs=[job],
+            worker_index=0,
+            workers_total=1,
+            reformat_job_name="test",
+            template_ds=full_template,
+            tmp_store=dataset._tmp_store(),
+            update_template_with_results=True,
+        )
+
+    fire()
+    repo = _primary_repo(dataset.store_factory)
+    snapshots_after_first = _snapshot_count(repo)
+
+    fire()  # everything already present -> no new commits
+    assert _snapshot_count(repo) == snapshots_after_first
+
+
+def test_serializer_threads_through_expansion_without_decoding(tmp_path: Path) -> None:
+    """A GribberishCodec serializer (decode-only) must survive dimension expansion
+    and ref emit without ever being invoked. We never decode here (no real GRIB) -
+    we assert the codec persists in metadata and the ref lands in the manifest."""
+    dataset = _make_dataset(tmp_path)
+    serializer = GribberishCodec(var="TMP").to_dict()
+    template_utils.write_metadata(
+        _create_template_ds(1, serializer=serializer), dataset.store_factory
+    )
+    repo = _primary_repo(dataset.store_factory)
+
+    full_template = _create_template_ds(2, serializer=serializer)
+    job = _make_region_job(full_template, region=slice(0, 2))
+
+    session = repo.writable_session("main")
+    job.sync_dims_to([session.store], 2)
+    new_init = APPEND_DIM_START + APPEND_DIM_FREQ
+    job._emit_refs(
+        [session.store],
+        [
+            VirtualRef(
+                "temperature_2m",
+                {"init_time": new_init, "lead_time": LEAD_TIMES[0]},
+                VirtualTestRegionJob.messages_url,
+                *_message_offset_length(1, 0),
+            )
+        ],
+    )
+    session.commit("expand + ref")
+
+    readonly = repo.readonly_session("main").store
+    array = zarr.open_group(readonly, mode="r")["temperature_2m"]
+    assert isinstance(array, zarr.Array)
+    assert isinstance(array.metadata, ArrayV3Metadata)
+    codec_dicts = [
+        codec.to_dict() if hasattr(codec, "to_dict") else codec
+        for codec in array.metadata.codecs
+    ]
+    assert {"name": "gribberish", "configuration": {"var": "TMP"}} in codec_dicts
+    assert asyncio.run(readonly.exists("temperature_2m/c/1/0/0/0")) is True

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -196,9 +196,8 @@ class VirtualTestRegionJob(
     def process_virtual_refs(
         self,
         remaining: Sequence[VirtualTestSourceFileCoord],
-        deadline: Timestamp | None,
     ) -> Iterator[VirtualRefBatch]:
-        batch_files = 1 if deadline is not None else self.backfill_batch_files
+        batch_files = self.backfill_batch_files
         init_index = self.template_ds.get_index("init_time")
         lead_index = self.template_ds.get_index("lead_time")
         for group in batched(remaining, batch_files, strict=False):
@@ -308,7 +307,6 @@ def _make_region_job(
     template_ds: xr.Dataset,
     *,
     region: slice,
-    deadline: Timestamp | None = None,
 ) -> VirtualTestRegionJob:
     return VirtualTestRegionJob(
         tmp_store=Path("unused-tmp.zarr"),
@@ -317,7 +315,6 @@ def _make_region_job(
         append_dim="init_time",
         region=region,
         reformat_job_name="test",
-        deadline=deadline,
     )
 
 
@@ -417,7 +414,6 @@ def test_process_virtual_rejects_empty_batch(tmp_path: Path) -> None:
         def process_virtual_refs(
             self,
             remaining: Sequence[VirtualTestSourceFileCoord],  # noqa: ARG002
-            deadline: Timestamp | None,  # noqa: ARG002
         ) -> Iterator[VirtualRefBatch]:
             yield VirtualRefBatch(source_coords=[], refs=[])
 
@@ -556,9 +552,7 @@ def test_virtual_operational_single_writer_expands_main(tmp_path: Path) -> None:
     # Start with an empty main (no future NaNs), then operationally expand it.
     template_utils.write_metadata(_create_template_ds(0), dataset.store_factory)
     full_template = _create_template_ds(4)
-    job = _make_region_job(
-        full_template, region=slice(0, 4), deadline=pd.Timestamp("2100-01-01")
-    )
+    job = _make_region_job(full_template, region=slice(0, 4))
 
     dataset._run_virtual_operational_update([job], workers_total=1)
 
@@ -573,9 +567,7 @@ def test_virtual_operational_second_fire_sees_no_new_work(tmp_path: Path) -> Non
     full_template = _create_template_ds(4)
 
     def fire() -> None:
-        job = _make_region_job(
-            full_template, region=slice(0, 4), deadline=pd.Timestamp("2100-01-01")
-        )
+        job = _make_region_job(full_template, region=slice(0, 4))
         dataset._run_virtual_operational_update([job], workers_total=1)
 
     fire()


### PR DESCRIPTION
The virtual write path for [virtual Icechunk datasets](docs/plans/virtual_icechunk_datasets.md). `VirtualRegionJob` writes virtual chunk references (byte ranges into public GRIB files) into icechunk instead of materializing rechunked data. No behavior change for existing materialized datasets.

## What's here

- **`VirtualRegionJob`** (sibling of `MaterializedRegionJob`):
  - `process_virtual` runs the per-batch write loop. Each yielded batch (whole source files) commits on its **own fresh writable session** — a committed icechunk session is read-only, so the per-batch loop reopens a session from the repo.
  - `process_virtual_refs` — abstract generator; yields `VirtualRefBatch`es (one commit's worth of whole files).
  - `filter_already_present` — manifest probe via `store.exists` (no chunk fetch/decode), fanned out concurrently.
  - `sync_dims_to` — grows the append dim by appending the new slice of the already-derived template with `compute=False`, so data vars stay dask-lazy and the decode-only `GribberishCodec` is never invoked. No-op on a pre-sized backfill branch.
  - `chunk_key` — derives chunk indices from the full-size template (so it can't drift from what readers resolve and never re-reads the growing store); shared by filter and emit.
  - Emit via `set_virtual_refs` (explicit `VirtualChunkSpec` per ref — handles the common sparse one-message-per-cell packing; `set_virtual_refs_arr` is a later optimization).
- **Driver fork** in `_process_region_jobs`: virtual + operational → single-writer-to-`main` (no temp branch / `parallel_setup` / `finalize`) for ~5 s per-file visibility; virtual backfill → the existing temp-branch flow, routed through `process_virtual`.
- **`get_jobs` partitioning**: shards if present, else chunks (virtual arrays have no shards). Materialized partitioning is byte-for-byte unchanged.
- **storage**: `_virtual_repository_config_and_credentials` also accepts local-filesystem containers (no credentials) so dev/test virtual datasets can point at local files.

## On the commit guard

The plan called for guarding commits on `session.has_uncommitted_changes` (empty icechunk commits raise). In implementation the generator contract makes that unnecessary: every yield is a non-empty batch and emitting refs always dirties the session, so the commit is never empty; the empty-poll / all-present cases yield no batch and never reach the commit. The loop instead **asserts** `batch.refs` (loud, early failure on a contract violation) and `commit_if_icechunk` stays unconditional. Plan doc updated to match.

## Tests

A synthetic virtual dataset (local-filesystem container, raw-float64 "messages" file, default `BytesCodec`) drives:
- unit tests — `chunk_key` (index mapping, unknown-label → `None`, unaligned-position assert), `_needed_append_dim_size`, empty-batch contract;
- integration — emit → commit → reopen → **value** read-back (catches bad chunk keys *and* byte ranges), filter skips present, `sync_dims_to` grow-then-noop, yield-is-the-commit-unit, two-worker disjoint backfill on a branch, operational single-writer expansion + idempotent second fire;
- a `GribberishCodec` test pins that the serializer threads through expansion without the decode-only codec being invoked.

All of `tests/common` + `tests/example` (1230 tests) and `tests/noaa` pass; `ruff` + `ty` clean.

Part of #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)