### PR TITLE
Unsuspend GEFS 10-day spatial dev crons to start the operational test

### DIFF
--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1157,7 +1157,7 @@ issue **#513** (its body holds the PR checklist; items are written "PR 1" not
 | PR 3c — move-only refactor | **merged** (#653) | Split `region_job.py` → `virtual_region_job.py` + `materialized_region_job.py`. |
 | PR 3d — move `process()` onto `MaterializedRegionJob` | **merged** (#654) | Removes the base `process()` stub; materialized `process_worker_jobs` narrows its jobs. |
 | PR 3e — consolidate processing-loop docs | **merged** (#655) | `docs/virtual_datasets.md` + seam section in `docs/parallel_processing.md`, linked from code. |
-| PR 4 — first concrete virtual dataset | **open** (#656) | `noaa-gefs-forecast-10-day-spatial-dev`: 4 inits/day, 0-240h, native 0.25° s-file grid, the 35-day vars available in s files (19). `-dev` suffix: a throwaway operational test; dataset structure questions are deliberately deferred. |
+| PR 4 — first concrete virtual dataset | **merged** (#656; fixes #658 #659) | `noaa-gefs-forecast-10-day-spatial-dev`: 4 inits/day, 0-240h, native 0.25° s-file grid, the 35-day vars available in s files (19). `-dev` suffix: a throwaway operational test; dataset structure questions are deliberately deferred. Month-long prod backfill (2026-05-12 06z – 2026-06-12 06z, 32 k8s workers) published 2026-06-12; spot checks (independent GRIB decodes vs store, null patterns, coverage) all passed. Crons unsuspended to start the operational test. |
 | PR 5 — persist container config | not started | `save_config()` on container drift; before first *externally published* virtual repo (first datasets run in prod unpublished). |
 | PR 6 — second concrete virtual dataset | not started | Different provider, proves abstractions generalize. |
 | PR 7 — validation phase | not started | Spatial-chunk validators + offline tooling. |

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/dynamical_dataset.py
@@ -58,9 +58,6 @@ class GefsForecast10DaySpatialDataset(
         # See "Publication timing measurements" in the virtual datasets plan.
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            # Suspended until the operational test launches (run the prod
-            # backfill first, then unsuspend).
-            suspend=True,
             schedule="43 3,9,15,21 * * *",
             # Must stay well under the 6h between fires so fires never overlap.
             pod_active_deadline=timedelta(hours=2, minutes=10),
@@ -74,7 +71,6 @@ class GefsForecast10DaySpatialDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            suspend=True,
             schedule="40 7 * * *",  # after the 00z init finishes publishing
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,

--- a/tests/noaa/gefs/forecast_10_day_spatial/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/dynamical_dataset_test.py
@@ -155,9 +155,8 @@ def test_operational_kubernetes_resources(
     # Virtual operational updates are strictly single-writer.
     assert update_cron_job.workers_total == 1
     assert update_cron_job.parallelism == 1
-    # Suspended until the operational test launches.
-    assert update_cron_job.suspend is True
-    assert validation_cron_job.suspend is True
+    assert update_cron_job.suspend is False
+    assert validation_cron_job.suspend is False
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
 
 


### PR DESCRIPTION
The month-long prod backfill (2026-05-12 06z – 2026-06-12 06z, 32 workers) finalized and published to `s3://dynamical-noaa-gefs` today. Spot checks all passed: 24 store values across 6 variables × varied inits/members/leads match independent direct-from-GRIB decodes exactly, lead-0 null patterns are correct, mid-month inits are fully populated, and pre-window inits are empty.

This removes `suspend=True` from both the update and validate crons so the operational test starts on the next deploy. Update fires at `43 3,9,15,21` (3 min before earliest observed publication start); validate at `07:40` after the 00z init finishes publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)