### PR TITLE
Resize GEFS 10-day spatial cron requests

### DIFF
--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/dynamical_dataset.py
@@ -66,10 +66,8 @@ class GefsForecast10DaySpatialDataset(
             pod_active_deadline=timedelta(hours=2, minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,
-            cpu="2",
-            memory="8G",
-            shared_memory="1G",
-            ephemeral_storage="10G",
+            cpu="1.7",
+            memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(


### PR DESCRIPTION
Trims the reformat (update) cron's resource requests, which the backfill and operational pods both inherit:

- cpu `2` → `1.7`
- memory `8G` → `7G`
- drop `shared_memory` (no `/dev/shm` volume)
- drop the explicit `ephemeral_storage` override (falls back to the 10G default)

With the chunk-ref cache capped (#662), the virtual write loop's working set sits well under 7G and the pods don't need a shared-memory volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)