### PR TITLE
Lift the virtual write loop into VirtualRegionJob (PR 7)

### DIFF
--- a/docs/plans/virtual_icechunk_datasets.md
+++ b/docs/plans/virtual_icechunk_datasets.md
@@ -1241,7 +1241,7 @@ issue **#513** (its body holds the PR checklist; items are written "PR 1" not
 | PR 4 — first concrete virtual dataset | **merged** (#656; fixes #658 #659) | `noaa-gefs-forecast-10-day-spatial-dev`: 4 inits/day, 0-240h, native 0.25° s-file grid, the 35-day vars available in s files (19). `-dev` suffix: a throwaway operational test; dataset structure questions are deliberately deferred. Month-long prod backfill (2026-05-12 06z – 2026-06-12 06z, 32 k8s workers) published 2026-06-12; spot checks (independent GRIB decodes vs store, null patterns, coverage) all passed. Crons unsuspended to start the operational test. |
 | PR 5 — persist container config | **merged** (#667) | `save_config()` on container drift in `parallel_setup`; before first *externally published* virtual repo (first datasets run in prod unpublished). |
 | PR 6 — second concrete virtual dataset | in progress | `ecmwf-ifs-ens-forecast-15-day-spatial-dev`: ECMWF IFS ENS, 51 members, 0-360h, native wrapped 0.25° grid. Different index format (JSON-lines, explicit lengths), multi-member-per-file packing (control `oper-fc` + perturbed `enfo-ef`), raw-value attrs. Validated end to end against live data; open-data ~4-day retention noted. |
-| PR 7 — extract common patterns into `VirtualRegionJob` | not started | With two concrete datasets in hand, lift the shared machinery out of the subclasses (see "Extracting common patterns" below). |
+| PR 7 — extract common patterns into `VirtualRegionJob` | in progress | Lifted the source-agnostic tick loop + unreadable-file skipping to the base (attrs → overridable seam → common machinery); the object-store-listing discovery is a separate opt-in util generic over obstore backends (`virtual_source_listing.discover_available_by_obstore_listing`), not base baggage. Subclasses supply `generate_source_file_coords`, `file_refs`, a one-line `discover_available`, `operational_update_jobs` (per-subclass, like materialized), optional `representative_var`/`filter_already_present`; the data→index relationship is `SourceFileCoord.get_index_url()`. Drew the seam from GEFS + ECMWF; each subclass `region_job.py` dropped ~100 lines. See "Extracting common patterns (PR 7) — as built" below. |
 | PR 8 — validation phase | not started | Spatial-chunk validators + offline tooling. |
 
 PR 3 was originally one combined PR (#648) but was resequenced into 3a + 3b after
@@ -1313,6 +1313,66 @@ rule, the index-byte-range parse), prefer a **utility implementations opt into**
 over a forced base method — "if [patterns] are common, we make them into utilities
 that implementations can pick from."
 
+#### Extracting common patterns (PR 7) — as built
+
+`VirtualRegionJob` is **source-agnostic** and organized in three tiers: **class
+attrs**, then the **overridable per-dataset seam**, then **common write-loop
+machinery** subclasses don't touch. The base assumes nothing about S3 or object
+listing — the loop works in coord space (it only asks `discover_available` which
+coords are ready) and drops ingested coords by identity. The seam:
+
+The core three, run in this order to drive an update:
+
+- `generate_source_file_coords` *(abstract, inherited from `RegionJob`)* — list every
+  source file this job covers.
+- `discover_available(pending) -> [(coord, size)]` *(abstract)* — given the files not
+  yet ingested, which are available to fetch now, each with its data-file size
+  (returns the same coord objects so the loop can drop them by identity).
+  Obstore-listable datasets delegate to the `discover_available_by_obstore_listing`
+  util (below) in a one-liner; a source obstore can't list (an HTML directory index,
+  a frontier to probe, assume-all) implements it directly. **Not** a base default —
+  the base carries no listing/S3 baggage.
+- `file_refs(coord, file_size) -> list[VirtualRef]` *(abstract)* — given one available
+  file, build every ref it contributes (or `[]` to skip). The index-format-specific
+  parse and the stale-index detection (byte ranges vs file size) live here, where GEFS
+  (colon-text, implied ends + size fallback) and ECMWF (JSON-lines, explicit lengths)
+  genuinely diverge.
+
+Plus the update factory and two presence-probe knobs:
+
+- `operational_update_jobs(...)` *(abstract, inherited)* — **kept per-subclass**,
+  like materialized: each encodes its own re-sweep window inline (GEFS 24h, ECMWF
+  48h) rather than reading a base `operational_window` knob.
+- `filter_already_present(candidates, store)` *(default: manifest probe)* — drop
+  candidates whose representative chunk is already a ref. Override for custom
+  presence logic.
+- `representative_var(coord)` *(default: first instant var among the coord's own
+  `data_vars`)* — which variable's chunk presence means the whole file is ingested.
+  The default reads the subset the file packs from `coord.data_vars`, so subset-packing
+  datasets (GEFS lead-0/pre-b22, ECMWF lead-0 max/min drop) need no override.
+
+Common machinery (subclasses don't implement): `process_virtual_refs` (the
+source-agnostic tick loop driving `discover_available` + `file_refs`) and
+`_file_refs_or_skip` (the broad per-file `try/except` — re-raise `AssertionError`,
+log, skip → `[]`; source-agnostic, the virtual analog of materialized's
+download/read error handling).
+
+The object-store-listing discovery is a **separate opt-in util**, not a base method:
+`virtual_source_listing.discover_available_by_obstore_listing(pending, *, store,
+location_prefix)` — generic over any obstore backend (S3, GCS, Azure, local; the
+caller passes the built store), a file is ready once both its data object and its
+index are listed. GEFS/ECMWF call it from their `discover_available`; a source
+obstore can't list (an HTTP file server with an HTML directory index) gets its own
+discovery util in the same module, and a non-listing dataset never imports any of
+it. The data→index relationship lives on the coord as `get_index_url()` (added to the base
+`SourceFileCoord`) — the coord owns its URLs.
+
+Class attrs the base offers: `tick_interval` (default 1s) and `download_concurrency`
+(default 32), overridden only when they differ — no S3 prefix/region attrs on the
+base. Net: each subclass `region_job.py` is its coord + `generate_source_file_coords`
++ `file_refs` + a one-line `discover_available` + `operational_update_jobs` +
+`representative_var`, ~100 lines lighter.
+
 Do not over-fit to GEFS: keep anything that's genuinely one provider's quirk
 (NOAA `.idx` parsing, the s-file var subsetting) in the subclass.
 
@@ -1336,6 +1396,20 @@ write-closure "batches") and rejected it: it needs a batch/closure abstraction p
 in-loop default-arg capture — *more* machinery than the two ~6-line
 `process_worker_jobs` methods — and the dataset-author surface is identical either
 way. See the [worker-processing seam](#the-worker-processing-seam).
+
+**<a name="decision-virtualref-vs-spec"></a>`VirtualRef` (our type), not icechunk's
+`VirtualChunkSpec`, as `file_refs`' return.** `VirtualChunkSpec` needs the resolved
+integer chunk **index** (`index=[i, j, k, l]`) up front; `VirtualRef` carries the
+ref in **coordinate-label space** (`data_var` + `out_loc`, e.g. `{init_time,
+lead_time, ensemble_member}`) and is resolved to an index centrally in `_emit_refs`
+via `chunk_key`. That decoupling is load-bearing: (1) the index isn't knowable when
+`file_refs` runs — the store is lazily expanded (`sync_dims_to`) only just before
+emit, so the ref's append-dim position may not exist yet; (2) the **same**
+`chunk_key` computes the filter's probe key and the emitted index, so the filter and
+emitter can't drift; (3) the chunk-boundary asserts run in one place. So each
+dataset's `file_refs` stays ignorant of store-expansion state and array geometry,
+and `VirtualRef → VirtualChunkSpec` happens once, in the base. (On the `VirtualRef`
+type itself:)
 
 **<a name="decision-virtualref-namedtuple"></a>`VirtualRef` is a `NamedTuple`, not
 a `FrozenBaseModel`.** It is a pure ephemeral in-process carrier — never

--- a/docs/virtual_datasets.md
+++ b/docs/virtual_datasets.md
@@ -10,12 +10,36 @@ How virtual jobs plug into worker parallelism and coordination is covered in [pa
 
 1. `generate_source_file_coords` lists candidate source files for the region.
 2. `filter_already_present` drops files whose refs are already in the manifest.
-3. `process_virtual_refs(remaining)` — the generator each dataset implements — discovers available source files and yields batches of `(source file coord, its VirtualRefs)` pairs.
+3. `process_virtual_refs(remaining)` — a concrete `VirtualRegionJob` generator — each tick asks `discover_available` which files are ready, builds their refs with `file_refs`, and yields batches of `(source file coord, its VirtualRefs)` pairs.
 4. Each yield is committed atomically: open fresh writable sessions (a committed icechunk session is read-only), grow the append dim if needed (`sync_dims_to`), `set_virtual_refs`, commit.
 
-**The yield is the commit unit.** The generator owns the batching policy: operational updates yield everything that arrived since the last poll tick (typically ~one file) for per-file visibility; backfills yield everything available. A yield must contain *whole* source files — never split a file across yields — and must never be empty (an empty icechunk commit raises). The loop asserts each file's refs cover the representative cell `filter_already_present` probes, so a file the filter could never see as ingested fails loudly instead of being re-ingested forever.
+**The yield is the commit unit.** The loop's batching policy: operational updates yield everything that arrived since the last poll tick (typically ~one file) for per-file visibility; backfills yield everything available. A yield contains *whole* source files — never split a file across yields — and is never empty (an empty icechunk commit raises). The loop asserts each file's refs cover the representative cell `filter_already_present` probes, so a file the filter could never see as ingested fails loudly instead of being re-ingested forever.
 
 `processing_mode` on the job selects the generator's stopping rule: `"backfill"` sweeps what exists once and exits; `"update"` polls until everything expected is ingested, with the pod's active deadline bounding how long it waits on a file that never publishes. `operational_update_jobs` implementations must construct jobs with `processing_mode="update"` (asserted by the driver).
+
+## What a `VirtualRegionJob` implementer writes
+
+`VirtualRegionJob` is **source-agnostic**: the base owns the tick loop (`process_virtual_refs`, working in coord space), the atomic-commit machinery, lazy append-dim expansion (`sync_dims_to`), central chunk-index resolution (`chunk_key`/`_emit_refs`), and unreadable-file skipping (`_file_refs_or_skip`). It assumes nothing about S3, object listing, or even that a source file *has* an index. A dataset fills in the seam.
+
+**The core three.** Most of a virtual dataset is three methods, run in this order to drive an update:
+
+1. `generate_source_file_coords(processing_region_ds, data_var_group) -> [coord]` — list every source file this job covers.
+2. `discover_available(pending) -> [(coord, file_size)]` — given the source files not yet ingested, return those available to fetch right now, each with its data-file size. Obstore-listable backends one-line this via `discover_available_by_obstore_listing` (below); other sources implement it directly.
+3. `file_refs(coord, file_size) -> [VirtualRef]` — given one available file, return every pointer it contributes — a `VirtualRef` is `(source location, byte offset, length) -> one output chunk` — or `[]` to skip the file. Resolve byte ranges however the source allows: parse a sidecar index, scan the data file, or (one message per file) point at the whole file. Refs are in coordinate-label space; the chunk index is resolved centrally.
+
+(Between 1 and 2 the base runs `filter_already_present` to drop files already in the manifest; steps 2–3 then repeat each tick until everything is ingested. See "The write loop" above.)
+
+**Also required:** `operational_update_jobs(...)` — the update factory (per-subclass, like materialized datasets); encodes the re-sweep window and constructs the job with `processing_mode="update"`.
+
+**On the `SourceFileCoord` subclass** (identifies one source file):
+
+- `get_url() -> str` — the canonical data-file URL refs point at (must match the virtual chunk container prefix).
+- `out_loc() -> {dim: label}` — the output cell the file fills. The inherited default works when the coord's fields are all dim names; override otherwise (e.g. a representative ensemble member for a multi-member file).
+- `get_index_url() -> str` — *optional*, only if the files have a sidecar byte-range index; used by the obstore-listing discovery util and by index-based `file_refs`. Nothing on the base calls it.
+
+**Optional overrides (working defaults):** `filter_already_present` (manifest probe), `representative_var` (first instant var among the coord's own `data_vars` — only override for a packing that rule misses), the `tick_interval` (1s) / `download_concurrency` (32) class attrs, and `process_virtual_refs` itself (only for a fundamentally different batching policy).
+
+**Discovery utilities** (opt-in, off the base, in `virtual_source_listing.py`): `discover_available_by_obstore_listing(pending, *, store, location_prefix)` works for any obstore backend (S3, GCS, Azure, local) — a file is ready once `store` lists both its data object and its index; the caller passes the built store. A source obstore can't list (an HTTP file server whose directory index is HTML, a frontier that must be probed) gets its own discovery util in the same module and a custom `discover_available`.
 
 ## Reader safety: one source file → one atomic commit
 

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -75,6 +75,10 @@ class SourceFileCoord(FrozenBaseModel):
         """Return the URL for this source file."""
         raise NotImplementedError("Return the URL of the source file.")
 
+    def get_index_url(self) -> str:
+        """Return the URL of this source file's byte-range index, if it has one."""
+        raise NotImplementedError("Return the URL of the source file's index.")
+
     def out_loc(
         self,
     ) -> Mapping[Dim, CoordinateValue]:

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -1,5 +1,7 @@
 import asyncio
+import time
 from collections.abc import Iterator, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, ClassVar, Final, Generic, Literal, NamedTuple
 
 import icechunk
@@ -12,6 +14,7 @@ from zarr.core.metadata import ArrayV3Metadata
 
 from reformatters.common import storage
 from reformatters.common.config_models import DataVar
+from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     DATA_VAR,
     SOURCE_FILE_COORD,
@@ -19,7 +22,9 @@ from reformatters.common.region_job import (
     RegionJob,
     SourceFileResult,
 )
-from reformatters.common.types import Dim
+from reformatters.common.types import Dim, Timedelta
+
+log = get_logger(__name__)
 
 
 class VirtualRef(NamedTuple):
@@ -42,42 +47,69 @@ class VirtualRegionJob(
     See docs/virtual_datasets.md for the write loop, filtering, and reader-safety guarantees.
     """
 
-    # Locked to None: an integer max_vars_per_job would split one source file's
-    # variables across separate jobs that commit independently, breaking the
-    # per-file commit atomicity virtual readers rely on.
+    # ----- Class attributes -----
+
+    # Locked to None: an int would split one file's vars across independently
+    # committing jobs, breaking the per-file commit atomicity readers rely on.
     max_vars_per_job: ClassVar[Final[int | None]] = None
 
     # Updates wait for source files as the provider publishes them, backfills check once
     processing_mode: Literal["backfill", "update"] = "backfill"
 
-    def process_virtual_refs(
-        self,
-        remaining: Sequence[SOURCE_FILE_COORD],
-    ) -> Iterator[Sequence[tuple[SOURCE_FILE_COORD, Sequence[VirtualRef]]]]:
-        """Discover available source files among `remaining` and yield their virtual references.
+    # When polling, pace each discovery sweep to at most one per tick.
+    tick_interval: ClassVar[Timedelta] = pd.Timedelta("1s")
+    # Concurrent file downloads while building refs (file_refs runs in a thread pool).
+    download_concurrency: ClassVar[int] = 32
 
-        Each yield is one commit's worth of *whole* source files as (coord, refs)
-        pairs — never split a file across yields, never yield an empty batch. The
-        generator owns the batching policy. See "The write loop" in
-        docs/virtual_datasets.md.
+    # ----- Overridable methods -----
+    # A dataset implements file_refs and generate_source_file_coords (from
+    # RegionJob); the rest have working defaults.
+
+    def file_refs(self, coord: SOURCE_FILE_COORD, file_size: int) -> list[VirtualRef]:
+        """Build every virtual ref a single source file contributes (or [] to skip it).
+
+        Resolve each message's byte range however the source allows — parse a sidecar
+        index (`coord.get_index_url()`), scan the data file, or (one message per file)
+        point at the whole file — and return a VirtualRef per (out cell, variable) in
+        coordinate-label space; the chunk index is resolved centrally later (see
+        _emit_refs). Return [] to drop an unreadable or stale file. `file_size` is
+        whatever discover_available reported (a listed size, a Content-Length), e.g.
+        to supply the missing final end byte of an index that omits it.
         """
         raise NotImplementedError(
-            "Yield batches of (source file coord, its VirtualRefs) pairs, "
-            "each one commit's worth of whole source files."
+            "Return the VirtualRefs for one source file, or [] to skip it."
         )
 
-    def representative_var(self, coord: SOURCE_FILE_COORD) -> DATA_VAR:  # noqa: ARG002
+    def discover_available(
+        self, pending: list[SOURCE_FILE_COORD]
+    ) -> list[tuple[SOURCE_FILE_COORD, int]]:
+        """Of the not-yet-present files, the subset fetchable now, each with its data-file size.
+
+        Return the same coord objects from `pending` (the loop drops them by
+        identity). For an obstore-listable backend, delegate to
+        `virtual_source_listing.discover_available_by_obstore_listing`; for a source
+        obstore can't list (an HTML directory index, a frontier to probe,
+        assume-all) implement it directly.
+        """
+        raise NotImplementedError(
+            "Return the (coord, file_size) pairs ready to fetch now."
+        )
+
+    def representative_var(self, coord: SOURCE_FILE_COORD) -> DATA_VAR:
         """The variable whose chunk presence means `coord`'s file is fully ingested.
 
-        Used by filter_already_present to probe a single representative chunk per
-        file. Default: the first instant var (most likely to have data at every
-        step), else the first data var; valid when every file contains every
-        variable. Override for one-variable-per-file packings (e.g. GEFS v12
-        reforecast) to return the candidate's own variable.
+        Probed by filter_already_present and asserted by the write loop, so it must
+        be a variable the file's refs actually cover. Default: the first instant var
+        (most likely to have data at every step) among the vars the file carries —
+        `coord.data_vars` if it declares which subset it packs, else all of
+        self.data_vars — falling back to the first such var. Override only for a
+        packing neither rule captures (e.g. one variable per file keyed off the
+        coord rather than its data_vars).
         """
+        file_vars = getattr(coord, "data_vars", None) or self.data_vars
         return next(
-            (var for var in self.data_vars if var.attrs.step_type == "instant"),
-            self.data_vars[0],
+            (var for var in file_vars if var.attrs.step_type == "instant"),
+            file_vars[0],
         )
 
     def filter_already_present(
@@ -108,7 +140,68 @@ class VirtualRegionJob(
         present = _exists_many(store, [key for _, key in keyed if key is not None])
         return [coord for coord, key in keyed if key is None or not present[key]]
 
-    # ----- Most subclasses will not need to override the attributes and methods below -----
+    # ----- Common write-loop machinery: subclasses do not implement these -----
+
+    def process_virtual_refs(
+        self,
+        remaining: Sequence[SOURCE_FILE_COORD],
+    ) -> Iterator[Sequence[tuple[SOURCE_FILE_COORD, Sequence[VirtualRef]]]]:
+        """Drive discover_available + file_refs, yielding one commit's worth per tick.
+
+        One yield per tick contains every file that became available since the last:
+        a backfill sweeps once and exits, an update polls until everything is
+        ingested. Each yield is whole source files as (coord, refs) pairs — never
+        split a file, never yield empty. Source-agnostic: it only asks
+        discover_available which coords are ready. Override only for a different
+        batching policy. See "The write loop" in docs/virtual_datasets.md.
+        """
+        pending = list(remaining)
+        with ThreadPoolExecutor(self.download_concurrency) as pool:
+            while pending:
+                tick_start = time.monotonic()
+                available = self.discover_available(pending)
+                if available:
+                    coords, sizes = zip(*available, strict=True)
+                    refs_per_file = pool.map(self._file_refs_or_skip, coords, sizes)
+                    # Drop files that yielded no refs (skipped as unreadable).
+                    batch = [
+                        (coord, refs)
+                        for coord, refs in zip(coords, refs_per_file, strict=True)
+                        if refs
+                    ]
+                    ready = {id(coord) for coord in coords}
+                    pending = [coord for coord in pending if id(coord) not in ready]
+                    skipped = len(coords) - len(batch)
+                    log.info(
+                        f"Ingesting {len(batch)} files"
+                        f"{f' ({skipped} skipped)' if skipped else ''}, "
+                        f"{len(pending)} still pending"
+                    )
+                    if batch:
+                        yield batch
+                if self.processing_mode == "backfill":
+                    if pending:
+                        log.info(
+                            f"{len(pending)} source files not present, skipping "
+                            f"(first: {pending[0].get_url()})"
+                        )
+                    return
+                if pending:
+                    elapsed = time.monotonic() - tick_start
+                    time.sleep(max(0.0, self.tick_interval.total_seconds() - elapsed))
+
+    def _file_refs_or_skip(
+        self, coord: SOURCE_FILE_COORD, file_size: int
+    ) -> list[VirtualRef]:
+        # Skip a file we can't build refs for rather than sink the job; AssertionError
+        # is our own invariant, so let it propagate.
+        try:
+            return self.file_refs(coord, file_size)
+        except AssertionError:
+            raise
+        except Exception:
+            log.exception(f"Skipping {coord.get_url()}: could not build virtual refs")
+            return []
 
     @classmethod
     def process_worker_jobs(
@@ -152,9 +245,6 @@ class VirtualRegionJob(
         current_size = self._append_dim_size(readonly_store)
 
         for file_refs_batch in self.process_virtual_refs(remaining):
-            # The generator yields whole files, so a batch always has refs; emitting
-            # them always dirties the session, so the commit below is never empty
-            # (an empty icechunk commit raises rather than no-ops).
             assert file_refs_batch, "process_virtual_refs yielded an empty batch"
             for coord, file_refs in file_refs_batch:
                 self._assert_probe_chunk_covered(coord, file_refs)
@@ -180,14 +270,8 @@ class VirtualRegionJob(
     def _assert_probe_chunk_covered(
         self, coord: SOURCE_FILE_COORD, file_refs: Sequence[VirtualRef]
     ) -> None:
-        """A file's refs must include the chunk filter_already_present probes.
-
-        The filter decides whether a whole file is already ingested by checking
-        one chunk: (representative_var, the file's out_loc). If a file's refs
-        never write that chunk, the filter never sees the file land and every
-        future fire re-ingests it; usually a representative_var override is
-        needed (see its docstring).
-        """
+        """A file's refs must cover the chunk filter_already_present probes
+        (representative_var at the file's out_loc)."""
         assert file_refs, f"empty refs for source file {coord}"
         rep = self.representative_var(coord)
         probe = self.chunk_key(coord.out_loc(), rep)
@@ -234,16 +318,11 @@ class VirtualRegionJob(
     ) -> tuple[int, ...] | None:
         """Map a source message's coordinate labels to its zarr chunk index.
 
-        Returns None if a label is not in the template's coords, which the filter
-        treats as "remaining". Asserts each label lands on an exact chunk boundary -
-        a virtual chunk is exactly one GRIB message, so any non-aligned position is
-        a bug.
+        Returns None if a label is not in the template's coords (the filter treats
+        that as "remaining").
         """
-        # Geometry (dim order, chunk sizes, coord positions) is read from the
-        # checked-in template (the authoritative metadata, git-reviewable), not the
-        # in-code DataVar.encoding which could drift from it. So the index matches
-        # what readers resolve and does not depend on how far the store has been
-        # expanded. Shared by the filter and the emitter so they cannot disagree.
+        # Geometry comes from the checked-in template, not the in-code
+        # DataVar.encoding which could drift; shared by the filter and emitter.
         template_var = self.template_ds[var.name]
         dims = tuple(str(d) for d in template_var.dims)
         chunks = template_var.encoding["chunks"]
@@ -261,11 +340,8 @@ class VirtualRegionJob(
                 if position < 0:
                     return None  # label not in coords -> not yet a position in this dataset
             else:
-                # A dim absent from out_loc (e.g. lat/lon) must be a single chunk;
-                # otherwise every ref would collapse to chunk 0 along it (later refs
-                # overwriting earlier, the rest left as permanent fill-value holes).
-                # A multi-chunk dim (e.g. ensemble_member packed one-per-file) must
-                # appear in out_loc so it resolves to the right chunk.
+                # A dim absent from out_loc must be single-chunk, else all refs
+                # collapse to chunk 0 along it.
                 assert chunk_size >= template_var.sizes[dim], (
                     f"dim {dim} is absent from out_loc but spans multiple chunks "
                     f"(size {template_var.sizes[dim]}, chunk {chunk_size}); out_loc "
@@ -285,14 +361,9 @@ class VirtualRegionJob(
         self, stores: Sequence[IcechunkStore], needed_append_dim_size: int
     ) -> None:
         """Grow the append dim (and its dependent coords) to `needed_append_dim_size`."""
-        # Writes only the new positions by appending the corresponding slice of the
-        # already-derived template; existing positions are untouched. Data vars stay
-        # dask-lazy under compute=False, so the decode-only serializer is never
-        # invoked. A no-op for any store already covering the size (so backfill's
-        # pre-sized branch never resizes, and parallel workers never conflict). Each
-        # store's missing slice is computed from its own committed size: replicas
-        # commit before the primary, so a partial commit can leave a replica ahead,
-        # and appending the primary's slice to it would duplicate positions.
+        # compute=False keeps data vars dask-lazy so the decode-only serializer is
+        # never invoked. Each store's missing slice is from its own committed size:
+        # replicas can be a commit ahead, so the primary's slice would duplicate.
         for store in stores:
             current_size = self._append_dim_size(store)
             if needed_append_dim_size <= current_size:
@@ -320,9 +391,7 @@ class VirtualRegionJob(
 
     def _processing_region_ds(self) -> xr.Dataset:
         processing_region = self.get_processing_region()
-        # Virtual refs point at raw source bytes, so no surrounding buffer is ever
-        # needed; a buffered region would make adjacent backfill workers generate
-        # overlapping candidates and emit refs into each other's regions.
+        # Virtual refs point at raw source bytes, so no surrounding buffer is needed.
         assert processing_region == self.region, (
             "VirtualRegionJob.get_processing_region must equal self.region"
         )

--- a/src/reformatters/common/virtual_source_listing.py
+++ b/src/reformatters/common/virtual_source_listing.py
@@ -1,0 +1,52 @@
+"""Object-store-listing source-file discovery for virtual datasets that opt into it.
+
+A `VirtualRegionJob.discover_available` implementation for sources listable with
+obstore (S3, GCS, Azure, local filesystem, ...), generic over the backend — the
+caller passes the built store. Sources obstore can't list (an HTML directory index,
+a frontier to probe) implement `discover_available` another way and never import this.
+"""
+
+import obstore
+
+from reformatters.common.region_job import SOURCE_FILE_COORD
+
+
+def discover_available_by_obstore_listing(
+    pending: list[SOURCE_FILE_COORD],
+    *,
+    store: obstore.store.ObjectStore,
+    location_prefix: str,
+    require_index: bool,
+) -> list[tuple[SOURCE_FILE_COORD, int]]:
+    """The ready subset of `pending`, each paired with its data file's size in bytes.
+
+    A file is ready once `store` lists its data object (`coord.get_url()`), plus, when
+    `require_index`, its index (`coord.get_index_url()`) — the index lands alongside
+    the data, so a source whose files have no sidecar index passes require_index=False.
+    `location_prefix` is the url:// prefix `store` is rooted at, stripped from coord
+    URLs to form store-relative keys. Returns the same coord objects from `pending`.
+    """
+    by_key = {coord.get_url().removeprefix(location_prefix): coord for coord in pending}
+    prefixes = sorted({key.rsplit("/", 1)[0] + "/" for key in by_key})
+    listed = _list_objects(store, prefixes)
+    return [
+        (coord, listed[key])
+        for key, coord in by_key.items()
+        if key in listed
+        and (
+            not require_index
+            or coord.get_index_url().removeprefix(location_prefix) in listed
+        )
+    ]
+
+
+def _list_objects(
+    store: obstore.store.ObjectStore, prefixes: list[str]
+) -> dict[str, int]:
+    """All object keys under each prefix in `store`, mapped to size in bytes."""
+    return {
+        meta["path"]: meta["size"]
+        for prefix in prefixes
+        for batch in obstore.list(store, prefix=prefix, chunk_size=10_000)
+        for meta in batch
+    }

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_spatial/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_spatial/region_job.py
@@ -1,10 +1,6 @@
-import time
-from collections.abc import Callable, Iterator, Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import ClassVar
 
-import obstore
 import pandas as pd
 import xarray as xr
 from zarr.abc.store import Store
@@ -19,6 +15,9 @@ from reformatters.common.region_job import (
 from reformatters.common.time_utils import whole_hours
 from reformatters.common.types import AppendDim, DatetimeLike, Dim, Timedelta, Timestamp
 from reformatters.common.virtual_region_job import VirtualRef, VirtualRegionJob
+from reformatters.common.virtual_source_listing import (
+    discover_available_by_obstore_listing,
+)
 from reformatters.ecmwf.ecmwf_config_models import (
     EcmwfDataVar,
     has_hour_0_values,
@@ -32,22 +31,6 @@ log = get_logger(__name__)
 
 _S3_LOCATION_PREFIX = "s3://ecmwf-forecasts/"
 _S3_BUCKET_REGION = "eu-central-1"
-
-
-def _vars_in_file(
-    data_vars: Sequence[EcmwfDataVar], init_time: pd.Timestamp, lead_time: pd.Timedelta
-) -> list[EcmwfDataVar]:
-    """The subset of data_vars an open-data file for (init_time, lead_time) contains.
-
-    Excludes variables not yet available at init_time and max/min variables that
-    have no value at lead_time=0h.
-    """
-    return [
-        var
-        for var in data_vars
-        if vars_available([var], init_time)
-        and (lead_time != pd.Timedelta(0) or has_hour_0_values(var))
-    ]
 
 
 class IfsEnsForecast15DaySpatialSourceFileCoord(SourceFileCoord):
@@ -84,8 +67,8 @@ class IfsEnsForecast15DaySpatialSourceFileCoord(SourceFileCoord):
         return self._base_url() + ".index"
 
     def out_loc(self) -> Mapping[Dim, CoordinateValue]:
-        # A single chunk location (the first member) for the filter's presence probe;
-        # the whole file commits atomically, so any member stands in for all of them.
+        # The whole file commits atomically, so the first member stands in as the
+        # filter's presence probe for all of them.
         return {
             "init_time": self.init_time,
             "lead_time": self.lead_time,
@@ -97,14 +80,6 @@ class EcmwfIfsEnsForecast15DaySpatialRegionJob(
     VirtualRegionJob[EcmwfDataVar, IfsEnsForecast15DaySpatialSourceFileCoord]
 ):
     """RegionJob for the ECMWF IFS ENS 15-day spatial (virtual) forecast dataset."""
-
-    # Reprocess this span of recent init times each operational update. Each fire
-    # re-sweeps the window, catching stragglers earlier fires gave up on.
-    operational_window: ClassVar[Timedelta] = pd.Timedelta("48h")
-    # When polling, pace bucket listings to at most one sweep per tick.
-    tick_interval: ClassVar[Timedelta] = pd.Timedelta("1s")
-    # Concurrent index file downloads (one ~2MB .index per source file).
-    download_concurrency: ClassVar[int] = 32
 
     def generate_source_file_coords(
         self, processing_region_ds: xr.Dataset, data_var_group: Sequence[EcmwfDataVar]
@@ -137,89 +112,17 @@ class EcmwfIfsEnsForecast15DaySpatialRegionJob(
                 )
         return coords
 
-    def process_virtual_refs(
-        self, remaining: Sequence[IfsEnsForecast15DaySpatialSourceFileCoord]
-    ) -> Iterator[
-        Sequence[tuple[IfsEnsForecast15DaySpatialSourceFileCoord, Sequence[VirtualRef]]]
-    ]:
-        """Each tick: list the bucket, fetch newly available files' indexes, yield their refs.
+    def discover_available(
+        self, pending: list[IfsEnsForecast15DaySpatialSourceFileCoord]
+    ) -> list[tuple[IfsEnsForecast15DaySpatialSourceFileCoord, int]]:
+        return discover_available_by_obstore_listing(
+            pending,
+            store=s3_store(_S3_LOCATION_PREFIX, region=_S3_BUCKET_REGION),
+            location_prefix=_S3_LOCATION_PREFIX,
+            require_index=True,
+        )
 
-        One yield (= one commit) per tick, containing every file that became
-        available since the last tick.
-        """
-        pending = {
-            coord.get_url().removeprefix(_S3_LOCATION_PREFIX): coord
-            for coord in remaining
-        }
-        with ThreadPoolExecutor(self.download_concurrency) as pool:
-            while pending:
-                tick_start = time.monotonic()
-                available = self._discover_available(pending)
-                if available:
-                    coords = [pending[key] for key in available]
-                    refs_per_file = pool.map(
-                        self._file_refs_or_skip, coords, available.values()
-                    )
-                    # Files with no refs were skipped (unreadable source); drop them
-                    # so a batch never carries a file with no chunks.
-                    batch = [
-                        (coord, refs)
-                        for coord, refs in zip(coords, refs_per_file, strict=True)
-                        if refs
-                    ]
-                    for key in available:
-                        del pending[key]
-                    skipped = len(coords) - len(batch)
-                    log.info(
-                        f"Ingesting {len(batch)} files"
-                        f"{f' ({skipped} skipped)' if skipped else ''}, "
-                        f"{len(pending)} still pending"
-                    )
-                    if batch:
-                        yield batch
-                if self.processing_mode == "backfill":
-                    if pending:
-                        log.info(
-                            f"{len(pending)} source files not present, skipping (first: {next(iter(pending))})"
-                        )
-                    return
-                if pending:
-                    elapsed = time.monotonic() - tick_start
-                    time.sleep(max(0.0, self.tick_interval.total_seconds() - elapsed))
-
-    def _discover_available(
-        self, pending: Mapping[str, IfsEnsForecast15DaySpatialSourceFileCoord]
-    ) -> dict[str, int]:
-        """The pending files retrievable now, mapped to their data file's size in bytes.
-
-        A file is available once the bucket lists both its .grib2 and .index objects
-        (refs need the index, and the index lands alongside the data).
-        """
-        listed: dict[str, int] = {}
-        for prefix in sorted({key.rsplit("/", 1)[0] + "/" for key in pending}):
-            listed |= _list_objects(prefix)
-        return {
-            key: listed[key]
-            for key in pending
-            if key in listed and _index_key(key) in listed
-        }
-
-    def _file_refs_or_skip(
-        self, coord: IfsEnsForecast15DaySpatialSourceFileCoord, file_size: int
-    ) -> list[VirtualRef]:
-        # Skip a file we can't turn into refs (a decode surprise, a transient read
-        # error) rather than sink the whole job; its chunks stay fill and validation
-        # surfaces the gap. AssertionError is our own invariant, so it propagates.
-        # PR 7 lifts this onto VirtualRegionJob; see docs/plans/virtual_icechunk_datasets.md.
-        try:
-            return self._file_refs(coord, file_size)
-        except AssertionError:
-            raise
-        except Exception:
-            log.exception(f"Skipping {coord.get_url()}: could not build virtual refs")
-            return []
-
-    def _file_refs(
+    def file_refs(
         self, coord: IfsEnsForecast15DaySpatialSourceFileCoord, file_size: int
     ) -> list[VirtualRef]:
         index_path = s3_download_to_disk(
@@ -242,9 +145,7 @@ class EcmwfIfsEnsForecast15DaySpatialRegionJob(
                 "ensemble_member": member,
             }
             for var, start, end in zip(coord.data_vars, starts, ends, strict=True):
-                # A matching index never references bytes past the data file. When it
-                # does, the source was re-published without regenerating the index and
-                # the offsets are unusable, so skip the whole file (its chunks stay fill).
+                # Byte ranges past the data file mean a stale/mismatched index; skip it.
                 if end > file_size or end <= start:
                     log.warning(
                         f"Skipping {coord.get_url()}: index byte ranges fall outside "
@@ -262,17 +163,6 @@ class EcmwfIfsEnsForecast15DaySpatialRegionJob(
                 )
         return refs
 
-    def representative_var(
-        self, coord: IfsEnsForecast15DaySpatialSourceFileCoord
-    ) -> EcmwfDataVar:
-        # A coord's file contains only its own vars (lead-0 coords drop max/min vars),
-        # so probe one of those rather than the base class's default drawn from all
-        # of self.data_vars.
-        return next(
-            (v for v in coord.data_vars if v.attrs.step_type == "instant"),
-            coord.data_vars[0],
-        )
-
     @classmethod
     def operational_update_jobs(
         cls,
@@ -286,19 +176,17 @@ class EcmwfIfsEnsForecast15DaySpatialRegionJob(
         Sequence[RegionJob[EcmwfDataVar, IfsEnsForecast15DaySpatialSourceFileCoord]],
         xr.Dataset,
     ]:
-        """Return a single polling job spanning the active window of recent init times.
+        """A single polling job over the recent init times (48h window, the last 2 daily inits).
 
-        The cron fires just before an init's publication window opens; the job
-        polls until all expected files are ingested, with the pod deadline
-        bounding how long it waits on a file that never publishes.
-        filter_already_present derives the remaining work from the icechunk
-        manifest. See "Operational updates" in docs/virtual_datasets.md.
+        Polls until all expected files are ingested; filter_already_present derives
+        the remaining work from the manifest. See "Operational updates" in
+        docs/virtual_datasets.md.
         """
         append_dim_end = pd.Timestamp.now()
         template_ds = get_template_fn(append_dim_end)
         init_times = template_ds.get_index(append_dim)
         window_start = int(
-            init_times.searchsorted(append_dim_end - cls.operational_window)
+            init_times.searchsorted(append_dim_end - pd.Timedelta("48h"))
         )
         job = cls(
             tmp_store=tmp_store,
@@ -312,15 +200,17 @@ class EcmwfIfsEnsForecast15DaySpatialRegionJob(
         return [job], template_ds
 
 
-def _index_key(data_key: str) -> str:
-    return data_key.removesuffix(".grib2") + ".index"
+def _vars_in_file(
+    data_vars: Sequence[EcmwfDataVar], init_time: pd.Timestamp, lead_time: pd.Timedelta
+) -> list[EcmwfDataVar]:
+    """The subset of data_vars an open-data file for (init_time, lead_time) contains.
 
-
-def _list_objects(prefix: str) -> dict[str, int]:
-    """All object keys under `prefix` in the ECMWF bucket, mapped to size in bytes."""
-    store = s3_store(_S3_LOCATION_PREFIX, region=_S3_BUCKET_REGION)
-    return {
-        meta["path"]: meta["size"]
-        for batch in obstore.list(store, prefix=prefix, chunk_size=10_000)
-        for meta in batch
-    }
+    Excludes variables not yet available at init_time and max/min variables that
+    have no value at lead_time=0h.
+    """
+    return [
+        var
+        for var in data_vars
+        if vars_available([var], init_time)
+        and (lead_time != pd.Timedelta(0) or has_hour_0_values(var))
+    ]

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
@@ -1,10 +1,7 @@
-import time
-from collections.abc import Callable, Iterator, Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import ClassVar, Literal
 
-import obstore
 import pandas as pd
 import xarray as xr
 from zarr.abc.store import Store
@@ -12,8 +9,11 @@ from zarr.abc.store import Store
 from reformatters.common.download import s3_download_to_disk, s3_store
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import RegionJob
-from reformatters.common.types import AppendDim, DatetimeLike, Timedelta
+from reformatters.common.types import AppendDim, DatetimeLike
 from reformatters.common.virtual_region_job import VirtualRef, VirtualRegionJob
+from reformatters.common.virtual_source_listing import (
+    discover_available_by_obstore_listing,
+)
 from reformatters.noaa.gefs.gefs_config_models import (
     GEFS_B22_TRANSITION_DATE,
     GEFS_CURRENT_ARCHIVE_START,
@@ -31,25 +31,6 @@ log = get_logger(__name__)
 
 _S3_LOCATION_PREFIX = "s3://noaa-gefs-pds/"
 _S3_BUCKET_REGION = "us-east-1"
-
-
-def _vars_in_s_file(
-    data_vars: Sequence[GEFSDataVar], init_time: pd.Timestamp, lead_time: pd.Timedelta
-) -> list[GEFSDataVar]:
-    """The subset of data_vars the s file for (init_time, lead_time) contains.
-
-    "s+b-b22" variables were only added to the s files at GEFS_B22_TRANSITION_DATE,
-    and accumulated/avg variables don't exist in the 0-hour forecast.
-    """
-    return [
-        var
-        for var in data_vars
-        if (
-            var.internal_attrs.gefs_file_type != "s+b-b22"
-            or init_time >= GEFS_B22_TRANSITION_DATE
-        )
-        and (lead_time != pd.Timedelta(0) or has_hour_0_values(var))
-    ]
 
 
 class GefsForecast10DaySpatialSourceFileCoord(GefsEnsembleSourceFileCoord):
@@ -84,11 +65,6 @@ class GefsForecast10DaySpatialRegionJob(
 ):
     """RegionJob for the GEFS 10-day spatial (virtual) forecast dataset."""
 
-    # Reprocess this span of recent init times each operational update. Each fire
-    # re-sweeps the window, catching stragglers earlier fires gave up on.
-    operational_window: ClassVar[Timedelta] = pd.Timedelta("24h")
-    # When polling, pace bucket listings to at most one sweep per tick.
-    tick_interval: ClassVar[Timedelta] = pd.Timedelta("1s")
     # Concurrent index file downloads. The .idx files are ~30KB latency-bound
     # requests; measured throughput vs pool width: 8 -> ~105 files/s,
     # 32 -> ~310, 64 -> ~380, 128 -> ~435 (diminishing).
@@ -116,89 +92,17 @@ class GefsForecast10DaySpatialRegionJob(
                     )
         return coords
 
-    def process_virtual_refs(
-        self, remaining: Sequence[GefsForecast10DaySpatialSourceFileCoord]
-    ) -> Iterator[
-        Sequence[tuple[GefsForecast10DaySpatialSourceFileCoord, Sequence[VirtualRef]]]
-    ]:
-        """Each tick: list the bucket, fetch newly available files' indexes, yield their refs.
+    def discover_available(
+        self, pending: list[GefsForecast10DaySpatialSourceFileCoord]
+    ) -> list[tuple[GefsForecast10DaySpatialSourceFileCoord, int]]:
+        return discover_available_by_obstore_listing(
+            pending,
+            store=s3_store(_S3_LOCATION_PREFIX, region=_S3_BUCKET_REGION),
+            location_prefix=_S3_LOCATION_PREFIX,
+            require_index=True,
+        )
 
-        One yield (= one commit) per tick, containing every file that became
-        available since the last tick.
-        """
-        pending = {
-            coord.get_url().removeprefix(_S3_LOCATION_PREFIX): coord
-            for coord in remaining
-        }
-        with ThreadPoolExecutor(self.download_concurrency) as pool:
-            while pending:
-                tick_start = time.monotonic()
-                available = self._discover_available(pending)
-                if available:
-                    coords = [pending[key] for key in available]
-                    refs_per_file = pool.map(
-                        self._file_refs_or_skip, coords, available.values()
-                    )
-                    # Files with no refs were skipped (unreadable source); drop them
-                    # so a batch never carries a file with no chunks.
-                    batch = [
-                        (coord, refs)
-                        for coord, refs in zip(coords, refs_per_file, strict=True)
-                        if refs
-                    ]
-                    for key in available:
-                        del pending[key]
-                    skipped = len(coords) - len(batch)
-                    log.info(
-                        f"Ingesting {len(batch)} files"
-                        f"{f' ({skipped} skipped)' if skipped else ''}, "
-                        f"{len(pending)} still pending"
-                    )
-                    if batch:
-                        yield batch
-                if self.processing_mode == "backfill":
-                    if pending:
-                        log.info(
-                            f"{len(pending)} source files not present, skipping (first: {next(iter(pending))})"
-                        )
-                    return
-                if pending:
-                    elapsed = time.monotonic() - tick_start
-                    time.sleep(max(0.0, self.tick_interval.total_seconds() - elapsed))
-
-    def _discover_available(
-        self, pending: Mapping[str, GefsForecast10DaySpatialSourceFileCoord]
-    ) -> dict[str, int]:
-        """The pending files retrievable now, mapped to their data file's size in bytes.
-
-        A file is available once the bucket lists both its data and index objects
-        (the .idx lands a few seconds after the .grib2, and refs need both).
-        """
-        listed: dict[str, int] = {}
-        for prefix in sorted({key.rsplit("/", 1)[0] + "/" for key in pending}):
-            listed |= _list_objects(prefix)
-        return {
-            key: listed[key]
-            for key in pending
-            if key in listed and f"{key}.idx" in listed
-        }
-
-    def _file_refs_or_skip(
-        self, coord: GefsForecast10DaySpatialSourceFileCoord, file_size: int
-    ) -> list[VirtualRef]:
-        # Skip a file we can't turn into refs (a decode surprise, a transient read
-        # error) rather than sink the whole job; its chunks stay fill and validation
-        # surfaces the gap. AssertionError is our own invariant, so it propagates.
-        # PR 7 lifts this onto VirtualRegionJob; see docs/plans/virtual_icechunk_datasets.md.
-        try:
-            return self._file_refs(coord, file_size)
-        except AssertionError:
-            raise
-        except Exception:
-            log.exception(f"Skipping {coord.get_url()}: could not build virtual refs")
-            return []
-
-    def _file_refs(
+    def file_refs(
         self, coord: GefsForecast10DaySpatialSourceFileCoord, file_size: int
     ) -> list[VirtualRef]:
         index_path = s3_download_to_disk(
@@ -218,10 +122,7 @@ class GefsForecast10DaySpatialRegionJob(
             file_size if end - start >= GRIB_INDEX_UNKNOWN_END_PAD else end
             for start, end in zip(starts, ends, strict=True)
         ]
-        # A matching index never references bytes past the data file. When it does, the
-        # source was re-published without regenerating the index and the offsets are
-        # unusable, so skip the whole file (its chunks stay fill). Returning no refs is
-        # the caller's signal to drop the file from the batch.
+        # Byte ranges past the data file mean a stale/mismatched index; skip the file.
         if any(
             end > file_size or end <= start
             for start, end in zip(starts, ends, strict=True)
@@ -245,17 +146,6 @@ class GefsForecast10DaySpatialRegionJob(
             for var, start, end in zip(coord.data_vars, starts, ends, strict=True)
         ]
 
-    def representative_var(
-        self, coord: GefsForecast10DaySpatialSourceFileCoord
-    ) -> GEFSDataVar:
-        # A coord's file contains only its own vars (lead-0 and pre-b22 coords
-        # carry a subset), so probe one of those rather than the base class's
-        # default drawn from all of self.data_vars.
-        return next(
-            (v for v in coord.data_vars if v.attrs.step_type == "instant"),
-            coord.data_vars[0],
-        )
-
     @classmethod
     def operational_update_jobs(
         cls,
@@ -269,19 +159,17 @@ class GefsForecast10DaySpatialRegionJob(
         Sequence[RegionJob[GEFSDataVar, GefsForecast10DaySpatialSourceFileCoord]],
         xr.Dataset,
     ]:
-        """Return a single polling job spanning the active window of recent init times.
+        """A single polling job over the recent init times (24h window, the last 4 inits).
 
-        The cron fires just before an init's publication window opens; the job
-        polls until all expected files are ingested, with the pod deadline
-        bounding how long it waits on a file that never publishes.
-        filter_already_present derives the remaining work from the icechunk
-        manifest. See "Operational updates" in docs/virtual_datasets.md.
+        Polls until all expected files are ingested; filter_already_present derives
+        the remaining work from the manifest. See "Operational updates" in
+        docs/virtual_datasets.md.
         """
         append_dim_end = pd.Timestamp.now()
         template_ds = get_template_fn(append_dim_end)
         init_times = template_ds.get_index(append_dim)
         window_start = int(
-            init_times.searchsorted(append_dim_end - cls.operational_window)
+            init_times.searchsorted(append_dim_end - pd.Timedelta("24h"))
         )
         job = cls(
             tmp_store=tmp_store,
@@ -295,11 +183,20 @@ class GefsForecast10DaySpatialRegionJob(
         return [job], template_ds
 
 
-def _list_objects(prefix: str) -> dict[str, int]:
-    """All object keys under `prefix` in the GEFS bucket, mapped to size in bytes."""
-    store = s3_store(_S3_LOCATION_PREFIX, region=_S3_BUCKET_REGION)
-    return {
-        meta["path"]: meta["size"]
-        for batch in obstore.list(store, prefix=prefix, chunk_size=10_000)
-        for meta in batch
-    }
+def _vars_in_s_file(
+    data_vars: Sequence[GEFSDataVar], init_time: pd.Timestamp, lead_time: pd.Timedelta
+) -> list[GEFSDataVar]:
+    """The subset of data_vars the s file for (init_time, lead_time) contains.
+
+    "s+b-b22" variables were only added to the s files at GEFS_B22_TRANSITION_DATE,
+    and accumulated/avg variables don't exist in the 0-hour forecast.
+    """
+    return [
+        var
+        for var in data_vars
+        if (
+            var.internal_attrs.gefs_file_type != "s+b-b22"
+            or init_time >= GEFS_B22_TRANSITION_DATE
+        )
+        and (lead_time != pd.Timedelta(0) or has_hour_0_values(var))
+    ]

--- a/tests/common/virtual_source_listing_test.py
+++ b/tests/common/virtual_source_listing_test.py
@@ -1,0 +1,104 @@
+from collections.abc import Mapping
+
+import obstore
+import pytest
+
+from reformatters.common import virtual_source_listing
+from reformatters.common.region_job import CoordinateValue, SourceFileCoord
+from reformatters.common.types import Dim
+from reformatters.common.virtual_source_listing import (
+    discover_available_by_obstore_listing,
+)
+
+_PREFIX = "s3://bucket/"
+
+
+class _Coord(SourceFileCoord):
+    key: str
+
+    def get_url(self) -> str:
+        return f"{_PREFIX}dir/{self.key}.grib2"
+
+    def get_index_url(self) -> str:
+        return f"{_PREFIX}dir/{self.key}.index"
+
+    def out_loc(self) -> Mapping[Dim, CoordinateValue]:
+        return {}
+
+
+def _fake_listing(monkeypatch: pytest.MonkeyPatch, listed: dict[str, int]) -> list[str]:
+    seen_prefixes: list[str] = []
+
+    def fake(store: obstore.store.ObjectStore, prefixes: list[str]) -> dict[str, int]:
+        seen_prefixes.extend(prefixes)
+        return listed
+
+    monkeypatch.setattr(virtual_source_listing, "_list_objects", fake)
+    return seen_prefixes
+
+
+_LISTING = {
+    "dir/both.grib2": 9000,
+    "dir/both.index": 200,
+    "dir/index_only.index": 150,
+    "dir/data_only.grib2": 9000,
+}
+
+
+def test_require_index_needs_both_data_and_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    both, index_only, data_only = (
+        _Coord(key="both"),
+        _Coord(key="index_only"),
+        _Coord(key="data_only"),
+    )
+    seen = _fake_listing(monkeypatch, _LISTING)
+
+    result = discover_available_by_obstore_listing(
+        [both, index_only, data_only],
+        store=obstore.store.MemoryStore(),  # unused; _list_objects is faked
+        location_prefix=_PREFIX,
+        require_index=True,
+    )
+
+    # Only the file with both objects listed; same coord object, paired with its size.
+    assert len(result) == 1
+    (coord, size) = result[0]
+    assert coord is both
+    assert size == 9000
+    assert seen == ["dir/"]  # the files' shared directory prefix
+
+
+def test_without_require_index_data_object_suffices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    both, index_only, data_only = (
+        _Coord(key="both"),
+        _Coord(key="index_only"),
+        _Coord(key="data_only"),
+    )
+    _fake_listing(monkeypatch, _LISTING)
+
+    result = discover_available_by_obstore_listing(
+        [both, index_only, data_only],
+        store=obstore.store.MemoryStore(),
+        location_prefix=_PREFIX,
+        require_index=False,
+    )
+
+    # index_only has no data object listed; the other two do.
+    assert {coord.key for coord, _ in result} == {"both", "data_only"}
+
+
+def test_empty_when_nothing_listed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_listing(monkeypatch, {})
+    assert (
+        discover_available_by_obstore_listing(
+            [_Coord(key="a")],
+            store=obstore.store.MemoryStore(),
+            location_prefix=_PREFIX,
+            require_index=True,
+        )
+        == []
+    )

--- a/tests/ecmwf/ifs_ens/forecast_15_day_spatial/region_job_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_spatial/region_job_test.py
@@ -13,6 +13,7 @@ from gribberish import (
     parse_grib_message_metadata,  # ty: ignore[unresolved-import] - native module member
 )
 
+from reformatters.common import virtual_region_job
 from reformatters.common.virtual_region_job import VirtualRef
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar
 from reformatters.ecmwf.ifs_ens.forecast_15_day_spatial import (
@@ -159,7 +160,7 @@ def test_file_refs_resolves_all_members(
     _fake_index_download(monkeypatch, tmp_path)
     coord = _coord((1, 2), data_vars)
 
-    refs = job._file_refs(coord, file_size=9000)
+    refs = job.file_refs(coord, file_size=9000)
 
     # Two members x two vars, each pointing at the one shared enfo-ef file.
     assert len(refs) == 4
@@ -192,38 +193,29 @@ def test_file_refs_skips_file_whose_index_points_past_eof(
     _fake_index_download(monkeypatch, tmp_path)
     coord = _coord((1, 2), data_vars)
     # A matching (larger) file resolves refs.
-    assert job._file_refs(coord, file_size=9000)
+    assert job.file_refs(coord, file_size=9000)
     # A file smaller than the index's max offset is stale/mismatched -> no refs.
-    assert job._file_refs(coord, file_size=400) == []
+    assert job.file_refs(coord, file_size=400) == []
 
 
-def _fake_list(monkeypatch: pytest.MonkeyPatch, listing: dict[str, int]) -> list[str]:
-    listings: list[str] = []
+def _fake_discover(
+    monkeypatch: pytest.MonkeyPatch,
+    ticks: list[list[tuple[IfsEnsForecast15DaySpatialSourceFileCoord, int]]],
+) -> list[int]:
+    """Drive the loop: return one canned (coord, size) list per discovery sweep."""
+    sweeps: list[int] = []
+    it = iter(ticks)
 
-    def fake_list_objects(prefix: str) -> dict[str, int]:
-        listings.append(prefix)
-        return listing
+    def fake(
+        pending: list[IfsEnsForecast15DaySpatialSourceFileCoord], **kwargs: object
+    ) -> list[tuple[IfsEnsForecast15DaySpatialSourceFileCoord, int]]:
+        sweeps.append(len(pending))
+        return next(it)
 
-    monkeypatch.setattr(region_job_module, "_list_objects", fake_list_objects)
-    return listings
-
-
-def test_discover_available_requires_data_and_index(
-    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    data_vars = [get_var("temperature_2m")]
-    job = make_job(template_ds, data_vars=data_vars)
-    index_key = _ENFO_FILE.removesuffix(".grib2") + ".index"
-    enfo2 = f"{_ENFO_PREFIX}20260513000000-6h-enfo-ef.grib2"
-    _fake_list(
-        monkeypatch,
-        {_ENFO_FILE: 9000, index_key: 200, enfo2: 9000},  # enfo2 has no .index yet
+    monkeypatch.setattr(
+        region_job_module, "discover_available_by_obstore_listing", fake
     )
-    pending = {
-        _ENFO_FILE: _coord(_PERTURBED, data_vars),
-        enfo2: _coord(_PERTURBED, data_vars, lead_time=pd.Timedelta("6h")),
-    }
-    assert job._discover_available(pending) == {_ENFO_FILE: 9000}
+    return sweeps
 
 
 def test_process_virtual_refs_backfill_sweeps_once(
@@ -232,17 +224,15 @@ def test_process_virtual_refs_backfill_sweeps_once(
     data_vars = [get_var("temperature_2m"), get_var("pressure_surface")]
     job = make_job(template_ds, data_vars=data_vars)
     _fake_index_download(monkeypatch, tmp_path)
-    index_key = _ENFO_FILE.removesuffix(".grib2") + ".index"
-    enfo2 = f"{_ENFO_PREFIX}20260513000000-6h-enfo-ef.grib2"
-    # File 1 fully published; file 2's .index has not landed yet.
-    listings = _fake_list(monkeypatch, {_ENFO_FILE: 9000, index_key: 200, enfo2: 9000})
-
     coord1 = _coord((1, 2), data_vars)
     coord2 = _coord((1, 2), data_vars, lead_time=pd.Timedelta("6h"))
+    # File 1 ready; file 2 not yet.
+    sweeps = _fake_discover(monkeypatch, [[(coord1, 9000)]])
+
     batches = list(job.process_virtual_refs([coord1, coord2]))
 
-    # A backfill sweeps once: one listing, one yield with only the ready file, exit.
-    assert listings == [_ENFO_PREFIX]
+    # A backfill sweeps once, yields the ready file, then exits.
+    assert len(sweeps) == 1
     (batch,) = batches
     ((coord, refs),) = batch
     assert coord.lead_time == pd.Timedelta("3h")
@@ -256,25 +246,13 @@ def test_process_virtual_refs_update_polls_until_all_ingested(
     job = make_job(template_ds, data_vars=data_vars, processing_mode="update")
     _fake_index_download(monkeypatch, tmp_path)
     sleeps: list[float] = []
-    monkeypatch.setattr(region_job_module.time, "sleep", sleeps.append)
-
-    index_key = _ENFO_FILE.removesuffix(".grib2") + ".index"
-    enfo2 = f"{_ENFO_PREFIX}20260513000000-6h-enfo-ef.grib2"
-    enfo2_index = enfo2.removesuffix(".grib2") + ".index"
-    # Tick 1: nothing; tick 2: file 1; tick 3: file 2 as well.
-    listings = iter(
-        [
-            {},
-            {_ENFO_FILE: 9000, index_key: 200},
-            {enfo2: 9000, enfo2_index: 200},
-        ]
-    )
-    monkeypatch.setattr(
-        region_job_module, "_list_objects", lambda prefix: next(listings)
-    )
+    monkeypatch.setattr(virtual_region_job.time, "sleep", sleeps.append)
 
     coord1 = _coord((1, 2), data_vars)
     coord2 = _coord((1, 2), data_vars, lead_time=pd.Timedelta("6h"))
+    # Tick 1: nothing; tick 2: file 1; tick 3: file 2.
+    _fake_discover(monkeypatch, [[], [(coord1, 9000)], [(coord2, 9000)]])
+
     batches = list(job.process_virtual_refs([coord1, coord2]))
 
     assert [[coord.lead_time for coord, _refs in batch] for batch in batches] == [
@@ -330,11 +308,11 @@ def test_real_source_all_vars_resolve_and_decode(template_ds: xr.Dataset) -> Non
     job = make_job(template_ds)
 
     key = coord.get_url().removeprefix(_S3_LOCATION_PREFIX)
-    available = job._discover_available({key: coord})
-    if key not in available:
+    available = job.discover_available([coord])
+    if not available:
         pytest.skip(f"ECMWF open data for {init} not currently in the bucket")
-    file_size = available[key]
-    refs = job._file_refs(coord, file_size)
+    [(_, file_size)] = available
+    refs = job.file_refs(coord, file_size)
 
     # 17 vars x 50 perturbed members.
     assert len(refs) == 17 * 50

--- a/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
@@ -13,6 +13,7 @@ from gribberish import (
     parse_grib_message_metadata,  # ty: ignore[unresolved-import] - native module member
 )
 
+from reformatters.common import virtual_region_job
 from reformatters.common.virtual_region_job import VirtualRef
 from reformatters.noaa.gefs.forecast_10_day_spatial import (
     region_job as region_job_module,
@@ -196,12 +197,32 @@ def _coord(
 
 def _fake_index_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     def fake_download(url: str, dataset_id: str, *, region: str) -> Path:
-        # Unique per url so concurrent _file_refs don't clobber each other's file.
+        # Unique per url so concurrent file_refs don't clobber each other's file.
         index_path = tmp_path / (url.rsplit("/", 1)[-1] + ".idx")
         index_path.write_text(_INDEX_CONTENT)
         return index_path
 
     monkeypatch.setattr(region_job_module, "s3_download_to_disk", fake_download)
+
+
+def _fake_discover(
+    monkeypatch: pytest.MonkeyPatch,
+    ticks: list[list[tuple[GefsForecast10DaySpatialSourceFileCoord, int]]],
+) -> list[int]:
+    """Drive the loop: return one canned (coord, size) list per discovery sweep."""
+    sweeps: list[int] = []
+    it = iter(ticks)
+
+    def fake(
+        pending: list[GefsForecast10DaySpatialSourceFileCoord], **kwargs: object
+    ) -> list[tuple[GefsForecast10DaySpatialSourceFileCoord, int]]:
+        sweeps.append(len(pending))
+        return next(it)
+
+    monkeypatch.setattr(
+        region_job_module, "discover_available_by_obstore_listing", fake
+    )
+    return sweeps
 
 
 def test_process_virtual_refs_backfill_sweeps_once(
@@ -210,25 +231,14 @@ def test_process_virtual_refs_backfill_sweeps_once(
     data_vars = [get_var("temperature_2m"), get_var("total_precipitation_surface")]
     job = make_job(template_ds, data_vars=data_vars)
     _fake_index_download(monkeypatch, tmp_path)
+    coord1, coord2 = _coord(1, data_vars), _coord(2, data_vars)
+    # Member 1 ready; member 2 not yet.
+    sweeps = _fake_discover(monkeypatch, [[(coord1, 9000)]])
 
-    member1 = f"{_PREFIX}gep01.t00z.pgrb2s.0p25.f003"
-    member2 = f"{_PREFIX}gep02.t00z.pgrb2s.0p25.f003"
-    listings: list[str] = []
+    batches = list(job.process_virtual_refs([coord1, coord2]))
 
-    def fake_list_objects(prefix: str) -> dict[str, int]:
-        listings.append(prefix)
-        # Member 1 fully published; member 2's .idx has not landed yet.
-        return {member1: 9000, f"{member1}.idx": 200, member2: 9000}
-
-    monkeypatch.setattr(region_job_module, "_list_objects", fake_list_objects)
-
-    batches = list(
-        job.process_virtual_refs([_coord(1, data_vars), _coord(2, data_vars)])
-    )
-
-    # A backfill sweeps once: one listing, one yield with only the file whose
-    # data and index are both listed, then exit without polling.
-    assert listings == [_PREFIX]
+    # A backfill sweeps once, yields the ready file, then exits without polling.
+    assert len(sweeps) == 1
     (batch,) = batches
     ((coord, refs),) = batch
     assert coord.ensemble_member == 1
@@ -242,6 +252,7 @@ def test_process_virtual_refs_backfill_sweeps_once(
     # APCP is the last message in the index; its end comes from the listed file size.
     assert apcp_ref.offset == 2500
     assert apcp_ref.length == 9000 - 2500
+    member1 = f"{_PREFIX}gep01.t00z.pgrb2s.0p25.f003"
     for ref in refs:
         assert ref.location == f"s3://noaa-gefs-pds/{member1}"
         assert ref.out_loc == {
@@ -258,28 +269,15 @@ def test_process_virtual_refs_update_polls_until_all_ingested(
     job = make_job(template_ds, data_vars=data_vars, processing_mode="update")
     _fake_index_download(monkeypatch, tmp_path)
     sleeps: list[float] = []
-    monkeypatch.setattr(region_job_module.time, "sleep", sleeps.append)
+    monkeypatch.setattr(virtual_region_job.time, "sleep", sleeps.append)
 
-    member1 = f"{_PREFIX}gep01.t00z.pgrb2s.0p25.f003"
-    member2 = f"{_PREFIX}gep02.t00z.pgrb2s.0p25.f003"
-    # Tick 1: nothing published; tick 2: member 1; tick 3: member 2 as well.
-    listings = iter(
-        [
-            {},
-            {member1: 9000, f"{member1}.idx": 200},
-            {member2: 9000, f"{member2}.idx": 200},
-        ]
-    )
-    monkeypatch.setattr(
-        region_job_module, "_list_objects", lambda prefix: next(listings)
-    )
+    coord1, coord2 = _coord(1, data_vars), _coord(2, data_vars)
+    # Tick 1: nothing; tick 2: member 1; tick 3: member 2.
+    _fake_discover(monkeypatch, [[], [(coord1, 9000)], [(coord2, 9000)]])
 
-    batches = list(
-        job.process_virtual_refs([_coord(1, data_vars), _coord(2, data_vars)])
-    )
+    batches = list(job.process_virtual_refs([coord1, coord2]))
 
-    # One yield per tick that found new files; exits once all are ingested
-    # without consuming a fourth listing.
+    # One yield per tick that found new files; exits once all are ingested.
     assert [
         [
             (coord.ensemble_member, [r.data_var.name for r in refs])
@@ -302,9 +300,9 @@ def test_file_refs_skips_file_whose_index_points_past_eof(
     _fake_index_download(monkeypatch, tmp_path)  # index's last message starts at 2500
     coord = _coord(1, data_vars)
     # A matching (larger) file resolves refs.
-    assert job._file_refs(coord, file_size=9000)
+    assert job.file_refs(coord, file_size=9000)
     # A file smaller than the index's max offset is stale/mismatched -> no refs.
-    assert job._file_refs(coord, file_size=2000) == []
+    assert job.file_refs(coord, file_size=2000) == []
 
 
 def test_process_virtual_refs_drops_files_with_stale_index(
@@ -313,23 +311,11 @@ def test_process_virtual_refs_drops_files_with_stale_index(
     data_vars = [get_var("temperature_2m")]
     job = make_job(template_ds, data_vars=data_vars)
     _fake_index_download(monkeypatch, tmp_path)
-    member1 = f"{_PREFIX}gep01.t00z.pgrb2s.0p25.f003"
-    member2 = f"{_PREFIX}gep02.t00z.pgrb2s.0p25.f003"
-    # member1's listed size (2000) is below the index's max offset (2500) -> skipped.
-    monkeypatch.setattr(
-        region_job_module,
-        "_list_objects",
-        lambda prefix: {
-            member1: 2000,
-            f"{member1}.idx": 200,
-            member2: 9000,
-            f"{member2}.idx": 200,
-        },
-    )
+    coord1, coord2 = _coord(1, data_vars), _coord(2, data_vars)
+    # member1's size (2000) is below the index's max offset (2500) -> file_refs skips it.
+    _fake_discover(monkeypatch, [[(coord1, 2000), (coord2, 9000)]])
 
-    batches = list(
-        job.process_virtual_refs([_coord(1, data_vars), _coord(2, data_vars)])
-    )
+    batches = list(job.process_virtual_refs([coord1, coord2]))
 
     (batch,) = batches
     ((coord, _refs),) = batch
@@ -342,10 +328,12 @@ def test_file_refs_or_skip_swallows_unexpected_errors(
     job = make_job(template_ds, data_vars=[get_var("temperature_2m")])
     coord = _coord(1, [get_var("temperature_2m")])
 
-    def boom(*args: object, **kwargs: object) -> list[VirtualRef]:
+    def boom(self: object, *args: object, **kwargs: object) -> list[VirtualRef]:
         raise RuntimeError("network blip")
 
-    monkeypatch.setattr(job, "_file_refs", boom)
+    # Patch on the class: file_refs is a public name, which pydantic's __setattr__
+    # rejects as a non-field on the model instance.
+    monkeypatch.setattr(type(job), "file_refs", boom)
     # An unexpected per-file error skips the file (no refs) rather than raising.
     assert job._file_refs_or_skip(coord, 9000) == []
 
@@ -356,33 +344,15 @@ def test_file_refs_or_skip_propagates_assertion_errors(
     job = make_job(template_ds, data_vars=[get_var("temperature_2m")])
     coord = _coord(1, [get_var("temperature_2m")])
 
-    def bad_invariant(*args: object, **kwargs: object) -> list[VirtualRef]:
+    def bad_invariant(
+        self: object, *args: object, **kwargs: object
+    ) -> list[VirtualRef]:
         raise AssertionError("our own invariant")
 
-    monkeypatch.setattr(job, "_file_refs", bad_invariant)
+    monkeypatch.setattr(type(job), "file_refs", bad_invariant)
     # Assertion failures are our own bugs and must surface, not be swallowed.
     with pytest.raises(AssertionError, match="our own invariant"):
         job._file_refs_or_skip(coord, 9000)
-
-
-def test_discover_available_requires_data_and_index(
-    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    data_vars = [get_var("temperature_2m")]
-    job = make_job(template_ds, data_vars=data_vars)
-    member1 = f"{_PREFIX}gep01.t00z.pgrb2s.0p25.f003"
-    member2 = f"{_PREFIX}gep02.t00z.pgrb2s.0p25.f003"
-    monkeypatch.setattr(
-        region_job_module,
-        "_list_objects",
-        lambda prefix: {member1: 9000, f"{member1}.idx": 200, f"{member2}.idx": 150},
-    )
-
-    pending = {
-        member1: _coord(1, data_vars),
-        member2: _coord(2, data_vars),  # .idx listed but data file is not
-    }
-    assert job._discover_available(pending) == {member1: 9000}
 
 
 @pytest.mark.slow
@@ -399,10 +369,9 @@ def test_real_source_all_vars_resolve_and_decode(template_ds: xr.Dataset) -> Non
     )
     job = make_job(template_ds)
 
+    [(_, file_size)] = job.discover_available([coord])
     key = coord.get_url().removeprefix("s3://noaa-gefs-pds/")
-    available = job._discover_available({key: coord})
-    file_size = available[key]
-    refs = job._file_refs(coord, file_size)
+    refs = job.file_refs(coord, file_size)
 
     assert len(refs) == 19
     for ref in refs:


### PR DESCRIPTION
Extracts the shared virtual machinery out of the two dataset `RegionJob`s into a **source-agnostic** `VirtualRegionJob` (#513 PR 7), now that GEFS 10-day spatial and ECMWF IFS-ENS spatial agree on the seam.

> Stacked on #671 (PR 6) — review that first; this PR's diff is just the extraction. GitHub retargets it to `main` once #671 merges.

## Shape

`VirtualRegionJob` is organized in tiers. The base assumes nothing about S3, object listing, or even that a source file *has* an index — the tick loop works in coord space and drops ingested coords by identity.

**Overridable per-dataset seam** — the core three, run in order to drive an update:
- `generate_source_file_coords(processing_region_ds, data_var_group) -> [coord]` *(abstract, from `RegionJob`)* — list every source file this job covers.
- `discover_available(pending) -> [(coord, size)]` *(abstract)* — given the not-yet-ingested files, which are available to fetch now (with sizes). Obstore-listable backends one-line this via the util below; other sources implement it directly.
- `file_refs(coord, file_size) -> [VirtualRef]` *(abstract)* — turn one available file into refs, or `[]` to skip. Resolve byte ranges however the source allows: a sidecar index, scanning the data file, or one-message-per-file. The index parse + stale-index detection live here (GEFS colon-text `.idx` with implied ends + size fallback; ECMWF JSON-lines `.index` with explicit lengths).

…plus the update factory and two presence-probe defaults:
- `operational_update_jobs` *(per-subclass, like materialized — re-sweep window encoded inline)*.
- `filter_already_present` *(default: manifest probe)*; `representative_var` *(default: first instant var among the coord's own `data_vars`, so subset-packing datasets need no override)*.

**Common machinery (subclasses don't touch):** `process_virtual_refs` (the source-agnostic loop), `_file_refs_or_skip`, plus the commit/atomicity machinery, `sync_dims_to`, `chunk_key`/`_emit_refs`.

**Discovery is an opt-in util, not base baggage:** `virtual_source_listing.discover_available_by_obstore_listing(pending, *, store, location_prefix, require_index)` — generic over any obstore backend (S3, GCS, Azure, local); the caller passes the built store. `require_index` toggles whether a file needs its index listed too (set `False` for sources with no sidecar index). A source obstore can't list (an HTTP file server with an HTML directory index) gets its own discovery util in the same module. The data→index relationship is `SourceFileCoord.get_index_url()` (optional — nothing on the base calls it).

## Result

- Each subclass `region_job.py` drops ~100+ lines (GEFS 305→202, ECMWF 326→216) — now its coord + `generate_source_file_coords` + a one-line `discover_available` + `file_refs` + `operational_update_jobs`, laid out in processing order.
- Behavior-preserving: full fast suite (1417) + ruff + ty pass; **both** datasets' slow real-source tests pass against live data, and `tests/common/virtual_source_listing_test.py` covers the listing util's data/index pairing and the `require_index=False` path.

Docs: `virtual_datasets.md` gains a "What a `VirtualRegionJob` implementer writes" section leading with the core-three flow; the plan's PR 7 "as built" section + a `VirtualRef`-vs-icechunk-`VirtualChunkSpec` decision entry are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)