### PR TITLE
Skip source files whose GRIB index references bytes past the data file

### DIFF
--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
@@ -140,13 +140,23 @@ class GefsForecast10DaySpatialRegionJob(
                     refs_per_file = pool.map(
                         self._file_refs, coords, available.values()
                     )
-                    batch = list(zip(coords, refs_per_file, strict=True))
+                    # Files with no refs were skipped (stale/mismatched index); drop
+                    # them so a batch never carries a file with no chunks.
+                    batch = [
+                        (coord, refs)
+                        for coord, refs in zip(coords, refs_per_file, strict=True)
+                        if refs
+                    ]
                     for key in available:
                         del pending[key]
+                    skipped = len(coords) - len(batch)
                     log.info(
-                        f"Ingesting {len(coords)} files, {len(pending)} still pending"
+                        f"Ingesting {len(batch)} files"
+                        f"{f' ({skipped} skipped)' if skipped else ''}, "
+                        f"{len(pending)} still pending"
                     )
-                    yield batch
+                    if batch:
+                        yield batch
                 if self.processing_mode == "backfill":
                     if pending:
                         log.info(
@@ -181,28 +191,46 @@ class GefsForecast10DaySpatialRegionJob(
             coord.get_index_url(), self.dataset_id, region=_S3_BUCKET_REGION
         )
         location = coord.get_url()
-        out_loc = coord.out_loc()
-        refs = []
-        for var in coord.data_vars:
-            starts, ends = grib_message_byte_ranges_from_index(
-                index_path, [var], coord.init_time, coord.lead_time
-            )
-            start, end = item(zip(starts, ends, strict=True))
-            if end - start >= GRIB_INDEX_UNKNOWN_END_PAD:
-                # Last message in the file; the index doesn't know its end byte.
-                end = file_size
-            refs.append(
-                VirtualRef(
-                    data_var=var,
-                    out_loc=out_loc,
-                    location=location,
-                    offset=start,
-                    length=end - start,
+        try:
+            # A matching index never references bytes past the data file. When it does,
+            # the source was re-published without regenerating the index (or vice versa)
+            # and every offset is suspect, so skip the whole file (its chunks stay fill).
+            # Returning no refs is the caller's signal to drop the file from the batch.
+            byte_offsets = [
+                int(line.split(":", 2)[1])
+                for line in index_path.read_text().splitlines()
+                if line.strip()
+            ]
+            if byte_offsets and max(byte_offsets) >= file_size:
+                log.warning(
+                    f"Skipping {location}: index references byte {max(byte_offsets)} "
+                    f">= data file size {file_size}; stale or mismatched index"
                 )
-            )
-        # Index files accumulate by the millions in backfills; never keep them.
-        index_path.unlink()
-        return refs
+                return []
+
+            out_loc = coord.out_loc()
+            refs = []
+            for var in coord.data_vars:
+                starts, ends = grib_message_byte_ranges_from_index(
+                    index_path, [var], coord.init_time, coord.lead_time
+                )
+                start, end = item(zip(starts, ends, strict=True))
+                if end - start >= GRIB_INDEX_UNKNOWN_END_PAD:
+                    # Last message in the file; the index doesn't know its end byte.
+                    end = file_size
+                refs.append(
+                    VirtualRef(
+                        data_var=var,
+                        out_loc=out_loc,
+                        location=location,
+                        offset=start,
+                        length=end - start,
+                    )
+                )
+            return refs
+        finally:
+            # Index files accumulate by the millions in backfills; never keep them.
+            index_path.unlink()
 
     def representative_var(
         self, coord: GefsForecast10DaySpatialSourceFileCoord

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
@@ -10,7 +10,6 @@ import xarray as xr
 from zarr.abc.store import Store
 
 from reformatters.common.download import s3_download_to_disk, s3_store
-from reformatters.common.iterating import item
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import RegionJob
 from reformatters.common.types import AppendDim, DatetimeLike, Timedelta
@@ -190,47 +189,46 @@ class GefsForecast10DaySpatialRegionJob(
         index_path = s3_download_to_disk(
             coord.get_index_url(), self.dataset_id, region=_S3_BUCKET_REGION
         )
-        location = coord.get_url()
         try:
-            # A matching index never references bytes past the data file. When it does,
-            # the source was re-published without regenerating the index (or vice versa)
-            # and every offset is suspect, so skip the whole file (its chunks stay fill).
-            # Returning no refs is the caller's signal to drop the file from the batch.
-            byte_offsets = [
-                int(line.split(":", 2)[1])
-                for line in index_path.read_text().splitlines()
-                if line.strip()
-            ]
-            if byte_offsets and max(byte_offsets) >= file_size:
-                log.warning(
-                    f"Skipping {location}: index references byte {max(byte_offsets)} "
-                    f">= data file size {file_size}; stale or mismatched index"
-                )
-                return []
-
-            out_loc = coord.out_loc()
-            refs = []
-            for var in coord.data_vars:
-                starts, ends = grib_message_byte_ranges_from_index(
-                    index_path, [var], coord.init_time, coord.lead_time
-                )
-                start, end = item(zip(starts, ends, strict=True))
-                if end - start >= GRIB_INDEX_UNKNOWN_END_PAD:
-                    # Last message in the file; the index doesn't know its end byte.
-                    end = file_size
-                refs.append(
-                    VirtualRef(
-                        data_var=var,
-                        out_loc=out_loc,
-                        location=location,
-                        offset=start,
-                        length=end - start,
-                    )
-                )
-            return refs
+            starts, ends = grib_message_byte_ranges_from_index(
+                index_path, coord.data_vars, coord.init_time, coord.lead_time
+            )
         finally:
             # Index files accumulate by the millions in backfills; never keep them.
             index_path.unlink()
+
+        # The last message in the file has no end byte in the index; the listed
+        # file size supplies it.
+        ends = [
+            file_size if end - start >= GRIB_INDEX_UNKNOWN_END_PAD else end
+            for start, end in zip(starts, ends, strict=True)
+        ]
+        # A matching index never references bytes past the data file. When it does, the
+        # source was re-published without regenerating the index and the offsets are
+        # unusable, so skip the whole file (its chunks stay fill). Returning no refs is
+        # the caller's signal to drop the file from the batch.
+        if any(
+            end > file_size or end <= start
+            for start, end in zip(starts, ends, strict=True)
+        ):
+            log.warning(
+                f"Skipping {coord.get_url()}: index byte ranges fall outside the "
+                f"{file_size}-byte data file; stale or mismatched index"
+            )
+            return []
+
+        out_loc = coord.out_loc()
+        location = coord.get_url()
+        return [
+            VirtualRef(
+                data_var=var,
+                out_loc=out_loc,
+                location=location,
+                offset=start,
+                length=end - start,
+            )
+            for var, start, end in zip(coord.data_vars, starts, ends, strict=True)
+        ]
 
     def representative_var(
         self, coord: GefsForecast10DaySpatialSourceFileCoord

--- a/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
@@ -195,7 +195,8 @@ def _coord(
 
 def _fake_index_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     def fake_download(url: str, dataset_id: str, *, region: str) -> Path:
-        index_path = tmp_path / "index.idx"
+        # Unique per url so concurrent _file_refs don't clobber each other's file.
+        index_path = tmp_path / (url.rsplit("/", 1)[-1] + ".idx")
         index_path.write_text(_INDEX_CONTENT)
         return index_path
 
@@ -290,6 +291,48 @@ def test_process_virtual_refs_update_polls_until_all_ingested(
     ]
     # Slept between ticks (after ticks 1 and 2, not after the final tick).
     assert len(sleeps) == 2
+
+
+def test_file_refs_skips_file_whose_index_points_past_eof(
+    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    data_vars = [get_var("temperature_2m")]
+    job = make_job(template_ds, data_vars=data_vars)
+    _fake_index_download(monkeypatch, tmp_path)  # index's last message starts at 2500
+    coord = _coord(1, data_vars)
+    # A matching (larger) file resolves refs.
+    assert job._file_refs(coord, file_size=9000)
+    # A file smaller than the index's max offset is stale/mismatched -> no refs.
+    assert job._file_refs(coord, file_size=2000) == []
+
+
+def test_process_virtual_refs_drops_files_with_stale_index(
+    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    data_vars = [get_var("temperature_2m")]
+    job = make_job(template_ds, data_vars=data_vars)
+    _fake_index_download(monkeypatch, tmp_path)
+    member1 = f"{_PREFIX}gep01.t00z.pgrb2s.0p25.f003"
+    member2 = f"{_PREFIX}gep02.t00z.pgrb2s.0p25.f003"
+    # member1's listed size (2000) is below the index's max offset (2500) -> skipped.
+    monkeypatch.setattr(
+        region_job_module,
+        "_list_objects",
+        lambda prefix: {
+            member1: 2000,
+            f"{member1}.idx": 200,
+            member2: 9000,
+            f"{member2}.idx": 200,
+        },
+    )
+
+    batches = list(
+        job.process_virtual_refs([_coord(1, data_vars), _coord(2, data_vars)])
+    )
+
+    (batch,) = batches
+    ((coord, _refs),) = batch
+    assert coord.ensemble_member == 2  # member1 dropped, only member2 ingested
 
 
 def test_discover_available_requires_data_and_index(


### PR DESCRIPTION
The full-archive GEFS backfill (2020→2026) hit a corrupt source file: gep04.t06z.pgrb2s.0p25.f120 for init 2022-09-21 06z crashed every worker with `OverflowError: cannot convert negative int to unsigned`.

## Root cause

NOAA re-packed that forecast file (different compression) **without regenerating its `.idx`**. The data file is valid GRIB (35 messages), but the index byte offsets are for the old version — only the first message lines up; the rest drift, and the last offset (16,618,300) lands ~305 KB past the actual end of the file (16,313,603).

With virtual datasets we trust the index *without reading the data*, so a mismatched index would write every chunk at a wrong byte range = **silent garbage**. (The original `OverflowError` only fired because this particular mismatch ran past EOF; an in-bounds mismatch would have ingested cleanly-but-wrong.)

## The guard

`_file_refs` now parses the index once for all of a file’s variables, then checks that every byte range it is about to write falls inside the data file (`end <= file_size` and `end > start`). A matching index always satisfies this; a stale/mismatched one does not (`file_size` is free — it comes from the bucket listing). When the check trips, the file is suspect, so:
- `_file_refs` skips it (returns no refs), and
- the tick loop drops it from the batch (so it never trips the probe-coverage check or hangs the poller).

Those chunks stay fill (NaN); **validation** surfaces the holes. This is the cheapest detector available at write time — an index that is wrong but stays *within* the file can only be caught at read time.

## Scope (measured)

Scan of the two inits worker 92 touched (range vs file_size):
- **2022-09-21 06z**: 11 of 2511 member files mismatched — all long leads (f120–f129), 7 members. Skipped; the other 2500 ingest normally.
- **2025-07-11 18z**: 0 mismatched (clean).

## Tests

- `_file_refs` returns refs for a matching file and `[]` when the file is smaller than its index ranges.
- the tick loop drops a stale-index file from the batch and ingests only the good one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)