### PR TITLE
Move process() onto MaterializedRegionJob (virtual datasets PR 3d)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Use ECMWF variable name for `long_name` and ECMWF short name for `short_name`.  
 ### RegionJob
 Base class: `src/reformatters/common/region_job.py`, commented example subclass: `src/reformatters/example/region_job.py`.
 
-Defines the **process** for reformatting a region of the dataset: downloading, reading, and writing data. `RegionJob` is the shared base (partitioning via `get_jobs()`, `generate_source_file_coords()`, `operational_update_jobs()`, `update_template_with_results()`, and an abstract `process()`); `MaterializedRegionJob(RegionJob)` adds the concrete download → read → write pipeline (`download_file()`, `read_data()`, `apply_data_transformations()`, `process()` and the parallelism tunables). Materialized (rechunked) datasets subclass `MaterializedRegionJob`. Key responsibilities:
+Defines the **process** for reformatting a region of the dataset: downloading, reading, and writing data. `RegionJob` is the shared base (partitioning via `get_jobs()`, `generate_source_file_coords()`, `operational_update_jobs()`, `update_template_with_results()`); `MaterializedRegionJob(RegionJob)` adds the concrete download → read → write pipeline (`download_file()`, `read_data()`, `apply_data_transformations()`, `process()` and the parallelism tunables). Materialized (rechunked) datasets subclass `MaterializedRegionJob`. Key responsibilities:
 - Implement `generate_source_file_coords()` - list source files needed for a region
 - Implement `download_file()` - retrieve a source file to local disk
 - Implement `read_data()` - load data from a local file into a numpy array

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1153,7 +1153,7 @@ issue **#513** (its body holds the PR checklist; items are written "PR 1" not
 | PR 3a — worker-processing seam (materialized only) | **merged** (#649) | See [B-method](#decision-b-method). |
 | PR 3b — `VirtualRegionJob` on the seam | **merged** (#650) | Supersedes #648 (closed). |
 | PR 3c — move-only refactor | **merged** (#653) | Split `region_job.py` → `virtual_region_job.py` + `materialized_region_job.py`. |
-| PR 3d — move `process()` onto `MaterializedRegionJob` | **open** | Removes the base `process()` stub; materialized `process_worker_jobs` narrows its jobs. |
+| PR 3d — move `process()` onto `MaterializedRegionJob` | **open** (#654) | Removes the base `process()` stub; materialized `process_worker_jobs` narrows its jobs. |
 | PR 3e — consolidate processing-loop docs | not started | Authoritative seam/lifecycle docs in `docs/`, linked from code. |
 | PR 4 — first concrete virtual dataset | not started | First `-spatial` dataset end to end. |
 | PR 5 — persist container config | not started | `save_config()` on container drift; before first *externally published* virtual repo (first datasets run in prod unpublished). |

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -149,7 +149,7 @@ DynamicalDataset                          # unchanged single base
 
 RegionJob                                 # shared base: fields, get_jobs,
 │                                         #   source_groups, generate_source_file_coords,
-│                                         #   operational_update_jobs (abstract), process (abstract)
+│                                         #   operational_update_jobs (abstract)
 ├── MaterializedRegionJob                 # existing process() pipeline + hooks + tunables
 │   ├── NoaaGfsCommonRegionJob → NoaaGfsForecastRegionJob   (base swap only)
 │   ├── NoaaHrrrRegionJob → …                                (base swap only)
@@ -196,7 +196,7 @@ ride their parent's swap. Tests pass unchanged. This is PR #1 on its own.
 - `get_jobs()` — region × variable-group fan-out (see
   [Partitioning](#partitioning)).
 - `source_groups()`, `get_processing_region()`, `generate_source_file_coords()`
-  (abstract), `operational_update_jobs()` (abstract), `process()` (abstract),
+  (abstract), `operational_update_jobs()` (abstract),
   `process_worker_jobs()` (abstract; the per-worker seam).
 
 **`MaterializedRegionJob` (subclass):** today's `process()` body, the
@@ -1039,13 +1039,19 @@ slotted onto 3a's seam.
 Pull `VirtualRegionJob` into `common/virtual_region_job.py` and
 `MaterializedRegionJob` into `common/materialized_region_job.py`, out of the
 shared `common/region_job.py` (base `RegionJob` stays). Pure moves, no logic
-changes; tests pass unchanged. While doing it, **revisit `RegionJob.process`**:
-it's an abstract stub on the base that only `MaterializedRegionJob` implements
-(virtual writes via `process_virtual`). It currently stays on the base so the
-materialized `process_worker_jobs` loop — which receives base-typed jobs — type-
-checks; decide whether the split lets it live on `MaterializedRegionJob` instead.
+changes; tests pass unchanged.
 
-### PR #3d — Consolidate processing-loop docs
+### PR #3d — Move `process()` onto `MaterializedRegionJob`
+
+`process()` was an abstract stub on the base that only `MaterializedRegionJob`
+implements (virtual writes via `process_virtual`); it stayed on the base only so
+the materialized `process_worker_jobs` loop — which receives base-typed jobs —
+type-checked. It now lives only on `MaterializedRegionJob`, whose
+`process_worker_jobs` asserts all jobs are materialized and casts the sequence,
+mirroring the virtual side's isinstance narrowing to `VirtualRegionJob` before
+`process_virtual`.
+
+### PR #3e — Consolidate processing-loop docs
 
 How materialized and virtual datasets run their per-worker processing (the
 [seam](#the-worker-processing-seam), the two coordination lifecycles, commit
@@ -1145,9 +1151,10 @@ issue **#513** (its body holds the PR checklist; items are written "PR 1" not
 | PR 1 — extract `MaterializedRegionJob` | **merged** (#643) | `RegionJob` base + `MaterializedRegionJob(RegionJob)`; all datasets swapped base. |
 | PR 2 — prep | **merged** (#647) | ECMWF parser → `grib_message_byte_ranges_from_index`; `Encoding.serializer`; `gribberish~=0.30` (`gribberish.zarr.GribberishCodec`, `.to_dict()` → `{"name":"gribberish","configuration":{"var":...}}`); `IcechunkVirtualConfig` (real icechunk objects via `InstanceOf`) + `manifest_append_dim_split(*, split_size, dim)`; threaded through `StoreFactory`; validator (config present ⇒ all ICECHUNK). |
 | PR 3a — worker-processing seam (materialized only) | **merged** (#649) | See [B-method](#decision-b-method). |
-| PR 3b — `VirtualRegionJob` on the seam | **open** (#650) | Supersedes #648 (closed). Review rounds 1–5 addressed. |
-| PR 3c — move-only refactor | not started | Split `region_job.py` → `virtual_region_job.py` + `materialized_region_job.py`; revisit `RegionJob.process` stub. |
-| PR 3d — consolidate processing-loop docs | not started | Authoritative seam/lifecycle docs in `docs/`, linked from code. |
+| PR 3b — `VirtualRegionJob` on the seam | **merged** (#650) | Supersedes #648 (closed). |
+| PR 3c — move-only refactor | **merged** (#653) | Split `region_job.py` → `virtual_region_job.py` + `materialized_region_job.py`. |
+| PR 3d — move `process()` onto `MaterializedRegionJob` | **open** | Removes the base `process()` stub; materialized `process_worker_jobs` narrows its jobs. |
+| PR 3e — consolidate processing-loop docs | not started | Authoritative seam/lifecycle docs in `docs/`, linked from code. |
 | PR 4 — first concrete virtual dataset | not started | First `-spatial` dataset end to end. |
 | PR 5 — persist container config | not started | `save_config()` on container drift; before first *externally published* virtual repo (first datasets run in prod unpublished). |
 | PR 6 — second concrete virtual dataset | not started | Different provider, proves abstractions generalize. |
@@ -1344,8 +1351,8 @@ commit.
 ### TODO
 
 The remaining work is now sequenced as formal PRs in the
-[implementation plan](#implementation-plan): **PR #3c** (move-only refactor +
-`RegionJob.process` revisit), **PR #3d** (consolidate processing-loop docs),
+[implementation plan](#implementation-plan): **PR #3d** (move `process()` onto
+`MaterializedRegionJob`), **PR #3e** (consolidate processing-loop docs),
 **PR #4** (first concrete `-spatial` dataset — pick from
 [candidates](#candidate-first-datasets)), **PR #5** (persist container config via
 `save_config()` before the first externally published virtual repo), **PR #6**

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from http import HTTPStatus
 from multiprocessing.shared_memory import SharedMemory
 from pathlib import Path
-from typing import Any, ClassVar, Generic
+from typing import Any, ClassVar, Generic, cast
 
 import httpx
 import numpy as np
@@ -135,8 +135,14 @@ class MaterializedRegionJob(
         primary_store = store_factory.primary_store(writable=True, branch=branch_name)
         replica_stores = store_factory.replica_stores(writable=True, branch=branch_name)
 
+        assert all(isinstance(job, MaterializedRegionJob) for job in worker_jobs)
+        jobs = cast(
+            "Sequence[MaterializedRegionJob[DATA_VAR, SOURCE_FILE_COORD]]", worker_jobs
+        )
+        del worker_jobs
+
         worker_results: dict[str, list[SourceFileResult]] = {}
-        for job in worker_jobs:
+        for job in jobs:
             template_utils.write_metadata(job.template_ds, job.tmp_store)
             results = job.process(
                 primary_store=primary_store, replica_stores=replica_stores

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -411,23 +411,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         ]
         return all_jobs
 
-    def process(
-        self,
-        primary_store: Store,
-        replica_stores: list[Store],
-    ) -> Mapping[str, Sequence[SOURCE_FILE_COORD]]:
-        """
-        Process this region, writing chunk data to primary_store (and replica_stores)
-        and returning the per-variable source file coordinates with their final status.
-
-        Implemented by MaterializedRegionJob. (VirtualRegionJob writes via
-        process_virtual instead; this stub stays on the base so the materialized
-        process_worker_jobs loop, which receives base-typed jobs, type-checks.)
-        """
-        raise NotImplementedError(
-            "Subclasses implement process() with variant-specific logic"
-        )
-
     @classmethod
     def process_worker_jobs(
         cls,

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -216,10 +216,9 @@ def test_update_template(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_backfill(monkeypatch: pytest.MonkeyPatch) -> None:
-    mock_job0 = Mock()
-    mock_job0.summary = lambda: "job0-summary"
-    mock_job1 = Mock()
-    mock_job1.summary = lambda: "job1-summary"
+    # template_ds and tmp_store are pydantic fields, which Mock(spec=...) misses
+    mock_job0 = Mock(spec=ExampleRegionJob, template_ds=Mock(), tmp_store=Mock())
+    mock_job1 = Mock(spec=ExampleRegionJob, template_ds=Mock(), tmp_store=Mock())
     monkeypatch.setattr(
         ExampleRegionJob,
         "get_jobs",


### PR DESCRIPTION
Follow-up to #653 (PR 3c), part of #513.

`RegionJob.process()` was an abstract stub on the base that only `MaterializedRegionJob` implements — `VirtualRegionJob` writes via `process_virtual` instead, so calling `process` on a virtual job always raised. The stub existed only so the materialized `process_worker_jobs` loop, which receives base-typed jobs per the seam's signature, type-checked.

This moves `process()` fully onto `MaterializedRegionJob`. Its `process_worker_jobs` now asserts all worker jobs are materialized and casts the sequence, mirroring the virtual side's `assert isinstance(job, VirtualRegionJob)` narrowing before `process_virtual`.

Also:
- `test_backfill`'s mock jobs now `Mock(spec=ExampleRegionJob)` so they pass the isinstance check (`template_ds`/`tmp_store` set explicitly since `Mock(spec=...)` misses pydantic fields); drops the vestigial `.summary` lambdas.
- Plan doc: this becomes PR 3d; consolidate-processing-loop-docs bumps to PR 3e; status table refreshed (3b/3c merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)