### PR TITLE
Validate GEFS 10-day spatial after each update, and alert on a single late cycle

### DIFF
--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/dynamical_dataset.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import timedelta
+from functools import partial
 
 import icechunk
 from pydantic import Field
@@ -85,4 +86,10 @@ class GefsForecast10DaySpatialDataset(
         # Minimal for now: the NaN validators decode one full GRIB message per
         # (lead, member) chunk touched, which is unbounded on a virtual store.
         # Manifest-aware validators are planned (virtual datasets plan, PR 7).
-        return (validation.check_forecast_current_data,)
+        # 6h cycle + ~3h48m = 9h48m plus a little buffer = 10h
+        return (
+            partial(
+                validation.check_forecast_current_data,
+                max_latest_init_time_age=timedelta(hours=10),
+            ),
+        )

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/dynamical_dataset.py
@@ -69,7 +69,8 @@ class GefsForecast10DaySpatialDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="40 7 * * *",  # after the 00z init finishes publishing
+            # Validate after each update: update fire (43 3,9,15,21) + its 2h10m deadline.
+            schedule="53 5,11,17,23 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/tests/noaa/gefs/forecast_10_day_spatial/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/dynamical_dataset_test.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import timedelta
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -161,5 +162,7 @@ def test_operational_kubernetes_resources(
 
 
 def test_validators(dataset: GefsForecast10DaySpatialDataset) -> None:
-    validators = tuple(dataset.validators())
-    assert validators == (validation.check_forecast_current_data,)
+    [validator] = dataset.validators()
+    assert isinstance(validator, partial)
+    assert validator.func is validation.check_forecast_current_data
+    assert validator.keywords == {"max_latest_init_time_age": timedelta(hours=10)}


### PR DESCRIPTION
## Validate GEFS 10-day spatial after each update, and alert on a single late cycle

Two related fixes to operational validation for this 4×/day-updating dataset.

### 1. Validate after every update, not once a day
The update cron runs **4×/day** (`43 3,9,15,21`) but validate ran **once a day** (`40 7`) — the only dataset out of step (siblings updating 4×/day all validate 4×/day; once-daily-updating datasets validate once daily). Following the convention **validate cron = update fire + update `pod_active_deadline`**:

`43 3,9,15,21` + `2h10m` → **`53 5,11,17,23 * * *`** (validate `pod_active_deadline` unchanged, 30m).

### 2. Tighten the freshness threshold
`check_forecast_current_data` defaulted to a **1-day** window, so even 4×/day validation wouldn't flag a stalled pipeline until the latest init crossed 24h stale. Set it to a schedule-independent bound on the latest init's *healthy* age:

`max_latest_init_time_age = 10h = 6h cycle + ~3h48m lag = 9h48m, plus a little buffer`

The lag (init time → first file lands and expands `init_time` on main) was **measured from the store**: the one clean steady-state scheduled fire (18z) gave 3h47m48s, matching the documented earliest-publication start (init+3:46). The latest init's healthy age tops out at ~9h48m just before the next init lands, so 10h **alerts whenever a cycle runs late** without false-alarming (NOAA doesn't jitter GEFS by an hour).

Checks: `ruff format`, `ruff check`, `ty`, dataset tests — all green. Schedules + validators live in `operational_kubernetes_resources`/`validators()`, not the template, so no template regen.

> Note: the running cluster cronjob won't pick up the schedule change until the next deploy; patch the live `…-validate` cronjob to `53 5,11,17,23 * * *` in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
