### PR TITLE
Consolidate processing-loop docs (virtual datasets PR 3e)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ tests/                       # Mirrors src/ structure
 docs/
 ├── dataset_integration_guide.md      # Step-by-step new dataset integration walkthrough
 ├── parallel_processing.md            # How parallel writes coordinate across workers
+├── virtual_datasets.md               # Writing + reading virtual (chunk reference) Icechunk datasets
 ├── add_new_variable.md               # Add new variable to an existing dataset
 ├── validation.md                     # Run + read validation plots; data quality checklist
 ├── chunk_shard_layout_tool.md        # Zarr V3 chunk/shard layout optimizer

--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -12,6 +12,15 @@ Work is split along two axes:
 
 The Cartesian product of regions and variable groups produces the full job list. Each worker gets every Nth job.
 
+## The worker-processing seam
+
+`RegionJob.process_worker_jobs(worker_jobs, store_factory, branch_name, worker_index)` is the single polymorphic call the coordinator (`DynamicalDataset._process_region_jobs`) drives every dataset variant through. Each variant owns its store/session lifecycle and commit cadence behind it:
+
+- **Materialized** — opens stores once and writes all of the worker's jobs in a single commit.
+- **Virtual** — commits each batch of source-file refs as its generator yields them, because a committed icechunk session is read-only (see [virtual_datasets.md](virtual_datasets.md#the-write-loop)).
+
+The only fork outside this call is the coordination lifecycle: everything runs the parallel temp-branch flow below except virtual operational updates, which are single-writer (see below).
+
 ## Reader safety
 
 Readers must always see a consistent view — either the old data or the fully updated data, never a partial state with some variables or time steps missing.
@@ -34,7 +43,7 @@ All metadata and chunk writes happen on a temporary branch (`_job_{job_name}`). 
 
 Virtual Icechunk datasets (`VirtualRegionJob`) are the one exception to the temp-branch coordinator. Their *operational* updates run **single-writer** and commit whole source files straight to `main` as each arrives, so readers see new data within seconds rather than at finalization. There is no temp branch, no `parallel_setup`, no coordination files, and no finalization step — `update()` routes virtual operational updates to `_run_virtual_operational_update` instead of `_process_region_jobs`.
 
-This is safe because each commit contains a *whole* source file's references (all of its chunks), so a reader on `main` always sees either none or all of a file's data. Reader-visible atomicity comes from icechunk's per-commit transaction, not from a branch swap. See [docs/plans/virtual_icechunk_datasets.md](plans/virtual_icechunk_datasets.md).
+This is safe because each commit contains a *whole* source file's references (all of its chunks), so a reader on `main` always sees either none or all of a file's data. Reader-visible atomicity comes from icechunk's per-commit transaction, not from a branch swap. See [virtual_datasets.md](virtual_datasets.md).
 
 Virtual *backfills* are **not** an exception — they use the normal temp-branch coordinator above (parallel across workers, pre-sized branch, finalize resets `main`).
 

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1153,8 +1153,8 @@ issue **#513** (its body holds the PR checklist; items are written "PR 1" not
 | PR 3a — worker-processing seam (materialized only) | **merged** (#649) | See [B-method](#decision-b-method). |
 | PR 3b — `VirtualRegionJob` on the seam | **merged** (#650) | Supersedes #648 (closed). |
 | PR 3c — move-only refactor | **merged** (#653) | Split `region_job.py` → `virtual_region_job.py` + `materialized_region_job.py`. |
-| PR 3d — move `process()` onto `MaterializedRegionJob` | **open** (#654) | Removes the base `process()` stub; materialized `process_worker_jobs` narrows its jobs. |
-| PR 3e — consolidate processing-loop docs | not started | Authoritative seam/lifecycle docs in `docs/`, linked from code. |
+| PR 3d — move `process()` onto `MaterializedRegionJob` | **merged** (#654) | Removes the base `process()` stub; materialized `process_worker_jobs` narrows its jobs. |
+| PR 3e — consolidate processing-loop docs | **open** (#655) | `docs/virtual_datasets.md` + seam section in `docs/parallel_processing.md`, linked from code. |
 | PR 4 — first concrete virtual dataset | not started | First `-spatial` dataset end to end. |
 | PR 5 — persist container config | not started | `save_config()` on container drift; before first *externally published* virtual repo (first datasets run in prod unpublished). |
 | PR 6 — second concrete virtual dataset | not started | Different provider, proves abstractions generalize. |

--- a/docs/virtual_datasets.md
+++ b/docs/virtual_datasets.md
@@ -1,0 +1,54 @@
+# Virtual Datasets
+
+A virtual dataset is an Icechunk store whose chunks are references — `(location, offset, length)` pointers into source files (e.g. GRIB messages) on the provider's object store — rather than copied bytes. A per-variable zarr serializer (e.g. `GribberishCodec`) decodes the referenced bytes at read time. Virtual datasets are written by `VirtualRegionJob` subclasses (`src/reformatters/common/virtual_region_job.py`).
+
+How virtual jobs plug into worker parallelism and coordination is covered in [parallel_processing.md](parallel_processing.md); this doc covers what is specific to writing and reading virtual datasets.
+
+## The write loop
+
+`VirtualRegionJob.process_virtual` runs the same loop for backfills and operational updates; only the branch differs (a temp branch for backfill, `main` for operational):
+
+1. `generate_source_file_coords` lists candidate source files for the region.
+2. `filter_already_present` drops files whose refs are already in the manifest.
+3. `process_virtual_refs(remaining)` — the generator each dataset implements — discovers available source files and yields batches of `VirtualRef`s.
+4. Each yield is committed atomically: open fresh writable sessions (a committed icechunk session is read-only), grow the append dim if needed (`sync_dims_to`), `set_virtual_refs`, commit.
+
+**The yield is the commit unit.** The generator owns the batching policy: operational updates yield ~one file at a time for per-file visibility; backfills yield ~N files per commit to amortize commit overhead. A yield must contain *whole* source files — never split a file across yields — and must never be empty (an empty icechunk commit raises).
+
+## Reader safety: one source file → one atomic commit
+
+All refs from a single source file, plus any append-dim expansion their positions require, land in one icechunk commit. A reader on `main` sees either none of a file's data or all of it. Atomicity is per *file*, not per init — readers see each lead time's data as its file is ingested, within seconds.
+
+This invariant is also what lets the filter probe a single representative cell per file: if one cell a file covers is present, the whole file is present.
+
+## Operational updates: single writer
+
+`operational_update_jobs()` returns **one** job spanning the active window (the recent, still-incomplete span of the append dim). One pod commits whole files straight to `main` as they arrive — no temp branch, no coordination files (`DynamicalDataset.update` routes to `_run_virtual_operational_update`).
+
+Single-writer is what makes lazy append-dim expansion safe: `main` grows exactly to the data ingested (never NaN-padded toward "now"), and a resize can never race another writer. If an update falls far behind, run a backfill to catch up rather than scaling operational updates to multiple workers.
+
+Crash recovery is automatic: committed refs are durable and the filter skips them on the next cron fire; uncommitted refs and expansions vanish and are re-discovered.
+
+## Backfill: parallel on a pre-sized temp branch
+
+Virtual backfills use the standard parallel temp-branch flow (see [parallel_processing.md](parallel_processing.md#icechunk-stores)). Worker 0 pre-sizes the full template on the branch, so every worker's `sync_dims_to` is a no-op and parallel workers write disjoint refs with no resize conflicts. Jobs partition by chunks along the append dim (virtual arrays have no shards).
+
+## Filtering: the manifest is the source of truth
+
+What is already ingested is derived from ref existence in the icechunk manifest (`store.exists(key)`), never from a progress coordinate or a chunk value read:
+
+- A manifest probe has no false-positives (skipping undone work would be a permanent miss); a false-negative just re-emits an identical ref, which is idempotent.
+- Never read or decode a virtual chunk to check presence (e.g. `.isnull()`) — that triggers a source-file download + decode per chunk.
+- `representative_var(coord)` must return a variable the candidate file actually contains; override it for one-variable-per-file packings.
+
+## Chunk keys
+
+`chunk_key` maps a ref's coordinate labels to its zarr chunk index, shared by the filter and the emitter so they cannot disagree. Geometry (dim order, chunk sizes) is read from the checked-in template, and the filter's string keys are built with zarr's own `chunk_key_encoding` — no hand-rolled formats that could drift. A label not yet present in the coords means "not yet ingested."
+
+## Replicas
+
+The loop opens sessions on all stores and commits replicas-then-primary. "Committed" is defined by the primary (the filter probes the primary's manifest), so a crash between replica and primary commits is replayed idempotently on the next fire; replicas may briefly be a commit ahead, never behind.
+
+## Storage and reading
+
+A virtual dataset requires every storage config to use the `ICECHUNK` format and an `icechunk_virtual_config` registering the source buckets as virtual chunk containers (`DynamicalDataset` validates this). Container definitions are stored in the repo's persistent config; readers supply an (anonymous) credentials map via `authorize_virtual_chunk_access` when opening the store.

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -388,7 +388,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     ) -> None:
         """Shared processing loop for both updates and backfills.
 
-        Coordinates parallel writes across multiple workers:
+        Coordinates parallel writes across multiple workers (see docs/parallel_processing.md):
         - Icechunk stores: uses a temp branch so readers on "main" never see partial data
         - Zarr v3 stores: defers metadata write until all workers finish
         """
@@ -470,7 +470,8 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     ) -> None:
         """Single-writer virtual dataset operational update: commit one or more
         whole source files straight to the "main" icechunk branch as they arrive
-        (no parallel_coordination), so readers see each file within seconds."""
+        (no parallel_coordination), so readers see each file within seconds.
+        See "Operational updates" in docs/virtual_datasets.md."""
         assert workers_total == 1, "Virtual operational updates run single-writer"
         assert worker_index == 0, "Virtual operational updates run single-writer"
         # A single active-window job whose generator polls the union of all

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -424,7 +424,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         Materialized and virtual datasets each own their store/session lifecycle and
         commit cadence behind this one call (see "The worker-processing seam" in
-        docs/plans/virtual_icechunk_datasets.md). Callers must pass at least one job.
+        docs/parallel_processing.md). Callers must pass at least one job.
         """
         raise NotImplementedError(
             "Subclasses implement process_worker_jobs with variant-specific logic"

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -37,7 +37,10 @@ class VirtualRef(NamedTuple):
 class VirtualRegionJob(
     RegionJob[DATA_VAR, SOURCE_FILE_COORD], Generic[DATA_VAR, SOURCE_FILE_COORD]
 ):
-    """Base class for processing a region of virtual Icechunk datasets that point to external files."""
+    """Base class for processing a region of virtual Icechunk datasets that point to external files.
+
+    See docs/virtual_datasets.md for the write loop, filtering, and reader-safety guarantees.
+    """
 
     # Locked to None: an integer max_vars_per_job would split one source file's
     # variables across separate jobs that commit independently, breaking the
@@ -50,13 +53,9 @@ class VirtualRegionJob(
     ) -> Iterator[Sequence[VirtualRef]]:
         """Discover available source files among `remaining` and yield their virtual references.
 
-        Each yield is one commit's worth of refs. The contract is that a yield
-        holds *whole* source files — every ref of a file is emitted in the same
-        batch, never split across yields — so a reader on `main` sees all of a
-        file's data or none of it. This is a discipline the generator must keep
-        (and tests check). The generator owns the batching policy: backfill yields
-        batches of ~N whole files to amortize commit overhead; operational yields
-        ~1 file at a time for per-file visibility.
+        Each yield is one commit's worth of *whole* source files — never split a
+        file across yields, never yield an empty batch. The generator owns the
+        batching policy. See "The write loop" in docs/virtual_datasets.md.
         """
         raise NotImplementedError(
             "Yield batches of VirtualRefs, each one commit's worth of whole source files."
@@ -134,12 +133,12 @@ class VirtualRegionJob(
     ) -> None:
         """Run the virtual write loop, committing each yielded batch atomically.
 
-        Same loop for backfill and operational; the only difference is the
-        `branch` the driver opened (a temp branch for backfill, "main" for the
-        single-writer operational update). sync_dims_to grows the store lazily (a
-        no-op on the pre-sized backfill branch). A fresh writable session is opened
-        per batch because an icechunk session becomes read-only after commit.
+        The same loop serves backfill (temp branch) and the single-writer
+        operational update ("main"); see "The write loop" in docs/virtual_datasets.md.
         """
+        # A fresh writable session is opened per batch because an icechunk
+        # session becomes read-only after commit. sync_dims_to grows the store
+        # lazily (a no-op on the pre-sized backfill branch).
         readonly_store = primary_repo.readonly_session(branch).store
         candidates = self.generate_source_file_coords(
             self._processing_region_ds(), self.data_vars


### PR DESCRIPTION
PR 3e of #513, follow-up to #654.

How materialized and virtual datasets run their per-worker processing was explained across code docstrings/comments and the plan doc. This pulls the authoritative version into `docs/` and links to it from code:

- **`docs/virtual_datasets.md` (new)** — durable home for virtual-dataset specifics: the write loop and yield-is-the-commit-unit contract, the one-file-one-commit reader-safety invariant, single-writer operational updates with lazy expansion, parallel backfill on the pre-sized branch, manifest-based filtering, chunk keys, replica ordering, and storage/reading requirements.
- **`docs/parallel_processing.md`** — minimal additions, keeping it about parallel processing: a short "worker-processing seam" section (`process_worker_jobs`, the materialized vs virtual commit cadence, where the coordination-lifecycle fork lives), and the virtual section now links to `virtual_datasets.md` instead of the plan doc.
- **Code** — docstrings keep brief user-facing contracts and link to the docs (`VirtualRegionJob` class, `process_virtual_refs`, `process_virtual`, `RegionJob.process_worker_jobs`, `_process_region_jobs`, `_run_virtual_operational_update`); the per-batch session detail in `process_virtual` moved from docstring to comment. No more `docs/plans/` links in src.
- AGENTS.md docs listing gains the new file.

No code behavior changes; ruff, ty, and the common region job / dataset tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)