### PR TITLE
Skip an unreadable source file instead of failing the whole virtual job

### DIFF
--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1160,10 +1160,48 @@ issue **#513** (its body holds the PR checklist; items are written "PR 1" not
 | PR 4 — first concrete virtual dataset | **open** (#656) | `noaa-gefs-forecast-10-day-spatial-dev`: 4 inits/day, 0-240h, native 0.25° s-file grid, the 35-day vars available in s files (19). `-dev` suffix: a throwaway operational test; dataset structure questions are deliberately deferred. |
 | PR 5 — persist container config | not started | `save_config()` on container drift; before first *externally published* virtual repo (first datasets run in prod unpublished). |
 | PR 6 — second concrete virtual dataset | not started | Different provider, proves abstractions generalize. |
-| PR 7 — validation phase | not started | Spatial-chunk validators + offline tooling. |
+| PR 7 — extract common patterns into `VirtualRegionJob` | not started | With two concrete datasets in hand, lift the shared machinery out of the subclasses (see "Extracting common patterns" below). |
+| PR 8 — validation phase | not started | Spatial-chunk validators + offline tooling. |
 
 PR 3 was originally one combined PR (#648) but was resequenced into 3a + 3b after
 the [B-method](#decision-b-method) design review; #648 is closed/superseded by #650.
+
+### Extracting common patterns (PR 7)
+
+The first virtual dataset (`noaa-gefs-forecast-10-day-spatial-dev`, PR 4) was
+built deliberately concrete: the whole discover → fetch → build-refs → batch →
+yield loop lives in the dataset's `RegionJob`, not the base, because we didn't
+yet know which parts generalize. Building the second virtual dataset (PR 6) is
+what reveals the real seam, so the extraction is sequenced **after** it — lifting
+shared machinery into `VirtualRegionJob` only once two implementations agree on
+its shape, rather than guessing from one.
+
+Candidates observed in the GEFS implementation that look common, not
+GEFS-specific (confirm against the second dataset before lifting):
+
+- **The tick loop** (`process_virtual_refs`): per-tick discover-diff-fetch-yield,
+  the backfill single-sweep vs update poll-until-empty fork, and the
+  `tick_interval` pacing. The dataset-specific part is only *how* a file's refs
+  are built; the loop shape is generic.
+- **Listing-based availability** (`_discover_available`): "a file is available
+  once its data and index objects are both listed, mapped to the data size."
+  Object-store listing is generic; the data/index key relationship is the
+  dataset's to define.
+- **Per-file ref resolution with unreadable-file skipping**: a file that can't be
+  turned into refs (corrupt/stale index — see "Skip source files…", a decode
+  surprise, a transient read error) returns no refs and is dropped from the
+  batch so its chunks stay fill and validation surfaces the gap. The broad
+  per-file `try/except` (re-raising `AssertionError`, logging, skipping) is the
+  virtual analog of `MaterializedRegionJob`'s `download_file`/`read_data` error
+  handling and belongs on the base. The stale-index *detection* (max byte offset
+  vs file size) is index-format-specific and stays with the dataset's ref
+  builder.
+- **The `_file_refs` seam itself**: today an unenforced GEFS convention. PR 7
+  should make it (or a better-named equivalent) the formal per-file method the
+  base loop calls, the way materialized has `download_file`/`read_data`.
+
+Do not over-fit to GEFS: keep anything that's genuinely one provider's quirk
+(NOAA `.idx` parsing, the s-file var subsetting) in the subclass.
 
 ### Decision log
 
@@ -1286,7 +1324,7 @@ not a framework-level rule.
 chunks for partially-published inits are expected) and `compare_replica_and_primary`
 (it would S3-fetch + GRIB-decode every compared chunk — the exact decode-in-steady-
 state cost the design avoids). Both are skipped for virtual; a manifest-aware
-virtual validator is deferred to the validation PR (#513 PR 7). The replica
+virtual validator is deferred to the validation PR (#513 PR 8). The replica
 comparator skip is latent until a virtual dataset gets a replica, but is removed
 now so it can't fire decode-heavy when that day comes.
 
@@ -1481,7 +1519,8 @@ The remaining work is now sequenced as formal PRs in the
 **PR #4** (first concrete `-spatial` dataset — pick from
 [candidates](#candidate-first-datasets)), **PR #5** (persist container config via
 `save_config()` before the first externally published virtual repo), **PR #6**
-(second dataset), **PR #7** (validation).
+(second dataset), **PR #7** (extract common patterns into `VirtualRegionJob`),
+**PR #8** (validation).
 
 ## Spike results
 

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1200,6 +1200,38 @@ GEFS-specific (confirm against the second dataset before lifting):
   should make it (or a better-named equivalent) the formal per-file method the
   base loop calls, the way materialized has `download_file`/`read_data`.
 
+**A possible seam shape** (sketched in the "Tick-loop design settled" discussion
+below — a direction to weigh against PR 6, *not* a committed API). Lift the loop
+onto the base and have it drive two per-dataset methods:
+
+- `discover(pending) -> available` — the subset of pending source files ready to
+  fetch now. GEFS does a **listing diff** (data + index both listed). A
+  non-listable or strongly rate-limited source could instead **walk/probe
+  expected files in publication order** (a "frontier prober"); a backfill could
+  assume-all. The loop is indifferent to which.
+- `file_refs(coord) -> refs` — build one file's virtual refs, with the
+  unreadable-file skipping above.
+
+The base owns everything between them:
+
+```python
+while pending and now() < poll_until:        # backfill: single pass; update: until empty / deadline
+    tick_start = monotonic()
+    available = self.discover(pending)        # subset of pending, ready now
+    if available:
+        refs = [r for f in pool.map(self.file_refs, available) for r in f]
+        pending -= available
+        yield refs                            # never empty (gated on available)
+    sleep(max(0.0, tick_interval - (monotonic() - tick_start)))
+```
+
+The per-dataset knobs (`tick_interval`, `download_concurrency`, backfill-vs-update)
+parameterize this one skeleton rather than forking it. Where a sub-step is broadly
+useful but not universal (object-store listing diff, the data+index availability
+rule, the index-byte-range parse), prefer a **utility implementations opt into**
+over a forced base method — "if [patterns] are common, we make them into utilities
+that implementations can pick from."
+
 Do not over-fit to GEFS: keep anything that's genuinely one provider's quirk
 (NOAA `.idx` parsing, the s-file var subsetting) in the subclass.
 

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
@@ -137,10 +137,10 @@ class GefsForecast10DaySpatialRegionJob(
                 if available:
                     coords = [pending[key] for key in available]
                     refs_per_file = pool.map(
-                        self._file_refs, coords, available.values()
+                        self._file_refs_or_skip, coords, available.values()
                     )
-                    # Files with no refs were skipped (stale/mismatched index); drop
-                    # them so a batch never carries a file with no chunks.
+                    # Files with no refs were skipped (unreadable source); drop them
+                    # so a batch never carries a file with no chunks.
                     batch = [
                         (coord, refs)
                         for coord, refs in zip(coords, refs_per_file, strict=True)
@@ -182,6 +182,21 @@ class GefsForecast10DaySpatialRegionJob(
             for key in pending
             if key in listed and f"{key}.idx" in listed
         }
+
+    def _file_refs_or_skip(
+        self, coord: GefsForecast10DaySpatialSourceFileCoord, file_size: int
+    ) -> list[VirtualRef]:
+        # Skip a file we can't turn into refs (a decode surprise, a transient read
+        # error) rather than sink the whole job; its chunks stay fill and validation
+        # surfaces the gap. AssertionError is our own invariant, so it propagates.
+        # PR 7 lifts this onto VirtualRegionJob; see docs/plans/virtual_icechunk_datasets.md.
+        try:
+            return self._file_refs(coord, file_size)
+        except AssertionError:
+            raise
+        except Exception:
+            log.exception(f"Skipping {coord.get_url()}: could not build virtual refs")
+            return []
 
     def _file_refs(
         self, coord: GefsForecast10DaySpatialSourceFileCoord, file_size: int

--- a/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
@@ -13,6 +13,7 @@ from gribberish import (
     parse_grib_message_metadata,  # ty: ignore[unresolved-import] - native module member
 )
 
+from reformatters.common.virtual_region_job import VirtualRef
 from reformatters.noaa.gefs.forecast_10_day_spatial import (
     region_job as region_job_module,
 )
@@ -333,6 +334,35 @@ def test_process_virtual_refs_drops_files_with_stale_index(
     (batch,) = batches
     ((coord, _refs),) = batch
     assert coord.ensemble_member == 2  # member1 dropped, only member2 ingested
+
+
+def test_file_refs_or_skip_swallows_unexpected_errors(
+    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    job = make_job(template_ds, data_vars=[get_var("temperature_2m")])
+    coord = _coord(1, [get_var("temperature_2m")])
+
+    def boom(*args: object, **kwargs: object) -> list[VirtualRef]:
+        raise RuntimeError("network blip")
+
+    monkeypatch.setattr(job, "_file_refs", boom)
+    # An unexpected per-file error skips the file (no refs) rather than raising.
+    assert job._file_refs_or_skip(coord, 9000) == []
+
+
+def test_file_refs_or_skip_propagates_assertion_errors(
+    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    job = make_job(template_ds, data_vars=[get_var("temperature_2m")])
+    coord = _coord(1, [get_var("temperature_2m")])
+
+    def bad_invariant(*args: object, **kwargs: object) -> list[VirtualRef]:
+        raise AssertionError("our own invariant")
+
+    monkeypatch.setattr(job, "_file_refs", bad_invariant)
+    # Assertion failures are our own bugs and must surface, not be swallowed.
+    with pytest.raises(AssertionError, match="our own invariant"):
+        job._file_refs_or_skip(coord, 9000)
 
 
 def test_discover_available_requires_data_and_index(


### PR DESCRIPTION
Follow-up to #665 (which handles the specific stale-index case): a broad safety net for the *unanticipated*.

## What

Wraps per-file ref building in the GEFS virtual tick loop with a broad `try/except`. A source file we cannot turn into refs — a decode surprise, a transient read error, some corruption we have not seen — is **skipped** (its chunks stay fill; validation surfaces the gap) rather than sinking the whole job. `AssertionError` **propagates**: our own invariants are bugs, not data problems, and should crash.

This mirrors `MaterializedRegionJob`'s `download_file`/`read_data` error handling (a single bad file fails without stopping the run), with one deliberate improvement: materialized catches *all* `Exception` including assertions; here assertions are re-raised.

## Layering

- #665 (`_file_refs`): detects the *known* stale/mismatched-index case explicitly, logs a clear warning.
- this PR (`_file_refs_or_skip`): catches *anything else* per-file, logs the full exception (Sentry), skips.

Both resolve to "no refs", and the tick loop drops the file from the batch.

## Scope / roadmap

Kept GEFS-local on purpose. The plan now sequences a dedicated **PR 7 — extract common patterns into `VirtualRegionJob`** (issue #513; validation moves to PR 8), which lifts this error handling, the tick loop, file-availability discovery, and per-file ref resolution onto the base once a second virtual dataset confirms the shape. Extracting from one implementation would be guessing; this PR establishes the pattern, PR 7 generalizes it. See the "Extracting common patterns" notes in `docs/plans/virtual_icechunk_datasets.md`.

## Tests

- an unexpected per-file error skips the file (returns no refs);
- an `AssertionError` propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
