### PR TITLE
Retry icechunk open_or_create for fresh-store worker races

### DIFF
--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -188,10 +188,15 @@ class StoreFactory(FrozenBaseModel):
             repo_config, credentials = _virtual_repository_config_and_credentials(
                 self.icechunk_virtual_config
             )
-            repo = icechunk.Repository.open_or_create(
-                ic_storage,
-                config=repo_config,
-                authorize_virtual_chunk_access=credentials,
+            # Retry to resolve multiple workers racing to create a new repo
+            repo = retry(
+                functools.partial(
+                    icechunk.Repository.open_or_create,
+                    ic_storage,
+                    config=repo_config,
+                    authorize_virtual_chunk_access=credentials,
+                ),
+                max_attempts=3,
             )
             repos.append((role, repo))
 


### PR DESCRIPTION
With many parallel workers starting against a brand-new icechunk store, several race into `Repository.open_or_create`'s create path; the losers raise `repo info object was updated after this session started` and crash the pod. The winner's create is atomic, so a retry resolves the losers to the open path. Observed as a round of pod restarts at the start of the first parallel backfill of `noaa-gefs-forecast-10-day-spatial-dev` (32 workers, fresh store); pods recovered via k8s restart, which this makes unnecessary.

Part of #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)