### PR TITLE
Persist virtual chunk container config so external readers recover it

### DIFF
--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1186,7 +1186,7 @@ issue **#513** (its body holds the PR checklist; items are written "PR 1" not
 | PR 3d — move `process()` onto `MaterializedRegionJob` | **merged** (#654) | Removes the base `process()` stub; materialized `process_worker_jobs` narrows its jobs. |
 | PR 3e — consolidate processing-loop docs | **merged** (#655) | `docs/virtual_datasets.md` + seam section in `docs/parallel_processing.md`, linked from code. |
 | PR 4 — first concrete virtual dataset | **merged** (#656; fixes #658 #659) | `noaa-gefs-forecast-10-day-spatial-dev`: 4 inits/day, 0-240h, native 0.25° s-file grid, the 35-day vars available in s files (19). `-dev` suffix: a throwaway operational test; dataset structure questions are deliberately deferred. Month-long prod backfill (2026-05-12 06z – 2026-06-12 06z, 32 k8s workers) published 2026-06-12; spot checks (independent GRIB decodes vs store, null patterns, coverage) all passed. Crons unsuspended to start the operational test. |
-| PR 5 — persist container config | in progress | `save_config()` on container drift in `parallel_setup`; before first *externally published* virtual repo (first datasets run in prod unpublished). |
+| PR 5 — persist container config | in progress (#667) | `save_config()` on container drift in `parallel_setup`; before first *externally published* virtual repo (first datasets run in prod unpublished). |
 | PR 6 — second concrete virtual dataset | not started | Different provider, proves abstractions generalize. |
 | PR 7 — extract common patterns into `VirtualRegionJob` | not started | With two concrete datasets in hand, lift the shared machinery out of the subclasses (see "Extracting common patterns" below). |
 | PR 8 — validation phase | not started | Spatial-chunk validators + offline tooling. |

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1083,12 +1083,27 @@ shakeout before the architecture is called settled, so the `fetch_config` reader
 path this fixes isn't yet load-bearing. The constraint is "before the first
 **externally published** virtual repo," not before the first prod write.
 
-The problem: nothing was persisted *into* the repo. Every open — writer and
-reader — passed an in-memory `config=` override
-(`_virtual_repository_config_and_credentials`), which works only because *we*
-always supply it. An external reader opening with no override got
-`RepositoryConfig.default()` (zero containers) → every virtual read raised "you
-need to authorize the virtual chunk container."
+The problem: the container *registrations* weren't persisted *into* the repo.
+Reading a virtual chunk needs two **separate** things, and only the first is
+persistable:
+
+1. The container **registered** — `set_virtual_chunk_container(VCC)`, the
+   `url_prefix` → backend-store mapping. Refs are stored relative to it, so it
+   must be present for the repo to resolve them. Part of `RepositoryConfig`;
+   persistable via `save_config`.
+2. The container **authorized** at open — `authorize_virtual_chunk_access={prefix:
+   creds}`, the credentials + explicit read-time grant. This is icechunk's
+   security boundary: it is **never** persisted and the reader must pass it on
+   every open, no matter what the repo creator wrote.
+
+We only ever supplied the registrations in-memory through the `config=` override,
+so an external reader opening with just an authorize map and no override has no
+registered containers and can't resolve the refs — and would have to reconstruct
+and `set_virtual_chunk_container` our exact config themselves, defeating the
+minimal-published-surface goal. Persisting does **not** remove the authorize
+requirement (nothing can); it removes the need for the reader to *register*. They
+recover the registrations from the repo via `fetch_config` on a plain
+`Repository.open(storage)` and supply only the anonymous authorize map.
 
 Implemented: `StoreFactory.persist_virtual_config()`, called once from
 `parallel_setup`'s worker-0 (`is_first`) branch — the single-writer chokepoint,

--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1082,20 +1082,48 @@ in production *unpublished* (not exposed to external readers) as a thorough
 shakeout before the architecture is called settled, so the `fetch_config` reader
 path this fixes isn't yet load-bearing. The constraint is "before the first
 **externally published** virtual repo," not before the first prod write.
-`Repository.create`
-persists the virtual-chunk container config, but nothing calls
-`repo.save_config()` afterward, so a later in-code container change affects only
-the writing process — an external reader recovering containers via `fetch_config`
-(the "Reader experience" / "En-masse repoint" promises) sees the creation-time
-set forever. Fix: call `save_config()` from the writable-open path when the
-in-code config differs, or document an explicit ops-card procedure.
+
+The problem: nothing was persisted *into* the repo. Every open — writer and
+reader — passed an in-memory `config=` override
+(`_virtual_repository_config_and_credentials`), which works only because *we*
+always supply it. An external reader opening with no override got
+`RepositoryConfig.default()` (zero containers) → every virtual read raised "you
+need to authorize the virtual chunk container."
+
+Implemented: `StoreFactory.persist_virtual_config()`, called once from
+`parallel_setup`'s worker-0 (`is_first`) branch — the single-writer chokepoint,
+which avoids the `RepositoryConfig.previous_file` optimistic-concurrency race a
+per-worker save would hit. It is **drift-gated**: `Repository.fetch_config` (a
+storage read, guarded by `Repository.exists` because `fetch_config` raises on a
+not-yet-created repo) compares the persisted container `url_prefix` set to the
+in-code set and only re-saves on a difference. No-op for materialized datasets.
+
+Decisions (icechunk 2.0.5, spiked):
+- **`save_config(self)` takes no args** — it persists *the repo's open-time
+  config*. The worker-0 repo is opened with the full override, so the persisted
+  config is containers + manifest_split + caching.
+- **`Repository.open(config=override)` merges field-by-field onto the persisted
+  config** (verified: a no-container override still recovered the persisted
+  containers). So (a) our writers' override keeps working unchanged once we
+  persist, and (b) persisting the full config including
+  `caching(num_chunk_refs=1M)` is benign — a reader who cares overrides it, and
+  1M is a *safer* default than icechunk's 5M (the value behind the original OOM).
+  We persist the whole config rather than a lean subset.
+- **Drift is keyed on `url_prefix` only.** Repointing a container (same prefix,
+  new backend) is a deliberate admin action paired with an explicit re-save, not
+  something the runtime diff detects.
 
 ### PR #6 — Second concrete virtual dataset
 
 Different provider (NOAA ↔ ECMWF) to prove the abstractions generalize; refine
 `VirtualRegionJob` defaults from what it needs.
 
-### PR #7 — Validation phase
+### PR #7 — Extract common patterns into `VirtualRegionJob`
+
+Sequenced after PR #6 so the seam is drawn from two implementations, not guessed
+from one. See [Extracting common patterns (PR 7)](#extracting-common-patterns-pr-7).
+
+### PR #8 — Validation phase
 
 Two sub-phases, sequenced after the first datasets are operationally stable:
 
@@ -1158,7 +1186,7 @@ issue **#513** (its body holds the PR checklist; items are written "PR 1" not
 | PR 3d — move `process()` onto `MaterializedRegionJob` | **merged** (#654) | Removes the base `process()` stub; materialized `process_worker_jobs` narrows its jobs. |
 | PR 3e — consolidate processing-loop docs | **merged** (#655) | `docs/virtual_datasets.md` + seam section in `docs/parallel_processing.md`, linked from code. |
 | PR 4 — first concrete virtual dataset | **merged** (#656; fixes #658 #659) | `noaa-gefs-forecast-10-day-spatial-dev`: 4 inits/day, 0-240h, native 0.25° s-file grid, the 35-day vars available in s files (19). `-dev` suffix: a throwaway operational test; dataset structure questions are deliberately deferred. Month-long prod backfill (2026-05-12 06z – 2026-06-12 06z, 32 k8s workers) published 2026-06-12; spot checks (independent GRIB decodes vs store, null patterns, coverage) all passed. Crons unsuspended to start the operational test. |
-| PR 5 — persist container config | not started | `save_config()` on container drift; before first *externally published* virtual repo (first datasets run in prod unpublished). |
+| PR 5 — persist container config | in progress | `save_config()` on container drift in `parallel_setup`; before first *externally published* virtual repo (first datasets run in prod unpublished). |
 | PR 6 — second concrete virtual dataset | not started | Different provider, proves abstractions generalize. |
 | PR 7 — extract common patterns into `VirtualRegionJob` | not started | With two concrete datasets in hand, lift the shared machinery out of the subclasses (see "Extracting common patterns" below). |
 | PR 8 — validation phase | not started | Spatial-chunk validators + offline tooling. |

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -87,6 +87,9 @@ def parallel_setup(
                 ic_stores[0],
                 ic_stores[1:],
             )
+            # Persist the virtual chunk container set so external readers recover it
+            # from the repo; no-op for materialized datasets. See PR 5 in docs/plans/virtual_icechunk_datasets.md.
+            store_factory.persist_virtual_config()
         # Zarr v3: do NOT expand (readers would see empty holes)
 
         if workers_total > 1:

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -87,8 +87,7 @@ def parallel_setup(
                 ic_stores[0],
                 ic_stores[1:],
             )
-            # Persist the virtual chunk container set so external readers recover it
-            # from the repo; no-op for materialized datasets. See PR 5 in docs/plans/virtual_icechunk_datasets.md.
+            # Persist virtual chunk containers so repo stays in sync with in-code config
             store_factory.persist_virtual_config()
         # Zarr v3: do NOT expand (readers would see empty holes)
 

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -218,11 +218,7 @@ class StoreFactory(FrozenBaseModel):
 
     def persist_virtual_config(self) -> None:
         """Persist the in-code virtual chunk container set into each icechunk repo so
-        external readers recover it via Repository.fetch_config and need only supply the
-        anonymous authorize map at open (credentials are never persisted). No-op for
-        materialized datasets. Single-writer: call once from parallel_setup. Repointing a
-        container (same url_prefix, new backend) is a deliberate admin re-save; see "PR 5"
-        in docs/plans/virtual_icechunk_datasets.md.
+        external readers don't need to provide it manually. No-op for materialized datasets.
         """
         if self.icechunk_virtual_config is None:
             return

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -160,6 +160,29 @@ class StoreFactory(FrozenBaseModel):
         replicas = tuple(repo for role, repo in repos if role != "primary")
         return primaries[0], replicas
 
+    def _icechunk_storages(self) -> list[tuple[str, str, icechunk.Storage]]:
+        """(role, store_path, storage) for each icechunk store, primary first then
+        replicas (replicas skipped in dev, matching replica_stores)."""
+        all_configs = [
+            ("primary", self.primary_storage_config),
+            *[
+                (f"replica-{i}", config)
+                for i, config in enumerate(self.replica_storage_configs)
+            ],
+        ]
+        if Config.is_dev:
+            all_configs = [all_configs[0]]
+
+        storages: list[tuple[str, str, icechunk.Storage]] = []
+        for role, config in all_configs:
+            if config.format != DatasetFormat.ICECHUNK:
+                continue
+            store_path = _get_store_path(self.dataset_id, self.version, config)
+            storages.append(
+                (role, store_path, _get_icechunk_storage(store_path, config))
+            )
+        return storages
+
     def icechunk_repos(
         self, *, sort: Literal["primary-first", "primary-last"]
     ) -> list[tuple[str, icechunk.Repository]]:
@@ -168,26 +191,11 @@ class StoreFactory(FrozenBaseModel):
         `role` uniquely identifies the repo within this StoreFactory:
         "primary" for the primary store, "replica-0", "replica-1", ... for replicas.
         """
+        repo_config, credentials = _virtual_repository_config_and_credentials(
+            self.icechunk_virtual_config
+        )
         repos: list[tuple[str, icechunk.Repository]] = []
-        all_configs = [
-            ("primary", self.primary_storage_config),
-            *[
-                (f"replica-{i}", config)
-                for i, config in enumerate(self.replica_storage_configs)
-            ],
-        ]
-        # In dev, skip replicas (same as replica_stores behavior)
-        if Config.is_dev:
-            all_configs = [all_configs[0]]
-
-        for role, config in all_configs:
-            if config.format != DatasetFormat.ICECHUNK:
-                continue
-            store_path = _get_store_path(self.dataset_id, self.version, config)
-            ic_storage = _get_icechunk_storage(store_path, config)
-            repo_config, credentials = _virtual_repository_config_and_credentials(
-                self.icechunk_virtual_config
-            )
+        for role, _store_path, ic_storage in self._icechunk_storages():
             # Retry to resolve multiple workers racing to create a new repo
             repo = retry(
                 functools.partial(
@@ -207,6 +215,40 @@ class StoreFactory(FrozenBaseModel):
                 return sorted(repos, key=lambda r: r[0] == "primary")
             case _ as unreachable:
                 assert_never(unreachable)
+
+    def persist_virtual_config(self) -> None:
+        """Persist the in-code virtual chunk container set into each icechunk repo so
+        external readers recover it via Repository.fetch_config and need only supply the
+        anonymous authorize map at open (credentials are never persisted). No-op for
+        materialized datasets. Single-writer: call once from parallel_setup. Repointing a
+        container (same url_prefix, new backend) is a deliberate admin re-save; see "PR 5"
+        in docs/plans/virtual_icechunk_datasets.md.
+        """
+        if self.icechunk_virtual_config is None:
+            return
+        in_code_prefixes = {
+            container.url_prefix
+            for container in self.icechunk_virtual_config.containers
+        }
+        repo_config, credentials = _virtual_repository_config_and_credentials(
+            self.icechunk_virtual_config
+        )
+        for role, store_path, ic_storage in self._icechunk_storages():
+            if icechunk.Repository.exists(ic_storage):
+                persisted = icechunk.Repository.fetch_config(ic_storage)
+                if (
+                    persisted is not None
+                    and set(persisted.virtual_chunk_containers or ())
+                    == in_code_prefixes
+                ):
+                    continue
+            repo = icechunk.Repository.open_or_create(
+                ic_storage,
+                config=repo_config,
+                authorize_virtual_chunk_access=credentials,
+            )
+            repo.save_config()
+            log.info(f"Persisted virtual chunk container config to {role} {store_path}")
 
     def _coordination_base_path(self) -> str:
         if Config.is_prod:

--- a/tests/common/test_parallel_coordination.py
+++ b/tests/common/test_parallel_coordination.py
@@ -29,6 +29,10 @@ class FakeStoreFactory:
         }
         self._primary_store: object = MagicMock(name="primary_zarr3_store")
         self._replica_stores: list[object] = []
+        self.persist_virtual_config_calls = 0
+
+    def persist_virtual_config(self) -> None:
+        self.persist_virtual_config_calls += 1
 
     def set_icechunk_repos(self, ordered: list[tuple[str, FakeRepo]]) -> None:
         self._icechunk_repos_by_sort["primary-first"] = list(ordered)
@@ -224,6 +228,9 @@ class TestParallelSetupFirstWorker:
             primary_session.store,
             [replica_session.store],
         )
+
+        # Worker 0 persists the virtual container config once after expanding.
+        assert factory.persist_virtual_config_calls == 1
 
         # ready.json records the snapshot per role.
         ready = json.loads(factory.files["job"]["setup/ready.json"])

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -479,6 +479,83 @@ class TestIcechunkVirtualConfig:
         assert not repo.config.virtual_chunk_containers
 
 
+def _spy_save_config(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Record each Repository.save_config call while still performing it."""
+    calls: list[int] = []
+    real = icechunk.Repository.save_config
+
+    def spy(self: icechunk.Repository) -> None:
+        calls.append(1)
+        real(self)
+
+    monkeypatch.setattr(icechunk.Repository, "save_config", spy)
+    return calls
+
+
+class TestPersistVirtualConfig:
+    def _virtual_factory(
+        self, tmp_path: str, *, prefix: str = "file:///data/"
+    ) -> StoreFactory:
+        container = icechunk.VirtualChunkContainer(
+            prefix, icechunk.local_filesystem_store("/data/")
+        )
+        return StoreFactory(
+            primary_storage_config=StorageConfig(
+                base_path=str(tmp_path), format=DatasetFormat.ICECHUNK
+            ),
+            dataset_id="test-dataset",
+            template_config_version="v1.0",
+            icechunk_virtual_config=IcechunkVirtualConfig(
+                containers=(container,),
+                manifest_split=manifest_append_dim_split(split_size=1, dim="init_time"),
+            ),
+        )
+
+    def test_persists_container_set_for_reader_recovery(self, tmp_path: str) -> None:
+        factory = self._virtual_factory(tmp_path)
+        factory.persist_virtual_config()
+        # A reader opens with no config override and still recovers the containers.
+        _role, _path, storage = factory._icechunk_storages()[0]
+        fetched = icechunk.Repository.fetch_config(storage)
+        assert fetched is not None
+        assert fetched.virtual_chunk_containers is not None
+        assert "file:///data/" in fetched.virtual_chunk_containers
+
+    def test_is_drift_gated_idempotent(
+        self, tmp_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        factory = self._virtual_factory(tmp_path)
+        calls = _spy_save_config(monkeypatch)
+        factory.persist_virtual_config()
+        factory.persist_virtual_config()  # containers unchanged -> no second save
+        assert calls == [1]
+
+    def test_resaves_on_container_change(
+        self, tmp_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._virtual_factory(tmp_path).persist_virtual_config()
+        calls = _spy_save_config(monkeypatch)
+        # Same store, different container set -> drift -> save again.
+        self._virtual_factory(
+            tmp_path, prefix="file:///other/"
+        ).persist_virtual_config()
+        assert calls == [1]
+
+    def test_noop_for_materialized(
+        self, tmp_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        factory = StoreFactory(
+            primary_storage_config=StorageConfig(
+                base_path=str(tmp_path), format=DatasetFormat.ICECHUNK
+            ),
+            dataset_id="test-dataset",
+            template_config_version="v1.0",
+        )
+        calls = _spy_save_config(monkeypatch)
+        factory.persist_virtual_config()
+        assert calls == []
+
+
 class TestBranchSupport:
     def test_icechunk_store_opens_on_specified_branch(self) -> None:
         factory = StoreFactory(


### PR DESCRIPTION
## PR 5 — persist virtual chunk container config

Part of #513 (virtual icechunk datasets). Sequenced before the first *externally published* virtual repo.

### Problem
Reading a virtual chunk needs two **separate** things, and only the first is persistable:

1. The container **registered** — `set_virtual_chunk_container(VCC)`, the `url_prefix` → backend-store mapping. Refs are stored relative to it, so it must be present for the repo to resolve them. Part of `RepositoryConfig`; persistable via `save_config`.
2. The container **authorized** at open — `authorize_virtual_chunk_access={prefix: creds}`, the credentials + explicit read-time grant. This is icechunk's security boundary: it is **never** persisted and the reader passes it on every open, regardless of what the repo creator wrote.

We only ever supplied the registrations in-memory through the `config=` override (`_virtual_repository_config_and_credentials`). So an external reader opening with just an authorize map and no override has no registered containers and can't resolve the refs — they'd have to reconstruct and `set_virtual_chunk_container` our exact config themselves, defeating the minimal-published-surface goal.

This PR persists the **registrations**. It does **not** (and can't) remove the `authorize_virtual_chunk_access` requirement — it removes the reader's need to *register*: they recover the registrations from the repo via `fetch_config` on a plain `Repository.open(storage)` and supply only the anonymous authorize map.

### Fix
`StoreFactory.persist_virtual_config()`, called once from `parallel_setup`'s worker-0 (`is_first`) branch — the single-writer chokepoint, which avoids the `RepositoryConfig.previous_file` optimistic-concurrency race a per-worker save would hit. **Drift-gated**: `Repository.fetch_config` (guarded by `Repository.exists`, since `fetch_config` raises on a not-yet-created repo) compares the persisted container `url_prefix` set to the in-code set and only re-saves on a difference. No-op for materialized datasets.

Also extracts a small `_icechunk_storages()` helper shared by `icechunk_repos()` and the new method.

### Decisions (icechunk 2.0.5, spiked)
- **`save_config(self)` takes no args** — it persists *the repo's open-time config*. Worker 0 opens with the full override, so the persisted config is containers + manifest_split + caching.
- **`Repository.open(config=override)` merges field-by-field onto the persisted config** (verified: a no-container override still recovered the persisted containers). So (a) our writers' override keeps working unchanged once we persist, and (b) persisting the full config incl. `caching(num_chunk_refs=1M)` is benign — a reader who cares overrides it, and 1M is a *safer* default than icechunk's 5M (the value behind the original OOM).
- **Drift is keyed on `url_prefix` only.** Repointing a container (same prefix, new backend) is a deliberate admin re-save, not something the runtime diff detects.

### Tests
`tests/common/test_storage.py::TestPersistVirtualConfig` — reader-recovery via `fetch_config`, drift-gated idempotency, re-save on container change, materialized no-op. Plus a `parallel_setup` wiring assertion in `test_parallel_coordination.py`.

### Docs
`docs/plans/virtual_icechunk_datasets.md`: rewrote the PR #5 section to the implemented design + decisions above; table row → *in progress*; renumbered the stale `### PR #7/#8` prose subsections to match the table (PR 7 = extract common patterns, PR 8 = validation).

Checks: `ruff format`, `ruff check`, `ty`, targeted tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
