### PR TITLE
Cap icechunk chunk-ref cache for virtual datasets to fix update OOM

### DIFF
--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1393,6 +1393,32 @@ backfills). For non-listable ordered sources (none yet), a frontier-prober slots
 into the same discover step. Measured `.idx` fetch throughput vs pool width: 8
 -> ~105 files/s, 32 -> ~310, 64 -> ~380 (chosen), 128 -> ~435.
 
+**Chunk-ref cache OOM (2026-06-12).** The first live operational update
+(manually fired mid-window) crash-looped through ~6 pods (8G each, lifetimes
+6–73 min, SIGKILL with no Python exception); each replacement pod resumed from
+the manifest within ~2–5 min and the init completed correctly — the
+restart-resilience design worked, but the kills needed a root cause. RSS-tracked
+replay (one init, ~300 commits): default icechunk config grows 461→1208 MB and
+*accelerating*; `CachingConfig(num_chunk_refs=0)` is flat 445→495 MB at equal
+throughput. Cause: every streaming commit rewrites the active manifest split
+(prod: week split ≈ 1.3M URL-bearing refs across vars) and the writer never
+reads old versions, so icechunk's default 5M-entry chunk-ref cache fills with
+dead manifest versions — multi-GB on virtual datasets. Fix: cap the chunk-ref
+cache in `_virtual_repository_config_and_credentials`. Sizing the cap (measured,
+not tuned to this one dataset): `num_chunk_refs=0` is flat but logs a "cache too
+small" WARN on every manifest load (Sentry spam); `1.3M` rises then *plateaus*
+~720 MB as eviction kicks in (bounded). A virtual ref ≈ 180 bytes (S3 URL +
+offset + length), so the chosen **1M-ref cap ≈ 200 MB** ceiling — a fixed,
+dataset-agnostic budget that holds a working set, stays bounded, and silences
+the warning. Existence checks (`filter_already_present`, ~2,511 candidates
+against the real prod month-store) are *cache-insensitive*: flat 2.5–2.6 s from
+0 to 5M, because the fire opens a cold cache and the cost is the async manifest
+fetches, not retention. Side finding: Sentry
+marks the monitor `timeout` once `max_runtime` passes even if a late `ok`
+arrives, and per-pod `in_progress` re-checkins share one `check_in_id`, so a
+crash-looping run looks like a single long run in Sentry crons — `pod_name` on
+log attributes is what revealed the restarts.
+
 ### Publication timing measurements (2026-06-11)
 
 Measured from S3 object `LastModified` over 6–10 recent inits (2026-06-09..11).

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -513,12 +513,7 @@ def _virtual_repository_config_and_credentials(
     for container in virtual_config.containers:
         config.set_virtual_chunk_container(container)
     config.manifest = icechunk.ManifestConfig(splitting=virtual_config.manifest_split)
-    # Cap the chunk-ref cache: each streaming commit rewrites the active manifest
-    # split, so the default (5M refs) accumulates dead manifest versions and OOMs
-    # update pods. ~1M refs (≈200 MB; a virtual ref is an S3 URL + offset + length)
-    # holds a working set and stays bounded as the cache evicts old versions, while
-    # avoiding icechunk's "cache too small" warning at 0. Per-dataset, not tuned to
-    # one manifest; see "Chunk-ref cache OOM" in docs/plans/virtual_icechunk_datasets.md.
+    # Cap the chunk-ref cache; the default OOMs streaming-commit writers, see "Chunk-ref cache OOM" in docs/plans/virtual_icechunk_datasets.md.
     config.caching = icechunk.CachingConfig(num_chunk_refs=1_000_000)
 
     # Every production source is S3 or S3-compatible (NOAA NODD, ECMWF, Source

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -513,6 +513,13 @@ def _virtual_repository_config_and_credentials(
     for container in virtual_config.containers:
         config.set_virtual_chunk_container(container)
     config.manifest = icechunk.ManifestConfig(splitting=virtual_config.manifest_split)
+    # Cap the chunk-ref cache: each streaming commit rewrites the active manifest
+    # split, so the default (5M refs) accumulates dead manifest versions and OOMs
+    # update pods. ~1M refs (≈200 MB; a virtual ref is an S3 URL + offset + length)
+    # holds a working set and stays bounded as the cache evicts old versions, while
+    # avoiding icechunk's "cache too small" warning at 0. Per-dataset, not tuned to
+    # one manifest; see "Chunk-ref cache OOM" in docs/plans/virtual_icechunk_datasets.md.
+    config.caching = icechunk.CachingConfig(num_chunk_refs=1_000_000)
 
     # Every production source is S3 or S3-compatible (NOAA NODD, ECMWF, Source
     # Coop) and anonymous-read, and icechunk only ships an S3 anonymous credential

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -424,6 +424,9 @@ class TestIcechunkVirtualConfig:
         assert manifest is not None
         assert manifest.splitting is not None
         assert manifest.splitting.split_sizes
+        caching = repo.config.caching
+        assert caching is not None
+        assert caching.num_chunk_refs == 1_000_000
 
     def test_unsupported_container_rejected(self) -> None:
         gcs_container = icechunk.VirtualChunkContainer(


### PR DESCRIPTION
## Problem

The first live operational update of `noaa-gefs-forecast-10-day-spatial-dev` crash-looped through ~6 pods (8G each, lifetimes 6–73 min, SIGKILL with no Python exception — the OOM-killer signature). The restart-resilience design worked (each pod resumed from the manifest in ~2–5 min and the init completed correctly), but the kills needed a root cause.

## Root cause

Every streaming commit rewrites the active manifest split (this dataset: a week split ≈ 1.3M URL-bearing refs), and the writer never reads old versions. icechunk's default 5M-entry chunk-ref cache fills with **dead manifest versions** — multi-GB on a virtual dataset.

RSS-tracked replay of one init (~300 commits):

| `num_chunk_refs` | write-loop RSS | behavior |
|---|---|---|
| 0 | flat ~490 MB | bounded, but logs a "cache too small" WARN on every manifest load |
| **1.3M** | rises → **plateaus ~720 MB** | bounded; cache evicts old versions at budget |
| 5M (default) | 461 → 1208 MB, accelerating | the leak |

## Fix

Cap `num_chunk_refs` at **1M (~200 MB ceiling**; a virtual ref ≈ 180 bytes = S3 URL + offset + length). A fixed, dataset-agnostic budget that holds a working set, stays bounded as the cache evicts old versions, and avoids the "cache too small" warning that `0` would spam to Sentry on every fire.

Existence checks are **cache-insensitive** — `filter_already_present` over ~2,511 candidates against the real prod month-store is flat 2.5–2.6s from 0 to 5M, because the fire opens a cold cache and the cost is the async manifest fetches, not retention. So the cap costs nothing at fire start.

Details and the Sentry observability gotchas (a crash-looping run looks like one long run in Sentry crons; `pod_name` log attributes are what revealed the restarts) are in the decision log of `docs/plans/virtual_icechunk_datasets.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)