### PR TITLE
Exploration: vertical-dimension structure for virtual datasets

### DIFF
--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -532,55 +532,72 @@ triggers, and a dataset needs groups if **either** holds:
    need two resolution groups (e.g. `/lead_0_240` at 0.25°, `/lead_243_840` at
    0.5°), or two separate datasets.
 
-### Open question (for TSC): always group vertical stacks, or only on conflict?
+### Open question (for TSC): where do vertical stacks (and single levels) live?
 
-**Decision needed.** Single/surface variables always live at the root, suffix-named.
-The question is where a *vertical stack* (pressure, model, height) lives.
+**Decision needed.** Dense pressure/model/height levels become a real vertical
+*dimension*. The question is the on-disk layout — what sits at the root vs. in named
+groups. Three options, in order of increasing uniformity (and decreasing root use).
 
 Fixed regardless of the choice: HRRR and ICON-EU publish `temperature` on **both**
 pressure and model levels, so the bare name collides and at least one stack **must**
-go in a group. This decision is really about the other six (single-vertical-type)
-datasets — and thus whether "pressure-level temperature" has a *uniform* location
-across the catalog.
+go in a group. The options mainly differ in what the *other six* (single-vertical-
+type) datasets do, and thus how uniform the catalog looks.
 
-**Option A — group only on conflict.** Single-type datasets keep the stack as a
-dimension on the root; group only where two types collide.
+**Option A — group only on conflict.** Single/surface and the single vertical stack
+both live at the root; group only where two vertical types collide.
 
 ```
 GFS:   /  temperature_2m, temperature(pressure_level), …
-HRRR:  /  temperature_2m, …   /pressure_level  temperature   /model_level  temperature
+HRRR:  /  temperature_2m, …   /pressure_level temperature   /model_level temperature
 ```
 - One `open_zarr()` on GFS/IFS yields surface + pressure together; no group knowledge.
 - Groups appear only where semantically needed; their presence signals "multiple
   vertical systems."
-- Pressure access differs GFS (root) vs HRRR (group) — not uniform.
+- ✗ Pressure access differs GFS (root) vs HRRR (group) — not uniform.
 
-**Option B — always group stacks.** Root holds only single/surface vars everywhere;
-every stack lives in a group named for its coordinate.
+**Option B — always group stacks, single-level at root.** Root holds single/surface
+vars everywhere; every vertical stack lives in a group named for its coordinate.
 
 ```
-GFS:   /  temperature_2m, …   /pressure_level  temperature
-HRRR:  /  temperature_2m, …   /pressure_level  temperature   /model_level  temperature
+GFS:   /  temperature_2m, …   /pressure_level temperature
+HRRR:  /  temperature_2m, …   /pressure_level temperature   /model_level temperature
 ```
-- Uniform: `pressure_level/temperature` everywhere; a dataset gaining a vertical
-  type never relocates existing vars.
-- GFS/IFS readers must open the `pressure_level` group (one-shot `open_zarr` gives
-  only surface vars); nests 6 of 8 datasets.
+- ✓ Uniform stacks: `pressure_level/temperature` everywhere; gaining a vertical type
+  never relocates existing vars.
+- Surface vars still at root (zero-change swap with materialized).
+- ✗ GFS/IFS readers must open the `pressure_level` group for pressure (one-shot
+  `open_zarr` gives only surface vars); nests 6 of 8 datasets.
 
-Either way, single/surface vars stay at root, so materialized→virtual swap-compat is
-the same for both (the suffix→dimension change for pressure breaks those few names
-regardless of grouping). Shared data model: every variable declares its vertical
-coordinate, so flat-vs-grouped is a rendering choice in our code and the policy can
-be applied uniformly. **This is why the policy is worth deciding deliberately now:
+**Option C — group everything, including `single_level` (empty root).** No variables
+at the root; every variable lives in a level-type group. You always open one group.
+
+```
+GFS:   /single_level temperature_2m, …   /pressure_level temperature
+HRRR:  /single_level temperature_2m, …   /pressure_level temperature   /model_level temperature
+MRMS:  /single_level …                    /height reflectivity
+```
+- ✓ Maximally consistent/"pedantic": every dataset is the same shape — a set of
+  level-type groups, root always empty — so there is never a "is it at root or in a
+  group?" ambiguity. The rule is one line: open the group for the level type you want.
+- Still swaps in for the materialized catalog: the `single_level` group holds exactly
+  today's variables, so a consumer changes `open_zarr(url)` →
+  `open_zarr(url, group="single_level")` (one-line) and gets the identical set.
+- ✗ Least discoverable: a bare `open_zarr(url)` yields nothing useful; you must know
+  to open `single_level`. (`open_datatree` still shows all groups at once.)
+
+Notes for all three: the suffix→dimension change for the few pressure names breaks
+those regardless of layout; the shared data model (every variable declares its
+vertical coordinate) means the layout is a rendering choice *in our code*. **But
 changing the layout of an already-published dataset is a breaking change for
-consumer code (a new dataset version), not something we would do lightly — even
-though our implementation could re-render either way.** (Same call also covers
-GEFS's shape-heterogeneity split — resolution windows as groups `/lead_0_240`,
-`/lead_243_840`, vs. separate datasets.)
+consumer code (a new dataset version), not done lightly — which is exactly why this
+policy is worth deciding deliberately now.** The same call covers GEFS's
+shape-heterogeneity split (resolution windows as groups `/lead_0_240`,
+`/lead_243_840`, vs. separate datasets).
 
 **Author's lean: Option A** — optimize the common, most-used single-type datasets
 for one-shot discovery; introduce groups only where a real name conflict requires
-them. Pending TSC input.
+them. Option C is the most consistent but least discoverable; Option B is the middle
+ground. Pending TSC input.
 
 ## Parked / next steps
 
