### PR TITLE
Finalize always writes template metadata to its own tmp_store

### DIFF
--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -160,9 +160,11 @@ def finalize(
     if update_template_with_results:
         assert len(all_jobs) > 0
         updated_template = all_jobs[0].update_template_with_results(merged_results)
-        template_utils.write_metadata(updated_template, tmp_store)
     else:
         updated_template = template_ds
+    # Ensure tmp_store has written metadata. Virtual workers (besides worker 0)
+    # do not otherwise write to tmp_store.
+    template_utils.write_metadata(updated_template, tmp_store)
 
     now = pd.Timestamp.now(tz="UTC")
     commit_message = f"Update at {now.strftime('%Y-%m-%dT%H:%M:%SZ')}"

--- a/tests/common/test_parallel_coordination.py
+++ b/tests/common/test_parallel_coordination.py
@@ -573,6 +573,10 @@ class TestFinalize:
             update_template_with_results=False,
         )
         stub_io["copy_zarr_metadata"].assert_not_called()
+        # Even without update_template_with_results, finalize writes template
+        # metadata to tmp_store so the copy below it never reads an empty dir.
+        stub_io["write_metadata"].assert_called_once()
+        stub_io["write_metadata"].reset_mock()
 
         # Update path: flips to True → zarr3 copy called once with zarr3_only=True.
         job = MagicMock()

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -791,7 +791,8 @@ def test_two_worker_backfill_disjoint(tmp_path: Path) -> None:
             workers_total=2,
             reformat_job_name="test",
             template_ds=template_ds,
-            tmp_store=dataset._tmp_store(),
+            # Distinct per worker, simulating separate pods
+            tmp_store=tmp_path / f"worker-{worker_index}-tmp.zarr",
             update_template_with_results=False,
         )
 


### PR DESCRIPTION
The first parallel (32-pod) backfill of `noaa-gefs-forecast-10-day-spatial-dev` crashed in finalize:

```
FileNotFoundError: '/app/data/tmp/<uuid>-tmp.zarr/zarr.json'
```

`finalize` copies template metadata from the worker's local `tmp_store`, but only worker 0 populates its tmp_store (in `parallel_setup`), and virtual region jobs never write locally — so the finalizing worker (highest index, a different pod) read from an empty directory. Materialized flows dodged this incidentally (the update path writes the trimmed template in finalize itself; materialized backfill workers populate tmp_store writing shards).

Fix: finalize always writes the template metadata it is about to copy into its own tmp_store (a cheap local write; redundant in the flows that already had it).

Why tests missed it: `get_local_tmp_store()` is `@cache`d per process, so in-process multi-worker tests shared one tmp_store. The two-worker virtual backfill test now passes a distinct tmp_store per worker like separate pods — it reproduces the crash without this fix.

Recovery for the stuck backfill: rerun the same backfill command once this merges; workers re-derive remaining work from the manifest (none), re-write results, and finalize completes.

Part of #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)