### PR TITLE
docs: describe dataset vertical-level structure in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ Base class: `src/reformatters/common/dynamical_dataset.py`, commented example su
 
 2. **Analysis dataset** Dimensions time, latitude/y, longitude/x [, ensemble_member]. When creating an analysis dataset from a forecast archive we take the shortest available lead time, flattening the init_time and lead_time dims into a single time dim.
 
-Vertical levels: Our current datasets include selected vertical levels, which we combine with the variable’s name to create the variable name in the dataset (e.g. temperature_2m). In the future we plan to include model_level and/or pressure_level dimensions for core variables to save their values at all levels.
+Vertical levels: Single-level and surface variables live at the dataset root with the level encoded in the variable name (e.g. `temperature_2m`, `pressure_surface`). A variable available on a dense, comparable set of vertical levels does not have a level suffix and instead lives in a zarr group named after its vertical dimension — the group name and dimension name are the same (`pressure_level`, `model_level`; others may be added as needed), e.g. `pressure_level/temperature` is a variable with dimensions (time, latitude, longitude, pressure_level). Dimension coordinates shared with the root (time, lead time, latitude/longitude, ensemble_member, spatial_ref) are duplicated into each group so a group can be opened on its own. A group with no variables is omitted.
 
 Spatial dimensions: If the source data uses a geographic projection we use dimensions latitude and longitude, else y and x are used for projected datasets.
 


### PR DESCRIPTION
Replaces the outdated "Vertical levels" note in AGENTS.md's **Common dataset structures** section with how we actually structure datasets:

- Single-level / surface variables live at the dataset root, with the level encoded in the variable name (`temperature_2m`).
- A variable on a dense, comparable set of vertical levels has no level suffix and lives in a zarr group named after its vertical dimension (group name = dimension name, e.g. `pressure_level/temperature`).
- Shared coordinates are duplicated into each group so a group opens independently; empty groups are omitted.

Minimal addition only — one paragraph replaced, no design history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaGdCbgmiwz1PzZpbc3ii2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaGdCbgmiwz1PzZpbc3ii2)_