@@ -607,7 +624,8 @@ Decision status and follow-ups (so they aren't lost):
   Decision E — for HRRR/ICON-EU the bare name `temperature` collides across pressure
   and model levels, so a group is required.
 - **E — group policy (layout):** **OPEN — pending TSC** (see "Open question (for
-  TSC): always group vertical stacks, or only on conflict?"). HRRR/ICON-EU must
-  group regardless; the call is whether single-vertical-type datasets keep the stack
-  as a root dimension (Option A, author's lean) or always nest it in a group (Option
-  B). Awaiting technical steering committee input.
+  TSC): where do vertical stacks (and single levels) live?"). HRRR/ICON-EU must group
+  regardless; the call is the catalog-wide layout: **A** group only on conflict
+  (single-type stays flat at root, author's lean), **B** always group vertical stacks
+  but keep single-level at root, or **C** group everything including a `single_level`
+  group (empty root, most consistent / least discoverable). Awaiting TSC input.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -529,33 +529,30 @@ triggers, and a dataset needs groups if **either** holds:
    need two resolution groups (e.g. `/lead_0_240` at 0.25°, `/lead_243_840` at
    0.5°), or two separate datasets.
 
-Manifest/chunk-policy differences are **not** a grouping trigger: we will not
-impose the reader complexity of multiple groups just to vary manifest chunking
-within a dataset.
+### Open question: always group `pressure_level`, or only when it conflicts?
 
-### Recommendation: per-dataset, not always-group
+**Undecided.** Should `pressure_level` *always* be its own group for consistency,
+or only when a dataset has another vertical-coordinate type to conflict with —
+storing it as a plain dimension on the root when there's no conflict?
 
-**Do not make `pressure_level` a group by default.** Decide layout per dataset at
-creation, from its known source structure:
+- **Conditional (lean):** if a dataset has a single vertical coordinate type, store
+  it as a dimension *on the root* (pressure for GFS/GEFS/IFS ENS/AIFS×2, height for
+  MRMS); only escalate to groups (`pressure_level/`, `model_level/`) when a second
+  type is present (HRRR, ICON-EU) — i.e. group only to resolve a name conflict.
+  This nests just 2 of 8 datasets and preserves the simple-root / swap-compatible
+  story from Decisions A/B; the uniform "every variable declares its vertical
+  coordinate" data model makes flat-vs-grouped a rendering choice, so escalating
+  later is mechanical. Since we already know each model's structure, the
+  "surprised later" risk is low.
+- **Always-group:** put pressure (and any vertical stack) in a named group in every
+  dataset, so layout is identical catalog-wide and a dataset gaining a second
+  vertical type never changes the location of existing variables. Costs needless
+  nesting for 6 of 8 datasets and breaks drop-in swap-compat with the materialized
+  catalog (readers would need `group=`).
 
-- **Single vertical coordinate type → flat (root) layout.** Pressure (or height for
-  MRMS) is a real dimension *at the root*; single/surface vars sit alongside it
-  suffix-named (spike 4). This is 6 of 8 models (GFS, GEFS, IFS ENS, AIFS×2, MRMS)
-  and preserves swap-compat with the materialized catalog.
-- **Multiple vertical coordinate types → groups** named by coordinate type
-  (`pressure_level/`, `model_level/`), single/surface at root. This is HRRR and
-  ICON-EU.
-- **Shape heterogeneity → groups** named by the homogeneous block (e.g. resolution
-  window), independent of vertical levels. GEFS full-range is the case.
-
-Rationale: always-grouping would nest 6 of 8 datasets for zero functional benefit
-and break the simple-root / swap-compatible story from Decisions A/B. The forward-
-compat worry ("what if a dataset gains model levels later?") is weak here because we
-already *know* each model's vertical structure, and because the uniform data model
-— **every variable declares its vertical coordinate** (`None` / `pressure_level` /
-`model_level` / `height`) — makes the flat-vs-grouped choice a *rendering* of that
-model, so a later escalation is mechanical, not a redesign. A1 is the single-
-coordinate rendering; groups are the multi-coordinate rendering.
+Resolving this also fixes the shape-heterogeneity layout (trigger 2): if we group
+by vertical type we likely also group the GEFS resolution windows
+(`/lead_0_240`, `/lead_243_840`) rather than splitting into separate datasets.
 
 ## Parked / next steps
 
@@ -580,7 +577,7 @@ Decision status and follow-ups (so they aren't lost):
 - **D — ensemble & manifest sizing:** validation task. Check
   `manifest_append_dim_split` size and `num_chunk_refs` cache against the
   ensemble × pressure projection before committing; `pressure_level` chunk size = 1.
-- **E — group policy:** **DECIDED** (see "When are zarr groups actually required?").
-  Per-dataset, not always-group: flat root for single-vertical-coordinate datasets
-  (6 of 8); groups only for multiple vertical coordinate types (HRRR, ICON-EU) or
-  shape heterogeneity (GEFS full-range resolution split).
+- **E — group policy:** **OPEN** (see "Open question: always group `pressure_level`,
+  or only when it conflicts?"). Should `pressure_level` always be its own group, or
+  only when a second vertical-coordinate type forces it — storing it as a root
+  dimension when there's no conflict? Leaning conditional; not decided.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -552,37 +552,35 @@ same shape:
 This is Option B below (single-level at root, every stack grouped), with two
 refinements: group name = dimension name, and empty groups are omitted.
 
-### Open sub-questions this leaves
+### Sub-questions
 
-1. **Shared-coordinate placement (the big one).** Where do the dimension
-   coordinates shared by root and groups live — `time`/`init_time`/`lead_time`,
-   `latitude`/`longitude` (or `y`/`x`), `ensemble_member`, and `spatial_ref`/CRS?
-   Spike (`spike_coords`) shows that if they live **only at the root**, opening a
-   child group on its own (`xr.open_zarr(url, group="pressure_level")`) returns the
-   variable with correct dim *sizes* but **no coordinate values** for time/lat/lon —
-   only the in-group `pressure_level` coord; just `open_datatree`/`open_groups`
-   (the DataTree model) inherits the root coords. So either (a) **duplicate** the
-   shared coords into every group so each group is independently openable (cheap —
-   coords are small real arrays, not virtual refs; costs a little metadata and write
-   coordination), or (b) **root-only + require DataTree reads** (no duplication, but
-   a plain per-group open is coordinate-less and surprising). Needs a call.
-2. **Other vertical coordinate types + the single-vs-Z boundary.** The decision
-   names only `pressure_level` and `model_level`. Still open: (a) the group/dim name
-   for **height-based** stacks (MRMS 3D reflectivity, 33 CAPPI levels — `height`?
-   `altitude`?) and **soil/depth** stacks (ECMWF `sol`, ICON `t_so`/`w_so` —
+1. **Shared-coordinate placement — DECIDED: duplicate into every group.** The
+   dimension coordinates shared by root and groups (`time`/`init_time`/`lead_time`,
+   `latitude`/`longitude` or `y`/`x`, `ensemble_member`, `spatial_ref`/CRS) are
+   **written into each group**, so every group is independently openable —
+   `xr.open_zarr(url, group="pressure_level")` returns fully-coordinated data without
+   needing the DataTree model. Rationale: spike `spike10` shows root-only coords leave
+   a child group coordinate-less on a plain per-group open; duplication is cheap
+   (coords are small real arrays, not virtual refs) and worth it for standalone
+   usability.
+2. **Other vertical coordinate types + the single-vs-Z boundary — OPEN (deferred).**
+   The decision names only `pressure_level` and `model_level`. Still open: (a) the
+   group/dim name for **height-based** stacks (MRMS 3D reflectivity, 33 CAPPI levels —
+   `height`? `altitude`?) and **soil/depth** stacks (ECMWF `sol`, ICON `t_so`/`w_so` —
    `depth_below_land_surface`?), and whether those are in scope now; (b) the rule for
    *what counts as a Z dimension* (dense + comparable → its own group/dim) **vs. a
    single-level var at root** (sparse/selected → suffix-named). E.g. a single
    selected pressure level — is `geopotential_height_500hpa` a root single-level var,
    or a `pressure_level` group of size 1? (Per Decision B's density × comparability,
    a single selected level stays suffix-named at root — worth restating explicitly.)
-3. **Scope of this decision.** It resolves *vertical* structure only. Still open:
-   the non-vertical heterogeneity case (GEFS 0.25°/0.5° across lead time — resolution
-   groups vs. separate datasets), and whether this structure also reshapes existing
-   *materialized* datasets or applies only to new virtual all-level datasets.
-4. **Empty root is allowed** (minor): a purely upper-air dataset would have a root
-   with shared coords but zero data variables. Structurally fine; just confirm it's
-   intended.
+3. **Scope of this decision — OPEN (deferred).** It resolves *vertical* structure
+   only. Still open: the non-vertical heterogeneity case (GEFS 0.25°/0.5° across lead
+   time — resolution groups vs. separate datasets), and whether this structure also
+   reshapes existing *materialized* datasets or applies only to new virtual all-level
+   datasets.
+4. **Empty root — CONFIRMED acceptable (and unlikely).** A purely upper-air dataset
+   would have a root with shared coords but zero data variables; structurally fine,
+   and not expected to come up in practice.
 
 ### Options considered (decided: Option B)
 
@@ -708,9 +706,9 @@ Decision status and follow-ups (so they aren't lost):
 - **E — group policy (layout):** **DECIDED — Option B, refined** (see "Decided
   layout"). Single-level at root; each vertical (Z) dimension in a group named after
   the dimension (`pressure_level`, `model_level` — group name = dim name); structure
-  uniform across all datasets; empty groups omitted. Open sub-questions remain:
-  **(1)** shared-coordinate placement (duplicate into each group vs. root-only +
-  DataTree reads — see spike `spike_coords`); **(2)** naming/scope for other Z types
+  uniform across all datasets; empty groups omitted. Shared coords are **duplicated
+  into each group** so groups are independently openable (sub-q 1 decided; empty root
+  confirmed fine, sub-q 4). Still open: **sub-q 2** naming/scope for other Z types
   (height for MRMS, soil/depth) and the dense-Z-dim vs. single-level-at-root boundary;
-  **(3)** the non-vertical resolution-heterogeneity case (GEFS) and whether this
+  **sub-q 3** the non-vertical resolution-heterogeneity case (GEFS) and whether this
   reshapes materialized datasets or only new virtual ones.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -563,16 +563,18 @@ refinements: group name = dimension name, and empty groups are omitted.
    a child group coordinate-less on a plain per-group open; duplication is cheap
    (coords are small real arrays, not virtual refs) and worth it for standalone
    usability.
-2. **Other vertical coordinate types + the single-vs-Z boundary — OPEN (deferred).**
-   The decision names only `pressure_level` and `model_level`. Still open: (a) the
-   group/dim name for **height-based** stacks (MRMS 3D reflectivity, 33 CAPPI levels —
-   `height`? `altitude`?) and **soil/depth** stacks (ECMWF `sol`, ICON `t_so`/`w_so` —
-   `depth_below_land_surface`?), and whether those are in scope now; (b) the rule for
-   *what counts as a Z dimension* (dense + comparable → its own group/dim) **vs. a
-   single-level var at root** (sparse/selected → suffix-named). E.g. a single
-   selected pressure level — is `geopotential_height_500hpa` a root single-level var,
-   or a `pressure_level` group of size 1? (Per Decision B's density × comparability,
-   a single selected level stays suffix-named at root — worth restating explicitly.)
+2. **Other vertical coordinate types + the single-vs-Z boundary — boundary DECIDED,
+   names deferred.**
+   - **Boundary rule — DECIDED:** a variable's levels become a real Z dimension (its
+     own group) **iff they form a dense + comparable set**; otherwise the variable
+     stays a single-level var at the root (suffix-named). This is Decision B's
+     density × comparability as the governing test. Consequences: a single selected
+     pressure level (`geopotential_height_500hpa`) is *not* dense → stays a root
+     single-level var, not a size-1 `pressure_level` group; a sparse handful of soil
+     layers likewise stays suffix-named at root unless dense + comparable.
+   - **Names — DEFERRED:** the group/dim names for other dense+comparable Z types
+     (height for MRMS 3D reflectivity; soil/depth for ECMWF `sol`, ICON
+     `t_so`/`w_so`) are not yet chosen. `pressure_level` and `model_level` stand.
 3. **Scope of this decision — OPEN (deferred).** It resolves *vertical* structure
    only. Still open: the non-vertical heterogeneity case (GEFS 0.25°/0.5° across lead
    time — resolution groups vs. separate datasets), and whether this structure also
@@ -708,7 +710,9 @@ Decision status and follow-ups (so they aren't lost):
   the dimension (`pressure_level`, `model_level` — group name = dim name); structure
   uniform across all datasets; empty groups omitted. Shared coords are **duplicated
   into each group** so groups are independently openable (sub-q 1 decided; empty root
-  confirmed fine, sub-q 4). Still open: **sub-q 2** naming/scope for other Z types
-  (height for MRMS, soil/depth) and the dense-Z-dim vs. single-level-at-root boundary;
-  **sub-q 3** the non-vertical resolution-heterogeneity case (GEFS) and whether this
-  reshapes materialized datasets or only new virtual ones.
+  confirmed fine, sub-q 4). Boundary rule decided (sub-q 2): a level set becomes its
+  own Z dimension/group **iff dense + comparable**, else the var stays a root
+  single-level (suffix-named). Still open: **sub-q 2 names** for other Z types (height
+  for MRMS, soil/depth) — deferred; **sub-q 3** the non-vertical resolution-
+  heterogeneity case (GEFS) and whether this reshapes materialized datasets or only
+  new virtual ones.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -465,39 +465,54 @@ uv run python docs/plans/vertical_structure_spikes/spike3_sparsity.py           
 uv run python docs/plans/vertical_structure_spikes/spike1_groups.py                # multi-group round-trip
 uv run python docs/plans/vertical_structure_spikes/spike2_alias.py                 # virtual alias one ref -> two paths
 uv run python docs/plans/vertical_structure_spikes/spike4_mixed_dims_flat.py       # mixed-dim vars in ONE flat group
-uv run python docs/plans/vertical_structure_spikes/spike5_model_level_availability.py  # pgrb2 vs pgrb2b level content
+uv run python docs/plans/vertical_structure_spikes/spike5_model_level_availability.py  # GFS pgrb2 vs pgrb2b level content
+uv run python docs/plans/vertical_structure_spikes/spike6_hrrr_gefs_levels.py      # HRRR wrfprs/wrfnat + GEFS (real .idx)
+uv run python docs/plans/vertical_structure_spikes/spike7_ecmwf_levels.py          # ECMWF IFS ENS / AIFS open-data .index
+uv run python docs/plans/vertical_structure_spikes/spike8_icon_eu_levels.py        # DWD ICON-EU pressure vs model levels
+uv run python docs/plans/vertical_structure_spikes/spike8b_icon_read_one_grib.py   # download+decode one ICON model-level GRIB
+uv run python docs/plans/vertical_structure_spikes/spike9_mrms_levels.py           # MRMS 3D products from real bucket
 ```
+
+(ECMWF/ICON spikes hit live, short-retention open-data servers — update the
+hard-coded date if it has aged out.)
 
 ## Source-data vertical-level review (all 8 catalog models)
 
 Reviewed which of our catalogued models publish **more than one dense vertical
 coordinate type** in the *files we'd virtualize* (the public GRIB archives), which
-is what would force a vertical-dimension/grouping decision. Empirical for the NOAA
-products (NODD `.idx` files, spikes 3/5 + `spike_hrrr_gefs.py`); ECMWF/DWD/MRMS from
-provider docs + live listings.
+is what would force a vertical-dimension/grouping decision. **All figures verified
+against real source files**, not docs (docs are often stale — see
+`source_data_exploration_guide.md` §5): NOAA from NODD `.idx` (spikes 3/5/6), ECMWF
+from the live open-data JSON `.index` files (spike 7), DWD ICON-EU from live
+directory listings plus one model-level GRIB downloaded and decoded with rasterio
+(spikes 8 / 8b), MRMS from the live `noaa-mrms-pds` bucket listing (spike 9). The
+real-file pass corrected one doc-sourced figure (AIFS Single is 14 pressure levels,
+not 13) and otherwise confirmed the structure.
 
 | Model | Single/surface | Pressure levels (dense) | Model/native levels (dense) | Other dense vertical | Multiple Z-types? |
 |---|---|---|---|---|---|
 | NOAA GFS | yes | **33** levels, 16 vars | no (1–2 hybrid msgs on NODD) | — | **No** — pressure only |
 | NOAA GEFS | yes | modest (0.5° a-file ~12; s-file 0.25° none) | no | — | **No** (but see resolution heterogeneity below) |
 | NOAA HRRR | yes | **39** levels, 14 vars (`wrfprs`) | **50** native levels, 20 vars (`wrfnat`) | — | **YES** — pressure + native |
-| NOAA MRMS | yes (mostly 2D) | no | no | 33 CAPPI height levels (~0.5–19 km), shared by all 3D mosaics | No — one height type |
-| ECMWF IFS ENS | yes | **14** levels (1000→10 hPa), full var set | no (MARS/paid only) | — | **No** — pressure only |
-| ECMWF AIFS Single | yes | **13** levels, narrower var set | no | — | **No** — pressure only |
-| ECMWF AIFS ENS | yes | **14** levels | no (only an *experimental* product) | — | **No** — pressure only |
-| DWD ICON-EU | yes (~100+ vars) | **~20** levels (T, FI, RELHUM, U, V) | **~74** model levels (T, U, V, W, P, QV, …) | — | **YES** — pressure + model |
+| NOAA MRMS | yes (mostly 2D) | no | no | **33** height levels (0.5–19 km) on 3 vars (`MergedReflectivityQC`, `MergedRhoHV`, `MergedZdr`) | No — one height type |
+| ECMWF IFS ENS | yes | **14** levels (1000→10 hPa), 9 params (d, gh, q, r, t, u, v, vo, w) | no (MARS/paid only) | 4 `sol` soil levels | **No** — pressure only |
+| ECMWF AIFS Single | yes | **14** levels, 7 params (gh, q, t, u, v, w, z) | no | 2 `sol` soil levels | **No** — pressure only |
+| ECMWF AIFS ENS | yes | **14** levels, 6 params (q, t, u, v, w, z) | no (only an *experimental* product) | 2 `sol` soil levels | **No** — pressure only |
+| DWD ICON-EU | yes (67 vars) | **20** levels, 7 vars (clc, fi, omega, relhum, t, u, v) | **74** model levels, 10 vars (clc, p, qc, qi, qv, t, tke, u, v, w) | — | **YES** — pressure + model (both: t, u, v, clc) |
 
 **Headline: only HRRR and ICON-EU (2 of 8) genuinely need multiple vertical-level
 groups.** Five products are pressure-only (or less); MRMS has a single dense
 vertical type (height), so it gets at most one vertical dimension and no
-pressure-vs-model decision. Crucially, we *know each model's answer up front* from
-this review — there is no "we'll be surprised later" risk that would argue for
-pre-emptively grouping everything.
+pressure-vs-model decision. (ECMWF's `sol` soil layers are a second vertical type
+in principle, but only 2–4 layers on soil vars — not the same atmospheric variable
+on two systems, so no group decision.) Crucially, we *know each model's answer up
+front* from this review — there is no "we'll be surprised later" risk that would
+argue for pre-emptively grouping everything.
 
 ## When are zarr groups actually required?
 
-Groups solve more than the vertical-coordinate problem. There are (at least) two
-*independent* triggers, and a dataset needs groups if **either** holds:
+Groups solve more than the vertical-coordinate problem. There are two *independent*
+triggers, and a dataset needs groups if **either** holds:
 
 1. **Multiple dense vertical coordinate types for the same variable** (Decision A's
    multi-Z case). `temperature` on both pressure and model levels can't share one
@@ -514,8 +529,9 @@ Groups solve more than the vertical-coordinate problem. There are (at least) two
    need two resolution groups (e.g. `/lead_0_240` at 0.25°, `/lead_243_840` at
    0.5°), or two separate datasets.
 
-(A third, softer trigger: wanting genuinely different chunk/manifest policies per
-block of variables.)
+Manifest/chunk-policy differences are **not** a grouping trigger: we will not
+impose the reader complexity of multiple groups just to vary manifest chunking
+within a dataset.
 
 ### Recommendation: per-dataset, not always-group
 

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -1,0 +1,273 @@
+# Vertical-dimension structure for virtual Icechunk datasets — exploration
+
+Status: exploration / decision input. Not a committed design.
+
+## Why this is on the table now
+
+Our catalogued datasets today are **materialized** (rechunked, copied bytes) and
+each one stores a hand-picked **selection of single-level variables**, with the
+level folded into the variable name (`temperature_2m`, `wind_u_100m`,
+`geopotential_height_500hpa`). Copying bytes made every extra variable and every
+extra level cost real storage, so the selection stayed small and flat.
+
+Virtual datasets (see [docs/virtual_datasets.md](../virtual_datasets.md)) change
+the economics. A virtual store is just `(location, offset, length)` pointers into
+the GRIB messages already sitting in NOAA's open-data buckets. The store is tiny
+regardless of how many variables or levels it references. So there is suddenly no
+storage reason to *not* include every variable, every pressure level, and every
+model level a source publishes. That forces a structural question we never had to
+answer while everything was a flat single-level selection:
+
+**How do we lay out a dataset that now has genuine vertical dimensions?**
+
+This doc breaks the dictated brain-dump into discrete questions, lays out the
+trade-offs, and reports results from runnable code spikes
+(`docs/plans/vertical_structure_spikes/`, reproduced inline below).
+
+## What the code today assumes
+
+A precondition for everything below: the current machinery assumes **one flat
+zarr group per dataset**. Concretely:
+
+- `TemplateConfig` exposes a single `dims: tuple[Dim, ...]`, a single flat
+  `data_vars` sequence, and a single `coords` sequence
+  (`src/reformatters/common/template_config.py`).
+- `get_template()` does `xr.open_zarr(self.template_path())` — root group only.
+- `VirtualRegionJob.chunk_key()` resolves geometry from `self.template_ds[var.name]`
+  and `filter_already_present` opens `zarr.open_group(store)[var.name]` — both
+  assume the var lives at the root (`src/reformatters/common/virtual_region_job.py`).
+- No dataset anywhere passes `group=` to `to_zarr`/`open_zarr`, and nothing uses
+  `DataTree` (confirmed by full-repo survey).
+
+So any "groups" option is a real change to these base classes, not just config.
+The spikes below test whether the *storage layer* (icechunk + zarr + xarray)
+supports what we'd need before we invest in that.
+
+---
+
+## The open questions
+
+### Q1. Suffix-naming vs. an explicit vertical dimension
+
+- **Option A (status quo):** keep flattening — every (variable, level) pair is its
+  own 1-D-over-append-dim array named `temperature_500hpa`, `temperature_2m`, …
+- **Option B:** introduce real `pressure_level` / `model_level` dimensions; the
+  variable is named plainly (`temperature`) and indexed by level.
+
+Trade-offs:
+
+| | Suffix-name (A) | Real dimension (B) |
+|---|---|---|
+| Reader ergonomics | `ds.temperature_500hpa` | `ds.temperature.sel(level=500)`, vectorized across levels |
+| Cross-level ops (lapse rate, integrals) | manual, name-parsing | natural array math |
+| Sparsity tolerance | perfect — only existing pairs exist | a level a var lacks becomes a NaN hole |
+| Back-compat with current catalog | identical | breaking |
+| CF-conventions friendliness | poor (level in name) | good (level coord with `Z` axis) |
+
+The deciding factor is **density of the (variable × level) grid**, measured in Q3.
+
+### Q2. Should level-type live in zarr groups?
+
+Different vertical coordinate types are genuinely different dimensions: a pressure
+variable is indexed by `[time, pressure_level, y, x]`, a model-level variable by
+`[time, model_level, y, x]`, a single-level variable by `[time, y, x]`. You cannot
+put all three in one flat group without either three separate `level` dims or
+forcing everything onto one axis.
+
+Proposed grouping: `single_level`, `pressure_level`, `model_level` (and possibly
+`surface`, `ensemble`…), each present only if it has ≥1 variable.
+
+Trade-offs: groups give each level-type its own clean dimension and let a reader
+open exactly the slice they want; the cost is more machinery (Q's precondition)
+and that a reader must know which group a variable is in.
+
+### Q3. How sparse is the (variable × level) cross product?
+
+This is the empirical crux. Measured against a real GFS `pgrb2.0p25.f000` index
+(696 GRIB messages) — see spike results below.
+
+### Q4. "Virtual alias": back-compat names at root pointing to a canonical location
+
+Because refs are just pointers, the *same* GRIB message can be referenced from two
+array paths: a back-compat `temperature_2m` at the root **and** a canonical
+`single_level/temperature_2m` (or `pressure_level` `temperature.sel(level=…)`).
+This is like a replica, but within one store's group tree. Trade-off: you keep a
+drop-in-compatible root surface and a clean organized surface simultaneously, at
+the cost of doubling the manifest ref count for aliased variables (no byte
+duplication). Tested in spike 2.
+
+### Q5. Swap-compatibility with the existing materialized catalog
+
+If a new virtual dataset keeps the current root + suffix names, it is a drop-in
+swap for the materialized version — existing readers keep working. The
+counter-argument: *now*, while these products are still young, is the cheapest
+time to make breaking structural changes.
+
+### Q6. Migration of the existing ~10–11 products
+
+Maintain the old-structure materialized products **and** publish new-structure
+virtual versions in parallel? The append-dim/operational machinery makes running
+both cheap-ish (virtual updates are a single small pod). Or cut over hard.
+
+### Q7. A consistent rule vs. a known-ahead-of-time layout
+
+Either commit to a rule ("anything on pressure/model levels lives in the
+`pressure_level`/`model_level` group with a real level dim; single levels stay
+suffix-named") so structure is predictable across datasets, or hard-code each
+dataset's known set of (ensemble × model_level × pressure_level) combinations.
+
+### Q8. Ever-any-variables-at-root, or everything in named groups?
+
+Philosophical consistency: is the root always empty (every variable lives in a
+named group), or do we keep root variables for the common single-level case?
+
+### Q9. Ensemble interaction
+
+`ensemble_member` is an independent dimension that multiplies into all of the
+above. It is orthogonal to level-type and does not change the grouping decision,
+but it does matter for chunk/manifest sizing.
+
+---
+
+## Code spikes (runnable, results inline)
+
+### Spike 3 — grid density (answers Q3, drives Q1/Q2)
+
+`spike3_sparsity.py` pulls a real GFS index and classifies every message.
+
+```
+total GRIB messages in file: 696
+  462  pressure (mb)
+  227  single/other
+    7  hybrid (model)
+
+PRESSURE-LEVEL: 16 distinct params across 33 levels
+  full grid 16 x 33 = 528 ; actual 462  => density 87.5%
+  10 params present at ALL 33 levels (HGT, TMP, RH, SPFH, VVEL, DZDT, UGRD, VGRD, ABSV, O3MR)
+  6  params present at 22 levels (cloud/precip mixing ratios)
+
+SINGLE-LEVEL: 64 params across 52 distinct 'level' strings
+  full grid 64 x 52 = 3328 ; actual 227  => density 6.8%
+```
+
+**Finding:** the two regimes could not be more different.
+
+- **Pressure levels are dense (~88%, core vars 100%).** A real `pressure_level`
+  dimension is the right structure — it wastes almost nothing and unlocks
+  vectorized vertical math. This validates Q1-Option-B *for pressure levels*.
+- **Single levels are sparse (~7%).** The 52 "levels" are heterogeneous, mostly
+  incomparable surfaces (`surface`, `mean sea level`, `2 m above ground`,
+  `planetary boundary layer`, `0-0.1 m below ground`, cloud layers…). Forcing
+  these onto one `single_level` axis would be ~93% NaN and semantically wrong
+  (the axis values aren't a coordinate you'd ever `.sel()` across). This validates
+  Q1-Option-A *for single levels*: keep the suffix names.
+
+The data says the answer is **not** "pick A or B globally" — it's **B for dense
+vertical coordinates (pressure, model), A for the sparse grab-bag of single
+levels.** Which is exactly the per-group split Q2 proposes.
+
+### Spike 1 — multi-group icechunk round-trip (feasibility for Q2)
+
+`spike1_groups.py` writes a root var + a `/pressure_level` group (extra `level`
+dim) + a `/single_level` group into one icechunk store, commits, reads back.
+
+Result: works cleanly. Each group reads via `xr.open_zarr(store, group=…)`, and
+`xr.open_datatree(store, engine="zarr")` returns the whole hierarchy at once:
+
+```
+Group: /
+    temperature_2m  (time, lat, lon)
+├── Group: /pressure_level
+│       temperature  (time, level, lat, lon)   level = [1000 850 500 250]
+└── Group: /single_level
+        temperature_2m, wind_u_100m  (time, lat, lon)
+```
+
+Notable bonus: **shared coordinates (time/lat/lon) declared at the root are
+inherited** by child groups in the DataTree view — they don't have to be
+duplicated per group. One small gotcha: `open_datatree` needs an explicit
+`engine="zarr"` because the installed `gribberish` backend confuses xarray's
+engine autodetection.
+
+### Spike 2 — virtual alias: one source ref at two paths (feasibility for Q4)
+
+`spike2_alias.py` registers a local virtual-chunk container, then sets the
+**same** `VirtualChunkSpec` (location/offset/length) on both `temperature_2m`
+(root) and `single_level/temperature_2m` (group), commits, reads both.
+
+```
+root values == source: True
+group values == source: True
+root == group (same bytes, one source): True
+```
+
+Result: aliasing works end-to-end. Both paths decode to the identical source
+bytes. **Cost:** two manifest ref entries instead of one (the ref count, and thus
+manifest size, doubles for each aliased variable); the underlying source bytes are
+not duplicated. For a back-compat root surface over a few dozen single-level vars
+this is cheap; aliasing whole pressure-level stacks would meaningfully grow the
+manifest and is probably not worth it.
+
+---
+
+## Synthesis & recommendation
+
+The measurements turn most of the either/or framing into a "both, by regime":
+
+1. **Use real vertical dimensions where the grid is dense, suffix names where it
+   is sparse.** Concretely: a `pressure_level` group (and a `model_level` group
+   when a source has hybrid levels) with plainly-named variables on a real `level`
+   coordinate; single/surface variables stay suffix-named. Spike 3 shows this is
+   the structure the data actually has — ~88% dense vs ~7% dense.
+
+2. **Group by level-type** (Q2). It's the only layout that gives each regime its
+   natural dimensionality, and spike 1 shows the storage stack fully supports it
+   (write per group, read per group or as a DataTree, coords inherited from root).
+   The real cost is the base-class work in Q's precondition, not storage.
+
+3. **For back-compat, prefer a root-level "single_level"-style surface that
+   reuses today's exact names** so a new virtual dataset can swap in for a
+   materialized one (Q5). Whether the back-compat names are *aliases* into a
+   canonical group (Q4) or simply *are* the single-level group laid out at the
+   root is an open sub-decision — note that for single levels the canonical
+   location and the back-compat location are the same names, so a separate
+   `single_level/` group would be pure duplication. The alias trick earns its
+   manifest cost mainly if we want a clean empty root *and* legacy names.
+
+4. **On "ever any variables at root" (Q8):** the pragmatic reading of spikes 1+3
+   is to **keep single-level variables at the root** (that's both the back-compat
+   surface and where the sparse grab-bag naturally lives) and **put only the
+   dense, real-dimension stacks in named groups** (`pressure_level`,
+   `model_level`). That keeps the simple case simple and reserves groups for where
+   they add structure. A fully-empty-root, everything-in-groups rule is cleaner in
+   theory but buys little and breaks swap-compat.
+
+5. **Migration (Q6):** running old materialized + new virtual in parallel is
+   feasible; recommend doing that for the existing products rather than a hard
+   cutover, and making the new virtual versions swap-compatible at the root.
+
+### Open decisions to settle before designing the base-class changes
+
+- **Group naming & rule (Q7):** lock the exact group names and a written rule for
+  which variables go where, so it's uniform across providers.
+- **Root = single_level, or aliases (Q4 vs Q8):** do single-level vars simply live
+  at root, or does the root hold aliases into a `single_level/` group?
+- **Per-group `dims`/`coords`/`data_vars` in `TemplateConfig`:** how to express a
+  multi-group template (e.g. `data_vars` keyed by group, or a small per-group
+  sub-config) and how `chunk_key`/`filter_already_present` address
+  `group/var`-pathed arrays.
+- **`model_level` scope:** GFS pgrb2 exposes only a handful of hybrid messages;
+  decide whether model levels come from a different product (e.g. `pgrb2b`/native)
+  before committing to the group.
+- **Ensemble sizing (Q9):** confirm manifest/chunk sizing with `ensemble_member ×
+  pressure_level` for the GEFS-style case.
+
+### Reproducing the spikes
+
+Scripts are committed under `docs/plans/vertical_structure_spikes/`:
+
+```
+uv run python docs/plans/vertical_structure_spikes/spike3_sparsity.py  # grid density (network: NODD idx)
+uv run python docs/plans/vertical_structure_spikes/spike1_groups.py    # multi-group round-trip
+uv run python docs/plans/vertical_structure_spikes/spike2_alias.py     # virtual alias one ref -> two paths
+```

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -341,10 +341,45 @@ pressure_level). Under A1 the "alias" idea (Q4) and "empty root" idea (Q8) mostl
 dissolve: single-level vars simply *are* the root, and pressure vars *are* the
 level-dim arrays in the same root — nothing to alias.
 
-### Decision B — Naming convention + the written rule
+**The one case A1 can't express: a variable on two vertical-coordinate types.**
+If a dataset publishes `temperature` on *both* pressure levels and model levels,
+a flat group can't hold two arrays named `temperature` that differ only in their Z
+dim. An array has exactly one Z axis, and a 5-D `temperature(time, pressure_level,
+model_level, y, x)` is nonsense (a cell is on one or the other, never both). Three
+ways out:
 
-With A1 everything shares one namespace, so the convention has to be unambiguous
-and uniform across providers. Proposed rules:
+1. **Groups (the clean answer): the group name *is* the vertical-coordinate type.**
+   `pressure_level/temperature`, `model_level/temperature`; single/surface vars stay
+   at root (suffix-named). This is exactly the case A2 exists for, and it gives a
+   crisp escalation rule: **use groups iff a dataset has more than one vertical
+   coordinate type for the same variable; otherwise stay flat.** Spike 1 confirms
+   root arrays and subgroups coexist in one store, so single-levels-at-root +
+   `pressure_level/` + `model_level/` is a valid layout.
+2. **Type-suffix the name** (`temperature` + `temperature_model_level`). Keeps the
+   flat namespace but is asymmetric (which Z-type wins the bare name?) and reads as
+   a special case — rejected.
+3. **One generalized `level` dim with auxiliary `level_type`/`level_value`
+   coords**, concatenating the two stacks (33 + 127 entries, *not* a cross product,
+   so no NaN blow-up). Technically CF-valid, but it reintroduces the
+   incomparable-axis ergonomics of the single-level MultiIndex idea below (you
+   can't `.sel(pressure_level=500)` cleanly, and slicing across the pressure↔model
+   boundary is meaningless) plus awkward CF round-trip — rejected for the same
+   reasons.
+
+The useful reframing: **A1 is just the single-vertical-coordinate special case of
+A2.** Model the data uniformly as "each variable declares its vertical coordinate"
+(`None` for single/surface, `pressure_level`, `model_level`, …); then *render*
+flat-at-root when a dataset has ≤1 vertical coordinate type (for swap-compat) and
+render as groups when it has more. Designing the var→vertical-coordinate
+association into the config now means flat-vs-grouped is a later rendering choice,
+not a rewrite. Note this collision does **not** arise for the immediate GFS/GEFS
+pressure-level work (GFS has no usable model levels — decision C), so A1 ships
+unblocked; the association just keeps the door open.
+
+### Decision B — Naming convention + the written rule — **DECIDED**
+
+Agreed. This is the naming convention of record. With A1 everything shares one
+namespace, so the convention is unambiguous and uniform across providers:
 
 - **Level-dim variables use the plain ECMWF name, no suffix:** `temperature`,
   `geopotential_height`, `relative_humidity`, `specific_humidity`, `wind_u`,
@@ -369,6 +404,21 @@ and uniform across providers. Proposed rules:
   mixing-ratio vars at 22 levels) simply have no ref above their top level. In a
   virtual store that is zero cost (absent chunk → fill value), so there is no
   reason to split the dimension by which vars reach which level.
+
+**Rejected: a MultiIndex `level` dim for single levels** (e.g.
+`.sel(level=("height_above_surface", "2m"))`). It doesn't help — the single-level
+grid stays ~7% sparse, and in a virtual store sparsity isn't even the cost
+(absent refs are free). The real objections are semantic and ergonomic: the
+single-level "levels" are *incomparable* (`2 m above ground` vs `mean sea level`
+vs `entire atmosphere` vs `boundary layer`), so the one thing a dimension buys —
+operating *across* it (slice/interpolate/integrate) — is meaningless for them; you
+always pick one named thing. `("height_above_surface","2m")` is more verbose and
+less discoverable than `temperature_2m`, and a pandas MultiIndex doesn't round-trip
+cleanly to Zarr/CF. The deciding factor stays **density × comparability**: pressure
+is the only single regime that is both, which is why it (and only it) gets a real
+dimension. Even a numeric `height_above_ground` sub-dim (2/10/80/100 m) is rejected:
+the heights are comparable but the cross product is still sparse (temperature only
+at 2 m, wind at 10/80/100 m), so single levels stay suffix-flat.
 
 ### Decision C — `model_level` scope (defer; provider-specific)
 
@@ -417,3 +467,24 @@ uv run python docs/plans/vertical_structure_spikes/spike2_alias.py              
 uv run python docs/plans/vertical_structure_spikes/spike4_mixed_dims_flat.py       # mixed-dim vars in ONE flat group
 uv run python docs/plans/vertical_structure_spikes/spike5_model_level_availability.py  # pgrb2 vs pgrb2b level content
 ```
+
+## Parked / next steps
+
+Decision status and follow-ups (so they aren't lost):
+
+- **A — machinery (per-variable dims):** *parked, to design next.* Draft the
+  concrete `DataVar.dims` (optional, default = template `dims`) + `update_template`
+  / `empty_copy_with_reindex` change as a small proposal / proof-of-concept diff.
+  Model each variable's vertical coordinate (`None` / `pressure_level` /
+  `model_level`) so flat-at-root vs. grouped is a later rendering choice — A1 is the
+  single-vertical-coordinate special case of A2.
+- **B — naming convention:** **DECIDED** (see Decision B). Plain ECMWF name ⇒ on a
+  `*_level` dim; suffix ⇒ one fixed level; `pressure_level` in hPa, CF
+  `air_pressure`, axis Z, positive down, descending; place on the real dim iff
+  densely published; single levels stay suffix-flat (MultiIndex rejected).
+- **C — `model_level` scope:** deferred, provider-specific. Not available for GFS on
+  NODD; revisit per provider when a dense native-level source exists. First
+  iteration is single-level (suffix) + `pressure_level` (real dim) only.
+- **D — ensemble & manifest sizing:** validation task. Check
+  `manifest_append_dim_split` size and `num_chunk_refs` cache against the
+  ensemble × pressure projection before committing; `pressure_level` chunk size = 1.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -474,6 +474,7 @@ uv run python docs/plans/vertical_structure_spikes/spike7_ecmwf_levels.py       
 uv run python docs/plans/vertical_structure_spikes/spike8_icon_eu_levels.py        # DWD ICON-EU pressure vs model levels
 uv run python docs/plans/vertical_structure_spikes/spike8b_icon_read_one_grib.py   # download+decode one ICON model-level GRIB
 uv run python docs/plans/vertical_structure_spikes/spike9_mrms_levels.py           # MRMS 3D products from real bucket
+uv run python docs/plans/vertical_structure_spikes/spike10_group_coord_inheritance.py  # do child groups carry root coords?
 ```
 
 (ECMWF/ICON spikes hit live, short-retention open-data servers — update the
@@ -532,11 +533,63 @@ triggers, and a dataset needs groups if **either** holds:
    need two resolution groups (e.g. `/lead_0_240` at 0.25°, `/lead_243_840` at
    0.5°), or two separate datasets.
 
-### Open question (for TSC): where do vertical stacks (and single levels) live?
+## Decided layout (Decision E) — Option B, refined
 
-**Decision needed.** Dense pressure/model/height levels become a real vertical
-*dimension*. The question is the on-disk layout — what sits at the root vs. in named
-groups. Three options, in order of increasing uniformity (and decreasing root use).
+**DECIDED.** Catalog-wide structure, applied uniformly so every dataset has the
+same shape:
+
+- **Single-level / surface variables always live at the root** (suffix-named, e.g.
+  `temperature_2m`).
+- **Variables with a vertical (Z) dimension live in a group named after that
+  dimension.** Supported: `model_level` and `pressure_level` — each string is *both*
+  the group name and the name of the vertical dimension of the variables inside it
+  (e.g. `pressure_level/temperature` indexed by `pressure_level`).
+- **This structure is used regardless of whether a dataset has zero, one, or
+  multiple vertical dimensions** — datasets are cross-consistent.
+- **A group with no variables does not exist** (e.g. a pressure-only dataset has a
+  `pressure_level` group but no `model_level` group).
+
+This is Option B below (single-level at root, every stack grouped), with two
+refinements: group name = dimension name, and empty groups are omitted.
+
+### Open sub-questions this leaves
+
+1. **Shared-coordinate placement (the big one).** Where do the dimension
+   coordinates shared by root and groups live — `time`/`init_time`/`lead_time`,
+   `latitude`/`longitude` (or `y`/`x`), `ensemble_member`, and `spatial_ref`/CRS?
+   Spike (`spike_coords`) shows that if they live **only at the root**, opening a
+   child group on its own (`xr.open_zarr(url, group="pressure_level")`) returns the
+   variable with correct dim *sizes* but **no coordinate values** for time/lat/lon —
+   only the in-group `pressure_level` coord; just `open_datatree`/`open_groups`
+   (the DataTree model) inherits the root coords. So either (a) **duplicate** the
+   shared coords into every group so each group is independently openable (cheap —
+   coords are small real arrays, not virtual refs; costs a little metadata and write
+   coordination), or (b) **root-only + require DataTree reads** (no duplication, but
+   a plain per-group open is coordinate-less and surprising). Needs a call.
+2. **Other vertical coordinate types + the single-vs-Z boundary.** The decision
+   names only `pressure_level` and `model_level`. Still open: (a) the group/dim name
+   for **height-based** stacks (MRMS 3D reflectivity, 33 CAPPI levels — `height`?
+   `altitude`?) and **soil/depth** stacks (ECMWF `sol`, ICON `t_so`/`w_so` —
+   `depth_below_land_surface`?), and whether those are in scope now; (b) the rule for
+   *what counts as a Z dimension* (dense + comparable → its own group/dim) **vs. a
+   single-level var at root** (sparse/selected → suffix-named). E.g. a single
+   selected pressure level — is `geopotential_height_500hpa` a root single-level var,
+   or a `pressure_level` group of size 1? (Per Decision B's density × comparability,
+   a single selected level stays suffix-named at root — worth restating explicitly.)
+3. **Scope of this decision.** It resolves *vertical* structure only. Still open:
+   the non-vertical heterogeneity case (GEFS 0.25°/0.5° across lead time — resolution
+   groups vs. separate datasets), and whether this structure also reshapes existing
+   *materialized* datasets or applies only to new virtual all-level datasets.
+4. **Empty root is allowed** (minor): a purely upper-air dataset would have a root
+   with shared coords but zero data variables. Structurally fine; just confirm it's
+   intended.
+
+### Options considered (decided: Option B)
+
+*Record of the options weighed before Decision E above chose Option B.* Dense
+pressure/model/height levels become a real vertical *dimension*; the question was
+the on-disk layout — what sits at the root vs. in named groups. Five options below,
+in order of increasing uniformity (and decreasing root use).
 
 Fixed regardless of the choice: HRRR and ICON-EU publish `temperature` on **both**
 pressure and model levels, so the bare name collides and at least one stack **must**
@@ -621,11 +674,12 @@ shape-heterogeneity split (resolution windows as groups `/lead_0_240`,
 **Taxonomy:** one store + groups (A/B/C, differing by how much goes in groups),
 multiple stores (D), or one flat store disambiguated by name (E).
 
-**Author's lean: Option A** — optimize the common, most-used single-type datasets
-for one-shot discovery; introduce groups only where a real name conflict requires
-them. C is the most consistent but least discoverable; B is the middle ground; D
-trades cohesion for the least machinery; E keeps one-open discoverability at the cost
-of asymmetric names. Pending TSC input.
+**Outcome: Option B chosen** (see Decision E above) — the author had leaned A, but
+cross-dataset structural consistency won out: every dataset has the same shape
+(single-level at root, each vertical stack in a like-named group), and a dataset
+gaining a vertical type never relocates existing variables. The trade accepted is
+that pressure access requires opening the `pressure_level` group even for
+single-vertical-type datasets like GFS/IFS.
 
 ## Parked / next steps
 
@@ -651,11 +705,12 @@ Decision status and follow-ups (so they aren't lost):
   question (which vertical types are in the dataset); the *layout* it forces is
   Decision E — for HRRR/ICON-EU the bare name `temperature` collides across pressure
   and model levels, so a group is required.
-- **E — group policy (layout):** **OPEN — pending TSC** (see "Open question (for
-  TSC): where do vertical stacks (and single levels) live?"). HRRR/ICON-EU must group
-  regardless; the call is the catalog-wide layout: **A** group only on conflict
-  (single-type stays flat at root, author's lean), **B** always group vertical stacks
-  but keep single-level at root, **C** group everything including a `single_level`
-  group (empty root, most consistent / least discoverable), **D** separate datasets
-  per level type (no groups, more stores), or **E** one flat store, type-suffixed
-  names (no groups). Awaiting TSC input.
+- **E — group policy (layout):** **DECIDED — Option B, refined** (see "Decided
+  layout"). Single-level at root; each vertical (Z) dimension in a group named after
+  the dimension (`pressure_level`, `model_level` — group name = dim name); structure
+  uniform across all datasets; empty groups omitted. Open sub-questions remain:
+  **(1)** shared-coordinate placement (duplicate into each group vs. root-only +
+  DataTree reads — see spike `spike_coords`); **(2)** naming/scope for other Z types
+  (height for MRMS, soil/depth) and the dense-Z-dim vs. single-level-at-root boundary;
+  **(3)** the non-vertical resolution-heterogeneity case (GEFS) and whether this
+  reshapes materialized datasets or only new virtual ones.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -585,7 +585,31 @@ MRMS:  /single_level …                    /height reflectivity
 - ✗ Least discoverable: a bare `open_zarr(url)` yields nothing useful; you must know
   to open `single_level`. (`open_datatree` still shows all groups at once.)
 
-Notes for all three: the suffix→dimension change for the few pressure names breaks
+A/B/C are all *one store, zarr groups*. Two alternatives sit outside that family:
+
+**Option D — separate datasets per level type (no groups; more stores).** Publish a
+store per level type instead of groups: e.g. `hrrr-forecast` (single + pressure) plus
+a separate `hrrr-forecast-model-level`; mirrors how we already split forecast vs.
+analysis into separate datasets.
+- ✓ No group machinery at all — each store is a simple flat dataset; lowest code
+  change. Independent versioning/lifecycle; consumer picks a URL.
+- ✗ Cross-level work spans stores (open + merge); coordinates (init_time, lat/lon,
+  ensemble) duplicated per store; more STAC collections; loses single-open /
+  `open_datatree` cohesion and cross-group atomic commits.
+
+**Option E — one flat store, type-suffixed names (no groups; two vertical dims
+coexist).** Resolve the collision by name, not path: a single root group holding
+`temperature(pressure_level)` and, say, `temperature_native(model_level)` — both
+vertical dims live in the same flat dataset (mixed dims are fine — spike 4).
+- ✓ One `open_zarr()` returns everything, even for HRRR/ICON-EU — most discoverable.
+- ✗ Asymmetric naming (which type gets the bare name?); two `*_level` dims in one
+  dataset; leaned against in Decision A.
+
+(Also considered and rejected — Decision A: a single generalized `level` dim
+concatenating pressure + model under one axis with a `level_type` aux coord;
+incomparable axis, poor `.sel`, awkward CF round-trip.)
+
+Notes for all options: the suffix→dimension change for the few pressure names breaks
 those regardless of layout; the shared data model (every variable declares its
 vertical coordinate) means the layout is a rendering choice *in our code*. **But
 changing the layout of an already-published dataset is a breaking change for
@@ -594,10 +618,14 @@ policy is worth deciding deliberately now.** The same call covers GEFS's
 shape-heterogeneity split (resolution windows as groups `/lead_0_240`,
 `/lead_243_840`, vs. separate datasets).
 
+**Taxonomy:** one store + groups (A/B/C, differing by how much goes in groups),
+multiple stores (D), or one flat store disambiguated by name (E).
+
 **Author's lean: Option A** — optimize the common, most-used single-type datasets
 for one-shot discovery; introduce groups only where a real name conflict requires
-them. Option C is the most consistent but least discoverable; Option B is the middle
-ground. Pending TSC input.
+them. C is the most consistent but least discoverable; B is the middle ground; D
+trades cohesion for the least machinery; E keeps one-open discoverability at the cost
+of asymmetric names. Pending TSC input.
 
 ## Parked / next steps
 
@@ -627,5 +655,7 @@ Decision status and follow-ups (so they aren't lost):
   TSC): where do vertical stacks (and single levels) live?"). HRRR/ICON-EU must group
   regardless; the call is the catalog-wide layout: **A** group only on conflict
   (single-type stays flat at root, author's lean), **B** always group vertical stacks
-  but keep single-level at root, or **C** group everything including a `single_level`
-  group (empty root, most consistent / least discoverable). Awaiting TSC input.
+  but keep single-level at root, **C** group everything including a `single_level`
+  group (empty root, most consistent / least discoverable), **D** separate datasets
+  per level type (no groups, more stores), or **E** one flat store, type-suffixed
+  names (no groups). Awaiting TSC input.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -529,30 +529,51 @@ triggers, and a dataset needs groups if **either** holds:
    need two resolution groups (e.g. `/lead_0_240` at 0.25°, `/lead_243_840` at
    0.5°), or two separate datasets.
 
-### Open question: always group `pressure_level`, or only when it conflicts?
+### Open question (for TSC): always group vertical stacks, or only on conflict?
 
-**Undecided.** Should `pressure_level` *always* be its own group for consistency,
-or only when a dataset has another vertical-coordinate type to conflict with —
-storing it as a plain dimension on the root when there's no conflict?
+**Decision needed.** Single/surface variables always live at the root, suffix-named.
+The question is where a *vertical stack* (pressure, model, height) lives.
 
-- **Conditional (lean):** if a dataset has a single vertical coordinate type, store
-  it as a dimension *on the root* (pressure for GFS/GEFS/IFS ENS/AIFS×2, height for
-  MRMS); only escalate to groups (`pressure_level/`, `model_level/`) when a second
-  type is present (HRRR, ICON-EU) — i.e. group only to resolve a name conflict.
-  This nests just 2 of 8 datasets and preserves the simple-root / swap-compatible
-  story from Decisions A/B; the uniform "every variable declares its vertical
-  coordinate" data model makes flat-vs-grouped a rendering choice, so escalating
-  later is mechanical. Since we already know each model's structure, the
-  "surprised later" risk is low.
-- **Always-group:** put pressure (and any vertical stack) in a named group in every
-  dataset, so layout is identical catalog-wide and a dataset gaining a second
-  vertical type never changes the location of existing variables. Costs needless
-  nesting for 6 of 8 datasets and breaks drop-in swap-compat with the materialized
-  catalog (readers would need `group=`).
+Fixed regardless of the choice: HRRR and ICON-EU publish `temperature` on **both**
+pressure and model levels, so the bare name collides and at least one stack **must**
+go in a group. This decision is really about the other six (single-vertical-type)
+datasets — and thus whether "pressure-level temperature" has a *uniform* location
+across the catalog.
 
-Resolving this also fixes the shape-heterogeneity layout (trigger 2): if we group
-by vertical type we likely also group the GEFS resolution windows
-(`/lead_0_240`, `/lead_243_840`) rather than splitting into separate datasets.
+**Option A — group only on conflict.** Single-type datasets keep the stack as a
+dimension on the root; group only where two types collide.
+
+```
+GFS:   /  temperature_2m, temperature(pressure_level), …
+HRRR:  /  temperature_2m, …   /pressure_level  temperature   /model_level  temperature
+```
+- One `open_zarr()` on GFS/IFS yields surface + pressure together; no group knowledge.
+- Groups appear only where semantically needed; their presence signals "multiple
+  vertical systems."
+- Pressure access differs GFS (root) vs HRRR (group) — not uniform.
+
+**Option B — always group stacks.** Root holds only single/surface vars everywhere;
+every stack lives in a group named for its coordinate.
+
+```
+GFS:   /  temperature_2m, …   /pressure_level  temperature
+HRRR:  /  temperature_2m, …   /pressure_level  temperature   /model_level  temperature
+```
+- Uniform: `pressure_level/temperature` everywhere; a dataset gaining a vertical
+  type never relocates existing vars.
+- GFS/IFS readers must open the `pressure_level` group (one-shot `open_zarr` gives
+  only surface vars); nests 6 of 8 datasets.
+
+Either way, single/surface vars stay at root, so materialized→virtual swap-compat is
+the same for both (the suffix→dimension change for pressure breaks those few names
+regardless of grouping). Shared data model: every variable declares its vertical
+coordinate, so flat-vs-grouped is a rendering choice and the policy can be applied
+uniformly. (Same call also covers GEFS's shape-heterogeneity split — resolution
+windows as groups `/lead_0_240`, `/lead_243_840`, vs. separate datasets.)
+
+**Author's lean: Option A** — optimize the common, most-used single-type datasets
+for one-shot discovery; introduce groups only where a real name conflict requires
+them. Pending TSC input.
 
 ## Parked / next steps
 
@@ -568,16 +589,16 @@ Decision status and follow-ups (so they aren't lost):
   `*_level` dim; suffix ⇒ one fixed level; `pressure_level` in hPa, CF
   `air_pressure`, axis Z, positive down, descending; place on the real dim iff
   densely published; single levels stay suffix-flat (MultiIndex rejected).
-- **C — `model_level` scope:** deferred, provider-specific. The source review
-  (above) shows **only HRRR (`wrfnat`, 50 levels) and DWD ICON-EU (~74 levels)**
-  publish dense model levels for the same vars as pressure — they are the concrete
-  multi-Z cases. GFS/GEFS/ECMWF have none in their public files. First iteration is
-  single-level (suffix) + `pressure_level` (real dim) only; bring in `model_level`
-  when building HRRR/ICON-EU.
-- **D — ensemble & manifest sizing:** validation task. Check
-  `manifest_append_dim_split` size and `num_chunk_refs` cache against the
-  ensemble × pressure projection before committing; `pressure_level` chunk size = 1.
-- **E — group policy:** **OPEN** (see "Open question: always group `pressure_level`,
-  or only when it conflicts?"). Should `pressure_level` always be its own group, or
-  only when a second vertical-coordinate type forces it — storing it as a root
-  dimension when there's no conflict? Leaning conditional; not decided.
+- **C — `model_level` inclusion:** **RESOLVED — include all available vertical
+  levels.** The source review shows only **HRRR (`wrfnat`, 50 levels)** and **DWD
+  ICON-EU (74 levels)** publish dense model levels for the same vars as pressure;
+  GFS/GEFS/ECMWF have none in their public files. Virtual HRRR and ICON-EU
+  (imminent) ship single + `pressure_level` + `model_level`. C is a *data-inclusion*
+  question (which vertical types are in the dataset); the *layout* it forces is
+  Decision E — for HRRR/ICON-EU the bare name `temperature` collides across pressure
+  and model levels, so a group is required.
+- **E — group policy (layout):** **OPEN — pending TSC** (see "Open question (for
+  TSC): always group vertical stacks, or only on conflict?"). HRRR/ICON-EU must
+  group regardless; the call is whether single-vertical-type datasets keep the stack
+  as a root dimension (Option A, author's lean) or always nest it in a group (Option
+  B). Awaiting technical steering committee input.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -468,6 +468,79 @@ uv run python docs/plans/vertical_structure_spikes/spike4_mixed_dims_flat.py    
 uv run python docs/plans/vertical_structure_spikes/spike5_model_level_availability.py  # pgrb2 vs pgrb2b level content
 ```
 
+## Source-data vertical-level review (all 8 catalog models)
+
+Reviewed which of our catalogued models publish **more than one dense vertical
+coordinate type** in the *files we'd virtualize* (the public GRIB archives), which
+is what would force a vertical-dimension/grouping decision. Empirical for the NOAA
+products (NODD `.idx` files, spikes 3/5 + `spike_hrrr_gefs.py`); ECMWF/DWD/MRMS from
+provider docs + live listings.
+
+| Model | Single/surface | Pressure levels (dense) | Model/native levels (dense) | Other dense vertical | Multiple Z-types? |
+|---|---|---|---|---|---|
+| NOAA GFS | yes | **33** levels, 16 vars | no (1–2 hybrid msgs on NODD) | — | **No** — pressure only |
+| NOAA GEFS | yes | modest (0.5° a-file ~12; s-file 0.25° none) | no | — | **No** (but see resolution heterogeneity below) |
+| NOAA HRRR | yes | **39** levels, 14 vars (`wrfprs`) | **50** native levels, 20 vars (`wrfnat`) | — | **YES** — pressure + native |
+| NOAA MRMS | yes (mostly 2D) | no | no | 33 CAPPI height levels (~0.5–19 km), shared by all 3D mosaics | No — one height type |
+| ECMWF IFS ENS | yes | **14** levels (1000→10 hPa), full var set | no (MARS/paid only) | — | **No** — pressure only |
+| ECMWF AIFS Single | yes | **13** levels, narrower var set | no | — | **No** — pressure only |
+| ECMWF AIFS ENS | yes | **14** levels | no (only an *experimental* product) | — | **No** — pressure only |
+| DWD ICON-EU | yes (~100+ vars) | **~20** levels (T, FI, RELHUM, U, V) | **~74** model levels (T, U, V, W, P, QV, …) | — | **YES** — pressure + model |
+
+**Headline: only HRRR and ICON-EU (2 of 8) genuinely need multiple vertical-level
+groups.** Five products are pressure-only (or less); MRMS has a single dense
+vertical type (height), so it gets at most one vertical dimension and no
+pressure-vs-model decision. Crucially, we *know each model's answer up front* from
+this review — there is no "we'll be surprised later" risk that would argue for
+pre-emptively grouping everything.
+
+## When are zarr groups actually required?
+
+Groups solve more than the vertical-coordinate problem. There are (at least) two
+*independent* triggers, and a dataset needs groups if **either** holds:
+
+1. **Multiple dense vertical coordinate types for the same variable** (Decision A's
+   multi-Z case). `temperature` on both pressure and model levels can't share one
+   flat array. → HRRR, ICON-EU.
+
+2. **A dimension whose extent varies across another dimension** (the heterogeneity
+   case). A virtual chunk is a raw GRIB message at its native grid — we can't
+   resample — so if the horizontal grid size changes along the append/lead axis, the
+   data is not rectangular and can't live in one array. **GEFS is the concrete
+   example:** its `s` files are 0.25° only through lead 240 h, after which only
+   `a`/`b` at 0.5° exist (`gefs_config_models.py:15-19`). Tellingly, our one existing
+   virtual GEFS dataset is `forecast_10_day_spatial` = exactly 240 h — capped at the
+   resolution boundary to sidestep this. Spanning the full 35 days virtually would
+   need two resolution groups (e.g. `/lead_0_240` at 0.25°, `/lead_243_840` at
+   0.5°), or two separate datasets.
+
+(A third, softer trigger: wanting genuinely different chunk/manifest policies per
+block of variables.)
+
+### Recommendation: per-dataset, not always-group
+
+**Do not make `pressure_level` a group by default.** Decide layout per dataset at
+creation, from its known source structure:
+
+- **Single vertical coordinate type → flat (root) layout.** Pressure (or height for
+  MRMS) is a real dimension *at the root*; single/surface vars sit alongside it
+  suffix-named (spike 4). This is 6 of 8 models (GFS, GEFS, IFS ENS, AIFS×2, MRMS)
+  and preserves swap-compat with the materialized catalog.
+- **Multiple vertical coordinate types → groups** named by coordinate type
+  (`pressure_level/`, `model_level/`), single/surface at root. This is HRRR and
+  ICON-EU.
+- **Shape heterogeneity → groups** named by the homogeneous block (e.g. resolution
+  window), independent of vertical levels. GEFS full-range is the case.
+
+Rationale: always-grouping would nest 6 of 8 datasets for zero functional benefit
+and break the simple-root / swap-compatible story from Decisions A/B. The forward-
+compat worry ("what if a dataset gains model levels later?") is weak here because we
+already *know* each model's vertical structure, and because the uniform data model
+— **every variable declares its vertical coordinate** (`None` / `pressure_level` /
+`model_level` / `height`) — makes the flat-vs-grouped choice a *rendering* of that
+model, so a later escalation is mechanical, not a redesign. A1 is the single-
+coordinate rendering; groups are the multi-coordinate rendering.
+
 ## Parked / next steps
 
 Decision status and follow-ups (so they aren't lost):
@@ -482,9 +555,16 @@ Decision status and follow-ups (so they aren't lost):
   `*_level` dim; suffix ⇒ one fixed level; `pressure_level` in hPa, CF
   `air_pressure`, axis Z, positive down, descending; place on the real dim iff
   densely published; single levels stay suffix-flat (MultiIndex rejected).
-- **C — `model_level` scope:** deferred, provider-specific. Not available for GFS on
-  NODD; revisit per provider when a dense native-level source exists. First
-  iteration is single-level (suffix) + `pressure_level` (real dim) only.
+- **C — `model_level` scope:** deferred, provider-specific. The source review
+  (above) shows **only HRRR (`wrfnat`, 50 levels) and DWD ICON-EU (~74 levels)**
+  publish dense model levels for the same vars as pressure — they are the concrete
+  multi-Z cases. GFS/GEFS/ECMWF have none in their public files. First iteration is
+  single-level (suffix) + `pressure_level` (real dim) only; bring in `model_level`
+  when building HRRR/ICON-EU.
 - **D — ensemble & manifest sizing:** validation task. Check
   `manifest_append_dim_split` size and `num_chunk_refs` cache against the
   ensemble × pressure projection before committing; `pressure_level` chunk size = 1.
+- **E — group policy:** **DECIDED** (see "When are zarr groups actually required?").
+  Per-dataset, not always-group: flat root for single-vertical-coordinate datasets
+  (6 of 8); groups only for multiple vertical coordinate types (HRRR, ICON-EU) or
+  shape heterogeneity (GEFS full-range resolution split).

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -522,16 +522,18 @@ triggers, and a dataset needs groups if **either** holds:
    multi-Z case). `temperature` on both pressure and model levels can't share one
    flat array. → HRRR, ICON-EU.
 
-2. **A dimension whose extent varies across another dimension** (the heterogeneity
-   case). A virtual chunk is a raw GRIB message at its native grid — we can't
-   resample — so if the horizontal grid size changes along the append/lead axis, the
-   data is not rectangular and can't live in one array. **GEFS is the concrete
-   example:** its `s` files are 0.25° only through lead 240 h, after which only
-   `a`/`b` at 0.5° exist (`gefs_config_models.py:15-19`). Tellingly, our one existing
-   virtual GEFS dataset is `forecast_10_day_spatial` = exactly 240 h — capped at the
-   resolution boundary to sidestep this. Spanning the full 35 days virtually would
-   need two resolution groups (e.g. `/lead_0_240` at 0.25°, `/lead_243_840` at
-   0.5°), or two separate datasets.
+2. **A dimension whose extent varies across another dimension *and we can't make it
+   uniform*** (the heterogeneity case). If the horizontal grid size changes along the
+   append/lead axis, the data isn't rectangular and can't live in one array — *unless*
+   we resample it onto a common grid. A **materialized** dataset can resample, so it
+   stays group-free; a **virtual** dataset can't (a chunk is a raw GRIB message at its
+   native grid), so it needs groups. **GEFS is the concrete example:** its `s` files
+   are 0.25° only through lead 240 h, after which only `a`/`b` at 0.5° exist
+   (`gefs_config_models.py:15-19`). Tellingly, our one existing virtual GEFS dataset
+   is `forecast_10_day_spatial` = exactly 240 h — capped at the resolution boundary to
+   sidestep this. Spanning the full 35 days *virtually* would need two resolution
+   groups (e.g. `/lead_0_240` at 0.25°, `/lead_243_840` at 0.5°), or two separate
+   datasets; the materialized 35-day GEFS resamples to one grid and needs neither.
 
 ## Decided layout (Decision E) — Option B, refined
 
@@ -548,6 +550,13 @@ same shape:
   multiple vertical dimensions** — datasets are cross-consistent.
 - **A group with no variables does not exist** (e.g. a pressure-only dataset has a
   `pressure_level` group but no `model_level` group).
+- **Applies to all datasets — materialized and virtual.** Today every materialized
+  dataset is single-level selections only, so they're all entirely at the root and
+  already conform. Note a selected single level such as `temperature_500hpa` is a
+  *single-level slice* and stays a root single-level var (it isn't dense, per the
+  sub-q 2 boundary rule) — even though the same physical variable may appear as a
+  dense `pressure_level/temperature` in a (e.g. virtual) dataset that includes the
+  full stack.
 
 This is Option B below (single-level at root, every stack grouped), with two
 refinements: group name = dimension name, and empty groups are omitted.
@@ -575,11 +584,14 @@ refinements: group name = dimension name, and empty groups are omitted.
    - **Names — DEFERRED:** the group/dim names for other dense+comparable Z types
      (height for MRMS 3D reflectivity; soil/depth for ECMWF `sol`, ICON
      `t_so`/`w_so`) are not yet chosen. `pressure_level` and `model_level` stand.
-3. **Scope of this decision — OPEN (deferred).** It resolves *vertical* structure
-   only. Still open: the non-vertical heterogeneity case (GEFS 0.25°/0.5° across lead
-   time — resolution groups vs. separate datasets), and whether this structure also
-   reshapes existing *materialized* datasets or applies only to new virtual all-level
-   datasets.
+3. **Scope of this decision — DECIDED.** The structure applies to **all** datasets,
+   materialized and virtual. (Today's materialized datasets are single-level
+   selections only, so they already conform — everything at the root.) Non-vertical
+   heterogeneity also gets groups, but **only when we can't make it uniform**: a
+   materialized dataset resamples a varying grid onto a common one (no groups); a
+   virtual dataset can't resample, so a dimension whose extent varies (e.g. GEFS
+   0.25°/0.5° across lead time) needs resolution groups (or separate datasets). See
+   trigger 2 in "When are zarr groups actually required?".
 4. **Empty root — CONFIRMED acceptable (and unlikely).** A purely upper-air dataset
    would have a root with shared coords but zero data variables; structurally fine,
    and not expected to come up in practice.
@@ -712,7 +724,8 @@ Decision status and follow-ups (so they aren't lost):
   into each group** so groups are independently openable (sub-q 1 decided; empty root
   confirmed fine, sub-q 4). Boundary rule decided (sub-q 2): a level set becomes its
   own Z dimension/group **iff dense + comparable**, else the var stays a root
-  single-level (suffix-named). Still open: **sub-q 2 names** for other Z types (height
-  for MRMS, soil/depth) — deferred; **sub-q 3** the non-vertical resolution-
-  heterogeneity case (GEFS) and whether this reshapes materialized datasets or only
-  new virtual ones.
+  single-level (suffix-named). Scope decided (sub-q 3): applies to **all** datasets
+  (materialized + virtual; today's materialized are single-level-only so already
+  conform); non-vertical heterogeneity gets groups only when it can't be made uniform
+  (virtual can't resample, materialized can). Still open: **sub-q 2 names** for other
+  Z types (height for MRMS, soil/depth) — deferred.

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -208,6 +208,35 @@ not duplicated. For a back-compat root surface over a few dozen single-level var
 this is cheap; aliasing whole pressure-level stacks would meaningfully grow the
 manifest and is probably not worth it.
 
+### Spike 4 — mixed-dim variables in one flat group (feasibility for Decision A)
+
+`spike4_mixed_dims_flat.py` writes a single-level and a pressure-level variable
+into one **root** group (no zarr group), commits, reads back.
+
+```
+vars + dims in ONE flat group:
+  temperature_2m   ('time', 'lat', 'lon')
+  temperature      ('time', 'level', 'lat', 'lon')
+single open_zarr, no group= needed.  temperature.sel(level=500) shape: (3, 4, 5)
+```
+
+**Finding:** real vertical dimensions don't need zarr groups. A flat dataset holds
+heterogeneous-dimension variables fine, so the grouping decision (Q2) is decoupled
+from the dimension decision (Q1). Drives Decision A.
+
+### Spike 5 — model-level availability in NODD GFS (feasibility for Decision C)
+
+`spike5_model_level_availability.py` classifies both GFS products' indexes:
+
+```
+GFS pgrb2  0p25:  pressure 16 vars x 33 levels ; hybrid/model 6 vars x [1,2]
+GFS pgrb2b 0p25:  pressure 15 vars x 22 levels ; hybrid/model 0 vars
+```
+
+**Finding:** neither standard NODD GFS product carries usable model levels. A
+`model_level` group/dimension is not feasible for GFS from these sources. Drives
+Decision C.
+
 ---
 
 ## Synthesis & recommendation
@@ -220,10 +249,14 @@ The measurements turn most of the either/or framing into a "both, by regime":
    coordinate; single/surface variables stay suffix-named. Spike 3 shows this is
    the structure the data actually has — ~88% dense vs ~7% dense.
 
-2. **Group by level-type** (Q2). It's the only layout that gives each regime its
-   natural dimensionality, and spike 1 shows the storage stack fully supports it
-   (write per group, read per group or as a DataTree, coords inherited from root).
-   The real cost is the base-class work in Q's precondition, not storage.
+2. **Real vertical dimensions do NOT require zarr groups** (Q2). Spike 4 shows a
+   single flat root group holds `temperature_2m(time, y, x)` and
+   `temperature(time, pressure_level, y, x)` side by side, read back with one
+   `open_zarr` (no `group=`). Spike 1 shows groups *also* work if we want them.
+   So the dimension decision (Q1) and the grouping decision (Q2) are independent:
+   we can get the dense `pressure_level` win in the existing single-group layout
+   and treat groups as a later, optional organizational choice. See expanded
+   decision A below.
 
 3. **For back-compat, prefer a root-level "single_level"-style surface that
    reuses today's exact names** so a new virtual dataset can swap in for a
@@ -246,28 +279,141 @@ The measurements turn most of the either/or framing into a "both, by regime":
    feasible; recommend doing that for the existing products rather than a hard
    cutover, and making the new virtual versions swap-compatible at the root.
 
-### Open decisions to settle before designing the base-class changes
+## Expanded open decisions
 
-- **Group naming & rule (Q7):** lock the exact group names and a written rule for
-  which variables go where, so it's uniform across providers.
-- **Root = single_level, or aliases (Q4 vs Q8):** do single-level vars simply live
-  at root, or does the root hold aliases into a `single_level/` group?
-- **Per-group `dims`/`coords`/`data_vars` in `TemplateConfig`:** how to express a
-  multi-group template (e.g. `data_vars` keyed by group, or a small per-group
-  sub-config) and how `chunk_key`/`filter_already_present` address
-  `group/var`-pathed arrays.
-- **`model_level` scope:** GFS pgrb2 exposes only a handful of hybrid messages;
-  decide whether model levels come from a different product (e.g. `pgrb2b`/native)
-  before committing to the group.
-- **Ensemble sizing (Q9):** confirm manifest/chunk sizing with `ensemble_member ×
-  pressure_level` for the GEFS-style case.
+These are the choices that are genuinely ours to make. Each is laid out as the
+real question, the options, and a recommendation.
+
+### Decision A — The machinery change: per-variable dims, not groups
+
+The framing "should we use groups?" buries the actual base-class gap. Look at what
+the code keys on:
+
+- `chunk_key()` already reads geometry **per variable** from the template:
+  `template_var.dims` and `template_var.encoding["chunks"]`
+  (`virtual_region_job.py`). It handles a dim being present or absent in `out_loc`
+  generically. **It already supports heterogeneous-dimension variables** — pass it
+  a `temperature` whose template var has a `pressure_level` dim and it just works,
+  as long as the source ref's `out_loc` carries the level label.
+- `filter_already_present()` / `_emit_refs()` address arrays by flat `var.name` at
+  the root — fine as long as variables stay in one group.
+- The one real blocker is `TemplateConfig`: `update_template()` builds **every**
+  variable with the same `self.dims` via
+  `make_empty_variable(self.dims, coords, dtype)`, and `self.dims` is a single
+  tuple. There is no way today to give `temperature` a `pressure_level` dim while
+  `temperature_2m` has none.
+
+So the decision is **per-variable dims (A1)** vs. **zarr groups + DataTree (A2)**,
+and spike 4 proves A1 is sufficient for real vertical dimensions.
+
+**A1 — per-variable dims in one flat group (recommended first step).**
+Add an optional `dims` to `DataVar` (default = template `dims`), add the
+`pressure_level` coordinate to `coords`, and teach `update_template` /
+`empty_copy_with_reindex` to honor per-var dims. `chunk_key` needs no change.
+`SourceFileCoord.out_loc()` for a pressure message must include its
+`pressure_level` label; `representative_var` must pick a (var, level) the file
+actually contains.
+- Pros: smallest change; one `open_zarr` for readers; single-level vars are byte-
+  for-byte unchanged at the root, so swap-compat with the materialized catalog is
+  free; `.sel(pressure_level=500)` works; **NaN holes on sparse upper levels cost
+  nothing** — a missing (var, level) chunk is simply an absent ref in a virtual
+  store, never stored bytes.
+- Cons: one flat namespace, so naming discipline matters (decision B); a single
+  array set and manifest for the whole dataset.
+
+**A2 — zarr groups + DataTree (defer).**
+`TemplateConfig` grows per-group `dims`/`coords`/`data_vars` (e.g. `data_vars`
+keyed by group, or a small per-group sub-config); `template_ds` becomes a
+DataTree or a dict of datasets; `chunk_key`/filter/emit address `group/var` paths;
+`get_template`, `write_metadata`, `empty_copy_with_reindex`, and `sync_dims_to`
+all loop over groups; coordination/finalize runs per group.
+- Pros: clean separation, per-group chunk policy, readers open only what they want,
+  no name collisions.
+- Cons: substantial churn across `TemplateConfig`, `RegionJob`,
+  `VirtualRegionJob`, `template_utils`, `storage`; readers must know the group; the
+  back-compat root either duplicates or uses aliases (decision below).
+
+**Recommendation:** ship A1 now. It delivers the dense-pressure win with minimal
+churn and preserves swap-compat. Groups can be layered on later (A2) without
+invalidating A1's variable names, and only when a dataset actually needs per-group
+chunking or the flat namespace becomes unwieldy (e.g. ensemble × model_level ×
+pressure_level). Under A1 the "alias" idea (Q4) and "empty root" idea (Q8) mostly
+dissolve: single-level vars simply *are* the root, and pressure vars *are* the
+level-dim arrays in the same root — nothing to alias.
+
+### Decision B — Naming convention + the written rule
+
+With A1 everything shares one namespace, so the convention has to be unambiguous
+and uniform across providers. Proposed rules:
+
+- **Level-dim variables use the plain ECMWF name, no suffix:** `temperature`,
+  `geopotential_height`, `relative_humidity`, `specific_humidity`, `wind_u`,
+  `wind_v`, `vertical_velocity`. A plain name *always means* "indexed by a
+  `*_level` dimension."
+- **Single/surface variables keep today's suffix convention exactly:**
+  `temperature_2m`, `wind_u_10m`, `pressure_surface`,
+  `pressure_reduced_to_mean_sea_level`. A suffixed name *always means* "one fixed
+  level." This is what makes `temperature` (pressure stack) and `temperature_2m`
+  (2 m) coexist without ambiguity.
+- **Dimension/coordinate:** `pressure_level`, values in **hPa** (matches the
+  legacy `_500hpa` suffix and the idx `mb` units), CF `standard_name`
+  `air_pressure`, `axis="Z"`, `positive="down"`. Pick and document an ordering
+  (recommend descending, surface→top: 1000 → 1).
+- **The placement rule (write it down):** a variable goes on the real
+  `pressure_level` dimension iff the source publishes it across a dense set of
+  pressure levels (e.g. ≥ ~80% of the union other core vars use); otherwise it
+  stays suffix-named. A variable may appear **both** ways (e.g. `temperature` on
+  the pressure stack *and* `temperature_2m`).
+- **Sparse-upper-level handling:** use one `pressure_level` dimension spanning the
+  full 33-level union; variables present only on a subset (spike 3: the 6
+  mixing-ratio vars at 22 levels) simply have no ref above their top level. In a
+  virtual store that is zero cost (absent chunk → fill value), so there is no
+  reason to split the dimension by which vars reach which level.
+
+### Decision C — `model_level` scope (defer; provider-specific)
+
+Spike 5 settles this for NOAA GFS: neither `pgrb2.0p25` nor `pgrb2b.0p25` on NODD
+carries usable model/hybrid levels (1–2 hybrid messages total; pgrb2b has none).
+GFS does not publish a full native-level 0.25° grid on NODD. So:
+
+- **Do not design a universal `model_level` structure now.** Pressure levels are
+  universally available and dense; ship `single_level (suffix) + pressure_level
+  (real dim)` first.
+- Treat `model_level` as **provider-specific and deferred** — HRRR native files,
+  IFS model-level products, ICON native levels each differ. Evaluate per provider
+  when a concrete dense-native-level source is identified. If/when one is, it is
+  the strongest case for A2 groups (a second `model_level` dimension alongside
+  `pressure_level` in one flat dataset is also possible but starts to strain the
+  flat namespace).
+
+### Decision D — Ensemble & manifest/chunk sizing (Q9)
+
+This is a sizing validation, not a structural choice, but it must be checked before
+committing. In a virtual store one ref = one GRIB message = one chunk, and lat/lon
+are a single chunk per message, so manifest entries ≈
+`#append_dim × #ensemble × #lead × #pressure_level × #vars`.
+
+- Pressure levels multiply the ref count of core vars by ~33. For a GEFS-style
+  ensemble (31 members) the pressure block alone is on the order of
+  `16 vars × 33 levels × 31 members × ~81 leads ≈ 1.3M refs per init_time` — large,
+  but exactly what icechunk manifest splitting is built for.
+- The existing `IcechunkVirtualConfig` already splits manifests along the append
+  dim (`manifest_append_dim_split`) and caps the chunk-ref cache
+  (`num_chunk_refs=1_000_000`, see `storage.py`). **Action:** validate the split
+  size and cache budget against the ensemble × pressure projection, and split more
+  aggressively if a single append-dim manifest shard exceeds comfortable size.
+- **Chunking note:** because a virtual chunk is one whole horizontal field,
+  `pressure_level` is chunked **1 per level** (each level is its own message) and
+  lat/lon are single-chunk. Encode `pressure_level` chunk size = 1.
 
 ### Reproducing the spikes
 
 Scripts are committed under `docs/plans/vertical_structure_spikes/`:
 
 ```
-uv run python docs/plans/vertical_structure_spikes/spike3_sparsity.py  # grid density (network: NODD idx)
-uv run python docs/plans/vertical_structure_spikes/spike1_groups.py    # multi-group round-trip
-uv run python docs/plans/vertical_structure_spikes/spike2_alias.py     # virtual alias one ref -> two paths
+uv run python docs/plans/vertical_structure_spikes/spike3_sparsity.py              # grid density (network: NODD idx)
+uv run python docs/plans/vertical_structure_spikes/spike1_groups.py                # multi-group round-trip
+uv run python docs/plans/vertical_structure_spikes/spike2_alias.py                 # virtual alias one ref -> two paths
+uv run python docs/plans/vertical_structure_spikes/spike4_mixed_dims_flat.py       # mixed-dim vars in ONE flat group
+uv run python docs/plans/vertical_structure_spikes/spike5_model_level_availability.py  # pgrb2 vs pgrb2b level content
 ```

--- a/docs/plans/vertical_structure_exploration.md
+++ b/docs/plans/vertical_structure_exploration.md
@@ -371,10 +371,13 @@ A2.** Model the data uniformly as "each variable declares its vertical coordinat
 (`None` for single/surface, `pressure_level`, `model_level`, …); then *render*
 flat-at-root when a dataset has ≤1 vertical coordinate type (for swap-compat) and
 render as groups when it has more. Designing the var→vertical-coordinate
-association into the config now means flat-vs-grouped is a later rendering choice,
-not a rewrite. Note this collision does **not** arise for the immediate GFS/GEFS
-pressure-level work (GFS has no usable model levels — decision C), so A1 ships
-unblocked; the association just keeps the door open.
+association into the config now means flat-vs-grouped is a later rendering choice in
+*our code*, not a rewrite. (To be clear: re-rendering an *already-published* dataset
+is still a breaking change for consumers — a new dataset version, not done lightly.
+The cheap-to-change part is our implementation, so we should set the layout policy
+deliberately up front.) Note this collision does **not** arise for the immediate
+GFS/GEFS pressure-level work (GFS has no usable model levels — decision C), so A1
+ships unblocked; the association just keeps the door open.
 
 ### Decision B — Naming convention + the written rule — **DECIDED**
 
@@ -567,9 +570,13 @@ HRRR:  /  temperature_2m, …   /pressure_level  temperature   /model_level  tem
 Either way, single/surface vars stay at root, so materialized→virtual swap-compat is
 the same for both (the suffix→dimension change for pressure breaks those few names
 regardless of grouping). Shared data model: every variable declares its vertical
-coordinate, so flat-vs-grouped is a rendering choice and the policy can be applied
-uniformly. (Same call also covers GEFS's shape-heterogeneity split — resolution
-windows as groups `/lead_0_240`, `/lead_243_840`, vs. separate datasets.)
+coordinate, so flat-vs-grouped is a rendering choice in our code and the policy can
+be applied uniformly. **This is why the policy is worth deciding deliberately now:
+changing the layout of an already-published dataset is a breaking change for
+consumer code (a new dataset version), not something we would do lightly — even
+though our implementation could re-render either way.** (Same call also covers
+GEFS's shape-heterogeneity split — resolution windows as groups `/lead_0_240`,
+`/lead_243_840`, vs. separate datasets.)
 
 **Author's lean: Option A** — optimize the common, most-used single-type datasets
 for one-shot discovery; introduce groups only where a real name conflict requires
@@ -583,8 +590,10 @@ Decision status and follow-ups (so they aren't lost):
   concrete `DataVar.dims` (optional, default = template `dims`) + `update_template`
   / `empty_copy_with_reindex` change as a small proposal / proof-of-concept diff.
   Model each variable's vertical coordinate (`None` / `pressure_level` /
-  `model_level`) so flat-at-root vs. grouped is a later rendering choice — A1 is the
-  single-vertical-coordinate special case of A2.
+  `model_level`) so flat-at-root vs. grouped is a rendering choice in our code — A1
+  is the single-vertical-coordinate special case of A2. (Cheap to re-render in code;
+  *not* cheap to change once published — that's a breaking version bump, so set the
+  layout policy (E) deliberately up front.)
 - **B — naming convention:** **DECIDED** (see Decision B). Plain ECMWF name ⇒ on a
   `*_level` dim; suffix ⇒ one fixed level; `pressure_level` in hPa, CF
   `air_pressure`, axis Z, positive down, descending; place on the real dim iff

--- a/docs/plans/vertical_structure_spikes/spike10_group_coord_inheritance.py
+++ b/docs/plans/vertical_structure_spikes/spike10_group_coord_inheritance.py
@@ -1,0 +1,44 @@
+# Does a child group opened on its own carry the shared dim coords (time/lat/lon)
+# that live only at the root, or only what's written into the group itself?
+import tempfile
+import icechunk, numpy as np, xarray as xr
+
+repo = icechunk.Repository.create(icechunk.local_filesystem_storage(tempfile.mkdtemp()))
+s = repo.writable_session("main")
+store = s.store
+
+# Root: single-level var + the shared coords (time/lat/lon)
+root = xr.Dataset(
+    {"temperature_2m": (("time", "lat", "lon"), np.zeros((3, 4, 5), "float32"))},
+    coords={"time": np.arange(3), "lat": np.arange(4), "lon": np.arange(5)},
+)
+root.to_zarr(store, mode="w", consolidated=False)
+
+# pressure_level group: temperature on (time, pressure_level, lat, lon).
+# Write ONLY the pressure_level coord in the group; do NOT repeat time/lat/lon.
+pl = xr.Dataset(
+    {
+        "temperature": (
+            ("time", "pressure_level", "lat", "lon"),
+            np.ones((3, 2, 4, 5), "float32"),
+        )
+    },
+    coords={"pressure_level": np.array([1000, 500])},
+)
+pl.to_zarr(store, group="pressure_level", mode="a", consolidated=False)
+s.commit("root coords only; group has its own z coord")
+
+ro = repo.readonly_session("main").store
+print("=== open_zarr(group='pressure_level') ALONE ===")
+g = xr.open_zarr(ro, group="pressure_level", consolidated=False)
+print("data_vars:", list(g.data_vars))
+print("coords present:", list(g.coords))
+print("has time coord values? ", "time" in g.coords)
+print("has lat coord values?  ", "lat" in g.coords)
+print("dims:", dict(g.sizes))
+
+print("\n=== open_datatree (whole hierarchy) ===")
+dt = xr.open_datatree(ro, engine="zarr", consolidated=False)
+pl_node = dt["pressure_level"]
+print("pressure_level node coords (incl inherited):", list(pl_node.coords))
+print("inherited time values:", pl_node.coords.get("time", "MISSING"))

--- a/docs/plans/vertical_structure_spikes/spike1_groups.py
+++ b/docs/plans/vertical_structure_spikes/spike1_groups.py
@@ -1,0 +1,71 @@
+"""Spike 1: can one icechunk store hold multiple groups with different dims,
+written and read back with xarray? Tests the proposed
+root / single_level / pressure_level / model_level structure.
+"""
+
+import tempfile
+
+import icechunk
+import numpy as np
+import xarray as xr
+
+tmp = tempfile.mkdtemp()
+repo = icechunk.Repository.create(icechunk.local_filesystem_storage(tmp))
+session = repo.writable_session("main")
+store = session.store
+
+# Root: a back-compat single-level variable, dims (time, lat, lon)
+root = xr.Dataset(
+    {"temperature_2m": (("time", "lat", "lon"), np.zeros((3, 4, 5), "float32"))},
+    coords={"time": np.arange(3), "lat": np.arange(4), "lon": np.arange(5)},
+)
+root.to_zarr(store, mode="w", consolidated=False)
+
+# Group: pressure_level, with an EXTRA dim `level`, dims (time, level, lat, lon)
+plevels = np.array([1000, 850, 500, 250], "int32")
+pl = xr.Dataset(
+    {
+        "temperature": (
+            ("time", "level", "lat", "lon"),
+            np.ones((3, 4, 4, 5), "float32"),
+        )
+    },
+    coords={
+        "time": np.arange(3),
+        "level": plevels,
+        "lat": np.arange(4),
+        "lon": np.arange(5),
+    },
+)
+pl.to_zarr(store, group="pressure_level", mode="a", consolidated=False)
+
+# Group: single_level, keeping suffix-named vars (sparse cross product)
+sl = xr.Dataset(
+    {
+        "temperature_2m": (("time", "lat", "lon"), np.zeros((3, 4, 5), "float32")),
+        "wind_u_100m": (("time", "lat", "lon"), np.zeros((3, 4, 5), "float32")),
+    },
+    coords={"time": np.arange(3), "lat": np.arange(4), "lon": np.arange(5)},
+)
+sl.to_zarr(store, group="single_level", mode="a", consolidated=False)
+
+session.commit("multi-group write")
+
+# ---- read back ----
+ro = repo.readonly_session("main").store
+print("=== read root group ===")
+print(list(xr.open_zarr(ro, consolidated=False).data_vars))
+print("\n=== read group='pressure_level' ===")
+pds = xr.open_zarr(ro, group="pressure_level", consolidated=False)
+print("dims:", dict(pds.sizes), "vars:", list(pds.data_vars))
+print("\n=== read group='single_level' ===")
+sds = xr.open_zarr(ro, group="single_level", consolidated=False)
+print("vars:", list(sds.data_vars))
+
+print("\n=== open_datatree (whole hierarchy at once) ===")
+dt = xr.open_datatree(ro, engine="zarr", consolidated=False)
+print(dt)
+print(
+    "\nnavigate: dt['pressure_level']['temperature'] level coord ->",
+    dt["pressure_level"]["temperature"].level.values,
+)

--- a/docs/plans/vertical_structure_spikes/spike2_alias.py
+++ b/docs/plans/vertical_structure_spikes/spike2_alias.py
@@ -1,0 +1,92 @@
+"""Spike 2: the 'virtual alias' idea. Can the SAME source-file byte range be
+referenced from TWO array paths in one icechunk store (a back-compat alias at
+root + a canonical location in a group)? And what does it cost in the manifest?
+"""
+
+import tempfile
+from pathlib import Path
+
+import icechunk
+import numpy as np
+import xarray as xr
+import zarr
+from icechunk import VirtualChunkSpec
+
+tmp = tempfile.mkdtemp()
+src_dir = Path(tempfile.mkdtemp())
+
+# Fake "source file": one chunk's worth of float32 bytes (like one decoded GRIB msg).
+payload = np.arange(4 * 5, dtype="float32").reshape(4, 5)
+src = src_dir / "source.bin"
+src.write_bytes(payload.tobytes())
+location = f"file://{src}"
+
+# Register the local dir as a virtual chunk container.
+config = icechunk.RepositoryConfig.default()
+container = icechunk.VirtualChunkContainer(
+    url_prefix=f"file://{src_dir}/",
+    store=icechunk.local_filesystem_store(str(src_dir)),
+)
+config.set_virtual_chunk_container(container)
+creds = icechunk.containers_credentials({f"file://{src_dir}/": None})
+
+repo = icechunk.Repository.create(
+    icechunk.local_filesystem_storage(tmp),
+    config=config,
+    authorize_virtual_chunk_access=creds,
+)
+session = repo.writable_session("main")
+store = session.store
+
+# Build empty arrays (no real chunks) at root and in a group, same shape/dtype.
+# No compressor/serializer: virtual refs are raw bytes, decoded as-is (real
+# datasets swap in a GribberishCodec serializer; uncompressed is enough here).
+enc = {"temperature_2m": {"compressors": None, "chunks": (4, 5)}}
+root = xr.Dataset(
+    {"temperature_2m": (("lat", "lon"), np.zeros((4, 5), "float32"))},
+    coords={"lat": np.arange(4), "lon": np.arange(5)},
+)
+root.to_zarr(store, mode="w", compute=False, consolidated=False, encoding=enc)
+canon = xr.Dataset(
+    {"temperature_2m": (("lat", "lon"), np.zeros((4, 5), "float32"))},
+    coords={"lat": np.arange(4), "lon": np.arange(5)},
+)
+canon.to_zarr(
+    store,
+    group="single_level",
+    mode="a",
+    compute=False,
+    consolidated=False,
+    encoding=enc,
+)
+
+spec = VirtualChunkSpec(
+    index=[0, 0], location=location, offset=0, length=payload.nbytes
+)
+# Same spec -> two different array paths.
+assert (
+    store.set_virtual_refs("temperature_2m", [spec], validate_containers=True) is None
+)
+assert (
+    store.set_virtual_refs(
+        "single_level/temperature_2m", [spec], validate_containers=True
+    )
+    is None
+)
+snap = session.commit("alias same ref at root and in group")
+print("committed snapshot:", snap)
+
+ro = repo.readonly_session("main").store
+a = xr.open_zarr(ro, consolidated=False)["temperature_2m"].values
+b = xr.open_zarr(ro, group="single_level", consolidated=False)["temperature_2m"].values
+print("root values == source:", np.array_equal(a, payload))
+print("group values == source:", np.array_equal(b, payload))
+print("root == group (same bytes, one source):", np.array_equal(a, b))
+
+# Manifest cost: each alias is a separate manifest entry even though bytes are shared.
+g = zarr.open_group(ro, mode="r")
+print(
+    "\nNote: 2 array paths -> 2 chunk-ref manifest entries pointing at the same "
+    "(location, offset, length). No byte duplication in source, but the ref count "
+    "(and manifest size) doubles for aliased variables."
+)

--- a/docs/plans/vertical_structure_spikes/spike3_sparsity.py
+++ b/docs/plans/vertical_structure_spikes/spike3_sparsity.py
@@ -1,0 +1,79 @@
+"""Spike 3: quantify single-level vs vertical-level structure in a real GFS file.
+
+Pulls a GFS pgrb2 .idx (the GRIB index NODD publishes alongside each file) and
+classifies every message by its level type, so we can see how dense/sparse a
+(variable x level) grid would actually be.
+"""
+
+import re
+import urllib.request
+from collections import defaultdict
+
+# A recent-ish GFS 0.25deg pgrb2 file index. pgrb2 carries the full pressure-level set.
+URL = "https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.20240101/00/atmos/gfs.t00z.pgrb2.0p25.f000.idx"
+
+raw = urllib.request.urlopen(URL, timeout=30).read().decode()
+lines = [ln for ln in raw.splitlines() if ln.strip()]
+print(f"total GRIB messages in file: {len(lines)}")
+
+# idx line: <n>:<offset>:d=<date>:<param>:<level>:<forecast>:...
+pressure = defaultdict(set)  # param -> set of hPa levels
+model_lvl = defaultdict(set)  # param -> set of hybrid levels
+single = defaultdict(list)  # level-string -> [params]
+level_types = defaultdict(int)
+
+for line in lines:
+    parts = line.split(":")
+    param = parts[3]
+    level = parts[4]
+    m = re.match(r"^(\d+) mb$", level)
+    mh = re.match(r"^(\d+) hybrid level$", level)
+    if m:
+        pressure[param].add(int(m.group(1)))
+        level_types["pressure (mb)"] += 1
+    elif mh:
+        model_lvl[param].add(int(mh.group(1)))
+        level_types["hybrid (model)"] += 1
+    else:
+        single[level].append(param)
+        level_types["single/other"] += 1
+
+print("\n=== message counts by level category ===")
+for k, v in sorted(level_types.items(), key=lambda x: -x[1]):
+    print(f"  {v:5d}  {k}")
+
+print(f"\n=== PRESSURE-LEVEL variables: {len(pressure)} distinct params ===")
+all_p_levels = sorted({lv for s in pressure.values() for lv in s}, reverse=True)
+print(f"distinct pressure levels present: {len(all_p_levels)}")
+print(f"levels: {all_p_levels}")
+print(
+    f"\n(variable x level) cross product if fully dense: "
+    f"{len(pressure)} x {len(all_p_levels)} = {len(pressure) * len(all_p_levels)}"
+)
+actual = sum(len(s) for s in pressure.values())
+print(f"actual pressure messages: {actual}")
+print(f"=> pressure grid density: {actual / (len(pressure) * len(all_p_levels)):.1%}")
+print("\nper-variable pressure-level counts (how many levels each var has):")
+for p, s in sorted(pressure.items(), key=lambda x: -len(x[1])):
+    print(f"  {len(s):3d} levels  {p}")
+
+print(
+    f"\n=== SINGLE-LEVEL / other: {sum(len(v) for v in single.values())} messages "
+    f"across {len(single)} distinct level strings ==="
+)
+# how sparse is (variable x single-level) if we tried to grid it?
+sl_pairs = [(p, lv) for lv, ps in single.items() for p in ps]
+sl_vars = {p for p, _ in sl_pairs}
+sl_levels = set(single.keys())
+print(f"distinct single-level 'level' strings: {len(sl_levels)}")
+print(f"distinct single-level params: {len(sl_vars)}")
+print(
+    f"(param x single-level) full grid: {len(sl_vars)} x {len(sl_levels)} = "
+    f"{len(sl_vars) * len(sl_levels)}; actual messages: {len(sl_pairs)}"
+)
+print(
+    f"=> single-level grid density: {len(sl_pairs) / (len(sl_vars) * len(sl_levels)):.1%}"
+)
+print("\nsample single-level level strings:")
+for lv in list(single.keys())[:25]:
+    print(f"  {lv!r}: {len(single[lv])} params")

--- a/docs/plans/vertical_structure_spikes/spike4_mixed_dims_flat.py
+++ b/docs/plans/vertical_structure_spikes/spike4_mixed_dims_flat.py
@@ -1,0 +1,33 @@
+# Decision-1 spike: can ONE flat root group hold a single-level var AND a
+# pressure-level var (extra `level` dim) together? If yes, real vertical dims
+# do NOT require zarr groups.
+import tempfile
+import icechunk, numpy as np, xarray as xr
+
+repo = icechunk.Repository.create(icechunk.local_filesystem_storage(tempfile.mkdtemp()))
+s = repo.writable_session("main")
+store = s.store
+ds = xr.Dataset(
+    {
+        "temperature_2m": (("time", "lat", "lon"), np.zeros((3, 4, 5), "float32")),
+        "temperature": (
+            ("time", "level", "lat", "lon"),
+            np.ones((3, 6, 4, 5), "float32"),
+        ),
+    },
+    coords={
+        "time": np.arange(3),
+        "level": np.array([1000, 850, 700, 500, 250, 100]),
+        "lat": np.arange(4),
+        "lon": np.arange(5),
+    },
+)
+ds.to_zarr(store, mode="w", consolidated=False)
+s.commit("mixed dims in one flat group")
+ro = repo.readonly_session("main").store
+back = xr.open_zarr(ro, consolidated=False)
+print("vars + dims in ONE flat group:")
+for n, v in back.data_vars.items():
+    print(f"  {n:16s} {v.dims}")
+print("single open_zarr, no group= needed. level coord:", back.level.values)
+print("temperature.sel(level=500) shape:", back.temperature.sel(level=500).shape)

--- a/docs/plans/vertical_structure_spikes/spike5_model_level_availability.py
+++ b/docs/plans/vertical_structure_spikes/spike5_model_level_availability.py
@@ -1,0 +1,31 @@
+import re, urllib.request
+from collections import defaultdict
+
+
+def classify(url, label):
+    raw = urllib.request.urlopen(url, timeout=30).read().decode()
+    lines = [ln for ln in raw.splitlines() if ln.strip()]
+    pres, hyb, single = defaultdict(set), defaultdict(set), defaultdict(list)
+    for line in lines:
+        p = line.split(":")
+        param, level = p[3], p[4]
+        if m := re.match(r"^(\d+) mb$", level):
+            pres[param].add(int(m.group(1)))
+        elif mh := re.match(r"^(\d+) hybrid level$", level):
+            hyb[param].add(int(mh.group(1)))
+        else:
+            single[level].append(param)
+    nhyb_levels = sorted({l for s in hyb.values() for l in s})
+    print(f"\n== {label} ==  ({len(lines)} msgs)")
+    print(
+        f"  pressure: {len(pres)} vars x {len(sorted({l for s in pres.values() for l in s}))} levels"
+    )
+    print(f"  hybrid/model: {len(hyb)} vars across levels {nhyb_levels}")
+    print(
+        f"  single/other: {sum(len(v) for v in single.values())} msgs, {len(single)} level-strings"
+    )
+
+
+base = "https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.20240101/00/atmos"
+classify(f"{base}/gfs.t00z.pgrb2.0p25.f000.idx", "GFS pgrb2 0p25")
+classify(f"{base}/gfs.t00z.pgrb2b.0p25.f000.idx", "GFS pgrb2b 0p25")

--- a/docs/plans/vertical_structure_spikes/spike6_hrrr_gefs_levels.py
+++ b/docs/plans/vertical_structure_spikes/spike6_hrrr_gefs_levels.py
@@ -1,0 +1,61 @@
+# ruff: skip
+import re, urllib.request
+from collections import defaultdict
+
+
+def fetch(url):
+    try:
+        return urllib.request.urlopen(url, timeout=30).read().decode()
+    except Exception as e:
+        return f"__ERR__ {e}"
+
+
+def classify(url, label):
+    raw = fetch(url)
+    if raw.startswith("__ERR__"):
+        print(f"\n== {label} ==  FETCH FAILED: {raw[:120]}\n   {url}")
+        return
+    lines = [ln for ln in raw.splitlines() if ln.strip()]
+    pres, hyb, depth, single = (
+        defaultdict(set),
+        defaultdict(set),
+        defaultdict(set),
+        defaultdict(list),
+    )
+    for line in lines:
+        p = line.split(":")
+        if len(p) < 5:
+            continue
+        param, level = p[3], p[4]
+        if m := re.match(r"^(\d+) mb$", level):
+            pres[param].add(int(m.group(1)))
+        elif mh := re.match(r"^(\d+) hybrid level$", level):
+            hyb[param].add(int(mh.group(1)))
+        elif md := re.match(r"^(\d+) sigma", level):
+            hyb[param].add(int(md.group(1)))
+        else:
+            single[level].append(param)
+    plev = sorted({l for s in pres.values() for l in s})
+    hlev = sorted({l for s in hyb.values() for l in s})
+    print(f"\n== {label} ==  ({len(lines)} msgs)  {url.split('/')[-1]}")
+    print(
+        f"  pressure(mb):  {len(pres):2d} vars x {len(plev):3d} levels  range {plev[:1]}..{plev[-1:]} "
+    )
+    print(
+        f"  hybrid/sigma:  {len(hyb):2d} vars x {len(hlev):3d} levels  range {hlev[:1]}..{hlev[-1:]}"
+    )
+    print(
+        f"  single/other:  {sum(len(v) for v in single.values()):3d} msgs, {len(single)} level-strings"
+    )
+
+
+# HRRR: wrfprs (pressure) vs wrfnat (native/hybrid model levels)
+hb = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20240101/conus"
+classify(f"{hb}/hrrr.t00z.wrfprsf00.grib2.idx", "HRRR wrfprs (pressure product)")
+classify(f"{hb}/hrrr.t00z.wrfnatf00.grib2.idx", "HRRR wrfnat (native product)")
+
+# GEFS 0.25 s-file and 0.5 a/b files; check pressure level density + resolution split
+gb = "https://noaa-gefs-pds.s3.amazonaws.com/gefs.20240101/00/atmos"
+classify(f"{gb}/pgrb2sp25/geavg.t00z.pgrb2s.0p25.f000.idx", "GEFS pgrb2s 0p25 (s-file)")
+classify(f"{gb}/pgrb2ap5/geavg.t00z.pgrb2a.0p50.f000.idx", "GEFS pgrb2a 0p50")
+classify(f"{gb}/pgrb2bp5/geavg.t00z.pgrb2b.0p50.f000.idx", "GEFS pgrb2b 0p50")

--- a/docs/plans/vertical_structure_spikes/spike7_ecmwf_levels.py
+++ b/docs/plans/vertical_structure_spikes/spike7_ecmwf_levels.py
@@ -1,0 +1,61 @@
+import json
+import re
+import urllib.request
+from collections import defaultdict
+
+B = "https://ecmwf-forecasts.s3.amazonaws.com"
+DATE = "20260621"
+
+
+def get(u):
+    return urllib.request.urlopen(u, timeout=30).read().decode()
+
+
+def list_keys(prefix):
+    y = get(f"{B}/?list-type=2&prefix={prefix}")
+    return re.findall(r"<Key>([^<]+)</Key>", y)
+
+
+def enumerate_index(index_key, label):
+    raw = get(f"{B}/{index_key}")
+    by = defaultdict(lambda: defaultdict(set))  # levtype -> param -> set(levels)
+    n = 0
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        d = json.loads(line)
+        n += 1
+        lt = d.get("levtype", "?")
+        param = d.get("param", "?")
+        lev = d.get("levelist", "-")
+        by[lt][param].add(str(lev))
+    print(f"\n==== {label} ====  ({n} messages)  {index_key.split('/')[-1]}")
+    for lt in sorted(by):
+        params = by[lt]
+        alllev = sorted(
+            {l for s in params.values() for l in s if l != "-"},
+            key=lambda v: (len(v), v),
+        )
+        print(f"  levtype={lt!r}: {len(params)} params, {len(alllev)} distinct levels")
+        if lt in ("pl", "ml"):
+            print(f"     levels: {alllev}")
+            print(f"     params: {sorted(params)}")
+
+
+for model, stream, lab in [
+    ("ifs", "enfo", "IFS ENS (enfo)"),
+    ("aifs-single", "oper", "AIFS Single (oper)"),
+    ("aifs-ens", "enfo", "AIFS ENS (enfo)"),
+]:
+    pre = f"{DATE}/00z/{model}/0p25/{stream}/"
+    keys = list_keys(pre)
+    idx = [k for k in keys if k.endswith(".index")]
+    # pick the step-0 (or earliest) index
+    idx_sorted = sorted(idx)
+    if not idx_sorted:
+        print(
+            f"\n==== {lab} ====  NO .index files under {pre}; sample keys: {keys[:4]}"
+        )
+        continue
+    enumerate_index(idx_sorted[0], lab)

--- a/docs/plans/vertical_structure_spikes/spike8_icon_eu_levels.py
+++ b/docs/plans/vertical_structure_spikes/spike8_icon_eu_levels.py
@@ -1,0 +1,52 @@
+import re
+import urllib.request
+from collections import defaultdict
+
+BASE = "https://opendata.dwd.de/weather/nwp/icon-eu/grib/00"
+
+
+def get(u):
+    return urllib.request.urlopen(u, timeout=30).read().decode()
+
+
+# 1. variable subdirectories
+top = get(f"{BASE}/")
+vars_ = sorted(set(re.findall(r'href="([a-z0-9_]+)/"', top)))
+print(f"ICON-EU /00/ variable dirs ({len(vars_)}): {vars_}")
+
+# 2. which vars have pressure-level / model-level / single-level files
+leveltype_by_var = defaultdict(set)
+for v in vars_:
+    try:
+        listing = get(f"{BASE}/{v}/")
+    except Exception as e:
+        continue
+    for lt in ("single-level", "pressure-level", "model-level"):
+        if lt in listing:
+            leveltype_by_var[lt].add(v)
+
+for lt in ("single-level", "pressure-level", "model-level"):
+    print(f"\n{lt}: {len(leveltype_by_var[lt])} vars -> {sorted(leveltype_by_var[lt])}")
+
+# 3. enumerate the actual pressure levels and model levels present for temperature `t`
+listing = get(f"{BASE}/t/")
+files = re.findall(r'href="(icon-eu[^"]+\.grib2\.bz2)"', listing)
+plev, mlev = set(), set()
+samp = {}
+for f in files:
+    if "pressure-level" in f:
+        m = re.search(r"pressure-level_\d+_\d+_(\d+)_T", f)
+        if m:
+            plev.add(int(m.group(1)))
+            samp.setdefault("pl", f)
+    elif "model-level" in f:
+        m = re.search(r"model-level_\d+_\d+_(\d+)_T", f)
+        if m:
+            mlev.add(int(m.group(1)))
+            samp.setdefault("ml", f)
+print(f"\ntemperature `t`: {len(plev)} pressure levels {sorted(plev)}")
+print(
+    f"temperature `t`: {len(mlev)} model levels min={min(mlev) if mlev else '-'} max={max(mlev) if mlev else '-'}"
+)
+print("sample pressure file:", samp.get("pl"))
+print("sample model file:   ", samp.get("ml"))

--- a/docs/plans/vertical_structure_spikes/spike8b_icon_read_one_grib.py
+++ b/docs/plans/vertical_structure_spikes/spike8b_icon_read_one_grib.py
@@ -1,0 +1,26 @@
+import bz2
+import urllib.request
+
+import xarray as xr
+
+url = (
+    "https://opendata.dwd.de/weather/nwp/icon-eu/grib/00/t/"
+    "icon-eu_europe_regular-lat-lon_model-level_2026062100_000_10_T.grib2.bz2"
+)
+raw = bz2.decompress(urllib.request.urlopen(url, timeout=60).read())
+open("/tmp/icon_t_ml10.grib2", "wb").write(raw)
+print(f"downloaded+decompressed {len(raw)} bytes")
+
+ds = xr.open_dataset("/tmp/icon_t_ml10.grib2", engine="cfgrib")
+print("data_vars:", list(ds.data_vars))
+v = next(iter(ds.data_vars.values()))
+print("shape:", v.shape, "dims:", v.dims)
+print("coords of interest:")
+for c in ds.coords:
+    val = ds.coords[c].values
+    if val.ndim == 0:
+        print(f"   {c} = {val}")
+print(
+    "attrs typeOfLevel / GRIB level:",
+    {k: v.attrs.get(k) for k in v.attrs if "level" in k.lower() or "Level" in k},
+)

--- a/docs/plans/vertical_structure_spikes/spike9_mrms_levels.py
+++ b/docs/plans/vertical_structure_spikes/spike9_mrms_levels.py
@@ -1,0 +1,27 @@
+# Enumerate MRMS CONUS products from the real public bucket and find the 3D
+# (multi-height) products. The trailing _NN.NN token is the height (km) only for
+# the 3D mosaics; for everything else it is a constant naming token.
+import re
+import urllib.request
+from collections import defaultdict
+
+B = "https://noaa-mrms-pds.s3.amazonaws.com"
+
+
+def get(u):
+    return urllib.request.urlopen(u, timeout=30).read().decode()
+
+
+x = get(f"{B}/?list-type=2&delimiter=/&prefix=CONUS/")
+prods = re.findall(r"<Prefix>CONUS/([^<]+)/</Prefix>", x)
+heights = defaultdict(set)
+for p in prods:
+    m = re.match(r"^(.*?)_(\d\d\.\d\d)$", p)
+    if m:
+        heights[m.group(1)].add(m.group(2))
+print(f"Total CONUS products: {len(prods)}")
+print("Products with >1 height level (genuine 3D stacks):")
+for base in sorted(heights):
+    hs = sorted(heights[base], key=float)
+    if len(hs) > 1:
+        print(f"  {base}: {len(hs)} levels {hs[0]}..{hs[-1]} km")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ ignore = [
     "ARG005",  # unused lambda arg
 ]
 # Throwaway exploration scripts, see docs/plans/vertical_structure_exploration.md
-"docs/plans/vertical_structure_spikes/*.py" = ["T20", "S", "INP", "PERF", "PLW", "ANN", "E401", "E741", "I001"]
+"docs/plans/vertical_structure_spikes/*.py" = ["T20", "S", "INP", "PERF", "PLW", "ANN", "E401", "E741", "I001", "BLE001", "F841", "RUF103"]
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ ignore = [
     "ARG005",  # unused lambda arg
 ]
 # Throwaway exploration scripts, see docs/plans/vertical_structure_exploration.md
-"docs/plans/vertical_structure_spikes/*.py" = ["T20", "S", "INP", "PERF", "PLW", "ANN", "E401", "E741", "I001", "BLE001", "F841", "RUF103"]
+"docs/plans/vertical_structure_spikes/*.py" = ["T20", "S", "INP", "PERF", "PLW", "ANN", "E401", "E741", "I001", "BLE001", "F841", "RUF103", "SIM115"]
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ ignore = [
     "ARG005",  # unused lambda arg
 ]
 # Throwaway exploration scripts, see docs/plans/vertical_structure_exploration.md
-"docs/plans/vertical_structure_spikes/*.py" = ["T20", "S", "INP", "PERF", "PLW"]
+"docs/plans/vertical_structure_spikes/*.py" = ["T20", "S", "INP", "PERF", "PLW", "ANN", "E401", "E741", "I001"]
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,10 @@ ignore = [
 [tool.ty.terminal]
 error-on-warning = true
 
+[tool.ty.src]
+# Throwaway exploration scripts, see docs/plans/vertical_structure_exploration.md
+exclude = ["docs/plans/vertical_structure_spikes/"]
+
 [tool.ty.rules]
 possibly-unresolved-reference = "error"
 possibly-missing-attribute = "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,8 @@ ignore = [
     "ARG001",  # unused function arg
     "ARG005",  # unused lambda arg
 ]
+# Throwaway exploration scripts, see docs/plans/vertical_structure_exploration.md
+"docs/plans/vertical_structure_spikes/*.py" = ["T20", "S", "INP", "PERF", "PLW"]
 
 [tool.ty.terminal]
 error-on-warning = true


### PR DESCRIPTION
## Summary

This PR adds a comprehensive exploration document and runnable code spikes investigating how to structure datasets with genuine vertical dimensions (pressure levels, model levels) in the virtual Icechunk format. The analysis synthesizes empirical findings from real source data to recommend a practical path forward.

## Key Changes

- **docs/plans/vertical_structure_exploration.md** (661 lines): Complete exploration document covering:
  - The problem: materialized datasets flatten vertical structure into variable names; virtual datasets make it cheap to include all levels, forcing a structural decision
  - Nine open questions (Q1–Q9) framing the design space: suffix-naming vs. real dimensions, zarr groups, sparsity, back-compat, migration strategy, etc.
  - Four expanded decisions (A–D) with recommendations:
    - **Decision A (recommended)**: Per-variable dimensions in one flat group (minimal machinery change, preserves swap-compat)
    - **Decision B**: Naming convention (plain names for level-dim vars like `temperature`, suffixed names for single-level like `temperature_2m`)
    - **Decision C**: Defer `model_level` support (GFS/GEFS don't publish usable model levels on NODD)
    - **Decision D**: Ensemble manifest/chunk sizing validation
  - Synthesis of empirical findings driving the recommendations

- **docs/plans/vertical_structure_spikes/** (9 runnable Python scripts):
  - `spike1_groups.py`: Multi-group icechunk round-trip (root + `/pressure_level` + `/single_level` groups)
  - `spike2_alias.py`: Virtual alias—same source ref at two array paths (back-compat + canonical)
  - `spike3_sparsity.py`: Grid density analysis on real GFS pgrb2 index (pressure 87.5% dense, single-level 6.8% dense)
  - `spike4_mixed_dims_flat.py`: Heterogeneous-dimension variables in one flat group
  - `spike5_model_level_availability.py`: GFS pgrb2 vs pgrb2b model-level content
  - `spike6_hrrr_gefs_levels.py`: HRRR wrfprs/wrfnat + GEFS level structure
  - `spike7_ecmwf_levels.py`: ECMWF IFS/AIFS open-data level types
  - `spike8_icon_eu_levels.py`: DWD ICON-EU pressure vs model levels
  - `spike8b_icon_read_one_grib.py`: Download and decode one ICON model-level GRIB
  - `spike9_mrms_levels.py`: MRMS 3D products from real bucket

- **pyproject.toml**: Exempted spike scripts from linting rules (T20, S, INP, PERF) as throwaway exploration code

## Notable Findings

1. **Pressure levels are dense (~88% of full grid), single levels are sparse (~7%)**: This empirical result drives the recommendation to use real `pressure_level` dimensions for dense coordinates and keep suffix-naming for the sparse grab-bag of single/surface levels.

2. **Real vertical dimensions do NOT require zarr groups**: Spike 4 proves a single flat root group can hold `temperature_2m(time, y, x)` and `temperature(time, pressure_level, y, x)` side-by-side, decoupling the dimension decision (Q1) from the grouping decision (Q2).

3. **Virtual aliasing works**: Spike 2 confirms the same source ref can be registered at two array paths (root back-compat name + canonical location), with the cost being doubled manifest ref entries (no byte duplication).

4. **GFS/GEFS don't publish usable model levels on NODD**: Spike 5 shows neither standard GFS product carries hybrid/model levels, so `model_level` support is deferred as provider-specific.

## Implementation Path

The recommendation is **Decision A1** (per-variable dims in one flat group):
- Add optional `dims` to `DataVar` config (default = template `dims`)
- Teach `TemplateConfig.update

https://claude.ai/code/session_01YaGdCbgmiwz1PzZpbc3ii2