### PR TITLE
Extract per-worker processing seam onto RegionJob (PR 3a)

### DIFF
--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -945,29 +945,60 @@ Mechanical; tests pass unchanged.
   open/create. Add the `DynamicalDataset` validator (virtual ⇒ all stores ICECHUNK
   ∧ non-empty containers).
 
-### PR #3 — `VirtualRegionJob` + driver
+### PR #3a — Worker-processing seam (materialized only)
+
+A behavior-preserving refactor that introduces the polymorphic seam 3b slots
+into, with **no virtual code** so it can land and be reviewed against the
+materialized test suite alone.
+
+- Add an abstract `process_worker_jobs(worker_jobs, store_factory, branch_name,
+  worker_index) -> dict[str, list[SourceFileResult]]` to `RegionJob`.
+- Move the open-stores → per-job `process()` → accumulate-results → commit body
+  out of `DynamicalDataset._process_region_jobs` and into
+  `MaterializedRegionJob.process_worker_jobs` (one commit per worker, exactly as
+  today). `_process_region_jobs` step 2 collapses to a single polymorphic call:
+  `self.region_job_class.process_worker_jobs(worker_jobs, self.store_factory,
+  branch_name, worker_index)`.
+- Each variant now owns its store/session lifecycle and commit cadence behind
+  this one call, so the coordinator names no concrete subclass. Materialized
+  region jobs (and their datasets/tests) are untouched; the seam is the only
+  change.
+
+### PR #3b — `VirtualRegionJob` (on the seam, B-method)
 
 The spike is already done (run ahead of this PR — see
-[Spike results](#spike-results)), so PR #3 is just the implementation it derisked.
+[Spike results](#spike-results)), so 3b is just the implementation it derisked,
+slotted onto 3a's seam.
 
-- Add `VirtualRegionJob` (the virtual write loop, `process_virtual_refs`
-  abstract generator, `filter_already_present` default, `sync_dims_to`,
-  `chunk_key`). Use `set_virtual_refs_arr` (columnar, zero-copy) for the emit
-  batches; `array.metadata.chunk_key_encoding.encode_chunk_key` + `store.exists`
-  for the filter.
-- Extend `_process_region_jobs` with the single fork (virtual + operational →
-  single-writer-to-`main`; else existing path). **Guard commits on
-  `session.has_uncommitted_changes`** — empty commits raise, and the shared
-  `storage.commit_if_icechunk` currently commits unconditionally, so either teach
-  it the guard or wrap the call.
+- Add `VirtualRegionJob` implementing `process_worker_jobs`: filter →
+  `process_virtual_refs` batches → per-batch **fresh writable session** (a
+  committed icechunk session is read-only) → `sync_dims_to` + emit + commit. The
+  variant difference from materialized is purely *batch count* (materialized
+  yields one commit's worth per worker; virtual yields many) — same seam, so
+  `_process_region_jobs` stays **variant-free**.
+- The **one** remaining driver fork is in `update()`: a virtual operational
+  update routes to the single-writer-streaming-to-`main` path
+  (`_run_virtual_operational_update`, which reuses the same per-batch loop on
+  `branch="main"` with no `parallel_setup`/`finalize`); everything else
+  (materialized backfill/update, virtual backfill) goes through the temp-branch
+  coordinator.
+- `VirtualRef` carries `(data_var, out_loc, location, offset, length)`; emit via
+  `set_virtual_refs` (explicit `VirtualChunkSpec`s);
+  `array.metadata.chunk_key_encoding.encode_chunk_key` + `store.exists` for the
+  filter. **No commit guard** — the generator contract forbids empty yields, so
+  the loop `assert`s `refs` and `commit_if_icechunk` stays unconditional.
+- Also lands: shards-else-chunks partitioning, the per-variable serializer
+  threading, the `StoreFactory.icechunk_repos()` accessor + local-filesystem
+  container support, per-store `sync_dims_to`, the virtual-region-job ⇒
+  `icechunk_virtual_config` validator, and the buffered-processing-region guard.
 - Document the `process_virtual_refs` generator contract: each yield is one
   commit's worth of whole files; operational yields ~1 file at a time for
-  per-file visibility, backfill yields batches of ~N files to amortize commit
-  overhead. No timer, no `max_seconds_between_commits` knob — the driver commits
-  on every yield.
+  per-file visibility, backfill can yield one big batch per worker (coarser
+  crash-recovery, fewer snapshots) — the generator owns batch size and stopping
+  (exhaust vs poll-until-deadline). No timer, no `max_seconds_between_commits`.
 - Integration tests: yield-count/grouping; concurrent disjoint-chunk backfill on
-  a branch; emit → commit → reopen → read-back round-trip (the spike already
-  proves this round-trip works on 2.0.5; the test pins it in CI).
+  a branch; operational single-writer expansion + idempotent second fire;
+  emit → commit → reopen → **value** read-back round-trip.
 
 ### PR #4 — First concrete virtual dataset (end to end)
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -19,7 +19,6 @@ from pydantic import Field, computed_field, model_validator
 
 from reformatters.common import (
     parallel_coordination,
-    storage,
     template_utils,
     validation,
 )
@@ -430,37 +429,15 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             icechunk_repos=icechunk_repos,
         )
 
-        # 2. Get stores and process jobs
-        worker_results: dict[str, list[SourceFileResult]] = {}
-        if worker_jobs:
-            primary_store = self.store_factory.primary_store(
-                writable=True, branch=branch_name
+        # 2. Process jobs. Each region job variant owns its own store/session
+        # lifecycle and commit cadence behind this one call.
+        worker_results: dict[str, list[SourceFileResult]] = (
+            self.region_job_class.process_worker_jobs(
+                worker_jobs, self.store_factory, branch_name, worker_index
             )
-            replica_stores = self.store_factory.replica_stores(
-                writable=True, branch=branch_name
-            )
-
-            for job in worker_jobs:
-                template_utils.write_metadata(job.template_ds, job.tmp_store)
-                results = job.process(
-                    primary_store=primary_store, replica_stores=replica_stores
-                )
-                for var_name, coords in results.items():
-                    worker_results.setdefault(var_name, []).extend(
-                        SourceFileResult(
-                            status=c.status,
-                            out_loc={**c.out_loc()},
-                            url=c.get_url(),
-                        )
-                        for c in coords
-                    )
-
-            now = pd.Timestamp.now(tz="UTC")
-            storage.commit_if_icechunk(
-                f"Update worker {worker_index} at {now.strftime('%Y-%m-%dT%H:%M:%SZ')}",
-                primary_store,
-                replica_stores,
-            )
+            if worker_jobs
+            else {}
+        )
 
         # 3. Write results and finalize
         if workers_total > 1:

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -25,6 +25,7 @@ from pydantic import (
 )
 from zarr.abc.store import Store
 
+from reformatters.common import storage, template_utils
 from reformatters.common.binary_rounding import round_float32_inplace
 from reformatters.common.config_models import DataVar
 from reformatters.common.iterating import dimension_slices, split_groups
@@ -422,6 +423,26 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             "Subclasses implement process() with variant-specific logic"
         )
 
+    @classmethod
+    def process_worker_jobs(
+        cls,
+        worker_jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
+        store_factory: storage.StoreFactory,
+        branch_name: str,
+        worker_index: int,
+    ) -> dict[str, list[SourceFileResult]]:
+        """Process one worker's region jobs against ``branch_name`` and return the
+        per-variable source file results.
+
+        Each variant owns its own store/session lifecycle and commit cadence, so the
+        shared coordinator (``DynamicalDataset._process_region_jobs``) drives every
+        variant through this one call. Implemented by the MaterializedRegionJob and
+        VirtualRegionJob subclasses.
+        """
+        raise NotImplementedError(
+            "Subclasses implement process_worker_jobs with variant-specific logic"
+        )
+
     def __repr__(self) -> str:
         return f"{type(self).__name__}(region=({self.region.start}, {self.region.stop}), data_vars={[v.name for v in self.data_vars]})"
 
@@ -507,6 +528,42 @@ class MaterializedRegionJob(
             round_float32_inplace(
                 data_array.values, keep_mantissa_bits=keep_mantissa_bits
             )
+
+    @classmethod
+    def process_worker_jobs(
+        cls,
+        worker_jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
+        store_factory: storage.StoreFactory,
+        branch_name: str,
+        worker_index: int,
+    ) -> dict[str, list[SourceFileResult]]:
+        """Write all of this worker's jobs to ``branch_name`` in a single commit."""
+        primary_store = store_factory.primary_store(writable=True, branch=branch_name)
+        replica_stores = store_factory.replica_stores(writable=True, branch=branch_name)
+
+        worker_results: dict[str, list[SourceFileResult]] = {}
+        for job in worker_jobs:
+            template_utils.write_metadata(job.template_ds, job.tmp_store)
+            results = job.process(
+                primary_store=primary_store, replica_stores=replica_stores
+            )
+            for var_name, coords in results.items():
+                worker_results.setdefault(var_name, []).extend(
+                    SourceFileResult(
+                        status=c.status,
+                        out_loc={**c.out_loc()},
+                        url=c.get_url(),
+                    )
+                    for c in coords
+                )
+
+        now = pd.Timestamp.now(tz="UTC")
+        storage.commit_if_icechunk(
+            f"Update worker {worker_index} at {now.strftime('%Y-%m-%dT%H:%M:%SZ')}",
+            primary_store,
+            replica_stores,
+        )
+        return worker_results
 
     def process(
         self,


### PR DESCRIPTION
**PR 3a of the Virtual Icechunk Datasets effort** (`Part of #513`). A small, behavior-preserving refactor that introduces the polymorphic seam the forthcoming `VirtualRegionJob` (3b) slots into — landed separately so it can be reviewed against the materialized test suite alone, with no virtual code in the diff.

## What changes

- Add an abstract `RegionJob.process_worker_jobs(worker_jobs, store_factory, branch_name, worker_index) -> dict[str, list[SourceFileResult]]`.
- Move the open-stores → per-job `process()` → accumulate-results → commit body out of `DynamicalDataset._process_region_jobs` and into `MaterializedRegionJob.process_worker_jobs` (still exactly one commit per worker).
- `_process_region_jobs` step 2 collapses to one polymorphic call; the coordinator no longer names a concrete region job variant.

## Why

Each region job variant owns a different commit cadence — materialized writes one commit per worker; the upcoming virtual variant writes many (one per source-file batch, because a committed icechunk session is read-only). Rather than fork the coordinator on the variant, the variant difference becomes "how many commit batches does a worker yield," owned behind this one call. 3b then adds `VirtualRegionJob.process_worker_jobs` and the coordinator stays variant-free; the only remaining fork is the genuinely-different single-writer-to-`main` operational lifecycle in `update()`.

See `docs/plans/virtual_icechunk_datasets.md` → Implementation plan → PR #3a / #3b.

## Testing

Behavior-preserving; covered by the existing materialized backfill/update paths. Full non-slow suite green (1289 passed), `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)