### PR TITLE
Tune operational update/validate schedules and pod deadlines

### DIFF
--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
@@ -30,7 +30,7 @@ class NasaSmapLevel336KmV9Dataset(
             # New data comes 1x per day, usually around 5:45 but sometimes later, more like 14:00
             # Run twice to pick up the later data too (updates only take a couple minutes)
             schedule="0 6,18 * * *",
-            pod_active_deadline=timedelta(minutes=30),
+            pod_active_deadline=timedelta(minutes=10),  # runs take <2 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="3",
@@ -42,7 +42,7 @@ class NasaSmapLevel336KmV9Dataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="30 6,18 * * *",
+            schedule="10 6,18 * * *",  # 10m (pod_active_deadline) after reformat at :00
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
@@ -23,7 +23,7 @@ class NoaaNdviCdrAnalysisDataset(
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
             schedule="0 20 * * *",
-            pod_active_deadline=timedelta(minutes=60),
+            pod_active_deadline=timedelta(minutes=30),  # runs take <24 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="2",
@@ -34,7 +34,7 @@ class NoaaNdviCdrAnalysisDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="30 21 * * *",
+            schedule="30 20 * * *",  # 30m (pod_active_deadline) after reformat at :00
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -47,7 +47,7 @@ class UarizonaSwannAnalysisDataset(
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
             schedule="0 20 * * *",
-            pod_active_deadline=timedelta(minutes=30),
+            pod_active_deadline=timedelta(minutes=10),  # runs take <4 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="4",
@@ -58,7 +58,7 @@ class UarizonaSwannAnalysisDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="30 20 * * *",
+            schedule="10 20 * * *",  # 10m (pod_active_deadline) after reformat at :00
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/dynamical_dataset.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/dynamical_dataset.py
@@ -59,15 +59,15 @@ class DwdIconEuForecast5DayDataset(
             secret_names=["source-coop-storage-options-key"],
         )
 
-        # ICON-EU runs at 00, 06, 12, 18 UTC. DWD's complete forecast is available ~3h45m after
-        # init. We schedule the reformat 3 minutes after that (3h48m after init). The archive job
-        # may not have finished copying to Source Coop yet, in which case download_file falls back
-        # to reading directly from DWD.
+        # ICON-EU runs at 00, 06, 12, 18 UTC. DWD's complete forecast (f120) is available by
+        # ~init+3h49m (p99). We schedule the reformat 3 minutes after that (3h52m after init).
+        # The archive job may not have finished copying to Source Coop yet, in which case
+        # download_file falls back to reading directly from DWD.
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="48 3,9,15,21 * * *",
-            pod_active_deadline=timedelta(minutes=5),
+            schedule="52 3,9,15,21 * * *",
+            pod_active_deadline=timedelta(minutes=10),  # runs take <5 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="3",
@@ -81,7 +81,7 @@ class DwdIconEuForecast5DayDataset(
 
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="53 3,9,15,21 * * *",
+            schedule="2 4,10,16,22 * * *",  # 10m (pod_active_deadline) after reformat at :52
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/ecmwf/aifs_single/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/dynamical_dataset.py
@@ -27,8 +27,10 @@ class EcmwfAifsSingleForecastDataset(
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="21 */6 * * *",
-            pod_active_deadline=timedelta(minutes=30),
+            # AIFS-single f360 (last lead) ecmwf-forecasts S3 p99 ~init+6h10m (recent
+            # files land 5h25m-6h03m), so fetch at init+6h13m.
+            schedule="13 */6 * * *",
+            pod_active_deadline=timedelta(minutes=10),  # runs take ~1 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="3.5",
@@ -41,7 +43,7 @@ class EcmwfAifsSingleForecastDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="51 */6 * * *",
+            schedule="23 */6 * * *",  # 10m (pod_active_deadline) after reformat at :13
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
@@ -33,7 +33,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
             # (Ensemble stats get uploaded 15-20 mins later, but we don't process those.)
             schedule="50 7 * * *",
             suspend=False,
-            pod_active_deadline=timedelta(hours=4.5),
+            pod_active_deadline=timedelta(minutes=35),  # runs take <26 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="3",
@@ -46,7 +46,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="5 12 * * *",
+            schedule="25 8 * * *",  # 35m (pod_active_deadline) after reformat at 07:50
             suspend=False,
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
@@ -23,9 +23,9 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
         workers = 2
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            # GEFS f006 (last lead time used) available ~3h48m after init on NOMADS. +3 min buffer.
+            # GEFS f006 (last lead time used) NOMADS last-modified ~init+3h48m. +3 min buffer.
             schedule="51 3,9,15,21 * * *",
-            pod_active_deadline=timedelta(hours=1),
+            pod_active_deadline=timedelta(minutes=30),  # runs take <22 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="14",  # fit on 16 vCPU node
@@ -38,7 +38,7 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="51 4,10,16,22 * * *",  # 1h (pod_active_deadline) after reformat
+            schedule="21 4,10,16,22 * * *",  # 30m (pod_active_deadline) after reformat at :51
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/noaa/gefs/forecast_35_day/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/dynamical_dataset.py
@@ -24,9 +24,11 @@ class GefsForecast35DayDataset(
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            # GEFS f384 last perturbed member available ~6h30m after 00z init on NOMADS. +3 min buffer.
+            # New 00z init's f384 last perturbed member NOMADS last-modified ~init+6h28m;
+            # +5 min buffer. The prior init (reprocessed each run, see operational_update_jobs)
+            # is by now complete out to f840 (lands ~init+27h).
             schedule="33 6 * * *",
-            pod_active_deadline=timedelta(hours=3.5),
+            pod_active_deadline=timedelta(minutes=30),  # runs take <23 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="6",  # fit on 8 vCPU node
@@ -39,8 +41,8 @@ class GefsForecast35DayDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="3 10 * * *",  # 3h30m (pod_active_deadline) after reformat at 06:33
-            pod_active_deadline=timedelta(minutes=30),
+            schedule="3 7 * * *",  # 30m (pod_active_deadline) after reformat at 06:33
+            pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="3",  # fit on 4 vCPU node

--- a/src/reformatters/noaa/gfs/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/analysis/dynamical_dataset.py
@@ -24,12 +24,12 @@ class NoaaGfsAnalysisDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Define Kubernetes cron jobs for operational updates and validation."""
-        # GFS f006 (last lead time used) available ~3h34m after init on NOMADS. +3 min buffer.
+        # GFS f006 (last lead time used) NOMADS last-modified ~init+3h36m. +3 min buffer.
         workers = self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="37 3,9,15,21 * * *",
-            pod_active_deadline=timedelta(minutes=30),
+            schedule="40 3,9,15,21 * * *",
+            pod_active_deadline=timedelta(minutes=10),  # runs take <3 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="7",
@@ -43,7 +43,7 @@ class NoaaGfsAnalysisDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
 
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="7 4,10,16,22 * * *",  # 30m (pod_active_deadline) after reformat at :37
+            schedule="50 3,9,15,21 * * *",  # 10m (pod_active_deadline) after reformat at :40
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
@@ -20,10 +20,10 @@ class NoaaGfsForecastDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            # GFS f384 (full forecast) lands ~init+5h12m-5h19m on S3/NOMADS (drifting
-            # later; not-found is not retried), so fetch at init+5h22m for margin.
-            schedule="22 5,11,17,23 * * *",
-            pod_active_deadline=timedelta(minutes=10),
+            # GFS f384 (full forecast) NOMADS p99 ~init+5h35m (recent files land
+            # 5h13m-5h24m, drifting later), so fetch at init+5h38m.
+            schedule="38 5,11,17,23 * * *",
+            pod_active_deadline=timedelta(minutes=10),  # runs take <3 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="3.5",
@@ -36,8 +36,8 @@ class NoaaGfsForecastDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="32 5,11,17,23 * * *",  # 10m (pod_active_deadline) after reformat at :22
-            pod_active_deadline=timedelta(minutes=5),
+            schedule="48 5,11,17,23 * * *",  # 10m (pod_active_deadline) after reformat at :38
+            pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="1.3",

--- a/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
@@ -29,10 +29,11 @@ class NoaaHrrrAnalysisDataset(
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
             # Every 3 hours at 57 minutes past the hour.
-            # HRRR f001 (last lead time used) available ~54m after init on NOMADS. +3 min buffer.
-            # We could of course increase this to hourly.
+            # HRRR f001 (last lead time used) NOMADS last-modified ~init+53m (max ~55m;
+            # we try S3 first to spare NOMADS, but NOMADS publishes first, by ~10 min at
+            # 06z). We could of course increase this to hourly.
             schedule="57 */3 * * *",
-            pod_active_deadline=timedelta(minutes=25),
+            pod_active_deadline=timedelta(minutes=15),  # runs take <9 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="7",
@@ -44,9 +45,9 @@ class NoaaHrrrAnalysisDataset(
 
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            # 25m (pod_active_deadline) after reformat at :57 = :82 = :22 of the next hour.
-            # "22 1-23/3 * * *" gives 01:22, 04:22, 07:22, ... matching reformat at 00:57, 03:57, 06:57, ...
-            schedule="22 1-23/3 * * *",
+            # 15m (pod_active_deadline) after reformat at :57 = :72 = :12 of the next hour.
+            # "12 1-23/3 * * *" gives 01:12, 04:12, 07:12, ... matching reformat at 00:57, 03:57, 06:57, ...
+            schedule="12 1-23/3 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
@@ -32,12 +32,13 @@ class NoaaHrrrForecast48HourDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Define Kubernetes cron jobs for operational updates and validation."""
         # We pull the 0, 6, 12, and 18 init times in this dataset.
-        # HRRR f048 (last lead time) available ~1h48m after init on NOMADS. +3 min buffer.
+        # HRRR f048 (last lead time) NOMADS last-modified ~init+1h50m (we try S3
+        # first to spare NOMADS, but NOMADS publishes first). +3 min buffer.
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="51 1,7,13,19 * * *",
-            pod_active_deadline=timedelta(minutes=15),  # usually takes 3 mins
+            schedule="53 1,7,13,19 * * *",
+            pod_active_deadline=timedelta(minutes=10),  # usually takes <2 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="3",
@@ -51,7 +52,7 @@ class NoaaHrrrForecast48HourDataset(
 
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="2 2,8,14,20 * * *",  # 15m (pod_active_deadline) after reformat at :47
+            schedule="3 2,8,14,20 * * *",  # 10m (pod_active_deadline) after reformat at :53
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/tests/noaa/gefs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/analysis/dynamical_dataset_test.py
@@ -34,7 +34,7 @@ def test_operational_kubernetes_resources(dataset: GefsAnalysisDataset) -> None:
 
     # Check validation job
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
-    assert validation_cron_job.schedule == "51 4,10,16,22 * * *"
+    assert validation_cron_job.schedule == "21 4,10,16,22 * * *"
     assert validation_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert validation_cron_job.cpu == "1.3"
     assert validation_cron_job.memory == "7G"

--- a/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
@@ -36,7 +36,7 @@ def test_operational_kubernetes_resources(dataset: GefsForecast35DayDataset) -> 
 
     # Check validation job
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
-    assert validation_cron_job.schedule == "3 10 * * *"
+    assert validation_cron_job.schedule == "3 7 * * *"
     assert validation_cron_job.secret_names == dataset.store_factory.k8s_secret_names()
     assert validation_cron_job.cpu == "3"
     assert validation_cron_job.memory == "30G"


### PR DESCRIPTION
Re-bases every materialized dataset's operational timing on **measured source availability** and **observed Sentry run times**.

## How timing was derived
- **Source availability:** [wxopticon summary.json](https://assets.dynamical.org/wxopticon/summary.json) per-lead-group p99s, cross-checked against actual file `Last-Modified` times. For NOAA, timing is based on **NOMADS** (which publishes before S3 — we hit S3 first only to spare NOMADS) via the `-ftp` products and direct NOMADS HEAD requests. For ECMWF, the `ecmwf-forecasts` S3 bucket.
  - Note: summary.json measures lead *groups*, so for analysis datasets (which use a single early lead like f006/f001) the group p99 overestimates; per-file listings pinned the true time.
- **Run times / deadlines:** Sentry cron-monitor check-in durations over recent runs.

## Update schedules
Fire ~3 min after the p99 availability of the actual gating lead.

| Dataset | Change | Basis |
|---|---|---|
| noaa-gfs-forecast | `22`→`38` | f384 NOMADS p99 ~5h35m (drifting later; old fire landed before data) |
| noaa-gfs-analysis | `37`→`40` | f006 NOMADS ~3h36m (old fire at the edge) |
| noaa-hrrr-forecast-48-hour | `51`→`53` | f048 NOMADS ~1h50m |
| noaa-hrrr-analysis | kept `57 */3` | f001 NOMADS ~53m (max 55m) |
| noaa-gefs-analysis | kept `51` | f006 NOMADS steady 3h48m |
| noaa-gefs-forecast-35-day | kept `33 6` | new init's f384 ~6h28m; prior init (reprocessed each run) complete to f840, which lands ~init+27h |
| ecmwf-aifs-single-forecast | `21`→`13` | f360 p99 ~6h10m (was 11 min late) |
| dwd-icon-eu-forecast-5-day | `48`→`52` | f120 p99 ~3h49m |
| ecmwf-aifs-ens-forecast / ifs-ens | kept | early-fire-and-poll / dissemination timing; aifs-ens self-heals via recent-init reprocess |

## Pod active deadlines
Set to ~6–10 min past observed max run time, rounded up to 5 min. Tightened several that predate parallel-pod updates: ifs-ens **4.5h→35m**, gefs-forecast-35-day **3.5h→30m**, gefs-analysis **1h→30m**, ndvi-cdr 60m→30m, hrrr-analysis 25m→15m, and 30m→10m for gfs-analysis/aifs-single/smap/swann. **No dataset needs a deadline over 35 min.**

## Validate jobs
All run ≤2.4 min, so every validate deadline is 10 min and each validate schedule = update schedule + update `pod_active_deadline`.

Virtual dataset (gefs-forecast-10-day-spatial) timing left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)