### PR TITLE
Vertical dimension support: group-keyed dims + DataTree templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Integrating a dataset requires subclassing three base classes. For a step by ste
 Base class: `src/reformatters/common/template_config.py`, commented example subclass: `src/reformatters/example/template_config.py`.
 
 Defines the **structure** of a dataset: dimensions, coordinates, data variables, and their attributes/encodings. Key responsibilities:
-- Declare `dims`, `append_dim`, `append_dim_start`, `append_dim_frequency`. `dims` is keyed by group: `dims = {ROOT: (...)}` for a single-level dataset, plus one entry per vertical group (e.g. `"pressure_level": (..., "pressure_level")`). Each `DataVar` sets `group` (default `ROOT`); its zarr path is `var.path`. See "Vertical levels" below and `docs/plans/vertical_dimension_structure.md`.
+- Declare `dims`, `append_dim`, `append_dim_start`, `append_dim_frequency`. `dims` is keyed by group: `dims = {ROOT: (...)}` for a single-level dataset, plus one entry per vertical group (e.g. `"pressure_level": (..., "pressure_level")`).
 - Implement `dataset_attributes`, `coords`, `data_vars`, `dimension_coordinates()`, and optionally `derive_coordinates()`
 - Generates and persists zarr metadata to `templates/latest.zarr` via `update_template()`. The template is an `xarray.DataTree` (one node per group; a single-level dataset is a one-node tree); `get_template()` returns that DataTree.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,9 @@ Integrating a dataset requires subclassing three base classes. For a step by ste
 Base class: `src/reformatters/common/template_config.py`, commented example subclass: `src/reformatters/example/template_config.py`.
 
 Defines the **structure** of a dataset: dimensions, coordinates, data variables, and their attributes/encodings. Key responsibilities:
-- Declare `dims`, `append_dim`, `append_dim_start`, `append_dim_frequency`
+- Declare `dims`, `append_dim`, `append_dim_start`, `append_dim_frequency`. `dims` is keyed by group: `dims = {ROOT: (...)}` for a single-level dataset, plus one entry per vertical group (e.g. `"pressure_level": (..., "pressure_level")`). Each `DataVar` sets `group` (default `ROOT`); its zarr path is `var.path`. See "Vertical levels" below and `docs/plans/vertical_dimension_structure.md`.
 - Implement `dataset_attributes`, `coords`, `data_vars`, `dimension_coordinates()`, and optionally `derive_coordinates()`
-- Generates and persists zarr metadata to `templates/latest.zarr` via `update_template()`
+- Generates and persists zarr metadata to `templates/latest.zarr` via `update_template()`. The template is an `xarray.DataTree` (one node per group; a single-level dataset is a one-node tree); `get_template()` returns that DataTree.
 
 Always regenerate the template after any metadata changes with `uv run main <dataset-id> update-template`.
 
@@ -83,7 +83,7 @@ Defines the **process** for reformatting a region of the dataset: downloading, r
 - Implement `download_file()` - retrieve a source file to local disk
 - Implement `read_data()` - load data from a local file into a numpy array
 - Implement `operational_update_jobs()` (class method) - factory for operational update jobs
-- Optionally override `source_groups()` (vars that can be accessed together), `get_processing_region()` (buffer processed region to support deaccumulation & interpolation), `apply_data_transformations()` (deaccumulation, etc.), `update_template_with_results()` (trim based on actual data processed).
+- Optionally override `source_file_var_groups()` (vars that share a source file; a single source file may span vertical groups), `get_processing_region()` (buffer processed region to support deaccumulation & interpolation), `apply_data_transformations()` (deaccumulation, etc.), `update_template_with_results()` (trim based on actual data processed).
 
 A `RegionJob` processes a slice of the append dimension (e.g., one shard along `init_time` or `time`) for a group of data variables.
 

--- a/docs/plans/vertical_dimension_structure.md
+++ b/docs/plans/vertical_dimension_structure.md
@@ -383,9 +383,10 @@ Decisions made during implementation (the plan above left some open):
   `VerticalGroup`.
 - **`source_groups` → `source_file_var_groups`** to disambiguate "vars sharing a source
   file" from a dataset's vertical groups.
-- **Per-job geometry** is read via `RegionJob._flat_job_dataset()` — the job's vars
-  gathered from the tree into one flat Dataset (keyed by bare name, unique within a job).
-  Used by `generate_source_file_coords` (coords) and materialized writes.
+- **Per-job geometry**: `generate_source_file_coords` gets a coords-only Dataset (the
+  region's coords merged across all groups — collision-free, since data var names can
+  repeat across vertical groups). Virtual ref/chunk geometry comes from `template_ds[var.path]`
+  directly; materialized jobs (single-level) subset the root Dataset by name.
 - DataTree API gaps to know: it supports `isel`/`sel`/`data_vars`/`coords`/`sizes`/`[name]`
   but NOT `assign_coords`/`get_index` and not attribute-style coord access — go through
   `tree.to_dataset()` for those (matters mostly in tests).

--- a/docs/plans/vertical_dimension_structure.md
+++ b/docs/plans/vertical_dimension_structure.md
@@ -356,3 +356,52 @@ xarray 2026.4) during design:
   openable (default omits child coords).
 - The `Group` type scheme: pydantic accepts `dict[Group, tuple]`, rejects typo'd
   keys; `ty` narrows `is ROOT` so `ROOT` cannot be used as a path string.
+
+---
+
+## 9. As built
+
+Implemented in PR "Vertical dimension support: group-keyed dims + DataTree templates".
+
+Decisions made during implementation (the plan above left some open):
+
+- **Representation — Decision A (DataTree is the canonical template).** `get_template()`
+  returns an `xr.DataTree` and `RegionJob.template_ds` is an `xr.DataTree`. This was
+  chosen over a flat path-keyed Dataset (a one-node tree per single-level dataset) so the
+  in-memory object matches the on-disk group hierarchy, coordinate scoping is structural
+  via inheritance, and there is no unenforceable "don't `to_zarr` me raw" invariant. A
+  single-level dataset is a one-node tree and writes **byte-identically** to the previous
+  Dataset path (verified: all 15 existing templates regenerate with zero diff).
+- **One write path.** `write_metadata` wraps a bare Dataset as `DataTree.from_dict({"/": ds})`
+  so there is a single `to_zarr(write_inherited_coords=True, write_empty_chunks=True)` call.
+- **`sync_dims_to` grows per group node.** `DataTree.to_zarr` does **not** support
+  `append_dim` (it raises `NotImplementedError`), so the append dim is grown by writing
+  each node's slice with `to_zarr(group=…, append_dim=…)`. Groups may sit at different
+  lengths transiently; each (store, group) resizes from its own committed size.
+- **`Dim` gained `pressure_level` and `model_level`** (`common/types.py`) — a vertical
+  group's dim name must be a valid `Dim` (group name == dim name). Keep in sync with
+  `VerticalGroup`.
+- **`source_groups` → `source_file_var_groups`** to disambiguate "vars sharing a source
+  file" from a dataset's vertical groups.
+- **Per-job geometry** is read via `RegionJob._flat_job_dataset()` — the job's vars
+  gathered from the tree into one flat Dataset (keyed by bare name, unique within a job).
+  Used by `generate_source_file_coords` (coords) and materialized writes.
+- DataTree API gaps to know: it supports `isel`/`sel`/`data_vars`/`coords`/`sizes`/`[name]`
+  but NOT `assign_coords`/`get_index` and not attribute-style coord access — go through
+  `tree.to_dataset()` for those (matters mostly in tests).
+
+Scope delivered: the full template + virtual infrastructure, group-aware, plus a
+synthetic multi-group template + virtual fixture under `tests/common/`. The whole
+materialized stack carries the DataTree `template_ds` (one field; its type can't split
+between virtual and materialized), but the materialized **chunk-write** path
+(`zarr.copy_data_var`, `shared_memory_utils.write_shards`) still writes at the root under
+the bare variable name — it is **not** yet group-aware. A guard in `DynamicalDataset`
+(`_validate_virtual_storage`) rejects a materialized dataset that declares any non-root
+var, so this fails loudly rather than silently miswriting. Likewise
+`update_template_with_results` trims every group to one global append-dim max (correct
+for single-group; a per-group trim is unneeded until materialized multi-group exists).
+
+Out of scope / follow-up: group-aware materialized writes, and the real multi-group
+datasets **NOAA HRRR** (`wrfprs` pressure + `wrfnat` model levels, virtual) and
+**DWD ICON-EU** — the next PR ("first shippable virtual dataset"), the first datasets to
+declare vertical groups in production.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ ignore = [
     "ARG005",  # unused lambda arg
     "RUF012",  # mutable default
 ]
-"**/template_config.py" = ["RUF012"]  # allow mutable dict for `dims: dict[Group, tuple]`
+"**/template_config.py" = ["RUF012"]  # allow mutable dict for `dims: dict[Group, tuple[Dim, ...]]`
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,12 +121,9 @@ ignore = [
     "SLF",     # private member access
     "ARG001",  # unused function arg
     "ARG005",  # unused lambda arg
-    "RUF012",  # mutable default — moot for the pydantic test configs (see below)
+    "RUF012",  # mutable default
 ]
-# Template configs declare `dims: dict[Group, tuple] = {ROOT: (...)}`. These are
-# pydantic fields (copied per instance), so the mutable-default concern is moot,
-# and the literal reads better than a `default_factory` lambda.
-"**/template_config.py" = ["RUF012"]
+"**/template_config.py" = ["RUF012"]  # allow mutable dict for `dims: dict[Group, tuple]`
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ ignore = [
     "SLF",     # private member access
     "ARG001",  # unused function arg
     "ARG005",  # unused lambda arg
+    "RUF012",  # mutable default — moot for the pydantic test configs (see below)
 ]
 # Template configs declare `dims: dict[Group, tuple] = {ROOT: (...)}`. These are
 # pydantic fields (copied per instance), so the mutable-default concern is moot,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,10 @@ ignore = [
     "ARG001",  # unused function arg
     "ARG005",  # unused lambda arg
 ]
+# Template configs declare `dims: dict[Group, tuple] = {ROOT: (...)}`. These are
+# pydantic fields (copied per instance), so the mutable-default concern is moot,
+# and the literal reads better than a `default_factory` lambda.
+"**/template_config.py" = ["RUF012"]
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from enum import Enum, auto
 from typing import Annotated, Any, Generic, Literal, TypeVar
 
 import numcodecs
@@ -7,20 +6,7 @@ import numcodecs.abc
 import pydantic
 
 from reformatters.common.pydantic import FrozenBaseModel
-from reformatters.common.types import TimedeltaUnits, TimestampUnits
-
-
-class RootGroup(Enum):
-    ROOT = auto()  # pure sentinel; the root zarr group has no name
-
-
-ROOT = RootGroup.ROOT
-
-# A variable on a dense, comparable vertical dimension lives in a zarr group named
-# after that dimension (group name == dimension name). Expand as new types are added.
-type VerticalGroup = Literal["pressure_level", "model_level"]
-# A variable's group: ROOT (single-level, lives at the dataset root) or a vertical group.
-type Group = VerticalGroup | RootGroup
+from reformatters.common.types import ROOT, Group, TimedeltaUnits, TimestampUnits
 
 
 def var_path(group: Group, name: str) -> str:

--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -217,5 +217,4 @@ class DataVar(FrozenBaseModel, Generic[INTERNAL_ATTRS_co]):
 
     @property
     def path(self) -> str:
-        """The variable's zarr path / identity key (`name` at root, else `group/name`)."""
         return var_path(self.group, self.name)

--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from enum import Enum, auto
 from typing import Annotated, Any, Generic, Literal, TypeVar
 
 import numcodecs
@@ -7,6 +8,27 @@ import pydantic
 
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.types import TimedeltaUnits, TimestampUnits
+
+
+class RootGroup(Enum):
+    ROOT = auto()  # pure sentinel; the root zarr group has no name
+
+
+ROOT = RootGroup.ROOT
+
+# A variable on a dense, comparable vertical dimension lives in a zarr group named
+# after that dimension (group name == dimension name). Expand as new types are added.
+type VerticalGroup = Literal["pressure_level", "model_level"]
+# A variable's group: ROOT (single-level, lives at the dataset root) or a vertical group.
+type Group = VerticalGroup | RootGroup
+
+
+def var_path(group: Group, name: str) -> str:
+    """The zarr path / identity key of a variable: `name` at root, else `group/name`."""
+    if group is ROOT:
+        return name
+    return f"{group}/{name}"
+
 
 type AttributeStr = Annotated[str, pydantic.Field(pattern=r"^[A-Z0-9].*[^.]$")]
 type Sentence = Annotated[str, pydantic.Field(pattern=r"^[A-Z].*\.$")]
@@ -188,6 +210,12 @@ INTERNAL_ATTRS_co = TypeVar(
 
 class DataVar(FrozenBaseModel, Generic[INTERNAL_ATTRS_co]):
     name: str
+    group: Group = ROOT
     encoding: Encoding
     attrs: DataVarAttrs
     internal_attrs: INTERNAL_ATTRS_co
+
+    @property
+    def path(self) -> str:
+        """The variable's zarr path / identity key (`name` at root, else `group/name`)."""
+        return var_path(self.group, self.name)

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -381,7 +381,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         worker_index: int,
         workers_total: int,
         reformat_job_name: str,
-        template_ds: xr.Dataset,
+        template_ds: xr.DataTree,
         tmp_store: Path,
         *,
         update_template_with_results: bool,
@@ -413,8 +413,10 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             existing_ds = xr.open_zarr(
                 self.store_factory.primary_store(), decode_timedelta=True, chunks=None
             )
+            # Structural drift is checked on the root group; this path is materialized
+            # (single-level) operational updates, whose vars all live at the root.
             template_utils.assert_no_structural_drift_from_existing_store(
-                template_ds, existing_ds, self.template_config.append_dim
+                template_ds.to_dataset(), existing_ds, self.template_config.append_dim
             )
 
         # 1. Set up / wait for setup
@@ -594,7 +596,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     def _tmp_store(self) -> Path:
         return get_local_tmp_store()
 
-    def _get_template(self, append_dim_end: DatetimeLike) -> xr.Dataset:
+    def _get_template(self, append_dim_end: DatetimeLike) -> xr.DataTree:
         return self.template_config.get_template(pd.Timestamp(append_dim_end))
 
     def _can_run_in_kubernetes(self) -> bool:

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -410,13 +410,14 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         # already-published store. Worker 0 checks before any writes; failing here
         # leaves the live archive untouched.
         if is_first and update_template_with_results:
-            existing_ds = xr.open_zarr(
-                self.store_factory.primary_store(), decode_timedelta=True, chunks=None
+            existing_ds = xr.open_datatree(
+                self.store_factory.primary_store(),  # ty: ignore[invalid-argument-type]
+                engine="zarr",
+                decode_timedelta=True,
+                chunks=None,
             )
-            # Structural drift is checked on the root group; this path is materialized
-            # (single-level) operational updates, whose vars all live at the root.
             template_utils.assert_no_structural_drift_from_existing_store(
-                template_ds.to_dataset(), existing_ds, self.template_config.append_dim
+                template_ds, existing_ds, self.template_config.append_dim
             )
 
         # 1. Set up / wait for setup

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -596,6 +596,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     def _assert_no_structural_drift(self, template_ds: xr.DataTree) -> None:
         existing_ds = xr.open_datatree(
+            # open_datatree's stub omits zarr Store (open_zarr accepts it); fine at runtime.
             self.store_factory.primary_store(),  # ty: ignore[invalid-argument-type]
             engine="zarr",
             decode_timedelta=True,

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -174,6 +174,8 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
             if issubclass(self.region_job_class, VirtualRegionJob):
                 # Virtual operational updates are single-writer streaming (see docs/parallel_processing.md)
+                if is_first:
+                    self._assert_no_structural_drift(template_ds)
                 self._run_virtual_operational_update(
                     all_jobs, worker_index, workers_total
                 )
@@ -410,15 +412,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         # already-published store. Worker 0 checks before any writes; failing here
         # leaves the live archive untouched.
         if is_first and update_template_with_results:
-            existing_ds = xr.open_datatree(
-                self.store_factory.primary_store(),  # ty: ignore[invalid-argument-type]
-                engine="zarr",
-                decode_timedelta=True,
-                chunks=None,
-            )
-            template_utils.assert_no_structural_drift_from_existing_store(
-                template_ds, existing_ds, self.template_config.append_dim
-            )
+            self._assert_no_structural_drift(template_ds)
 
         # 1. Set up / wait for setup
         setup_info = parallel_coordination.parallel_setup(
@@ -599,6 +593,17 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     def _get_template(self, append_dim_end: DatetimeLike) -> xr.DataTree:
         return self.template_config.get_template(pd.Timestamp(append_dim_end))
+
+    def _assert_no_structural_drift(self, template_ds: xr.DataTree) -> None:
+        existing_ds = xr.open_datatree(
+            self.store_factory.primary_store(),  # ty: ignore[invalid-argument-type]
+            engine="zarr",
+            decode_timedelta=True,
+            chunks=None,
+        )
+        template_utils.assert_no_structural_drift_from_existing_store(
+            template_ds, existing_ds, self.template_config.append_dim
+        )
 
     def _can_run_in_kubernetes(self) -> bool:
         # This is a method to support testing without changing the Config.env

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -596,7 +596,6 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     def _assert_no_structural_drift(self, template_ds: xr.DataTree) -> None:
         existing_ds = xr.open_datatree(
-            # open_datatree's stub omits zarr Store (open_zarr accepts it); fine at runtime.
             self.store_factory.primary_store(),  # ty: ignore[invalid-argument-type]
             engine="zarr",
             decode_timedelta=True,

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -23,7 +23,7 @@ from reformatters.common import (
     validation,
 )
 from reformatters.common.config import Config
-from reformatters.common.config_models import DataVar
+from reformatters.common.config_models import ROOT, DataVar
 from reformatters.common.iterating import digest, get_worker_jobs, item
 from reformatters.common.kubernetes import (
     CronJob,
@@ -697,4 +697,13 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 assert var.encoding.compressors == (), (
                     f"virtual data var {var.name} must declare compressors=()"
                 )
+        else:
+            # The materialized chunk-write path (zarr.copy_data_var, write_shards) is
+            # not yet group-aware; only virtual datasets support vertical groups today.
+            grouped = [
+                v.path for v in self.template_config.data_vars if v.group is not ROOT
+            ]
+            assert not grouped, (
+                f"materialized datasets do not yet support vertical groups: {grouped}"
+            )
         return self

--- a/src/reformatters/common/iterating.py
+++ b/src/reformatters/common/iterating.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections import deque
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from itertools import batched, islice, pairwise, product, starmap
 from typing import Any, Literal
 
@@ -10,6 +10,14 @@ import xarray as xr
 def node_group_name(node: xr.DataTree) -> str | None:
     """The group name of a DataTree node, or None for the root."""
     return None if node.path == "/" else node.path.removeprefix("/")
+
+
+def walk_data_arrays(tree: xr.DataTree) -> Iterator[tuple[str, xr.DataArray]]:
+    """Yield (var_path, DataArray) for every data var across all of a template's groups."""
+    for node in tree.subtree:
+        prefix = f"{group}/" if (group := node_group_name(node)) else ""
+        for name, data_array in node.to_dataset().data_vars.items():
+            yield f"{prefix}{name}", data_array
 
 
 def dimension_slices(

--- a/src/reformatters/common/iterating.py
+++ b/src/reformatters/common/iterating.py
@@ -12,10 +12,16 @@ def node_group_name(node: xr.DataTree) -> str | None:
     return None if node.path == "/" else node.path.removeprefix("/")
 
 
+def node_path_prefix(node: xr.DataTree) -> str:
+    """A node's prefix for building var/coord paths: "" for root, else "group/"."""
+    group = node_group_name(node)
+    return "" if group is None else f"{group}/"
+
+
 def walk_data_arrays(tree: xr.DataTree) -> Iterator[tuple[str, xr.DataArray]]:
     """Yield (var_path, DataArray) for every data var across all of a template's groups."""
     for node in tree.subtree:
-        prefix = f"{group}/" if (group := node_group_name(node)) else ""
+        prefix = node_path_prefix(node)
         for name, data_array in node.to_dataset().data_vars.items():
             yield f"{prefix}{name}", data_array
 

--- a/src/reformatters/common/iterating.py
+++ b/src/reformatters/common/iterating.py
@@ -7,6 +7,11 @@ from typing import Any, Literal
 import xarray as xr
 
 
+def node_group_name(node: xr.DataTree) -> str | None:
+    """The group name of a DataTree node, or None for the root."""
+    return None if node.path == "/" else node.path.removeprefix("/")
+
+
 def dimension_slices(
     ds: xr.Dataset, dim: str, kind: Literal["shards", "chunks"] = "shards"
 ) -> Sequence[slice]:

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -190,7 +190,7 @@ class MaterializedRegionJob(
         """
         processing_region_ds, output_region_ds = self._get_region_datasets()
 
-        data_var_groups = self.source_groups(self.data_vars)
+        data_var_groups = self.source_file_var_groups(self.data_vars)
         if self.max_vars_per_download_group is not None:
             data_var_groups = split_groups(
                 data_var_groups, self.max_vars_per_download_group
@@ -258,7 +258,7 @@ class MaterializedRegionJob(
                             copy_data_var,
                             data_var.name,
                             self.region,
-                            self.template_ds,
+                            output_region_ds,
                             self.append_dim,
                             self.tmp_store,
                             primary_store,
@@ -277,7 +277,7 @@ class MaterializedRegionJob(
         return results
 
     def _get_region_datasets(self) -> tuple[xr.Dataset, xr.Dataset]:
-        ds: xr.Dataset = self.template_ds[[v.name for v in self.data_vars]]  # ty: ignore[invalid-assignment]
+        ds = self._flat_job_dataset()
         processing_region = self.get_processing_region()
         processing_region_ds = ds.isel({self.append_dim: processing_region})
         output_region_ds = ds.isel({self.append_dim: self.region})

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -277,7 +277,9 @@ class MaterializedRegionJob(
         return results
 
     def _get_region_datasets(self) -> tuple[xr.Dataset, xr.Dataset]:
-        ds = self._flat_job_dataset()
+        # Materialized datasets are single-level (DynamicalDataset enforces it), so the
+        # root node holds every var; subset it to this job's vars by name.
+        ds: xr.Dataset = self.template_ds.to_dataset()[[v.name for v in self.data_vars]]  # ty: ignore[invalid-assignment]
         processing_region = self.get_processing_region()
         processing_region_ds = ds.isel({self.append_dim: processing_region})
         output_region_ds = ds.isel({self.append_dim: self.region})

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -46,7 +46,7 @@ def parallel_setup(
     workers_total: int,
     reformat_job_name: str,
     branch_name: str,
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     tmp_store: Path,
     icechunk_repos: list[tuple[str, icechunk.Repository]],
 ) -> SetupInfo:
@@ -153,7 +153,7 @@ def finalize(
     merged_results: Mapping[str, Sequence[SourceFileResult]],
     reformat_job_name: str,
     branch_name: str,
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     tmp_store: Path,
     setup_info: SetupInfo,
     workers_total: int,

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from enum import Enum, auto
 from itertools import chain, pairwise
 from pathlib import Path
@@ -28,7 +28,7 @@ from zarr.abc.store import Store
 from reformatters.common import storage
 from reformatters.common.config_models import DataVar
 from reformatters.common.iterating import (
-    dimension_slices,
+    chunk_slices,
     split_groups,
     spread_evenly,
 )
@@ -44,6 +44,14 @@ from reformatters.common.types import (
 log = get_logger(__name__)
 
 type CoordinateValue = int | float | pd.Timestamp | pd.Timedelta | str
+
+
+def walk_data_arrays(tree: xr.DataTree) -> Iterator[tuple[str, xr.DataArray]]:
+    """Yield (var_path, DataArray) for every data var across all of a template's groups."""
+    for node in tree.subtree:
+        group_prefix = "" if node.path == "/" else node.path.removeprefix("/") + "/"
+        for name, data_array in node.to_dataset().data_vars.items():
+            yield f"{group_prefix}{name}", data_array
 
 
 class SourceFileStatus(Enum):
@@ -118,7 +126,9 @@ def region_slice(s: slice) -> slice:
 
 class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     tmp_store: Path
-    template_ds: xr.Dataset
+    # The whole-dataset template as a DataTree (root + one node per vertical group;
+    # a single-level dataset is a one-node tree). Each data var lives at its var.path.
+    template_ds: xr.DataTree
     data_vars: Sequence[DATA_VAR]
     append_dim: AppendDim
     # integer slice along append_dim
@@ -130,12 +140,15 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     max_vars_per_job: ClassVar[int | None] = None
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[DATA_VAR],
     ) -> Sequence[Sequence[DATA_VAR]]:
         """
         Return groups of variables, where all variables in a group can be retrieved from the same source file.
+
+        Distinct from a dataset's vertical groups (DataVar.group): this groups vars by
+        which source file they share, and a single source file may span vertical groups.
 
         This is a class method so it can be called by RegionJob factory methods.
         """
@@ -146,7 +159,9 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         """Number of variable groups produced by get_jobs for a given set of data_vars."""
         if cls.max_vars_per_job is None:
             return 1
-        return len(split_groups(cls.source_groups(data_vars), cls.max_vars_per_job))
+        return len(
+            split_groups(cls.source_file_var_groups(data_vars), cls.max_vars_per_job)
+        )
 
     def get_processing_region(self) -> slice:
         """
@@ -156,6 +171,22 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         return a modified slice (e.g. `slice(self.region.start - 1, self.region.stop + 1)`).
         """
         return self.region
+
+    def _flat_job_dataset(self) -> xr.Dataset:
+        """This job's data vars gathered from the template tree into one flat Dataset.
+
+        Keyed by bare variable name (unique within a job's source-file var group). Used
+        to read coordinate values over the processing region and, for materialized jobs,
+        as per-variable write geometry. Vars from different vertical groups bring their
+        own dims, so the result may mix dimensionalities.
+        """
+        paths = {var.path for var in self.data_vars}
+        arrays = {
+            data_array.name: data_array
+            for path, data_array in walk_data_arrays(self.template_ds)
+            if path in paths
+        }
+        return xr.Dataset(arrays)
 
     def generate_source_file_coords(
         self, processing_region_ds: xr.Dataset, data_var_group: Sequence[DATA_VAR]
@@ -167,7 +198,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[SourceFileResult]]
-    ) -> xr.Dataset:
+    ) -> xr.DataTree:
         """
         Update template dataset based on processing results. This method is called
         during operational updates.
@@ -188,8 +219,8 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
         Returns
         -------
-        xr.Dataset
-            Updated template dataset reflecting the actual processing results.
+        xr.DataTree
+            Updated template tree reflecting the actual processing results.
         """
         max_append_dim_processed = max(
             (
@@ -215,11 +246,11 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[DATA_VAR],
         reformat_job_name: str,
-    ) -> tuple[Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]], xr.Dataset]:
+    ) -> tuple[Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]], xr.DataTree]:
         """
         Return the sequence of RegionJob instances necessary to update the dataset
         from its current state to include the latest available data.
@@ -242,7 +273,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             The primary store to read existing data from and write updates to.
         tmp_store : Path
             The temporary Zarr store to write into while processing.
-        get_template_fn : Callable[[DatetimeLike], xr.Dataset]
+        get_template_fn : Callable[[DatetimeLike], xr.DataTree]
             Function to get the template_ds for the operational update.
         append_dim : AppendDim
             The dimension along which data is appended (e.g., "time").
@@ -256,7 +287,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         -------
         Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]]
             RegionJob instances that need processing for operational updates.
-        xr.Dataset
+        xr.DataTree
             The template_ds for the operational update.
         """
         raise NotImplementedError(
@@ -278,7 +309,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     def get_jobs(
         cls,
         tmp_store: Path,
-        template_ds: xr.Dataset,
+        template_ds: xr.DataTree,
         append_dim: AppendDim,
         all_data_vars: Sequence[DATA_VAR],
         reformat_job_name: str,
@@ -299,8 +330,8 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         ----------
         tmp_store : Path
             The temporary Zarr store to write into while processing.
-        template_ds : xr.Dataset
-            Dataset template defining structure and metadata.
+        template_ds : xr.DataTree
+            Template tree defining structure and metadata (one node per group).
         append_dim : AppendDim
             The dimension along which data is appended (e.g., "time").
         all_data_vars : Sequence[DATA_VAR]
@@ -327,18 +358,23 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         """
 
         # Data variables -- filter and group
-        assert {v.name for v in all_data_vars} == set(template_ds.data_vars)
+        template_arrays = list(walk_data_arrays(template_ds))
+        assert {v.path for v in all_data_vars} == {path for path, _ in template_arrays}
 
         data_vars: Sequence[DATA_VAR]
         if filter_variable_names:
-            data_vars = [v for v in all_data_vars if v.name in filter_variable_names]
+            data_vars = [
+                v
+                for v in all_data_vars
+                if v.name in filter_variable_names or v.path in filter_variable_names
+            ]
         else:
             data_vars = all_data_vars
 
         if cls.max_vars_per_job is not None:
-            # Split by source groups first as those are efficient groupings,
+            # Split by source file var groups first as those are efficient groupings,
             # then split further to create smaller jobs for parallelism.
-            data_var_groups = cls.source_groups(data_vars)
+            data_var_groups = cls.source_file_var_groups(data_vars)
             data_var_groups = split_groups(data_var_groups, cls.max_vars_per_job)
         else:
             data_var_groups = [data_vars]
@@ -347,15 +383,20 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         # Materialized arrays partition by shard; virtual arrays use chunks.
         # All data vars must agree: a mix would partition by whichever var is first,
         # and a chunk-sized region over a sharded var would cause multiple workers
-        # to write to the same shard.
-        sharded = [
-            v.encoding.get("shards") is not None for v in template_ds.data_vars.values()
-        ]
-        assert len(set(sharded)) == 1, (
-            "all data vars must agree on whether they are sharded"
+        # to write to the same shard. The append-dim chunk/shard size is uniform
+        # across vertical groups (enforced in TemplateConfig), so partitioning is shared.
+        sharded = {da.encoding.get("shards") is not None for _, da in template_arrays}
+        assert len(sharded) == 1, "all data vars must agree on whether they are sharded"
+        kind = "shards" if sharded.pop() else "chunks"
+        append_chunk_sizes = {
+            da.encoding[kind][da.dims.index(append_dim)] for _, da in template_arrays
+        }
+        assert len(append_chunk_sizes) == 1, (
+            f"Inconsistent {kind} sizes along {append_dim}: {append_chunk_sizes}"
         )
-        kind = "shards" if sharded[0] else "chunks"
-        regions = dimension_slices(template_ds, append_dim, kind=kind)
+        regions = chunk_slices(
+            len(template_ds.coords[append_dim]), append_chunk_sizes.pop()
+        )
 
         # Filter regions by time
         if (

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -119,7 +119,6 @@ def region_slice(s: slice) -> slice:
 
 class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     tmp_store: Path
-    # Whole-dataset template tree: root + one node per vertical group (single-level = one node).
     template_ds: xr.DataTree
     data_vars: Sequence[DATA_VAR]
     append_dim: AppendDim
@@ -360,8 +359,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         # Materialized arrays partition by shard; virtual arrays use chunks. All data
         # vars must agree: a mix would partition by whichever var is first, and a
         # chunk-sized region over a sharded var would let multiple workers write the
-        # same shard. The tree-walking twin of iterating.dimension_slices (whose flat
-        # Dataset can't hold same-named vars from different groups).
+        # same shard.
         sharded = {da.encoding.get("shards") is not None for _, da in template_arrays}
         assert len(sharded) == 1, "all data vars must agree on whether they are sharded"
         kind = "shards" if sharded.pop() else "chunks"

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from enum import Enum, auto
 from itertools import chain, pairwise
 from pathlib import Path
@@ -29,9 +29,9 @@ from reformatters.common import storage
 from reformatters.common.config_models import DataVar
 from reformatters.common.iterating import (
     chunk_slices,
-    node_group_name,
     split_groups,
     spread_evenly,
+    walk_data_arrays,
 )
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import FrozenBaseModel
@@ -45,14 +45,6 @@ from reformatters.common.types import (
 log = get_logger(__name__)
 
 type CoordinateValue = int | float | pd.Timestamp | pd.Timedelta | str
-
-
-def walk_data_arrays(tree: xr.DataTree) -> Iterator[tuple[str, xr.DataArray]]:
-    """Yield (var_path, DataArray) for every data var across all of a template's groups."""
-    for node in tree.subtree:
-        prefix = f"{group}/" if (group := node_group_name(node)) else ""
-        for name, data_array in node.to_dataset().data_vars.items():
-            yield f"{prefix}{name}", data_array
 
 
 class SourceFileStatus(Enum):
@@ -171,20 +163,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         return a modified slice (e.g. `slice(self.region.start - 1, self.region.stop + 1)`).
         """
         return self.region
-
-    def _flat_job_dataset(self) -> xr.Dataset:
-        """This job's data vars gathered from the template tree into one flat Dataset,
-        keyed by bare variable name (unique within a job's source-file var group)."""
-        paths = {var.path for var in self.data_vars}
-        arrays = {
-            data_array.name: data_array
-            for path, data_array in walk_data_arrays(self.template_ds)
-            if path in paths
-        }
-        assert len(arrays) == len(paths), (
-            f"data var names collide across groups within one job: {sorted(paths)}"
-        )
-        return xr.Dataset(arrays)
 
     def generate_source_file_coords(
         self, processing_region_ds: xr.Dataset, data_var_group: Sequence[DATA_VAR]

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -29,6 +29,7 @@ from reformatters.common import storage
 from reformatters.common.config_models import DataVar
 from reformatters.common.iterating import (
     chunk_slices,
+    node_group_name,
     split_groups,
     spread_evenly,
 )
@@ -49,9 +50,9 @@ type CoordinateValue = int | float | pd.Timestamp | pd.Timedelta | str
 def walk_data_arrays(tree: xr.DataTree) -> Iterator[tuple[str, xr.DataArray]]:
     """Yield (var_path, DataArray) for every data var across all of a template's groups."""
     for node in tree.subtree:
-        group_prefix = "" if node.path == "/" else node.path.removeprefix("/") + "/"
+        prefix = f"{group}/" if (group := node_group_name(node)) else ""
         for name, data_array in node.to_dataset().data_vars.items():
-            yield f"{group_prefix}{name}", data_array
+            yield f"{prefix}{name}", data_array
 
 
 class SourceFileStatus(Enum):
@@ -126,8 +127,7 @@ def region_slice(s: slice) -> slice:
 
 class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     tmp_store: Path
-    # The whole-dataset template as a DataTree (root + one node per vertical group;
-    # a single-level dataset is a one-node tree). Each data var lives at its var.path.
+    # Whole-dataset template tree: root + one node per vertical group (single-level = one node).
     template_ds: xr.DataTree
     data_vars: Sequence[DATA_VAR]
     append_dim: AppendDim
@@ -173,19 +173,17 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         return self.region
 
     def _flat_job_dataset(self) -> xr.Dataset:
-        """This job's data vars gathered from the template tree into one flat Dataset.
-
-        Keyed by bare variable name (unique within a job's source-file var group). Used
-        to read coordinate values over the processing region and, for materialized jobs,
-        as per-variable write geometry. Vars from different vertical groups bring their
-        own dims, so the result may mix dimensionalities.
-        """
+        """This job's data vars gathered from the template tree into one flat Dataset,
+        keyed by bare variable name (unique within a job's source-file var group)."""
         paths = {var.path for var in self.data_vars}
         arrays = {
             data_array.name: data_array
             for path, data_array in walk_data_arrays(self.template_ds)
             if path in paths
         }
+        assert len(arrays) == len(paths), (
+            f"data var names collide across groups within one job: {sorted(paths)}"
+        )
         return xr.Dataset(arrays)
 
     def generate_source_file_coords(
@@ -348,7 +346,8 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             Keep only shards containing at least one of the specified timestamps.
             Timestamps must exactly match coordinate values. Empty list returns no jobs.
         filter_variable_names : list[str] | None, default None
-            Keep only the specified variables. If None, all variables are included.
+            Keep only the specified variables, matched by bare name or by var.path
+            (a bare name selects that var in every group). If None, all are included.
 
         Returns
         -------
@@ -380,11 +379,11 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             data_var_groups = [data_vars]
 
         # Regions along append dimension.
-        # Materialized arrays partition by shard; virtual arrays use chunks.
-        # All data vars must agree: a mix would partition by whichever var is first,
-        # and a chunk-sized region over a sharded var would cause multiple workers
-        # to write to the same shard. The append-dim chunk/shard size is uniform
-        # across vertical groups (enforced in TemplateConfig), so partitioning is shared.
+        # Materialized arrays partition by shard; virtual arrays use chunks. All data
+        # vars must agree: a mix would partition by whichever var is first, and a
+        # chunk-sized region over a sharded var would let multiple workers write the
+        # same shard. The tree-walking twin of iterating.dimension_slices (whose flat
+        # Dataset can't hold same-named vars from different groups).
         sharded = {da.encoding.get("shards") is not None for _, da in template_arrays}
         assert len(sharded) == 1, "all data vars must agree on whether they are sharded"
         kind = "shards" if sharded.pop() else "chunks"

--- a/src/reformatters/common/template_config.py
+++ b/src/reformatters/common/template_config.py
@@ -16,6 +16,7 @@ from reformatters.common.config_models import (
     DataVar,
     Group,
 )
+from reformatters.common.iterating import node_group_name
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.types import AppendDim, DatetimeLike, Dim, Timedelta, Timestamp
 
@@ -137,7 +138,7 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
 
         nodes: dict[str, xr.Dataset] = {}
         for node in on_disk.subtree:
-            group_prefix = "" if node.path == "/" else node.path.removeprefix("/") + "/"
+            group_prefix = f"{group}/" if (group := node_group_name(node)) else ""
             ds = template_utils.empty_copy_with_reindex(
                 node.to_dataset(),
                 self.append_dim,
@@ -249,6 +250,8 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
         assert used <= declared, (
             f"data var group(s) {used - declared} are not declared in dims"
         )
+        orphans = {g for g in self.dims if g is not ROOT} - used
+        assert not orphans, f"vertical group(s) {orphans} declared in dims but unused"
 
         paths = [var.path for var in self.data_vars]
         assert len(paths) == len(set(paths)), (

--- a/src/reformatters/common/template_config.py
+++ b/src/reformatters/common/template_config.py
@@ -28,10 +28,6 @@ SPATIAL_REF_COORDS = ((), np.array(0))
 class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
     """Define a subclass of this class to configure the structure of a dataset."""
 
-    # Dimensions per zarr group, keyed by group. dims[ROOT] is the root/single-level
-    # dims; dims["pressure_level"] etc. are a vertical group's full dims (the shared
-    # dims plus the vertical dim, whose name equals the group name). A single-level
-    # dataset declares only {ROOT: (...)}. See docs/plans/vertical_dimension_structure.md.
     dims: dict[Group, tuple[Dim, ...]]
     append_dim: AppendDim
     append_dim_start: Timestamp
@@ -40,19 +36,18 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
     @property
     def all_dims(self) -> tuple[Dim, ...]:
         """De-duplicated union of every group's dims, root dims first."""
-        ordered: dict[Dim, None] = {}
+        result: list[Dim] = []
         for group_dims in self.dims.values():
             for dim in group_dims:
-                ordered[dim] = None
-        return tuple(ordered)
+                if dim not in result:
+                    result.append(dim)
+        return tuple(result)
 
     @property
     def groups(self) -> tuple[Group, ...]:
-        """Groups to write: ROOT (always, holds shared coords) then each vertical group
-        that has at least one data var (empty vertical groups are omitted)."""
-        used = {var.group for var in self.data_vars}
-        vertical = tuple(g for g in self.dims if g is not ROOT and g in used)
-        return (ROOT, *vertical)
+        """ROOT (holds shared coords) then each declared vertical group. Every declared
+        vertical group must be used by a var (enforced by `_assert_valid_structure`)."""
+        return (ROOT, *(g for g in self.dims if g is not ROOT))
 
     @computed_field
     @property
@@ -118,11 +113,7 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
 
     def get_template(self, end_time: DatetimeLike) -> xr.DataTree:
         """
-        Returns the template, as a DataTree, expanded to the given end time.
-
-        A single-level dataset is a one-node tree (just the root); a dataset with
-        vertical groups has one child node per group. Each node's append dimension
-        is reindexed and its coordinates re-derived.
+        Returns the template as a DataTree, with append dim in all Zarr groups expanded to the given end time.
 
         Args:
             end_time (pd.Timestamp): End time (exclusive) for the append dimension

--- a/src/reformatters/common/template_config.py
+++ b/src/reformatters/common/template_config.py
@@ -16,7 +16,6 @@ from reformatters.common.config_models import (
     DataVar,
     Group,
 )
-from reformatters.common.iterating import node_group_name
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.types import AppendDim, DatetimeLike, Dim, Timedelta, Timestamp
 
@@ -134,11 +133,9 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
         on_disk = xr.open_datatree(self.template_path(), decode_timedelta=True)
         new_append_coords = self.append_dim_coordinates(end_time)
         coord_fill_values = {c.name: c.encoding.fill_value for c in self.coords}
-        var_by_path = {var.path: var for var in self.data_vars}
 
         nodes: dict[str, xr.Dataset] = {}
         for node in on_disk.subtree:
-            group_prefix = f"{group}/" if (group := node_group_name(node)) else ""
             ds = template_utils.empty_copy_with_reindex(
                 node.to_dataset(),
                 self.append_dim,
@@ -158,13 +155,16 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
                 ds[coord_name].encoding["fill_value"] = coord_fill_values[
                     str(coord_name)
                 ]
-            for var_name in ds.data_vars:
-                var = var_by_path[f"{group_prefix}{var_name}"]
-                assert "fill_value" not in ds[var_name].encoding, (
-                    "Fill value round tripped. That's good but not the previous behavior and if you see this AND the fill_value is correct, you can remove the workaround."
-                )
-                ds[var_name].encoding["fill_value"] = var.encoding.fill_value
             nodes[node.path] = ds
+
+        # Same fill_value workaround for data vars, keyed off the config (which may be a
+        # subset of the on-disk template) so each var is restored at its group node.
+        for var in self.data_vars:
+            var_array = nodes[self._group_node_path(var.group)][var.name]
+            assert "fill_value" not in var_array.encoding, (
+                "Fill value round tripped. That's good but not the previous behavior and if you see this AND the fill_value is correct, you can remove the workaround."
+            )
+            var_array.encoding["fill_value"] = var.encoding.fill_value
 
         template = xr.DataTree.from_dict(nodes)
 

--- a/src/reformatters/common/template_config.py
+++ b/src/reformatters/common/template_config.py
@@ -10,9 +10,11 @@ from pydantic import computed_field
 
 from reformatters.common import template_utils
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     DatasetAttributes,
     DataVar,
+    Group,
 )
 from reformatters.common.pydantic import FrozenBaseModel
 from reformatters.common.types import AppendDim, DatetimeLike, Dim, Timedelta, Timestamp
@@ -26,10 +28,31 @@ SPATIAL_REF_COORDS = ((), np.array(0))
 class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
     """Define a subclass of this class to configure the structure of a dataset."""
 
-    dims: tuple[Dim, ...]
+    # Dimensions per zarr group, keyed by group. dims[ROOT] is the root/single-level
+    # dims; dims["pressure_level"] etc. are a vertical group's full dims (the shared
+    # dims plus the vertical dim, whose name equals the group name). A single-level
+    # dataset declares only {ROOT: (...)}. See docs/plans/vertical_dimension_structure.md.
+    dims: dict[Group, tuple[Dim, ...]]
     append_dim: AppendDim
     append_dim_start: Timestamp
     append_dim_frequency: Timedelta
+
+    @property
+    def all_dims(self) -> tuple[Dim, ...]:
+        """De-duplicated union of every group's dims, root dims first."""
+        ordered: dict[Dim, None] = {}
+        for group_dims in self.dims.values():
+            for dim in group_dims:
+                ordered[dim] = None
+        return tuple(ordered)
+
+    @property
+    def groups(self) -> tuple[Group, ...]:
+        """Groups to write: ROOT (always, holds shared coords) then each vertical group
+        that has at least one data var (empty vertical groups are omitted)."""
+        used = {var.group for var in self.data_vars}
+        vertical = tuple(g for g in self.dims if g is not ROOT and g in used)
+        return (ROOT, *vertical)
 
     @computed_field
     @property
@@ -58,7 +81,9 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
         Compute non-dimension coordinates.
         For example, if init_time is the append dimension, `{"valid_time": ds["init_time"] + ds["lead_time"]}`
         """
-        non_dimension_coords = {c.name for c in self.coords if c.name not in self.dims}
+        non_dimension_coords = {
+            c.name for c in self.coords if c.name not in self.all_dims
+        }
         missing = non_dimension_coords - {"spatial_ref"}
         if len(missing):
             raise NotImplementedError(
@@ -91,88 +116,172 @@ class TemplateConfig(FrozenBaseModel, Generic[DATA_VAR]):
             self.append_dim_start, end, freq=self.append_dim_frequency, inclusive="left"
         )
 
-    def get_template(self, end_time: DatetimeLike) -> xr.Dataset:
+    def get_template(self, end_time: DatetimeLike) -> xr.DataTree:
         """
-        Returns a template dataset expanded to the given end time.
+        Returns the template, as a DataTree, expanded to the given end time.
+
+        A single-level dataset is a one-node tree (just the root); a dataset with
+        vertical groups has one child node per group. Each node's append dimension
+        is reindexed and its coordinates re-derived.
 
         Args:
             end_time (pd.Timestamp): End time (exclusive) for the append dimension
 
         Returns:
-            xr.Dataset: Template dataset with dimension coordinates
+            xr.DataTree: Template tree with dimension coordinates
         """
-        ds: xr.Dataset = xr.open_zarr(self.template_path(), decode_timedelta=True)
+        on_disk = xr.open_datatree(self.template_path(), decode_timedelta=True)
+        new_append_coords = self.append_dim_coordinates(end_time)
+        coord_fill_values = {c.name: c.encoding.fill_value for c in self.coords}
+        var_by_path = {var.path: var for var in self.data_vars}
 
-        # Expand init_time dimension with complete coordinates
-        ds = template_utils.empty_copy_with_reindex(
-            ds,
-            self.append_dim,
-            self.append_dim_coordinates(end_time),
-            derive_coordinates_fn=self.derive_coordinates,
-        )
+        nodes: dict[str, xr.Dataset] = {}
+        for node in on_disk.subtree:
+            group_prefix = "" if node.path == "/" else node.path.removeprefix("/") + "/"
+            ds = template_utils.empty_copy_with_reindex(
+                node.to_dataset(),
+                self.append_dim,
+                new_append_coords,
+                derive_coordinates_fn=self.derive_coordinates,
+            )
+            # Coordinates which are dask arrays are not written with .to_zarr(store, compute=False)
+            # We want to write all coords when writing metadata, so ensure they are loaded as numpy arrays.
+            for coordinate in ds.coords.values():
+                coordinate.load()
+
+            # Work around what appears to be a bug where fill_value is not set in encodings read from existing zarr template
+            for coord_name in ds.coords:
+                assert "fill_value" not in ds[coord_name].encoding, (
+                    "Fill value round tripped. That's good but not the previous behavior and if you see this AND the fill_value is correct, you can remove the workaround."
+                )
+                ds[coord_name].encoding["fill_value"] = coord_fill_values[
+                    str(coord_name)
+                ]
+            for var_name in ds.data_vars:
+                var = var_by_path[f"{group_prefix}{var_name}"]
+                assert "fill_value" not in ds[var_name].encoding, (
+                    "Fill value round tripped. That's good but not the previous behavior and if you see this AND the fill_value is correct, you can remove the workaround."
+                )
+                ds[var_name].encoding["fill_value"] = var.encoding.fill_value
+            nodes[node.path] = ds
+
+        template = xr.DataTree.from_dict(nodes)
 
         # Ensure attributes have not been changed without calling update_template()
-        assert ds.attrs["dataset_id"] == self.dataset_id
-        assert ds.attrs["dataset_version"] == self.version
+        assert template.attrs["dataset_id"] == self.dataset_id
+        assert template.attrs["dataset_version"] == self.version
 
-        # Coordinates which are dask arrays are not written with .to_zarr(store, compute=False)
-        # We want to write all coords when writing metadata, so ensure they are loaded as numpy arrays.
-        for coordinate in ds.coords.values():
-            coordinate.load()
-
-        # Work around what appears to be a bug where fill_value is not set in encodings read from existing zarr template
-        for coord in self.coords:
-            assert "fill_value" not in ds[coord.name].encoding, (
-                "Fill value round tripped. That's good but not the previous behavior and if you see this AND the fill_value is correct, you can remove the workaround."
-            )
-            ds[coord.name].encoding["fill_value"] = coord.encoding.fill_value
-        for var in self.data_vars:
-            assert "fill_value" not in ds[var.name].encoding, (
-                "Fill value round tripped. That's good but not the previous behavior and if you see this AND the fill_value is correct, you can remove the workaround."
-            )
-            ds[var.name].encoding["fill_value"] = var.encoding.fill_value
-
-        return ds
+        return template
 
     def update_template(self) -> None:
         """
         Updates the template file on disk with the latest configuration.
         """
         coords = self.dimension_coordinates()
-        assert set(coords) == set(self.dims), (
-            f"`dimension_coordinates` must return coordinates for all dimensions {self.dims}"
+        assert set(coords) == set(self.all_dims), (
+            f"`dimension_coordinates` must return coordinates for all dims {self.all_dims}"
         )
+        self._assert_valid_structure()
 
-        data_vars = {
-            var_config.name: template_utils.make_empty_variable(
-                self.dims, coords, var_config.encoding.dtype
-            )
-            for var_config in self.data_vars
+        nodes = {
+            self._group_node_path(group): self._build_node_dataset(group, coords)
+            for group in self.groups
         }
+        written_coords = {name for ds in nodes.values() for name in ds.coords}
+        assert written_coords == {c.name for c in self.coords}, (
+            f"coords {written_coords} written across groups must match self.coords "
+            f"{ {c.name for c in self.coords} }"
+        )
+        template = xr.DataTree.from_dict(nodes)
+        template_utils.write_metadata(template, self.template_path())
 
+    @staticmethod
+    def _group_node_path(group: Group) -> str:
+        return "/" if group is ROOT else f"/{group}"
+
+    def _build_node_dataset(self, group: Group, coords: dict[str, Any]) -> xr.Dataset:
+        """Build one zarr group's empty dataset: its data vars plus its dims' coords
+        (shared coords + any vertical coord) and the derived coords."""
+        group_dims = self.dims[group]
+        data_vars = {
+            var.name: template_utils.make_empty_variable(
+                group_dims, coords, var.encoding.dtype
+            )
+            for var in self.data_vars
+            if var.group == group
+        }
         ds = xr.Dataset(
             data_vars,
-            coords,
+            {dim: coords[dim] for dim in group_dims},
             self.dataset_attributes.model_dump(exclude_none=True),
         )
-
         derived_coords = self.derive_coordinates(ds)
         assert set(derived_coords).isdisjoint(ds.dims), (
-            f"Return coordinates for dataset dimensions {self.dims} from `dimension_coordinates` rather than `derive_coordinates`."
+            "Return coordinates for dataset dimensions from `dimension_coordinates` "
+            "rather than `derive_coordinates`."
         )
         ds = ds.assign_coords(derived_coords)
 
-        assert {d.name for d in self.data_vars} == set(ds.data_vars)
-        for var_config in self.data_vars:
-            template_utils.assign_var_metadata(ds[var_config.name], var_config)
-
-        assert {c.name for c in self.coords} == set(ds.coords)
-        for coord_config in self.coords:
+        for var in self.data_vars:
+            if var.group == group:
+                template_utils.assign_var_metadata(ds[var.name], var)
+        coord_config = {c.name: c for c in self.coords}
+        for coord_name in ds.coords:
             template_utils.assign_var_metadata(
-                ds.coords[coord_config.name], coord_config
+                ds.coords[coord_name], coord_config[str(coord_name)]
+            )
+        return ds
+
+    def _assert_valid_structure(self) -> None:
+        """Enforce the group invariants (see docs/plans/vertical_dimension_structure.md)."""
+        root_dims = self.dims[ROOT]
+        for group, group_dims in self.dims.items():
+            if group is ROOT:
+                continue
+            added = tuple(d for d in group_dims if d not in root_dims)
+            assert added == (group,), (
+                f"vertical group {group!r} must add exactly its own dim to the root "
+                f"dims; dims[{group!r}] adds {added}, expected ({group!r},)"
             )
 
-        template_utils.write_metadata(ds, self.template_path())
+        declared = set(self.dims)
+        used = {var.group for var in self.data_vars}
+        assert used <= declared, (
+            f"data var group(s) {used - declared} are not declared in dims"
+        )
+
+        paths = [var.path for var in self.data_vars]
+        assert len(paths) == len(set(paths)), (
+            f"duplicate (group, name) across data_vars: {paths}"
+        )
+
+        group_names = {g for g in self.dims if g is not ROOT}
+        root_var_names = {var.name for var in self.data_vars if var.group is ROOT}
+        assert root_var_names.isdisjoint(group_names), (
+            f"root data var name(s) {root_var_names & group_names} collide with a group name"
+        )
+
+        append_dim_chunks = {self._append_dim_chunk_size(var) for var in self.data_vars}
+        assert len(append_dim_chunks) <= 1, (
+            f"all data vars must share one append-dim chunk size, got {append_dim_chunks}"
+        )
+
+        for var in self.data_vars:
+            n_dims = len(self.dims[var.group])
+            for kind in ("chunks", "shards"):
+                value = getattr(var.encoding, kind)
+                if isinstance(value, tuple):
+                    assert len(value) == n_dims, (
+                        f"{var.path} encoding {kind} has {len(value)} entries, "
+                        f"expected {n_dims} (the dims of group {var.group!r})"
+                    )
+
+    def _append_dim_chunk_size(self, var: DataVar[Any]) -> int:
+        dims = self.dims[var.group]
+        chunks = var.encoding.chunks
+        if isinstance(chunks, int):
+            return chunks
+        return chunks[dims.index(self.append_dim)]
 
     def append_dim_coordinate_chunk_size(self) -> int:
         """

--- a/src/reformatters/common/template_utils.py
+++ b/src/reformatters/common/template_utils.py
@@ -26,10 +26,9 @@ log = get_logger(__name__)
 def _to_zarr_metadata(
     template: xr.DataTree, store: Store | Path, mode: Literal["w", "w-"]
 ) -> None:
-    # safe_chunks=False: with compute=False no dask chunks are written, so alignment
-    # is irrelevant; aligning instead builds a per-chunk dask graph that OOMs large arrays.
-    # write_inherited_coords=True writes each group's own copy of the shared coords so
-    # groups open standalone; see docs/plans/vertical_dimension_structure.md.
+    # safe_chunks=False avoids a per-chunk dask graph that OOMs large arrays (compute=False
+    # writes no data chunks anyway). write_inherited_coords=True duplicates shared coords
+    # into each group so groups open standalone; see docs/plans/vertical_dimension_structure.md.
     template.to_zarr(
         store,
         mode=mode,
@@ -159,6 +158,21 @@ def _structural_signature(
     }
 
 
+def _non_append_dimension_coords(
+    tree: xr.DataTree, append_dim: str
+) -> dict[str, xr.DataArray]:
+    """Dimension coordinates (across all groups) other than the append dim, by name —
+    the 1D axis labels (latitude/longitude, pressure_level, model_level, …). Reordering
+    one relabels existing chunks. Excludes the growing append dim, 2D auxiliary coords
+    (projected lat/lon, valid_time), and scalars (spatial_ref), which need not match."""
+    coords: dict[str, xr.DataArray] = {}
+    for node in tree.subtree:
+        for name, coord in node.to_dataset().coords.items():
+            if coord.dims == (name,) and name != append_dim:
+                coords[str(name)] = coord
+    return coords
+
+
 def assert_no_structural_drift_from_existing_store(
     template_ds: xr.DataTree, existing_ds: xr.DataTree, append_dim: str
 ) -> None:
@@ -171,10 +185,11 @@ def assert_no_structural_drift_from_existing_store(
     shards — the update would corrupt the archive or break readers. This guard runs on
     worker 0 before any data is written and raises before damage is done.
 
-    Compares every variable across all groups (by var.path). Only variables present in
-    `existing_ds` are checked, so the template may freely add new variables. Backfills
-    are exempt (they rewrite the whole store and may legitimately change structure), so
-    callers only run this for operational updates.
+    Compares every variable across all groups (by var.path) and every non-append
+    dimension coordinate's values (a reordered vertical level or moved lat/lon would
+    relabel existing chunks). Only variables/coords present in `existing_ds` are checked, so the
+    template may freely add new ones. Backfills are exempt (they rewrite the whole store
+    and may legitimately change structure), so callers only run this for operational updates.
 
     The append dimension's chunk/shard size is compared in dev/prod but skipped under
     Config.env == test, where the integration auto-shrink helper sizes append-dim chunks
@@ -204,6 +219,17 @@ def assert_no_structural_drift_from_existing_store(
                     f"{path}.{field}: existing store has {existing_value!r}, "
                     f"update template has {template_value!r}"
                 )
+
+    template_coords = _non_append_dimension_coords(template_ds, append_dim)
+    for name, existing_coord in _non_append_dimension_coords(
+        existing_ds, append_dim
+    ).items():
+        if name not in template_coords:
+            mismatches.append(
+                f"coord {name}: in existing store but missing from update template"
+            )
+        elif not existing_coord.equals(template_coords[name]):
+            mismatches.append(f"coord {name}: values differ from the existing store")
 
     if mismatches:
         raise ValueError(

--- a/src/reformatters/common/template_utils.py
+++ b/src/reformatters/common/template_utils.py
@@ -15,6 +15,7 @@ from zarr.abc.store import Store
 
 from reformatters.common.config import Config
 from reformatters.common.config_models import Coordinate, DataVar
+from reformatters.common.iterating import walk_data_arrays
 from reformatters.common.logging import get_logger
 from reformatters.common.storage import StoreFactory, commit_if_icechunk
 from reformatters.common.zarr import assert_fill_values_set
@@ -159,7 +160,7 @@ def _structural_signature(
 
 
 def assert_no_structural_drift_from_existing_store(
-    template_ds: xr.Dataset, existing_ds: xr.Dataset, append_dim: str
+    template_ds: xr.DataTree, existing_ds: xr.DataTree, append_dim: str
 ) -> None:
     """Fail an operational update whose template would change the structure of the
     already-published store.
@@ -170,9 +171,10 @@ def assert_no_structural_drift_from_existing_store(
     shards — the update would corrupt the archive or break readers. This guard runs on
     worker 0 before any data is written and raises before damage is done.
 
-    Only variables present in `existing_ds` are checked, so the template may freely add
-    new variables. Backfills are exempt (they rewrite the whole store and may
-    legitimately change structure), so callers only run this for operational updates.
+    Compares every variable across all groups (by var.path). Only variables present in
+    `existing_ds` are checked, so the template may freely add new variables. Backfills
+    are exempt (they rewrite the whole store and may legitimately change structure), so
+    callers only run this for operational updates.
 
     The append dimension's chunk/shard size is compared in dev/prod but skipped under
     Config.env == test, where the integration auto-shrink helper sizes append-dim chunks
@@ -180,25 +182,26 @@ def assert_no_structural_drift_from_existing_store(
     change is caught here as well as at PR time by the template-drift test.
     """
     compare_append_axis = not Config.is_test
+    template_by_path = dict(walk_data_arrays(template_ds))
     mismatches: list[str] = []
-    for var_name in map(str, existing_ds.data_vars):
-        if var_name not in template_ds.data_vars:
+    for path, existing_var in walk_data_arrays(existing_ds):
+        if path not in template_by_path:
             mismatches.append(
-                f"{var_name}: in existing store but missing from update template"
+                f"{path}: in existing store but missing from update template"
             )
             continue
 
         existing_sig = _structural_signature(
-            existing_ds[var_name], append_dim, compare_append_axis=compare_append_axis
+            existing_var, append_dim, compare_append_axis=compare_append_axis
         )
         template_sig = _structural_signature(
-            template_ds[var_name], append_dim, compare_append_axis=compare_append_axis
+            template_by_path[path], append_dim, compare_append_axis=compare_append_axis
         )
         for field, existing_value in existing_sig.items():
             template_value = template_sig[field]
             if existing_value != template_value:
                 mismatches.append(
-                    f"{var_name}.{field}: existing store has {existing_value!r}, "
+                    f"{path}.{field}: existing store has {existing_value!r}, "
                     f"update template has {template_value!r}"
                 )
 

--- a/src/reformatters/common/template_utils.py
+++ b/src/reformatters/common/template_utils.py
@@ -40,7 +40,7 @@ def _to_zarr_metadata(
 
 
 def write_metadata(
-    template_ds: xr.Dataset | xr.DataTree,
+    template_ds: xr.DataTree,
     storage: zarr.storage.StoreLike | StoreFactory,
     mode: Literal["w", "w-"] | None = None,
     skip_icechunk_commit: bool = False,
@@ -49,12 +49,6 @@ def write_metadata(
     replica_stores: list[Store]
 
     assert_fill_values_set(template_ds)
-    # A plain Dataset (single-level) wraps as a one-node tree so there's one write path.
-    template = (
-        template_ds
-        if isinstance(template_ds, xr.DataTree)
-        else xr.DataTree.from_dict({"/": template_ds})
-    )
 
     if isinstance(storage, StoreFactory):
         store = storage.primary_store(writable=True)
@@ -86,10 +80,10 @@ def write_metadata(
 
         for replica_store in replica_stores:
             log.info(f"Writing metadata to replica {replica_store} with mode {mode}")
-            _to_zarr_metadata(template, replica_store, mode)
+            _to_zarr_metadata(template_ds, replica_store, mode)
 
         log.info(f"Writing metadata to store {store} with mode {mode}")
-        _to_zarr_metadata(template, store, mode)
+        _to_zarr_metadata(template_ds, store, mode)
 
     if isinstance(store, Path | str):
         sort_consolidated_metadata(Path(store) / "zarr.json")

--- a/src/reformatters/common/template_utils.py
+++ b/src/reformatters/common/template_utils.py
@@ -22,8 +22,29 @@ from reformatters.common.zarr import assert_fill_values_set
 log = get_logger(__name__)
 
 
+def _to_zarr_metadata(
+    template: xr.DataTree, store: Store | Path, mode: Literal["w", "w-"]
+) -> None:
+    # safe_chunks=False: with compute=False only metadata and numpy coordinates
+    # are written, no dask chunks, so dask/zarr chunk alignment is irrelevant.
+    # The alternative, aligning dask chunks to the stored chunks (align_chunks=True
+    # or chunking templates at stored sizes), builds a task-per-chunk dask graph
+    # even under compute=False, which is slow/OOM on our largest arrays.
+    # write_inherited_coords=True writes each group's own copy of the shared coords
+    # so groups open standalone; see docs/plans/vertical_dimension_structure.md. It
+    # is a no-op for a single-level dataset (a one-node tree, no child groups).
+    template.to_zarr(
+        store,
+        mode=mode,
+        compute=False,
+        write_inherited_coords=True,
+        safe_chunks=False,
+        write_empty_chunks=True,
+    )
+
+
 def write_metadata(
-    template_ds: xr.Dataset,
+    template_ds: xr.Dataset | xr.DataTree,
     storage: zarr.storage.StoreLike | StoreFactory,
     mode: Literal["w", "w-"] | None = None,
     skip_icechunk_commit: bool = False,
@@ -32,6 +53,13 @@ def write_metadata(
     replica_stores: list[Store]
 
     assert_fill_values_set(template_ds)
+    # A single-level dataset's template is a plain Dataset; wrap it as a one-node tree
+    # so there is one write path. A one-node tree writes byte-identically to the Dataset.
+    template = (
+        template_ds
+        if isinstance(template_ds, xr.DataTree)
+        else xr.DataTree.from_dict({"/": template_ds})
+    )
 
     if isinstance(storage, StoreFactory):
         store = storage.primary_store(writable=True)
@@ -61,29 +89,12 @@ def write_metadata(
             category=UserWarning,
         )
 
-        # safe_chunks=False: with compute=False only metadata and numpy coordinates
-        # are written, no dask chunks, so dask/zarr chunk alignment is irrelevant.
-        # The alternative, aligning dask chunks to the stored chunks (align_chunks=True
-        # or chunking templates at stored sizes), builds a task-per-chunk dask graph
-        # even under compute=False, which is slow/OOM on our largest arrays.
         for replica_store in replica_stores:
             log.info(f"Writing metadata to replica {replica_store} with mode {mode}")
-            template_ds.to_zarr(
-                replica_store,
-                mode=mode,
-                compute=False,
-                safe_chunks=False,
-                write_empty_chunks=True,
-            )
+            _to_zarr_metadata(template, replica_store, mode)
 
         log.info(f"Writing metadata to store {store} with mode {mode}")
-        template_ds.to_zarr(
-            store,
-            mode=mode,
-            compute=False,
-            safe_chunks=False,
-            write_empty_chunks=True,
-        )
+        _to_zarr_metadata(template, store, mode)
 
     if isinstance(store, Path | str):
         sort_consolidated_metadata(Path(store) / "zarr.json")

--- a/src/reformatters/common/template_utils.py
+++ b/src/reformatters/common/template_utils.py
@@ -25,14 +25,10 @@ log = get_logger(__name__)
 def _to_zarr_metadata(
     template: xr.DataTree, store: Store | Path, mode: Literal["w", "w-"]
 ) -> None:
-    # safe_chunks=False: with compute=False only metadata and numpy coordinates
-    # are written, no dask chunks, so dask/zarr chunk alignment is irrelevant.
-    # The alternative, aligning dask chunks to the stored chunks (align_chunks=True
-    # or chunking templates at stored sizes), builds a task-per-chunk dask graph
-    # even under compute=False, which is slow/OOM on our largest arrays.
-    # write_inherited_coords=True writes each group's own copy of the shared coords
-    # so groups open standalone; see docs/plans/vertical_dimension_structure.md. It
-    # is a no-op for a single-level dataset (a one-node tree, no child groups).
+    # safe_chunks=False: with compute=False no dask chunks are written, so alignment
+    # is irrelevant; aligning instead builds a per-chunk dask graph that OOMs large arrays.
+    # write_inherited_coords=True writes each group's own copy of the shared coords so
+    # groups open standalone; see docs/plans/vertical_dimension_structure.md.
     template.to_zarr(
         store,
         mode=mode,
@@ -53,8 +49,7 @@ def write_metadata(
     replica_stores: list[Store]
 
     assert_fill_values_set(template_ds)
-    # A single-level dataset's template is a plain Dataset; wrap it as a one-node tree
-    # so there is one write path. A one-node tree writes byte-identically to the Dataset.
+    # A plain Dataset (single-level) wraps as a one-node tree so there's one write path.
     template = (
         template_ds
         if isinstance(template_ds, xr.DataTree)

--- a/src/reformatters/common/types.py
+++ b/src/reformatters/common/types.py
@@ -34,6 +34,10 @@ type Dim = Literal[
     "x",
     "y",
     "statistic",
+    # Vertical group dimensions (a group's name equals its dimension name); keep in
+    # sync with VerticalGroup in config_models.py.
+    "pressure_level",
+    "model_level",
 ]
 type AppendDim = Literal["init_time", "time"]
 assert set(get_args(AppendDim)) <= set(get_args(Dim))

--- a/src/reformatters/common/types.py
+++ b/src/reformatters/common/types.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import Enum, auto
 from typing import Annotated, Literal, get_args
 
 import numpy as np
@@ -34,10 +35,23 @@ type Dim = Literal[
     "x",
     "y",
     "statistic",
-    # Vertical group dimensions (a group's name equals its dimension name); keep in
-    # sync with VerticalGroup in config_models.py.
+    # Vertical group dimensions (a group's name equals its dimension name, see VerticalGroup).
     "pressure_level",
     "model_level",
 ]
 type AppendDim = Literal["init_time", "time"]
-assert set(get_args(AppendDim)) <= set(get_args(Dim))
+assert set(get_args(AppendDim.__value__)) <= set(get_args(Dim.__value__))
+
+
+class RootGroup(Enum):
+    ROOT = auto()  # pure sentinel; the root zarr group has no name
+
+
+ROOT = RootGroup.ROOT
+
+# A variable on a dense, comparable vertical dimension lives in a zarr group named
+# after that dimension (group name == dimension name). Expand as new types are added.
+type VerticalGroup = Literal["pressure_level", "model_level"]
+# A variable's group: ROOT (single-level, lives at the dataset root) or a vertical group.
+type Group = VerticalGroup | RootGroup
+assert set(get_args(VerticalGroup.__value__)) <= set(get_args(Dim.__value__))

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -14,6 +14,7 @@ from zarr.core.metadata import ArrayV3Metadata
 
 from reformatters.common import storage
 from reformatters.common.config_models import DataVar
+from reformatters.common.iterating import node_group_name
 from reformatters.common.logging import get_logger
 from reformatters.common.region_job import (
     DATA_VAR,
@@ -322,11 +323,9 @@ class VirtualRegionJob(
         Returns None if a label is not in the template's coords (the filter treats
         that as "remaining").
         """
-        # Geometry comes from the checked-in template, not the in-code
-        # DataVar.encoding which could drift; shared by the filter and emitter.
-        # Index by var.path so a vertical-group var resolves to its group node, and
-        # read coordinate positions from the var's own DataArray (which carries its
-        # vertical coord, absent from the root).
+        # Geometry comes from the checked-in template, not in-code DataVar.encoding
+        # which could drift. Index by var.path so a vertical-group var resolves to its
+        # group node (its DataArray carries the vertical coord, absent from the root).
         template_var = self.template_ds[var.path]
         dims = tuple(str(d) for d in template_var.dims)
         chunks = template_var.encoding["chunks"]
@@ -364,13 +363,13 @@ class VirtualRegionJob(
     ) -> None:
         """Grow the append dim (and its dependent coords) to `needed_append_dim_size`
         in every group (DataTree.to_zarr has no append_dim, so each node is appended
-        on its own; groups may sit at different lengths transiently)."""
+        on its own)."""
         # compute=False keeps data vars dask-lazy so the decode-only serializer is
-        # never invoked. Each (store, group)'s missing slice is from its own committed
-        # size: replicas can be a commit ahead, so the primary's slice would duplicate.
+        # never invoked. Each (store, group)'s missing slice is read from its own
+        # committed size.
         for store in stores:
             for node in self.template_ds.subtree:
-                group = None if node.path == "/" else node.path.removeprefix("/")
+                group = node_group_name(node)
                 current_size = self._append_dim_size(store, group)
                 if needed_append_dim_size <= current_size:
                     continue

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -130,7 +130,7 @@ class VirtualRegionJob(
             if index is None:
                 keyed.append((coord, None))
                 continue
-            array = group[var.name]
+            array = group[var.path]
             assert isinstance(array, zarr.Array)
             metadata = array.metadata
             assert isinstance(metadata, ArrayV3Metadata)
@@ -276,7 +276,7 @@ class VirtualRegionJob(
         rep = self.representative_var(coord)
         probe = self.chunk_key(coord.out_loc(), rep)
         assert any(
-            ref.data_var.name == rep.name and self.chunk_key(ref.out_loc, rep) == probe
+            ref.data_var.path == rep.path and self.chunk_key(ref.out_loc, rep) == probe
             for ref in file_refs
         ), (
             f"refs for {coord} do not cover representative chunk "
@@ -295,7 +295,7 @@ class VirtualRegionJob(
                 f"ref {ref.data_var.name} {dict(ref.out_loc)} did not resolve to a "
                 "chunk index after expansion"
             )
-            specs_by_var.setdefault(ref.data_var.name, []).append(
+            specs_by_var.setdefault(ref.data_var.path, []).append(
                 VirtualChunkSpec(
                     index=list(index),
                     location=ref.location,
@@ -304,12 +304,13 @@ class VirtualRegionJob(
                 )
             )
         for store in stores:
-            for var_name, specs in specs_by_var.items():
+            for array_path, specs in specs_by_var.items():
+                # array_path is group-qualified (e.g. "pressure_level/temperature").
                 failed = store.set_virtual_refs(
-                    var_name, specs, validate_containers=True
+                    array_path, specs, validate_containers=True
                 )
                 assert failed is None, (
-                    f"{len(failed)} virtual ref(s) for {var_name} did not match a "
+                    f"{len(failed)} virtual ref(s) for {array_path} did not match a "
                     f"registered container, e.g. {failed[:3]}"
                 )
 
@@ -323,7 +324,10 @@ class VirtualRegionJob(
         """
         # Geometry comes from the checked-in template, not the in-code
         # DataVar.encoding which could drift; shared by the filter and emitter.
-        template_var = self.template_ds[var.name]
+        # Index by var.path so a vertical-group var resolves to its group node, and
+        # read coordinate positions from the var's own DataArray (which carries its
+        # vertical coord, absent from the root).
+        template_var = self.template_ds[var.path]
         dims = tuple(str(d) for d in template_var.dims)
         chunks = template_var.encoding["chunks"]
         assert len(chunks) == len(dims)
@@ -333,9 +337,7 @@ class VirtualRegionJob(
         for dim, chunk_size in zip(dims, chunks, strict=True):
             if dim in labels:
                 position = int(
-                    self.template_ds.get_index(dim).get_indexer(
-                        pd.Index([labels[dim]])
-                    )[0]
+                    template_var.get_index(dim).get_indexer(pd.Index([labels[dim]]))[0]
                 )
                 if position < 0:
                     return None  # label not in coords -> not yet a position in this dataset
@@ -360,32 +362,46 @@ class VirtualRegionJob(
     def sync_dims_to(
         self, stores: Sequence[IcechunkStore], needed_append_dim_size: int
     ) -> None:
-        """Grow the append dim (and its dependent coords) to `needed_append_dim_size`."""
+        """Grow the append dim (and its dependent coords) to `needed_append_dim_size`
+        in every group (DataTree.to_zarr has no append_dim, so each node is appended
+        on its own; groups may sit at different lengths transiently)."""
         # compute=False keeps data vars dask-lazy so the decode-only serializer is
-        # never invoked. Each store's missing slice is from its own committed size:
-        # replicas can be a commit ahead, so the primary's slice would duplicate.
+        # never invoked. Each (store, group)'s missing slice is from its own committed
+        # size: replicas can be a commit ahead, so the primary's slice would duplicate.
         for store in stores:
-            current_size = self._append_dim_size(store)
-            if needed_append_dim_size <= current_size:
-                continue
-            slice_ds = self.template_ds.isel(
-                {self.append_dim: slice(current_size, needed_append_dim_size)}
-            )
-            slice_ds.to_zarr(
-                store, append_dim=self.append_dim, compute=False, consolidated=False
-            )
+            for node in self.template_ds.subtree:
+                group = None if node.path == "/" else node.path.removeprefix("/")
+                current_size = self._append_dim_size(store, group)
+                if needed_append_dim_size <= current_size:
+                    continue
+                slice_ds = node.to_dataset().isel(
+                    {self.append_dim: slice(current_size, needed_append_dim_size)}
+                )
+                slice_ds.to_zarr(
+                    store,
+                    group=group,
+                    append_dim=self.append_dim,
+                    compute=False,
+                    consolidated=False,
+                )
 
     def _needed_append_dim_size(self, refs: Sequence[VirtualRef]) -> int:
-        positions = self.template_ds.get_index(self.append_dim).get_indexer(
-            pd.Index([ref.out_loc[self.append_dim] for ref in refs])
+        positions = (
+            self.template_ds.coords[self.append_dim]
+            .to_index()
+            .get_indexer(pd.Index([ref.out_loc[self.append_dim] for ref in refs]))
         )
         assert (positions >= 0).all(), (
             "a ref's append-dim label is not present in the template"
         )
         return int(positions.max()) + 1
 
-    def _append_dim_size(self, store: IcechunkStore) -> int:
-        array = zarr.open_group(store, mode="r")[self.append_dim]
+    def _append_dim_size(self, store: IcechunkStore, group: str | None = None) -> int:
+        node = zarr.open_group(store, mode="r")
+        if group is not None:
+            node = node[group]
+            assert isinstance(node, zarr.Group)
+        array = node[self.append_dim]
         assert isinstance(array, zarr.Array)
         return int(array.shape[0])
 
@@ -395,8 +411,7 @@ class VirtualRegionJob(
         assert processing_region == self.region, (
             "VirtualRegionJob.get_processing_region must equal self.region"
         )
-        ds: xr.Dataset = self.template_ds[[v.name for v in self.data_vars]]  # ty: ignore[invalid-assignment]
-        return ds.isel({self.append_dim: processing_region})
+        return self._flat_job_dataset().isel({self.append_dim: processing_region})
 
 
 def _exists_many(store: IcechunkStore, keys: Sequence[str]) -> dict[str, bool]:

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -410,7 +410,15 @@ class VirtualRegionJob(
         assert processing_region == self.region, (
             "VirtualRegionJob.get_processing_region must equal self.region"
         )
-        return self._flat_job_dataset().isel({self.append_dim: processing_region})
+        # generate_source_file_coords reads only coordinate values, so pass the region's
+        # coords from every group — never the data vars, whose names can collide across
+        # vertical groups.
+        coords = {
+            name: coord
+            for node in self.template_ds.subtree
+            for name, coord in node.to_dataset().coords.items()
+        }
+        return xr.Dataset(coords=coords).isel({self.append_dim: processing_region})
 
 
 def _exists_many(store: IcechunkStore, keys: Sequence[str]) -> dict[str, bool]:

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -243,7 +243,12 @@ class VirtualRegionJob(
             self._processing_region_ds(), self.data_vars
         )
         remaining = self.filter_already_present(candidates, readonly_store)
-        current_size = self._append_dim_size(readonly_store)
+        # The smallest group, so the sync_dims_to shortcut below can never skip a group
+        # that lags root (e.g. after a partially-applied prior grow).
+        current_size = min(
+            self._append_dim_size(readonly_store, node_group_name(node))
+            for node in self.template_ds.subtree
+        )
 
         for file_refs_batch in self.process_virtual_refs(remaining):
             assert file_refs_batch, "process_virtual_refs yielded an empty batch"

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -9,6 +9,7 @@ from icechunk.store import IcechunkStore
 from zarr.abc.store import Store
 from zarr.codecs import BloscCodec
 
+from reformatters.common.iterating import node_group_name
 from reformatters.common.logging import get_logger
 from reformatters.common.retry import retry
 
@@ -102,7 +103,7 @@ def _coord_chunk_globs(template_ds: xr.Dataset | xr.DataTree) -> list[str]:
     if isinstance(template_ds, xr.DataTree):
         globs = []
         for node in template_ds.subtree:
-            prefix = "" if node.path == "/" else node.path.removeprefix("/") + "/"
+            prefix = f"{group}/" if (group := node_group_name(node)) else ""
             globs.extend(
                 f"{prefix}{coord}/c/**/*" for coord in node.to_dataset().coords
             )

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -99,11 +99,16 @@ def _copy_data_var_chunks(
 
 
 def _coord_chunk_globs(template_ds: xr.DataTree) -> list[str]:
-    """Glob patterns for every coordinate's chunk files, group-prefixed."""
+    """Glob patterns for every coordinate's chunk files, group-prefixed. The `c/**/*`
+    pattern catches chunked coords (`<coord>/c/0`, `<coord>/c/0/0`); the bare `c` catches
+    a scalar coord whose single chunk is the file `<coord>/c` (the caller's is_file filter
+    drops the `c/` directory matched by the bare pattern for non-scalar coords)."""
     globs = []
     for node in template_ds.subtree:
         prefix = node_path_prefix(node)
-        globs.extend(f"{prefix}{coord}/c/**/*" for coord in node.to_dataset().coords)
+        for coord in node.to_dataset().coords:
+            globs.append(f"{prefix}{coord}/c/**/*")
+            globs.append(f"{prefix}{coord}/c")
     return globs
 
 

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -97,8 +97,21 @@ def _copy_data_var_chunks(
         sync_to_store(store, key, file.read_bytes())
 
 
+def _coord_chunk_globs(template_ds: xr.Dataset | xr.DataTree) -> list[str]:
+    """Glob patterns for every coordinate's chunk files, group-prefixed for a tree."""
+    if isinstance(template_ds, xr.DataTree):
+        globs = []
+        for node in template_ds.subtree:
+            prefix = "" if node.path == "/" else node.path.removeprefix("/") + "/"
+            globs.extend(
+                f"{prefix}{coord}/c/**/*" for coord in node.to_dataset().coords
+            )
+        return globs
+    return [f"{coord}/c/**/*" for coord in template_ds.coords]
+
+
 def copy_zarr_metadata(
-    template_ds: xr.Dataset,
+    template_ds: xr.Dataset | xr.DataTree,
     tmp_store: Path,
     primary_store: Store,
     replica_stores: Iterable[Store] = (),
@@ -118,11 +131,14 @@ def copy_zarr_metadata(
     assert not (icechunk_only and zarr3_only)
 
     coord_chunk_files: list[Path] = []
-    for coord in template_ds.coords:
-        coord_chunk_files.extend(
-            f for f in tmp_store.glob(f"{coord}/c/**/*") if f.is_file()
-        )
-    zarr_json_files = [tmp_store / "zarr.json", *tmp_store.glob("*/zarr.json")]
+    for coord_glob in _coord_chunk_globs(template_ds):
+        coord_chunk_files.extend(f for f in tmp_store.glob(coord_glob) if f.is_file())
+    # Shallowest first so a parent group's metadata is written before its children's
+    # (icechunk rejects a child array whose parent group does not yet exist).
+    zarr_json_files = sorted(
+        tmp_store.rglob("zarr.json"),
+        key=lambda p: len(p.relative_to(tmp_store).parts),
+    )
 
     def _ordered_files(store: Store) -> list[Path]:
         # Zarr v3: coordinate label chunks before metadata, so readers never see
@@ -181,7 +197,14 @@ def sync_to_store(store: Store, key: str, data: bytes) -> None:
     )
 
 
-def assert_fill_values_set(xr_obj: xr.Dataset | xr.DataArray) -> None:
+def assert_fill_values_set(
+    xr_obj: xr.Dataset | xr.DataArray | xr.DataTree,
+) -> None:
+    if isinstance(xr_obj, xr.DataTree):
+        for node in xr_obj.subtree:
+            assert_fill_values_set(node.to_dataset())
+        return
+
     if isinstance(xr_obj, xr.DataArray):
         assert "fill_value" in xr_obj.encoding, (
             f"Fill value not set for DataArray {xr_obj.name}"

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -98,21 +98,17 @@ def _copy_data_var_chunks(
         sync_to_store(store, key, file.read_bytes())
 
 
-def _coord_chunk_globs(template_ds: xr.Dataset | xr.DataTree) -> list[str]:
-    """Glob patterns for every coordinate's chunk files, group-prefixed for a tree."""
-    if isinstance(template_ds, xr.DataTree):
-        globs = []
-        for node in template_ds.subtree:
-            prefix = f"{group}/" if (group := node_group_name(node)) else ""
-            globs.extend(
-                f"{prefix}{coord}/c/**/*" for coord in node.to_dataset().coords
-            )
-        return globs
-    return [f"{coord}/c/**/*" for coord in template_ds.coords]
+def _coord_chunk_globs(template_ds: xr.DataTree) -> list[str]:
+    """Glob patterns for every coordinate's chunk files, group-prefixed."""
+    globs = []
+    for node in template_ds.subtree:
+        prefix = f"{group}/" if (group := node_group_name(node)) else ""
+        globs.extend(f"{prefix}{coord}/c/**/*" for coord in node.to_dataset().coords)
+    return globs
 
 
 def copy_zarr_metadata(
-    template_ds: xr.Dataset | xr.DataTree,
+    template_ds: xr.DataTree,
     tmp_store: Path,
     primary_store: Store,
     replica_stores: Iterable[Store] = (),

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -9,7 +9,7 @@ from icechunk.store import IcechunkStore
 from zarr.abc.store import Store
 from zarr.codecs import BloscCodec
 
-from reformatters.common.iterating import node_group_name
+from reformatters.common.iterating import node_path_prefix
 from reformatters.common.logging import get_logger
 from reformatters.common.retry import retry
 
@@ -102,7 +102,7 @@ def _coord_chunk_globs(template_ds: xr.DataTree) -> list[str]:
     """Glob patterns for every coordinate's chunk files, group-prefixed."""
     globs = []
     for node in template_ds.subtree:
-        prefix = f"{group}/" if (group := node_group_name(node)) else ""
+        prefix = node_path_prefix(node)
         globs.extend(f"{prefix}{coord}/c/**/*" for coord in node.to_dataset().coords)
     return globs
 

--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/region_job.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/region_job.py
@@ -115,13 +115,13 @@ class NasaSmapLevel336KmV9RegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[NasaSmapDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[NasaSmapDataVar, NasaSmapLevel336KmV9SourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         """
         Return the sequence of RegionJob instances necessary to update the dataset

--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/template_config.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/template_config.py
@@ -8,6 +8,7 @@ from pydantic import computed_field
 from pyproj import Transformer
 
 from reformatters.common.config_models import (
+    ROOT,
     BaseInternalAttrs,
     Coordinate,
     CoordinateAttrs,
@@ -15,6 +16,7 @@ from reformatters.common.config_models import (
     DataVar,
     DataVarAttrs,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import (
@@ -37,7 +39,7 @@ class NasaSmapDataVar(DataVar[NasaSmapInternalAttrs]):
 
 
 class NasaSmapLevel336KmV9TemplateConfig(TemplateConfig[NasaSmapDataVar]):
-    dims: tuple[Dim, ...] = ("time", "y", "x")
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time", "y", "x")}
     append_dim: AppendDim = "time"
     append_dim_start: Timestamp = pd.Timestamp("2015-04-01T00:00")
     append_dim_frequency: Timedelta = pd.Timedelta("1D")
@@ -264,8 +266,8 @@ class NasaSmapLevel336KmV9TemplateConfig(TemplateConfig[NasaSmapDataVar]):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=np.nan,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/region_job.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/region_job.py
@@ -313,13 +313,13 @@ class NoaaNdviCdrAnalysisRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[NoaaNdviCdrDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[NoaaNdviCdrDataVar, NoaaNdviCdrAnalysisSourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         existing_ds = xr.open_zarr(primary_store)
         append_dim_start = existing_ds[append_dim].max()

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/template_config.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/template_config.py
@@ -7,6 +7,7 @@ import pandas as pd
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     BaseInternalAttrs,
     Coordinate,
     CoordinateAttrs,
@@ -14,6 +15,7 @@ from reformatters.common.config_models import (
     DataVar,
     DataVarAttrs,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import (
@@ -52,7 +54,7 @@ class NoaaNdviCdrDataVar(DataVar[NoaaNdviCdrInternalAttrs]):
 
 
 class NoaaNdviCdrAnalysisTemplateConfig(TemplateConfig[NoaaNdviCdrDataVar]):
-    dims: tuple[Dim, ...] = ("time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time", "latitude", "longitude")}
     append_dim: AppendDim = "time"
     append_dim_start: Timestamp = pd.Timestamp("1981-06-24")
     append_dim_frequency: Timedelta = pd.Timedelta("1D")
@@ -221,16 +223,16 @@ class NoaaNdviCdrAnalysisTemplateConfig(TemplateConfig[NoaaNdviCdrDataVar]):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=0,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 
         encoding_int16_default = Encoding(
             dtype="int16",
             fill_value=QA_ENCODING_FILL_VALUE,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_2BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/contrib/uarizona/swann/analysis/region_job.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/region_job.py
@@ -90,13 +90,13 @@ class UarizonaSwannAnalysisRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[UarizonaSwannDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[UarizonaSwannDataVar, UarizonaSwannAnalysisSourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         existing_ds = xr.open_zarr(primary_store)
         append_dim_start = cls._update_append_dim_start(existing_ds)

--- a/src/reformatters/contrib/uarizona/swann/analysis/template_config.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/template_config.py
@@ -6,6 +6,7 @@ import pandas as pd
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     BaseInternalAttrs,
     Coordinate,
     CoordinateAttrs,
@@ -13,6 +14,7 @@ from reformatters.common.config_models import (
     DataVar,
     DataVarAttrs,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import (
@@ -35,7 +37,7 @@ class UarizonaSwannDataVar(DataVar[UarizonaSwannInternalAttrs]):
 
 
 class UarizonaSwannAnalysisTemplateConfig(TemplateConfig[UarizonaSwannDataVar]):
-    dims: tuple[Dim, ...] = ("time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time", "latitude", "longitude")}
     append_dim: AppendDim = "time"
     append_dim_start: Timestamp = pd.Timestamp("1981-10-01")
     append_dim_frequency: Timedelta = pd.Timedelta("1D")
@@ -209,8 +211,8 @@ class UarizonaSwannAnalysisTemplateConfig(TemplateConfig[UarizonaSwannDataVar]):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=0,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
@@ -91,7 +91,7 @@ class DwdIconEuForecast5DayRegionJob(
     MaterializedRegionJob[DwdIconEuDataVar, DwdIconEuForecast5DaySourceFileCoord]
 ):
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[DwdIconEuDataVar],
     ) -> Sequence[Sequence[DwdIconEuDataVar]]:
@@ -204,13 +204,13 @@ class DwdIconEuForecast5DayRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[DwdIconEuDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[DwdIconEuDataVar, DwdIconEuForecast5DaySourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         """Return RegionJob instances to update the dataset from its current state to the latest available data."""
         existing_ds = xr.open_zarr(primary_store, chunks=None)

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/template_config.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/template_config.py
@@ -7,6 +7,7 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     BaseInternalAttrs,
     Coordinate,
     CoordinateAttrs,
@@ -14,6 +15,7 @@ from reformatters.common.config_models import (
     DataVar,
     DataVarAttrs,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.deaccumulation import (
@@ -62,7 +64,9 @@ class DwdIconEuDataVar(DataVar[DwdIconEuInternalAttrs]):
 
 
 class DwdIconEuForecast5DayTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
-    dims: tuple[Dim, ...] = ("init_time", "lead_time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: ("init_time", "lead_time", "latitude", "longitude")
+    }
     append_dim: AppendDim = "init_time"
     append_dim_start: Timestamp = pd.Timestamp("2026-02-10T00:00")
     append_dim_frequency: Timedelta = pd.Timedelta("6h")
@@ -332,8 +336,8 @@ class DwdIconEuForecast5DayTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=np.nan,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/region_job.py
@@ -103,7 +103,7 @@ class EcmwfAifsEnsForecastRegionJob(
     max_vars_per_job: ClassVar[int] = 4
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[EcmwfDataVar],
     ) -> Sequence[Sequence[EcmwfDataVar]]:
@@ -237,13 +237,13 @@ class EcmwfAifsEnsForecastRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[EcmwfDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[EcmwfDataVar, EcmwfAifsEnsForecastSourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         existing_ds = xr.open_zarr(primary_store, chunks=None)
         append_dim_start = existing_ds[append_dim].max()

--- a/src/reformatters/ecmwf/aifs_ens/forecast/template_config.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/template_config.py
@@ -7,11 +7,13 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     DataVarAttrs,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.deaccumulation import (
@@ -31,13 +33,15 @@ from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, EcmwfInternalAt
 
 
 class EcmwfAifsEnsForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
-    dims: tuple[Dim, ...] = (
-        "init_time",
-        "lead_time",
-        "ensemble_member",
-        "latitude",
-        "longitude",
-    )
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: (
+            "init_time",
+            "lead_time",
+            "ensemble_member",
+            "latitude",
+            "longitude",
+        )
+    }
     append_dim: AppendDim = "init_time"
     # AIFS-ENS first appears in the ecmwf-forecasts open data bucket on 2025-07-02 00z.
     append_dim_start: Timestamp = pd.Timestamp("2025-07-02T00:00")
@@ -311,8 +315,8 @@ class EcmwfAifsEnsForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=np.nan,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -98,7 +98,7 @@ class EcmwfAifsSingleForecastRegionJob(
     max_vars_per_download_group: ClassVar[int] = 10
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[EcmwfDataVar],
     ) -> Sequence[Sequence[EcmwfDataVar]]:
@@ -231,13 +231,13 @@ class EcmwfAifsSingleForecastRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[EcmwfDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[EcmwfDataVar, EcmwfAifsSingleForecastSourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         existing_ds = xr.open_zarr(primary_store, chunks=None)
         append_dim_start = existing_ds[append_dim].max()

--- a/src/reformatters/ecmwf/aifs_single/forecast/template_config.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/template_config.py
@@ -7,11 +7,13 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     DataVarAttrs,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.deaccumulation import (
@@ -35,7 +37,9 @@ from reformatters.ecmwf.ecmwf_config_models import (
 
 
 class EcmwfAifsSingleForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
-    dims: tuple[Dim, ...] = ("init_time", "lead_time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: ("init_time", "lead_time", "latitude", "longitude")
+    }
     append_dim: AppendDim = "init_time"
     # Start from 2024-04-01 when PL u/v are available and the grid is regular 0.25 degree.
     # Earlier data (2024-02-29 to 2024-03-13) uses a reduced Gaussian grid.
@@ -288,8 +292,8 @@ class EcmwfAifsSingleForecastTemplateConfig(TemplateConfig[EcmwfDataVar]):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=np.nan,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -54,7 +54,7 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
     max_vars_per_job: ClassVar[int] = 1
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[EcmwfDataVar],
     ) -> Sequence[Sequence[EcmwfDataVar]]:
@@ -246,13 +246,13 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[EcmwfDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[EcmwfDataVar, IfsEnsSourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         """
         Return the sequence of RegionJob instances necessary to update the dataset
@@ -267,7 +267,7 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
             The primary store to read existing data from and write updates to.
         tmp_store : Path
             The temporary Zarr store to write into while processing.
-        get_template_fn : Callable[[DatetimeLike], xr.Dataset]
+        get_template_fn : Callable[[DatetimeLike], xr.DataTree]
             Function to get the template_ds for the operational update.
         append_dim : AppendDim
             The dimension along which data is appended (e.g., "time").

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py
@@ -7,11 +7,13 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     DataVarAttrs,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.deaccumulation import (
@@ -35,13 +37,15 @@ from reformatters.ecmwf.ecmwf_config_models import (
 
 
 class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVar]):
-    dims: tuple[Dim, ...] = (
-        "init_time",
-        "lead_time",
-        "ensemble_member",
-        "latitude",
-        "longitude",
-    )
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: (
+            "init_time",
+            "lead_time",
+            "ensemble_member",
+            "latitude",
+            "longitude",
+        )
+    }
     append_dim: AppendDim = "init_time"
     # While this dataset has a longer history, April 2024 is when we have enough 0.25 degree resolution data to start processing, with
     # the correct number of longitude values (1440), and the majority of the variables we are interested in are available.
@@ -331,8 +335,8 @@ class EcmwfIfsEnsForecast15Day025DegreeTemplateConfig(TemplateConfig[EcmwfDataVa
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=np.nan,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/example/region_job.py
+++ b/src/reformatters/example/region_job.py
@@ -62,7 +62,7 @@ class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCo
     # Implement this method only if different variables must be retrieved from different urls
     #
     # # @classmethod
-    # def source_groups(
+    # def source_file_var_groups(
     #     cls,
     #     data_vars: Sequence[ExampleDataVar],
     # ) -> Sequence[Sequence[ExampleDataVar]]:
@@ -160,7 +160,7 @@ class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCo
 
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[SourceFileResult]]
-    ) -> xr.Dataset:
+    ) -> xr.DataTree:
         """
         Update template dataset based on processing results. This method is called
         during operational updates.
@@ -217,11 +217,13 @@ class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCo
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[ExampleDataVar],
         reformat_job_name: str,
-    ) -> tuple[Sequence[RegionJob[ExampleDataVar, ExampleSourceFileCoord]], xr.Dataset]:
+    ) -> tuple[
+        Sequence[RegionJob[ExampleDataVar, ExampleSourceFileCoord]], xr.DataTree
+    ]:
         """
         Return the sequence of RegionJob instances necessary to update the dataset
         from its current state to include the latest available data.
@@ -244,7 +246,7 @@ class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCo
             The primary store to read existing data from and write updates to.
         tmp_store : Path
             The temporary Zarr store to write into while processing.
-        get_template_fn : Callable[[DatetimeLike], xr.Dataset]
+        get_template_fn : Callable[[DatetimeLike], xr.DataTree]
             Function to get the template_ds for the operational update.
         append_dim : AppendDim
             The dimension along which data is appended (e.g., "time").

--- a/src/reformatters/example/template_config.py
+++ b/src/reformatters/example/template_config.py
@@ -44,6 +44,12 @@ class ExampleDataVar(DataVar[ExampleInternalAttrs]):
 
 
 class ExampleTemplateConfig(TemplateConfig[ExampleDataVar]):
+    # Single-level dataset: all vars live at the root. To add a vertical group, add an
+    # entry whose key is the group/dimension name and whose dims are the root dims plus
+    # that dimension, then set group=... on the group's DataVars (their zarr path becomes
+    # "<group>/<name>"). E.g.:
+    #   "pressure_level": ("init_time", "lead_time", "latitude", "longitude", "pressure_level"),
+    # See docs/plans/vertical_dimension_structure.md.
     dims: dict[Group, tuple[Dim, ...]] = {
         ROOT: ("init_time", "lead_time", "latitude", "longitude")
     }

--- a/src/reformatters/example/template_config.py
+++ b/src/reformatters/example/template_config.py
@@ -7,6 +7,7 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     BaseInternalAttrs,
     Coordinate,
     CoordinateAttrs,  # noqa: F401
@@ -14,6 +15,7 @@ from reformatters.common.config_models import (
     DataVar,
     DataVarAttrs,  # noqa: F401
     Encoding,  # noqa: F401
+    Group,
     StatisticsApproximate,  # noqa: F401
 )
 from reformatters.common.template_config import (
@@ -42,7 +44,9 @@ class ExampleDataVar(DataVar[ExampleInternalAttrs]):
 
 
 class ExampleTemplateConfig(TemplateConfig[ExampleDataVar]):
-    dims: tuple[Dim, ...] = ("init_time", "lead_time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: ("init_time", "lead_time", "latitude", "longitude")
+    }
     append_dim: AppendDim = "init_time"
     append_dim_start: Timestamp = pd.Timestamp("2020-01-01T00:00")
     append_dim_frequency: Timedelta = pd.Timedelta("6h")
@@ -290,8 +294,8 @@ class ExampleTemplateConfig(TemplateConfig[ExampleDataVar]):
         # encoding_float32_default = Encoding(
         #     dtype="float32",
         #     fill_value=np.nan,
-        #     chunks=tuple(var_chunks[d] for d in self.dims),
-        #     shards=tuple(var_shards[d] for d in self.dims),
+        #     chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+        #     shards=tuple(var_shards[d] for d in self.dims[ROOT]),
         #     compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         # )
 

--- a/src/reformatters/noaa/gefs/analysis/region_job.py
+++ b/src/reformatters/noaa/gefs/analysis/region_job.py
@@ -81,7 +81,7 @@ class GefsAnalysisRegionJob(
         )
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls, data_vars: Sequence[GEFSDataVar]
     ) -> Sequence[Sequence[GEFSDataVar]]:
         # max_vars_per_download_group = 1 will cause all variables to be processed independently
@@ -153,7 +153,7 @@ class GefsAnalysisRegionJob(
         self, coord: GefsAnalysisSourceFileCoord, data_var: GEFSDataVar
     ) -> ArrayND[np.generic]:
         """Read data from the source file for the given coordinate and variable."""
-        return read_data(self.template_ds, coord, data_var)
+        return read_data(self.template_ds.to_dataset(), coord, data_var)
 
     def apply_data_transformations(
         self, data_array: xr.DataArray, data_var: GEFSDataVar
@@ -194,12 +194,12 @@ class GefsAnalysisRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[GEFSDataVar],
         reformat_job_name: str,
     ) -> tuple[
-        Sequence[RegionJob[GEFSDataVar, GefsAnalysisSourceFileCoord]], xr.Dataset
+        Sequence[RegionJob[GEFSDataVar, GefsAnalysisSourceFileCoord]], xr.DataTree
     ]:
         """
         Return the sequence of RegionJob instances necessary to update the dataset
@@ -231,7 +231,7 @@ class GefsAnalysisRegionJob(
 
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[SourceFileResult]]
-    ) -> xr.Dataset:
+    ) -> xr.DataTree:
         # Remove the last hour because most variables (except precip) lack hour 0 values.
         # Precipitation extends to hour 6 of the latest forecast, but other variables do not,
         # so we trim the final hour to keep all variables aligned.

--- a/src/reformatters/noaa/gefs/analysis/template_config.py
+++ b/src/reformatters/noaa/gefs/analysis/template_config.py
@@ -5,10 +5,12 @@ import pandas as pd
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import TemplateConfig
@@ -25,7 +27,7 @@ from reformatters.noaa.gefs.gefs_config_models import GEFSDataVar
 class GefsAnalysisTemplateConfig(TemplateConfig[GEFSDataVar]):
     """Template configuration for GEFS analysis dataset."""
 
-    dims: tuple[Dim, ...] = ("time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time", "latitude", "longitude")}
     append_dim: AppendDim = "time"
     append_dim_start: Timestamp = pd.Timestamp("2000-01-01T00:00")
     append_dim_frequency: Timedelta = pd.Timedelta("3h")
@@ -115,9 +117,9 @@ class GefsAnalysisTemplateConfig(TemplateConfig[GEFSDataVar]):
             "longitude": var_chunks["longitude"] * 12,  # 4 shards over 1440 pixels
         }
 
-        assert self.dims == tuple(var_chunks.keys())
+        assert self.dims[ROOT] == tuple(var_chunks.keys())
 
-        var_chunks_ordered = tuple(var_chunks[dim] for dim in self.dims)
-        var_shards_ordered = tuple(var_shards[dim] for dim in self.dims)
+        var_chunks_ordered = tuple(var_chunks[dim] for dim in self.dims[ROOT])
+        var_shards_ordered = tuple(var_shards[dim] for dim in self.dims[ROOT])
 
         return get_shared_data_var_configs(var_chunks_ordered, var_shards_ordered)

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/region_job.py
@@ -151,13 +151,13 @@ class GefsForecast10DaySpatialRegionJob(
         cls,
         primary_store: Store,  # noqa: ARG003 - the icechunk manifest, not a coordinate, tracks ingested data
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[GEFSDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[GEFSDataVar, GefsForecast10DaySpatialSourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         """A single polling job over the recent init times (24h window, the last 4 inits).
 
@@ -167,7 +167,7 @@ class GefsForecast10DaySpatialRegionJob(
         """
         append_dim_end = pd.Timestamp.now()
         template_ds = get_template_fn(append_dim_end)
-        init_times = template_ds.get_index(append_dim)
+        init_times = template_ds.to_dataset().get_index(append_dim)
         window_start = int(
             init_times.searchsorted(append_dim_end - pd.Timedelta("24h"))
         )

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/template_config.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/template_config.py
@@ -8,10 +8,12 @@ from gribberish.zarr import GribberishCodec
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.pydantic import replace
@@ -62,13 +64,15 @@ class GefsForecast10DaySpatialTemplateConfig(TemplateConfig[GEFSDataVar]):
     and lead times stop at 240h where the s files end. See docs/virtual_datasets.md.
     """
 
-    dims: tuple[Dim, ...] = (
-        "init_time",
-        "ensemble_member",
-        "lead_time",
-        "latitude",
-        "longitude",
-    )
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: (
+            "init_time",
+            "ensemble_member",
+            "lead_time",
+            "latitude",
+            "longitude",
+        )
+    }
     append_dim: AppendDim = "init_time"
     append_dim_start: Timestamp = pd.Timestamp("2020-10-01T00:00")
     append_dim_frequency: Timedelta = pd.Timedelta("6h")

--- a/src/reformatters/noaa/gefs/forecast_35_day/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/region_job.py
@@ -42,7 +42,7 @@ class GefsForecast35DayRegionJob(
     max_vars_per_job = 3
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls, data_vars: Sequence[GEFSDataVar]
     ) -> Sequence[Sequence[GEFSDataVar]]:
         """
@@ -94,7 +94,7 @@ class GefsForecast35DayRegionJob(
         self, coord: GefsForecast35DaySourceFileCoord, data_var: GEFSDataVar
     ) -> ArrayND[np.generic]:
         """Read data from the source file for the given coordinate and variable."""
-        return read_data(self.template_ds, coord, data_var)
+        return read_data(self.template_ds.to_dataset(), coord, data_var)
 
     def apply_data_transformations(
         self, data_array: xr.DataArray, data_var: GEFSDataVar
@@ -129,12 +129,12 @@ class GefsForecast35DayRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[GEFSDataVar],
         reformat_job_name: str,
     ) -> tuple[
-        Sequence[RegionJob[GEFSDataVar, GefsForecast35DaySourceFileCoord]], xr.Dataset
+        Sequence[RegionJob[GEFSDataVar, GefsForecast35DaySourceFileCoord]], xr.DataTree
     ]:
         """
         Return the sequence of RegionJob instances necessary to update the dataset

--- a/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
@@ -7,10 +7,12 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import SPATIAL_REF_COORDS, TemplateConfig
@@ -27,13 +29,15 @@ from reformatters.noaa.gefs.gefs_config_models import GEFSDataVar
 class GefsForecast35DayTemplateConfig(TemplateConfig[GEFSDataVar]):
     """Template configuration for GEFS 35-day forecast dataset."""
 
-    dims: tuple[Dim, ...] = (
-        "init_time",
-        "ensemble_member",
-        "lead_time",
-        "latitude",
-        "longitude",
-    )
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: (
+            "init_time",
+            "ensemble_member",
+            "lead_time",
+            "latitude",
+            "longitude",
+        )
+    }
     append_dim: AppendDim = "init_time"
     append_dim_start: Timestamp = pd.Timestamp("2020-10-01T00:00")
     append_dim_frequency: Timedelta = pd.Timedelta("24h")
@@ -279,8 +283,8 @@ class GefsForecast35DayTemplateConfig(TemplateConfig[GEFSDataVar]):
             "longitude": var_chunks["longitude"] * 23,  # 4 shards over 1440 pixels
         }
 
-        assert self.dims == tuple(var_chunks.keys())
-        var_chunks_ordered = tuple(var_chunks[dim] for dim in self.dims)
-        var_shards_ordered = tuple(var_shards[dim] for dim in self.dims)
+        assert self.dims[ROOT] == tuple(var_chunks.keys())
+        var_chunks_ordered = tuple(var_chunks[dim] for dim in self.dims[ROOT])
+        var_shards_ordered = tuple(var_shards[dim] for dim in self.dims[ROOT])
 
         return get_shared_data_var_configs(var_chunks_ordered, var_shards_ordered)

--- a/src/reformatters/noaa/gfs/analysis/region_job.py
+++ b/src/reformatters/noaa/gfs/analysis/region_job.py
@@ -66,7 +66,7 @@ class NoaaGfsAnalysisRegionJob(NoaaGfsCommonRegionJob):
 
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[SourceFileResult]]
-    ) -> xr.Dataset:
+    ) -> xr.DataTree:
         # Remove the last hour. We pull accumulated variables (precipitation) from the 1 hour lead time,
         # but use the 0 hour lead time for other variables. This results in one additional
         # hour of data for accumulated variables. Trim it off so we aren't left with nans for

--- a/src/reformatters/noaa/gfs/analysis/template_config.py
+++ b/src/reformatters/noaa/gfs/analysis/template_config.py
@@ -7,10 +7,12 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import SPATIAL_REF_COORDS
@@ -25,7 +27,7 @@ from reformatters.noaa.models import NoaaDataVar
 
 
 class NoaaGfsAnalysisTemplateConfig(NoaaGfsCommonTemplateConfig):
-    dims: tuple[Dim, ...] = ("time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time", "latitude", "longitude")}
     append_dim: AppendDim = "time"
     append_dim_start: Timestamp = pd.Timestamp("2021-05-01T00:00")
     append_dim_frequency: Timedelta = pd.Timedelta("1h")
@@ -113,8 +115,8 @@ class NoaaGfsAnalysisTemplateConfig(NoaaGfsCommonTemplateConfig):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=np.nan,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/noaa/gfs/forecast/template_config.py
+++ b/src/reformatters/noaa/gfs/forecast/template_config.py
@@ -7,10 +7,12 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import SPATIAL_REF_COORDS
@@ -24,7 +26,9 @@ from reformatters.noaa.models import NoaaDataVar
 
 
 class NoaaGfsForecastTemplateConfig(NoaaGfsCommonTemplateConfig):
-    dims: tuple[Dim, ...] = ("init_time", "lead_time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: ("init_time", "lead_time", "latitude", "longitude")
+    }
     append_dim: AppendDim = "init_time"
     append_dim_start: Timestamp = pd.Timestamp("2021-05-01T00:00")
     append_dim_frequency: Timedelta = pd.Timedelta("6h")
@@ -216,8 +220,8 @@ class NoaaGfsForecastTemplateConfig(NoaaGfsCommonTemplateConfig):
             # While in general we use nan as a fill_value, these datasets were backfilled
             # with fill_value = 0 and write_missing_chunks defaulting to false so we retain the 0 fill value
             fill_value=0,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/noaa/gfs/region_job.py
+++ b/src/reformatters/noaa/gfs/region_job.py
@@ -81,7 +81,7 @@ class NoaaGfsCommonRegionJob(
     """Common RegionJob for GFS datasets."""
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[NoaaDataVar],
     ) -> Sequence[Sequence[NoaaDataVar]]:
@@ -194,11 +194,11 @@ class NoaaGfsCommonRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[NoaaDataVar],
         reformat_job_name: str,
-    ) -> tuple[Sequence[RegionJob[NoaaDataVar, NoaaGfsSourceFileCoord]], xr.Dataset]:
+    ) -> tuple[Sequence[RegionJob[NoaaDataVar, NoaaGfsSourceFileCoord]], xr.DataTree]:
         """
         Return the sequence of RegionJob instances necessary to update the dataset
         from its current state to include the latest available data.

--- a/src/reformatters/noaa/hrrr/analysis/region_job.py
+++ b/src/reformatters/noaa/hrrr/analysis/region_job.py
@@ -63,7 +63,7 @@ class NoaaHrrrAnalysisRegionJob(NoaaHrrrRegionJob):
 
     def update_template_with_results(
         self, process_results: Mapping[str, Sequence[SourceFileResult]]
-    ) -> xr.Dataset:
+    ) -> xr.DataTree:
         # Remove the last hour. We pull accumulated variables (precipitation) from the 1 hour lead time,
         # but use the 0 hour lead time for other variables. This results in one additional
         # hour of data for accumulated variables. Trim it off so we aren't left with nans for

--- a/src/reformatters/noaa/hrrr/analysis/template_config.py
+++ b/src/reformatters/noaa/hrrr/analysis/template_config.py
@@ -7,10 +7,12 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import SPATIAL_REF_COORDS
@@ -27,7 +29,7 @@ from reformatters.noaa.hrrr.template_config import NoaaHrrrCommonTemplateConfig
 
 
 class NoaaHrrrAnalysisTemplateConfig(NoaaHrrrCommonTemplateConfig):
-    dims: tuple[Dim, ...] = ("time", "y", "x")
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time", "y", "x")}
     append_dim: AppendDim = "time"
     # HRRR operational start is 2014-09-30. We start at 2014-10-01 to skip the incomplete first day.
     append_dim_start: Timestamp = pd.Timestamp("2014-10-01T00:00")
@@ -126,8 +128,8 @@ class NoaaHrrrAnalysisTemplateConfig(NoaaHrrrCommonTemplateConfig):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=np.nan,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/template_config.py
@@ -7,10 +7,12 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     Coordinate,
     CoordinateAttrs,
     DatasetAttributes,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import SPATIAL_REF_COORDS
@@ -35,7 +37,7 @@ EXPECTED_FORECAST_LENGTH_BY_INIT_HOUR = pd.Series(
 
 class NoaaHrrrForecast48HourTemplateConfig(NoaaHrrrCommonTemplateConfig):
     # HRRR uses a projected coordinate system with x/y dimensions
-    dims: tuple[Dim, ...] = ("init_time", "lead_time", "y", "x")
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("init_time", "lead_time", "y", "x")}
     append_dim: AppendDim = "init_time"
     append_dim_start: Timestamp = pd.Timestamp("2018-07-13T12:00")  # start of HRRR v3
     append_dim_frequency: Timedelta = pd.Timedelta("6h")
@@ -233,8 +235,8 @@ class NoaaHrrrForecast48HourTemplateConfig(NoaaHrrrCommonTemplateConfig):
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=0.0,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -87,7 +87,7 @@ class NoaaHrrrRegionJob(
     max_vars_per_download_group = 5
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[NoaaHrrrDataVar],
     ) -> Sequence[Sequence[NoaaHrrrDataVar]]:
@@ -100,13 +100,13 @@ class NoaaHrrrRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[NoaaHrrrDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[NoaaHrrrDataVar, NoaaHrrrSourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         """Generate operational update jobs for HRRR forecast data."""
         # For operational updates, we want to process recent forecast data

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -87,7 +87,7 @@ class NoaaMrmsRegionJob(
         return slice(max(0, self.region.start - 1), self.region.stop)
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[NoaaMrmsDataVar],
     ) -> Sequence[Sequence[NoaaMrmsDataVar]]:
@@ -239,13 +239,13 @@ class NoaaMrmsRegionJob(
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[NoaaMrmsDataVar],
         reformat_job_name: str,
     ) -> tuple[
         Sequence[RegionJob[NoaaMrmsDataVar, NoaaMrmsSourceFileCoord]],
-        xr.Dataset,
+        xr.DataTree,
     ]:
         existing_ds = xr.open_zarr(primary_store, chunks=None, decode_timedelta=True)
         ds_max_time = existing_ds[append_dim].max().item()

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
@@ -7,6 +7,7 @@ import xarray as xr
 from pydantic import computed_field
 
 from reformatters.common.config_models import (
+    ROOT,
     BaseInternalAttrs,
     Coordinate,
     CoordinateAttrs,
@@ -14,6 +15,7 @@ from reformatters.common.config_models import (
     DataVar,
     DataVarAttrs,
     Encoding,
+    Group,
     StatisticsApproximate,
 )
 from reformatters.common.template_config import SPATIAL_REF_COORDS, TemplateConfig
@@ -48,7 +50,7 @@ class NoaaMrmsDataVar(DataVar[NoaaMrmsInternalAttrs]):
 
 
 class NoaaMrmsConusAnalysisHourlyTemplateConfig(TemplateConfig[NoaaMrmsDataVar]):
-    dims: tuple[Dim, ...] = ("time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time", "latitude", "longitude")}
     append_dim: AppendDim = "time"
     # Iowa Mesonet archive for MRMS has significant data availability November 2014 onwards.
     append_dim_start: Timestamp = pd.Timestamp("2014-11-01T00:00")
@@ -202,8 +204,8 @@ class NoaaMrmsConusAnalysisHourlyTemplateConfig(TemplateConfig[NoaaMrmsDataVar])
         encoding_float32_default = Encoding(
             dtype="float32",
             fill_value=np.nan,
-            chunks=tuple(var_chunks[d] for d in self.dims),
-            shards=tuple(var_shards[d] for d in self.dims),
+            chunks=tuple(var_chunks[d] for d in self.dims[ROOT]),
+            shards=tuple(var_shards[d] for d in self.dims[ROOT]),
             compressors=[BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE],
         )
 

--- a/tests/chunk_utils.py
+++ b/tests/chunk_utils.py
@@ -1,5 +1,6 @@
 import math
 from collections.abc import Iterable
+from typing import cast
 
 import xarray as xr
 
@@ -22,12 +23,14 @@ def _shrink_dim(size: int, chunk: int, shard: int) -> tuple[int, int]:
     return new_chunk, new_shard
 
 
-def shrink_chunks_and_shards(
-    ds: xr.Dataset, dims: Iterable[str] | None = None
-) -> xr.Dataset:
+def shrink_chunks_and_shards[T: (xr.Dataset, xr.DataTree)](
+    ds: T, dims: Iterable[str] | None = None
+) -> T:
     """
     Shrink every data var's chunk and shard encoding to the smallest layout that
     still exercises the same structure as production at this dataset's sizes.
+
+    Accepts a template as either a Dataset or a DataTree (per-node shrink).
 
     Integration tests trim the append/lead/ensemble dims then write a small
     region. With production chunk geometry that means allocating, filling, and
@@ -46,6 +49,17 @@ def shrink_chunks_and_shards(
     those dimensions, e.g. shrink the spatial dims while leaving the append dim
     at production size for a shard-boundary test.
     """
+    if isinstance(ds, xr.DataTree):
+        return cast(
+            "T",
+            xr.DataTree.from_dict(
+                {
+                    node.path: shrink_chunks_and_shards(node.to_dataset(), dims)
+                    for node in ds.subtree
+                }
+            ),
+        )
+
     selected = set(dims) if dims is not None else None
     for var in ds.data_vars.values():
         chunks = list(var.encoding["chunks"])

--- a/tests/common/common_template_config_subclasses_test.py
+++ b/tests/common/common_template_config_subclasses_test.py
@@ -83,6 +83,17 @@ def dataset(request: pytest.FixtureRequest) -> DynamicalDataset[Any, Any]:
 @pytest.mark.parametrize(
     "dataset", DYNAMICAL_DATASETS, ids=[d.dataset_id for d in DYNAMICAL_DATASETS]
 )
+def test_template_config_structure_is_valid(
+    dataset: DynamicalDataset[Any, Any],
+) -> None:
+    """Every config passes the structure validators: group dims, (group, name)
+    uniqueness, no vertical dim unused by any var, uniform append-dim chunking, etc."""
+    dataset.template_config._assert_valid_structure()
+
+
+@pytest.mark.parametrize(
+    "dataset", DYNAMICAL_DATASETS, ids=[d.dataset_id for d in DYNAMICAL_DATASETS]
+)
 def test_update_template_matches_existing_template(
     template_setup: TemplateSetup,
 ) -> None:

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -255,6 +255,32 @@ class TestIcechunkVirtualConfigValidation:
         assert dataset.store_factory.icechunk_virtual_config is None
 
 
+class GroupedVarConfig(ExampleConfig):
+    @computed_field
+    @property
+    def data_vars(self) -> list[ExampleDataVar]:
+        return [ExampleDataVar(name="temperature", group="pressure_level")]
+
+
+class GroupedVarDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
+    template_config: GroupedVarConfig = GroupedVarConfig()
+    region_job_class: type[ExampleRegionJob] = ExampleRegionJob
+    primary_storage_config: ExampleDatasetStorageConfig = ExampleDatasetStorageConfig()
+
+    def operational_kubernetes_resources(
+        self,
+        image_tag: str,  # noqa: ARG002
+    ) -> Sequence[CronJob]:
+        return ()
+
+
+def test_materialized_dataset_rejects_vertical_group_var() -> None:
+    # The materialized chunk-write path is not group-aware, so DynamicalDataset's
+    # _validate_virtual_storage rejects a materialized dataset with any non-root var.
+    with pytest.raises(ValidationError, match="do not yet support vertical groups"):
+        GroupedVarDataset()
+
+
 def test_update_template(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_update_template = Mock()
     monkeypatch.setattr(ExampleConfig, "update_template", mock_update_template)

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -280,7 +280,11 @@ def test_backfill(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(template_utils, "write_metadata", Mock())
 
-    monkeypatch.setattr(ExampleConfig, "get_template", lambda self, end: xr.Dataset())
+    monkeypatch.setattr(
+        ExampleConfig,
+        "get_template",
+        lambda self, end: xr.DataTree.from_dict({"/": xr.Dataset()}),
+    )
     dataset = ExampleDataset(
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,
@@ -310,7 +314,9 @@ def test_backfill_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     monkeypatch.setattr(
         ExampleConfig,
         "get_template",
-        lambda self, end: xr.Dataset(attrs={"cool": "weather"}),
+        lambda self, end: xr.DataTree.from_dict(
+            {"/": xr.Dataset(attrs={"cool": "weather"})}
+        ),
     )
     backfill_mock = Mock()
     monkeypatch.setattr(
@@ -386,7 +392,11 @@ def test_backfill_kubernetes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     )
 
     # Mock template retrieval and metadata writing
-    monkeypatch.setattr(ExampleConfig, "get_template", lambda self, end: xr.Dataset())
+    monkeypatch.setattr(
+        ExampleConfig,
+        "get_template",
+        lambda self, end: xr.DataTree.from_dict({"/": xr.Dataset()}),
+    )
     monkeypatch.setattr(template_utils, "write_metadata", lambda *args, **kwargs: None)
 
     dataset = ExampleDataset(
@@ -686,7 +696,11 @@ def test_backfill_kubernetes_overwrite_existing_flag(
         Mock(return_value="test-image-tag"),
     )
     monkeypatch.setattr(subprocess, "run", Mock())
-    monkeypatch.setattr(ExampleConfig, "get_template", lambda self, end: xr.Dataset())
+    monkeypatch.setattr(
+        ExampleConfig,
+        "get_template",
+        lambda self, end: xr.DataTree.from_dict({"/": xr.Dataset()}),
+    )
     monkeypatch.setattr(
         ExampleRegionJob, "get_jobs", Mock(return_value=[Mock(spec=ExampleRegionJob)])
     )
@@ -727,7 +741,11 @@ def test_backfill_kubernetes_overwrite_existing_flag_fails_if_not_all_stores_exi
         "open_zarr",
         Mock(side_effect=zarr.errors.GroupNotFoundError("Group not found")),
     )
-    monkeypatch.setattr(ExampleConfig, "get_template", lambda self, end: xr.Dataset())
+    monkeypatch.setattr(
+        ExampleConfig,
+        "get_template",
+        lambda self, end: xr.DataTree.from_dict({"/": xr.Dataset()}),
+    )
 
     monkeypatch.setattr(
         dynamical_dataset,
@@ -787,7 +805,9 @@ def test_backfill_local_fails_in_wrong_environment(
     monkeypatch.setattr(template_utils, "write_metadata", Mock())
     monkeypatch.setattr(DynamicalDataset, "backfill", Mock())
     monkeypatch.setattr(
-        DynamicalDataset, "_get_template", Mock(return_value=xr.Dataset())
+        DynamicalDataset,
+        "_get_template",
+        Mock(return_value=xr.DataTree.from_dict({"/": xr.Dataset()})),
     )
 
     dataset = ExampleDataset(

--- a/tests/common/iterating_test.py
+++ b/tests/common/iterating_test.py
@@ -13,9 +13,48 @@ from reformatters.common.iterating import (
     get_worker_jobs,
     group_by,
     item,
+    node_group_name,
+    node_path_prefix,
     shard_slice_indexers,
     spread_evenly,
+    walk_data_arrays,
 )
+
+
+def _two_node_tree() -> xr.DataTree:
+    root = xr.Dataset(
+        {"temperature_2m": xr.Variable(("time",), np.zeros(2, dtype=np.float32))},
+        coords={"time": [0, 1]},
+    )
+    pressure = xr.Dataset(
+        {
+            "temperature": xr.Variable(
+                ("time", "pressure_level"), np.zeros((2, 3), dtype=np.float32)
+            )
+        },
+        coords={"time": [0, 1], "pressure_level": [1000.0, 850.0, 500.0]},
+    )
+    return xr.DataTree.from_dict({"/": root, "/pressure_level": pressure})
+
+
+def test_node_group_name_root_and_child() -> None:
+    root, pressure = _two_node_tree().subtree
+    assert node_group_name(root) is None
+    assert node_group_name(pressure) == "pressure_level"
+
+
+def test_node_path_prefix_root_and_child() -> None:
+    root, pressure = _two_node_tree().subtree
+    assert node_path_prefix(root) == ""
+    assert node_path_prefix(pressure) == "pressure_level/"
+
+
+def test_walk_data_arrays_yields_group_qualified_paths() -> None:
+    tree = _two_node_tree()
+    paths = [path for path, _ in walk_data_arrays(tree)]
+    assert paths == ["temperature_2m", "pressure_level/temperature"]
+    by_path = dict(walk_data_arrays(tree))
+    assert by_path["pressure_level/temperature"].dims == ("time", "pressure_level")
 
 
 def test_group_by_parity_preserves_order() -> None:

--- a/tests/common/multi_group_template_test.py
+++ b/tests/common/multi_group_template_test.py
@@ -195,10 +195,8 @@ def test_validator_rejects_orphan_vertical_group() -> None:
                 _data_var("temperature", "pressure_level", 4),
             ]
 
-    config = OrphanGroup()
-    assert config.groups == (ROOT, "pressure_level")  # the node is omitted...
     with pytest.raises(AssertionError, match="declared in dims but unused"):
-        config._assert_valid_structure()  # ...and the config is rejected
+        OrphanGroup()._assert_valid_structure()
 
 
 def test_validator_group_must_add_its_own_dim() -> None:

--- a/tests/common/multi_group_template_test.py
+++ b/tests/common/multi_group_template_test.py
@@ -71,7 +71,7 @@ def _data_var(name: str, group: Group, n_dims: int) -> _DV:
 
 
 class MultiGroupConfig(TemplateConfig[_DV]):
-    dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+    dims: dict[Group, tuple[Dim, ...]] = {
         ROOT: ("init_time", "latitude", "longitude"),
         "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
         "model_level": ("init_time", "latitude", "longitude", "model_level"),
@@ -203,7 +203,7 @@ def test_validator_rejects_orphan_vertical_group() -> None:
 
 def test_validator_group_must_add_its_own_dim() -> None:
     class BadAddedDim(MultiGroupConfig):
-        dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+        dims: dict[Group, tuple[Dim, ...]] = {
             ROOT: ("init_time", "latitude", "longitude"),
             # pressure_level group adds "model_level" instead of "pressure_level"
             "pressure_level": ("init_time", "latitude", "longitude", "model_level"),
@@ -216,7 +216,7 @@ def test_validator_group_must_add_its_own_dim() -> None:
 
 def test_validator_root_var_name_cannot_equal_group_name() -> None:
     class RootNameCollision(MultiGroupConfig):
-        dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+        dims: dict[Group, tuple[Dim, ...]] = {
             ROOT: ("init_time", "latitude", "longitude"),
             "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
         }
@@ -236,7 +236,7 @@ def test_validator_root_var_name_cannot_equal_group_name() -> None:
 
 def test_validator_uniform_append_dim_chunk_size() -> None:
     class NonUniformAppendChunk(MultiGroupConfig):
-        dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+        dims: dict[Group, tuple[Dim, ...]] = {
             ROOT: ("init_time", "latitude", "longitude"),
             "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
         }

--- a/tests/common/multi_group_template_test.py
+++ b/tests/common/multi_group_template_test.py
@@ -1,0 +1,265 @@
+"""Multi-group (vertical dimension) template tests.
+
+A synthetic dataset that mixes a root single-level variable with two vertical
+groups that share a leaf variable name (`pressure_level/temperature` and
+`model_level/temperature`) — the case a flat Dataset could not represent. Exercises
+update_template, get_template, standalone group opening, and the structure validators.
+"""
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from pydantic import computed_field
+
+from reformatters.common.config_models import (
+    ROOT,
+    BaseInternalAttrs,
+    Coordinate,
+    CoordinateAttrs,
+    DatasetAttributes,
+    DataVar,
+    Encoding,
+    Group,
+)
+from reformatters.common.template_config import TemplateConfig
+from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
+
+_LAT = np.array([10.0, 11.0, 12.0])
+_LON = np.array([20.0, 21.0])
+_PRESSURE_LEVELS = np.array([1000.0, 850.0, 500.0])
+_MODEL_LEVELS = np.array([1, 2, 3, 4])
+
+
+class _IA(BaseInternalAttrs):
+    pass
+
+
+class _DV(DataVar[_IA]):
+    pass
+
+
+def _coord(name: str, dtype: Literal["float64", "int64"] = "float64") -> Coordinate:
+    # A single chunk larger than any test coordinate length.
+    return Coordinate(
+        name=name,
+        encoding=Encoding(dtype=dtype, chunks=1000, shards=None, fill_value=0.0),
+        attrs=CoordinateAttrs(units=None, statistics_approximate=None),
+    )
+
+
+def _data_var(name: str, group: Group, n_dims: int) -> _DV:
+    return _DV(
+        name=name,
+        group=group,
+        encoding=Encoding(
+            dtype="float32",
+            chunks=(1,) + (1,) * (n_dims - 1),
+            shards=None,
+            fill_value=np.nan,
+            compressors=(),
+        ),
+        attrs=__import__(
+            "reformatters.common.config_models", fromlist=["DataVarAttrs"]
+        ).DataVarAttrs(long_name="X", short_name="x", units="K", step_type="instant"),
+        internal_attrs=_IA(keep_mantissa_bits="no-rounding"),
+    )
+
+
+class MultiGroupConfig(TemplateConfig[_DV]):
+    dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+        ROOT: ("init_time", "latitude", "longitude"),
+        "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
+        "model_level": ("init_time", "latitude", "longitude", "model_level"),
+    }
+    append_dim: AppendDim = "init_time"
+    append_dim_start: Timestamp = pd.Timestamp("2020-01-01")
+    append_dim_frequency: Timedelta = pd.Timedelta("6h")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def dataset_attributes(self) -> DatasetAttributes:
+        return DatasetAttributes(
+            dataset_id="multi-group-test",
+            dataset_version="0.1.0",
+            name="Multi group test",
+            description="Synthetic multi-group dataset.",
+            attribution="Test.",
+            license="CC-BY-4.0",
+            spatial_domain="Global",
+            spatial_resolution="0.25 degrees (~20km)",
+            time_domain="2020 to present",
+            time_resolution="6 hourly",
+        )
+
+    def dimension_coordinates(self) -> dict[str, Any]:
+        return {
+            "init_time": self.append_dim_coordinates(
+                self.append_dim_start + self.append_dim_frequency
+            ),
+            "latitude": _LAT,
+            "longitude": _LON,
+            "pressure_level": _PRESSURE_LEVELS,
+            "model_level": _MODEL_LEVELS,
+        }
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def coords(self) -> Sequence[Coordinate]:
+        return [
+            _coord("init_time", "int64"),
+            _coord("latitude"),
+            _coord("longitude"),
+            _coord("pressure_level"),
+            _coord("model_level", "int64"),
+            Coordinate(
+                name="spatial_ref",
+                encoding=Encoding(dtype="int64", chunks=(), shards=None, fill_value=0),
+                attrs=CoordinateAttrs(units=None, statistics_approximate=None),
+            ),
+        ]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def data_vars(self) -> Sequence[_DV]:
+        return [
+            _data_var("temperature_2m", ROOT, 3),
+            _data_var("temperature", "pressure_level", 4),
+            _data_var("temperature", "model_level", 4),
+        ]
+
+
+@pytest.fixture
+def config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MultiGroupConfig:
+    # Redirect the on-disk template to a temp dir so the test never writes the repo.
+    template_path = tmp_path / "templates" / "latest.zarr"
+    monkeypatch.setattr(MultiGroupConfig, "template_path", lambda self: template_path)
+    return MultiGroupConfig()
+
+
+def test_update_template_writes_three_node_tree(config: MultiGroupConfig) -> None:
+    config.update_template()
+    tree = xr.open_datatree(config.template_path(), consolidated=False)
+    assert set(tree.groups) == {"/", "/pressure_level", "/model_level"}
+    assert tree["pressure_level/temperature"].dims == (
+        "init_time",
+        "latitude",
+        "longitude",
+        "pressure_level",
+    )
+    assert tree["model_level/temperature"].dims == (
+        "init_time",
+        "latitude",
+        "longitude",
+        "model_level",
+    )
+    # The same leaf name lives in two groups without colliding.
+    assert "temperature_2m" in tree["/"].data_vars
+
+
+def test_groups_open_standalone_with_shared_coords(config: MultiGroupConfig) -> None:
+    config.update_template()
+    pressure = xr.open_zarr(
+        config.template_path(), group="pressure_level", consolidated=False
+    )
+    # Shared coords are duplicated into the group; the other group's vertical coord is not.
+    assert {"init_time", "latitude", "longitude", "pressure_level"} <= set(
+        pressure.coords
+    )
+    assert "model_level" not in pressure.coords
+    assert "temperature" in pressure.data_vars
+
+
+def test_get_template_returns_reindexed_tree(config: MultiGroupConfig) -> None:
+    config.update_template()
+    tree = config.get_template(pd.Timestamp("2020-01-02"))
+    assert isinstance(tree, xr.DataTree)
+    # init_time reindexed from start to the requested end (every 6h over one day).
+    assert tree["/"].sizes["init_time"] == 4
+    assert tree["pressure_level"].sizes["init_time"] == 4
+    assert tree["pressure_level/temperature"].encoding["fill_value"] is not None
+
+
+def test_validator_rejects_orphan_vertical_group() -> None:
+    class OrphanGroup(MultiGroupConfig):
+        @computed_field  # type: ignore[prop-decorator]
+        @property
+        def data_vars(self) -> Sequence[_DV]:
+            # model_level is declared in dims but used by no var.
+            return [
+                _data_var("temperature_2m", ROOT, 3),
+                _data_var("temperature", "pressure_level", 4),
+            ]
+
+    config = OrphanGroup()
+    assert config.groups == (ROOT, "pressure_level")  # the node is omitted...
+    with pytest.raises(AssertionError, match="declared in dims but unused"):
+        config._assert_valid_structure()  # ...and the config is rejected
+
+
+def test_validator_group_must_add_its_own_dim() -> None:
+    class BadAddedDim(MultiGroupConfig):
+        dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+            ROOT: ("init_time", "latitude", "longitude"),
+            # pressure_level group adds "model_level" instead of "pressure_level"
+            "pressure_level": ("init_time", "latitude", "longitude", "model_level"),
+            "model_level": ("init_time", "latitude", "longitude", "model_level"),
+        }
+
+    with pytest.raises(AssertionError, match="must add exactly its own dim"):
+        BadAddedDim()._assert_valid_structure()
+
+
+def test_validator_root_var_name_cannot_equal_group_name() -> None:
+    class RootNameCollision(MultiGroupConfig):
+        dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+            ROOT: ("init_time", "latitude", "longitude"),
+            "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
+        }
+
+        @computed_field  # type: ignore[prop-decorator]
+        @property
+        def data_vars(self) -> Sequence[_DV]:
+            # A root var literally named "pressure_level" collides with the group node.
+            return [
+                _data_var("pressure_level", ROOT, 3),
+                _data_var("temperature", "pressure_level", 4),
+            ]
+
+    with pytest.raises(AssertionError, match="collide with a group name"):
+        RootNameCollision()._assert_valid_structure()
+
+
+def test_validator_uniform_append_dim_chunk_size() -> None:
+    class NonUniformAppendChunk(MultiGroupConfig):
+        dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+            ROOT: ("init_time", "latitude", "longitude"),
+            "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
+        }
+
+        @computed_field  # type: ignore[prop-decorator]
+        @property
+        def data_vars(self) -> Sequence[_DV]:
+            root = _data_var("temperature_2m", ROOT, 3)
+            # Pressure var with init_time chunk size 2 instead of 1.
+            pressure = _DV(
+                name="temperature",
+                group="pressure_level",
+                encoding=Encoding(
+                    dtype="float32",
+                    chunks=(2, 1, 1, 1),
+                    shards=None,
+                    fill_value=np.nan,
+                    compressors=(),
+                ),
+                attrs=root.attrs,
+                internal_attrs=_IA(keep_mantissa_bits="no-rounding"),
+            )
+            return [root, pressure]
+
+    with pytest.raises(AssertionError, match="append-dim chunk size"):
+        NonUniformAppendChunk()._assert_valid_structure()

--- a/tests/common/multi_group_template_test.py
+++ b/tests/common/multi_group_template_test.py
@@ -184,6 +184,76 @@ def test_get_template_returns_reindexed_tree(config: MultiGroupConfig) -> None:
     assert tree["pressure_level/temperature"].encoding["fill_value"] is not None
 
 
+class OnlyVerticalConfig(MultiGroupConfig):
+    dims: dict[Group, tuple[Dim, ...]] = {
+        ROOT: ("init_time", "latitude", "longitude"),
+        "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
+    }
+
+    def dimension_coordinates(self) -> dict[str, Any]:
+        return {
+            "init_time": self.append_dim_coordinates(
+                self.append_dim_start + self.append_dim_frequency
+            ),
+            "latitude": _LAT,
+            "longitude": _LON,
+            "pressure_level": _PRESSURE_LEVELS,
+        }
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def coords(self) -> Sequence[Coordinate]:
+        return [
+            _coord("init_time", "int64"),
+            _coord("latitude"),
+            _coord("longitude"),
+            _coord("pressure_level"),
+            Coordinate(
+                name="spatial_ref",
+                encoding=Encoding(dtype="int64", chunks=(), shards=None, fill_value=0),
+                attrs=CoordinateAttrs(units=None, statistics_approximate=None),
+            ),
+        ]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def data_vars(self) -> Sequence[_DV]:
+        # No root data var: every data var lives in the pressure_level group.
+        return [_data_var("temperature", "pressure_level", 4)]
+
+
+@pytest.fixture
+def only_vertical_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> OnlyVerticalConfig:
+    template_path = tmp_path / "templates" / "latest.zarr"
+    monkeypatch.setattr(OnlyVerticalConfig, "template_path", lambda self: template_path)
+    return OnlyVerticalConfig()
+
+
+def test_only_vertical_vars_dataset_round_trips(
+    only_vertical_config: OnlyVerticalConfig,
+) -> None:
+    only_vertical_config.update_template()
+    tree = xr.open_datatree(only_vertical_config.template_path(), consolidated=False)
+
+    # The root node carries the shared coords but has no data vars of its own.
+    root = tree["/"]
+    assert dict(root.data_vars) == {}
+    assert {"init_time", "latitude", "longitude"} <= set(root.coords)
+
+    # The pressure_level group still opens standalone with its var + shared coords.
+    pressure = xr.open_zarr(
+        only_vertical_config.template_path(),
+        group="pressure_level",
+        consolidated=False,
+    )
+    assert "temperature" in pressure.data_vars
+    assert {"init_time", "latitude", "longitude", "pressure_level"} <= set(
+        pressure.coords
+    )
+
+
 def test_validator_rejects_orphan_vertical_group() -> None:
     class OrphanGroup(MultiGroupConfig):
         @computed_field  # type: ignore[prop-decorator]
@@ -261,3 +331,71 @@ def test_validator_uniform_append_dim_chunk_size() -> None:
 
     with pytest.raises(AssertionError, match="append-dim chunk size"):
         NonUniformAppendChunk()._assert_valid_structure()
+
+
+def test_validator_encoding_chunk_length_must_match_group_dims() -> None:
+    class WrongChunkLength(MultiGroupConfig):
+        dims: dict[Group, tuple[Dim, ...]] = {
+            ROOT: ("init_time", "latitude", "longitude"),
+            "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
+        }
+
+        @computed_field  # type: ignore[prop-decorator]
+        @property
+        def data_vars(self) -> Sequence[_DV]:
+            # pressure_level group has 4 dims, but this var declares a 3-tuple chunks.
+            short = _DV(
+                name="temperature",
+                group="pressure_level",
+                encoding=Encoding(
+                    dtype="float32",
+                    chunks=(1, 1, 1),  # 3 entries, expected 4
+                    shards=None,
+                    fill_value=np.nan,
+                    compressors=(),
+                ),
+                attrs=_data_var("temperature_2m", ROOT, 3).attrs,
+                internal_attrs=_IA(keep_mantissa_bits="no-rounding"),
+            )
+            return [_data_var("temperature_2m", ROOT, 3), short]
+
+    with pytest.raises(AssertionError, match="encoding chunks has 3 entries"):
+        WrongChunkLength()._assert_valid_structure()
+
+
+def test_validator_rejects_duplicate_group_name() -> None:
+    class DuplicateVar(MultiGroupConfig):
+        @computed_field  # type: ignore[prop-decorator]
+        @property
+        def data_vars(self) -> Sequence[_DV]:
+            return [
+                _data_var("temperature_2m", ROOT, 3),
+                _data_var("temperature", "pressure_level", 4),
+                _data_var("temperature", "model_level", 4),
+                # Second pressure_level/temperature -> duplicate (group, name).
+                _data_var("temperature", "pressure_level", 4),
+            ]
+
+    with pytest.raises(AssertionError, match=r"duplicate \(group, name\)"):
+        DuplicateVar()._assert_valid_structure()
+
+
+def test_validator_var_group_must_be_declared_in_dims() -> None:
+    class UndeclaredGroup(MultiGroupConfig):
+        dims: dict[Group, tuple[Dim, ...]] = {
+            ROOT: ("init_time", "latitude", "longitude"),
+            "pressure_level": ("init_time", "latitude", "longitude", "pressure_level"),
+        }
+
+        @computed_field  # type: ignore[prop-decorator]
+        @property
+        def data_vars(self) -> Sequence[_DV]:
+            # model_level is never declared in dims above.
+            return [
+                _data_var("temperature_2m", ROOT, 3),
+                _data_var("temperature", "pressure_level", 4),
+                _data_var("temperature", "model_level", 4),
+            ]
+
+    with pytest.raises(AssertionError, match="not declared in dims"):
+        UndeclaredGroup()._assert_valid_structure()

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -297,6 +297,113 @@ def test_source_file_coord_append_dim_coord() -> None:
     assert coord.append_dim_coord == pd.Timestamp("2025-01-01T00")
 
 
+def _multi_group_template_and_vars() -> tuple[xr.DataTree, list[ExampleDataVar]]:
+    """Root temperature_2m + pressure_level/temperature + model_level/temperature,
+    one chunk per init_time, so get_jobs produces one region per var group."""
+    num_time = 2
+    init_times = pd.date_range("2025-01-01", freq="6h", periods=num_time)
+
+    def _root_var() -> xr.Variable:
+        return xr.Variable(
+            data=dask.array.full(
+                (num_time, _LAT_SIZE, _LON_SIZE), np.nan, dtype=np.float32, chunks=-1
+            ),
+            dims=["init_time", "latitude", "longitude"],
+            encoding={
+                "dtype": "float32",
+                "chunks": (1, _LAT_SIZE, _LON_SIZE),
+                "shards": None,
+                "fill_value": np.nan,
+            },
+        )
+
+    def _vertical_var(level_dim: str, n_levels: int) -> xr.Variable:
+        return xr.Variable(
+            data=dask.array.full(
+                (num_time, _LAT_SIZE, _LON_SIZE, n_levels),
+                np.nan,
+                dtype=np.float32,
+                chunks=-1,
+            ),
+            dims=["init_time", "latitude", "longitude", level_dim],
+            encoding={
+                "dtype": "float32",
+                "chunks": (1, _LAT_SIZE, _LON_SIZE, 1),
+                "shards": None,
+                "fill_value": np.nan,
+            },
+        )
+
+    shared_coords = {
+        "init_time": init_times,
+        "latitude": np.linspace(0, 90, _LAT_SIZE),
+        "longitude": np.linspace(0, 140, _LON_SIZE),
+    }
+    root = xr.Dataset(
+        {"temperature_2m": _root_var()},
+        coords=shared_coords,
+        attrs={"dataset_id": "test-multi-group"},
+    )
+    pressure = xr.Dataset(
+        {"temperature": _vertical_var("pressure_level", 2)},
+        coords={**shared_coords, "pressure_level": [1000.0, 850.0]},
+    )
+    model = xr.Dataset(
+        {"temperature": _vertical_var("model_level", 3)},
+        coords={**shared_coords, "model_level": [1, 2, 3]},
+    )
+    for ds in (root, pressure, model):
+        ds["init_time"].encoding["fill_value"] = -1
+        ds["latitude"].encoding["fill_value"] = np.nan
+        ds["longitude"].encoding["fill_value"] = np.nan
+    pressure["pressure_level"].encoding["fill_value"] = np.nan
+    model["model_level"].encoding["fill_value"] = -1
+    tree = xr.DataTree.from_dict(
+        {"/": root, "/pressure_level": pressure, "/model_level": model}
+    )
+    data_vars = [
+        ExampleDataVar(name="temperature_2m"),
+        ExampleDataVar(name="temperature", group="pressure_level"),
+        ExampleDataVar(name="temperature", group="model_level"),
+    ]
+    return tree, data_vars
+
+
+def _job_var_paths(jobs: Sequence[ExampleRegionJob]) -> set[str]:
+    return {var.path for job in jobs for var in job.data_vars}
+
+
+def test_get_jobs_bare_name_filter_selects_var_in_every_group() -> None:
+    template_ds, data_vars = _multi_group_template_and_vars()
+    jobs = ExampleRegionJob.get_jobs(
+        tmp_store=get_local_tmp_store(),
+        template_ds=template_ds,
+        append_dim="init_time",
+        all_data_vars=data_vars,
+        reformat_job_name="test-job",
+        filter_variable_names=["temperature"],
+    )
+    # "temperature" is the leaf name in both vertical groups (and not the root var),
+    # so the bare name keeps both grouped vars and excludes temperature_2m.
+    assert _job_var_paths(jobs) == {
+        "pressure_level/temperature",
+        "model_level/temperature",
+    }
+
+
+def test_get_jobs_path_filter_selects_single_group() -> None:
+    template_ds, data_vars = _multi_group_template_and_vars()
+    jobs = ExampleRegionJob.get_jobs(
+        tmp_store=get_local_tmp_store(),
+        template_ds=template_ds,
+        append_dim="init_time",
+        all_data_vars=data_vars,
+        reformat_job_name="test-job",
+        filter_variable_names=["pressure_level/temperature"],
+    )
+    assert _job_var_paths(jobs) == {"pressure_level/temperature"}
+
+
 def test_get_jobs_grouping_no_filters(template_ds: xr.DataTree) -> None:
     data_vars = [ExampleDataVar(name=str(name)) for name in template_ds.data_vars]
     tmp_store = get_local_tmp_store()

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -66,7 +66,7 @@ class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCo
     max_vars_per_job: ClassVar[int] = 2
 
     @classmethod
-    def source_groups(
+    def source_file_var_groups(
         cls,
         data_vars: Sequence[ExampleDataVar],
     ) -> Sequence[Sequence[ExampleDataVar]]:
@@ -113,7 +113,7 @@ def _create_template_ds(
     var_fill_value: float = np.nan,
     num_vars: int = 4,
     num_time: int = 48,
-) -> xr.Dataset:
+) -> xr.DataTree:
     ds = xr.Dataset(
         {
             f"var{i}": xr.Variable(
@@ -143,11 +143,11 @@ def _create_template_ds(
     ds["time"].encoding["fill_value"] = -1
     ds["latitude"].encoding["fill_value"] = np.nan
     ds["longitude"].encoding["fill_value"] = np.nan
-    return ds
+    return xr.DataTree.from_dict({"/": ds})
 
 
 @pytest.fixture
-def template_ds() -> xr.Dataset:
+def template_ds() -> xr.DataTree:
     return _create_template_ds(var_fill_value=np.nan, num_vars=4, num_time=48)
 
 
@@ -254,7 +254,7 @@ def test_region_job_empty_chunk_writing(
     np.testing.assert_array_equal(second_day, np.full_like(second_day, var_fill_value))
 
 
-def test_update_template_with_results(template_ds: xr.Dataset) -> None:
+def test_update_template_with_results(template_ds: xr.DataTree) -> None:
     tmp_store = get_local_tmp_store()
 
     job = ExampleRegionJob(
@@ -297,7 +297,7 @@ def test_source_file_coord_append_dim_coord() -> None:
     assert coord.append_dim_coord == pd.Timestamp("2025-01-01T00")
 
 
-def test_get_jobs_grouping_no_filters(template_ds: xr.Dataset) -> None:
+def test_get_jobs_grouping_no_filters(template_ds: xr.DataTree) -> None:
     data_vars = [ExampleDataVar(name=str(name)) for name in template_ds.data_vars]
     tmp_store = get_local_tmp_store()
     jobs = ExampleRegionJob.get_jobs(
@@ -332,7 +332,7 @@ def test_get_jobs_grouping_no_filters(template_ds: xr.Dataset) -> None:
     ]
 
 
-def test_get_jobs_grouping_filters(template_ds: xr.Dataset) -> None:
+def test_get_jobs_grouping_filters(template_ds: xr.DataTree) -> None:
     data_vars = [ExampleDataVar(name=str(name)) for name in template_ds.data_vars]
     tmp_store = get_local_tmp_store()
     jobs = ExampleRegionJob.get_jobs(
@@ -372,7 +372,7 @@ def test_get_jobs_grouping_filters(template_ds: xr.Dataset) -> None:
     )
 
 
-def test_get_jobs_grouping_filters_and_worker_index(template_ds: xr.Dataset) -> None:
+def test_get_jobs_grouping_filters_and_worker_index(template_ds: xr.DataTree) -> None:
     data_vars = [ExampleDataVar(name=str(name)) for name in template_ds.data_vars]
     tmp_store = get_local_tmp_store()
     all_jobs = ExampleRegionJob.get_jobs(
@@ -405,7 +405,7 @@ def test_get_jobs_grouping_filters_and_worker_index(template_ds: xr.Dataset) -> 
     ]
 
 
-def test_get_jobs_grouping_filter_contains(template_ds: xr.Dataset) -> None:
+def test_get_jobs_grouping_filter_contains(template_ds: xr.DataTree) -> None:
     data_vars = [ExampleDataVar(name=str(name)) for name in template_ds.data_vars]
     tmp_store = get_local_tmp_store()
     jobs = ExampleRegionJob.get_jobs(
@@ -432,7 +432,7 @@ def test_get_jobs_grouping_filter_contains(template_ds: xr.Dataset) -> None:
 
 
 def test_get_jobs_grouping_filter_contains_second_shard(
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
 ) -> None:
     data_vars = [ExampleDataVar(name=str(name)) for name in template_ds.data_vars]
     tmp_store = get_local_tmp_store()
@@ -459,7 +459,7 @@ def test_get_jobs_grouping_filter_contains_second_shard(
     ]
 
 
-def test_get_jobs_grouping_filter_contains_all_shards(template_ds: xr.Dataset) -> None:
+def test_get_jobs_grouping_filter_contains_all_shards(template_ds: xr.DataTree) -> None:
     data_vars = [ExampleDataVar(name=str(name)) for name in template_ds.data_vars]
     tmp_store = get_local_tmp_store()
     jobs = ExampleRegionJob.get_jobs(
@@ -526,6 +526,7 @@ def test_get_jobs_many_shards_combined_filters() -> None:
     large_template_ds["latitude"].encoding["fill_value"] = np.nan
     large_template_ds["longitude"].encoding["fill_value"] = np.nan
 
+    large_template_tree = xr.DataTree.from_dict({"/": large_template_ds})
     data_vars = [ExampleDataVar(name=str(name)) for name in large_template_ds.data_vars]
     tmp_store = get_local_tmp_store()
     init_time_coords = large_template_ds.coords["init_time"].values
@@ -540,7 +541,7 @@ def test_get_jobs_many_shards_combined_filters() -> None:
 
     jobs = ExampleRegionJob.get_jobs(
         tmp_store=tmp_store,
-        template_ds=large_template_ds,
+        template_ds=large_template_tree,
         append_dim="init_time",
         all_data_vars=data_vars,
         reformat_job_name="test-job",
@@ -570,7 +571,7 @@ def test_get_jobs_many_shards_combined_filters() -> None:
 
 
 @pytest.fixture
-def small_template_ds() -> xr.Dataset:
+def small_template_ds() -> xr.DataTree:
     """4 shards, 2 hours each, 1 variable for fast tests."""
     num_time = 8
     ds = xr.Dataset(
@@ -600,11 +601,11 @@ def small_template_ds() -> xr.Dataset:
     ds["time"].encoding["fill_value"] = -1
     ds["latitude"].encoding["fill_value"] = np.nan
     ds["longitude"].encoding["fill_value"] = np.nan
-    return ds
+    return xr.DataTree.from_dict({"/": ds})
 
 
 def _get_regions(
-    ds: xr.Dataset,
+    ds: xr.DataTree,
     filter_start: pd.Timestamp | None = None,
     filter_end: pd.Timestamp | None = None,
     filter_contains: list[pd.Timestamp] | None = None,
@@ -628,7 +629,7 @@ def _get_regions(
 
 class TestFilterStartEdgeCases:
     def test_filter_start_equals_first_coord(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_start at first coord keeps all shards."""
         regions = _get_regions(
@@ -637,7 +638,7 @@ class TestFilterStartEdgeCases:
         assert regions == [slice(0, 2), slice(2, 4), slice(4, 6), slice(6, 8)]
 
     def test_filter_start_equals_last_coord(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_start at last coord keeps only last shard."""
         regions = _get_regions(
@@ -646,7 +647,7 @@ class TestFilterStartEdgeCases:
         assert regions == [slice(6, 8)]
 
     def test_filter_start_before_all_coords(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_start before data keeps all shards."""
         regions = _get_regions(
@@ -654,7 +655,9 @@ class TestFilterStartEdgeCases:
         )
         assert regions == [slice(0, 2), slice(2, 4), slice(4, 6), slice(6, 8)]
 
-    def test_filter_start_after_all_coords(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_start_after_all_coords(
+        self, small_template_ds: xr.DataTree
+    ) -> None:
         """filter_start after data keeps no shards."""
         regions = _get_regions(
             small_template_ds, filter_start=pd.Timestamp("2026-01-01")
@@ -662,7 +665,7 @@ class TestFilterStartEdgeCases:
         assert regions == []
 
     def test_filter_start_on_shard_boundary(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_start exactly at shard 2 boundary (hour 4)."""
         regions = _get_regions(
@@ -670,7 +673,7 @@ class TestFilterStartEdgeCases:
         )
         assert regions == [slice(4, 6), slice(6, 8)]
 
-    def test_filter_start_mid_shard(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_start_mid_shard(self, small_template_ds: xr.DataTree) -> None:
         """filter_start in middle of shard 1 (hour 3) keeps shard 1 onward."""
         regions = _get_regions(
             small_template_ds, filter_start=pd.Timestamp("2025-01-01 03:00")
@@ -679,7 +682,9 @@ class TestFilterStartEdgeCases:
 
 
 class TestFilterEndEdgeCases:
-    def test_filter_end_equals_first_coord(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_end_equals_first_coord(
+        self, small_template_ds: xr.DataTree
+    ) -> None:
         """filter_end at first coord keeps no shards (min must be < end)."""
         regions = _get_regions(
             small_template_ds, filter_end=pd.Timestamp("2025-01-01 00:00")
@@ -687,7 +692,7 @@ class TestFilterEndEdgeCases:
         assert regions == []
 
     def test_filter_end_equals_second_coord(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_end at second coord keeps only first shard."""
         regions = _get_regions(
@@ -695,24 +700,24 @@ class TestFilterEndEdgeCases:
         )
         assert regions == [slice(0, 2)]
 
-    def test_filter_end_after_all_coords(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_end_after_all_coords(self, small_template_ds: xr.DataTree) -> None:
         """filter_end after data keeps all shards."""
         regions = _get_regions(small_template_ds, filter_end=pd.Timestamp("2026-01-01"))
         assert regions == [slice(0, 2), slice(2, 4), slice(4, 6), slice(6, 8)]
 
-    def test_filter_end_before_all_coords(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_end_before_all_coords(self, small_template_ds: xr.DataTree) -> None:
         """filter_end before data keeps no shards."""
         regions = _get_regions(small_template_ds, filter_end=pd.Timestamp("2024-01-01"))
         assert regions == []
 
-    def test_filter_end_on_shard_boundary(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_end_on_shard_boundary(self, small_template_ds: xr.DataTree) -> None:
         """filter_end exactly at shard 2 boundary (hour 4) keeps shards 0,1."""
         regions = _get_regions(
             small_template_ds, filter_end=pd.Timestamp("2025-01-01 04:00")
         )
         assert regions == [slice(0, 2), slice(2, 4)]
 
-    def test_filter_end_mid_shard(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_end_mid_shard(self, small_template_ds: xr.DataTree) -> None:
         """filter_end in middle of shard 1 (hour 3) keeps shards 0,1."""
         regions = _get_regions(
             small_template_ds, filter_end=pd.Timestamp("2025-01-01 03:00")
@@ -721,33 +726,35 @@ class TestFilterEndEdgeCases:
 
 
 class TestFilterContainsEdgeCases:
-    def test_filter_contains_not_in_coords(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_contains_not_in_coords(
+        self, small_template_ds: xr.DataTree
+    ) -> None:
         """filter_contains with non-existent timestamp returns no shards."""
         regions = _get_regions(
             small_template_ds, filter_contains=[pd.Timestamp("2025-01-01 00:30")]
         )
         assert regions == []
 
-    def test_filter_contains_empty_list(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_contains_empty_list(self, small_template_ds: xr.DataTree) -> None:
         """filter_contains with empty list returns no shards."""
         regions = _get_regions(small_template_ds, filter_contains=[])
         assert regions == []
 
-    def test_filter_contains_first_coord(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_contains_first_coord(self, small_template_ds: xr.DataTree) -> None:
         """filter_contains with first coord returns first shard."""
         regions = _get_regions(
             small_template_ds, filter_contains=[pd.Timestamp("2025-01-01 00:00")]
         )
         assert regions == [slice(0, 2)]
 
-    def test_filter_contains_last_coord(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_contains_last_coord(self, small_template_ds: xr.DataTree) -> None:
         """filter_contains with last coord returns last shard."""
         regions = _get_regions(
             small_template_ds, filter_contains=[pd.Timestamp("2025-01-01 07:00")]
         )
         assert regions == [slice(6, 8)]
 
-    def test_filter_contains_duplicates(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_contains_duplicates(self, small_template_ds: xr.DataTree) -> None:
         """filter_contains with duplicate timestamps deduplicates."""
         regions = _get_regions(
             small_template_ds,
@@ -760,7 +767,7 @@ class TestFilterContainsEdgeCases:
         assert regions == [slice(2, 4)]
 
     def test_filter_contains_multiple_shards(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains spanning shards 0 and 2 (skipping 1)."""
         regions = _get_regions(
@@ -774,7 +781,9 @@ class TestFilterContainsEdgeCases:
 
 
 class TestCombinedFilterEdgeCases:
-    def test_filter_start_greater_than_end(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_start_greater_than_end(
+        self, small_template_ds: xr.DataTree
+    ) -> None:
         """filter_start > filter_end returns no shards."""
         regions = _get_regions(
             small_template_ds,
@@ -783,7 +792,7 @@ class TestCombinedFilterEdgeCases:
         )
         assert regions == []
 
-    def test_filter_start_equals_end(self, small_template_ds: xr.Dataset) -> None:
+    def test_filter_start_equals_end(self, small_template_ds: xr.DataTree) -> None:
         """filter_start == filter_end returns no shards (end is exclusive)."""
         regions = _get_regions(
             small_template_ds,
@@ -793,7 +802,7 @@ class TestCombinedFilterEdgeCases:
         assert regions == []
 
     def test_filter_contains_outside_start_end_range(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains timestamps outside start/end range returns no shards."""
         regions = _get_regions(
@@ -805,7 +814,7 @@ class TestCombinedFilterEdgeCases:
         assert regions == []
 
     def test_all_filters_narrow_to_single_shard(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """All filters combine to select single shard."""
         regions = _get_regions(
@@ -819,7 +828,7 @@ class TestCombinedFilterEdgeCases:
     # --- filter_contains + filter_end interactions ---
 
     def test_filter_contains_equals_filter_end(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains at exactly filter_end is excluded (end is exclusive)."""
         # filter_end=04:00 excludes shard 2 (hours 4,5), filter_contains=[04:00] is in shard 2
@@ -831,7 +840,7 @@ class TestCombinedFilterEdgeCases:
         assert regions == []
 
     def test_filter_contains_in_last_included_shard_before_end(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains in last shard before filter_end is included."""
         # filter_end=04:00 keeps shards 0,1. filter_contains=[03:00] is in shard 1
@@ -843,7 +852,7 @@ class TestCombinedFilterEdgeCases:
         assert regions == [slice(2, 4)]
 
     def test_filter_contains_in_first_excluded_shard_after_end(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains in first excluded shard (after filter_end) returns empty."""
         # filter_end=04:00 keeps shards 0,1 (hours 0-3). filter_contains=[05:00] is in shard 2
@@ -857,7 +866,7 @@ class TestCombinedFilterEdgeCases:
     # --- filter_contains + filter_start interactions ---
 
     def test_filter_contains_equals_filter_start(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains at exactly filter_start is included."""
         # filter_start=04:00 keeps shards 2,3. filter_contains=[04:00] is in shard 2
@@ -869,7 +878,7 @@ class TestCombinedFilterEdgeCases:
         assert regions == [slice(4, 6)]
 
     def test_filter_contains_in_last_excluded_shard_before_start(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains in last excluded shard (before filter_start) returns empty."""
         # filter_start=04:00 keeps shards 2,3. filter_contains=[03:00] is in shard 1 (excluded)
@@ -881,7 +890,7 @@ class TestCombinedFilterEdgeCases:
         assert regions == []
 
     def test_filter_contains_in_first_included_shard_at_start(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains in first included shard (at filter_start) is included."""
         # filter_start=04:00 keeps shards 2,3. filter_contains=[05:00] is in shard 2
@@ -895,7 +904,7 @@ class TestCombinedFilterEdgeCases:
     # --- filter_contains with mixed included/excluded timestamps ---
 
     def test_filter_contains_some_in_range_some_out(
-        self, small_template_ds: xr.Dataset
+        self, small_template_ds: xr.DataTree
     ) -> None:
         """filter_contains with some timestamps in range and some out keeps only valid."""
         # filter_start=02:00, filter_end=06:00 keeps shards 1,2 (hours 2-5)
@@ -915,7 +924,7 @@ class TestCombinedFilterEdgeCases:
 
 class TestSingleShardEdgeCases:
     @pytest.fixture
-    def single_shard_ds(self) -> xr.Dataset:
+    def single_shard_ds(self) -> xr.DataTree:
         """Dataset with only 1 shard (2 hours)."""
         ds = xr.Dataset(
             {
@@ -944,9 +953,11 @@ class TestSingleShardEdgeCases:
         ds["time"].encoding["fill_value"] = -1
         ds["latitude"].encoding["fill_value"] = np.nan
         ds["longitude"].encoding["fill_value"] = np.nan
-        return ds
+        return xr.DataTree.from_dict({"/": ds})
 
-    def test_single_shard_filter_start_keeps(self, single_shard_ds: xr.Dataset) -> None:
+    def test_single_shard_filter_start_keeps(
+        self, single_shard_ds: xr.DataTree
+    ) -> None:
         """Single shard kept when filter_start matches."""
         regions = _get_regions(
             single_shard_ds, filter_start=pd.Timestamp("2025-01-01 00:00")
@@ -954,13 +965,13 @@ class TestSingleShardEdgeCases:
         assert regions == [slice(0, 2)]
 
     def test_single_shard_filter_start_excludes(
-        self, single_shard_ds: xr.Dataset
+        self, single_shard_ds: xr.DataTree
     ) -> None:
         """Single shard excluded when filter_start is after."""
         regions = _get_regions(single_shard_ds, filter_start=pd.Timestamp("2025-01-02"))
         assert regions == []
 
-    def test_single_shard_filter_end_keeps(self, single_shard_ds: xr.Dataset) -> None:
+    def test_single_shard_filter_end_keeps(self, single_shard_ds: xr.DataTree) -> None:
         """Single shard kept when filter_end is after."""
         regions = _get_regions(
             single_shard_ds, filter_end=pd.Timestamp("2025-01-01 01:00")
@@ -968,7 +979,7 @@ class TestSingleShardEdgeCases:
         assert regions == [slice(0, 2)]
 
     def test_single_shard_filter_end_excludes(
-        self, single_shard_ds: xr.Dataset
+        self, single_shard_ds: xr.DataTree
     ) -> None:
         """Single shard excluded when filter_end is at or before first coord."""
         regions = _get_regions(
@@ -977,7 +988,7 @@ class TestSingleShardEdgeCases:
         assert regions == []
 
     def test_single_shard_filter_contains_keeps(
-        self, single_shard_ds: xr.Dataset
+        self, single_shard_ds: xr.DataTree
     ) -> None:
         """Single shard kept when filter_contains matches."""
         regions = _get_regions(
@@ -986,7 +997,7 @@ class TestSingleShardEdgeCases:
         assert regions == [slice(0, 2)]
 
     def test_single_shard_filter_contains_excludes(
-        self, single_shard_ds: xr.Dataset
+        self, single_shard_ds: xr.DataTree
     ) -> None:
         """Single shard excluded when filter_contains doesn't match."""
         regions = _get_regions(
@@ -1007,13 +1018,14 @@ class TestDownloadErrorLogging:
     """Test that download errors for recent files use quiet logging for expected errors."""
 
     def _make_job(self, time: pd.Timestamp) -> ExampleRegionJob:
-        template_ds = _create_template_ds(num_vars=1, num_time=48)
-        template_ds = template_ds.assign_coords(
-            time=pd.date_range(time, freq="h", periods=48)
+        ds = (
+            _create_template_ds(num_vars=1, num_time=48)
+            .to_dataset()
+            .assign_coords(time=pd.date_range(time, freq="h", periods=48))
         )
         return ExampleRegionJob(
             tmp_store=get_local_tmp_store(),
-            template_ds=template_ds,
+            template_ds=xr.DataTree.from_dict({"/": ds}),
             data_vars=[ExampleDataVar(name="var0")],
             append_dim="time",
             region=slice(0, 12),

--- a/tests/common/template_config_test.py
+++ b/tests/common/template_config_test.py
@@ -8,10 +8,12 @@ import xarray as xr
 
 # Use a dummy DataVar that is a subtype of BaseInternalAttrs, as required by the type var
 from reformatters.common.config_models import (
+    ROOT,
     BaseInternalAttrs,
     Coordinate,
     DatasetAttributes,
     DataVar,
+    Group,
 )
 from reformatters.common.template_config import (
     SPATIAL_REF_COORDS,
@@ -35,7 +37,7 @@ class ExampleDatasetAttributes(DatasetAttributes):
 class ExampleConfig(TemplateConfig[ExampleDataVar]):
     """A minimal concrete implementation to test the happy-path logic."""
 
-    dims: tuple[Dim, ...] = ("time",)
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time",)}  # noqa: RUF012
     append_dim: AppendDim = "time"
     append_dim_start: Timestamp = pd.Timestamp("2000-01-01")
     append_dim_frequency: Timedelta = pd.Timedelta(days=1)
@@ -76,7 +78,7 @@ class BadCoordsConfig(ExampleConfig):
 @pytest.fixture
 def example_config() -> ExampleConfig:
     return ExampleConfig(
-        dims=("time",),
+        dims={ROOT: ("time",)},
         append_dim="time",
         append_dim_start=pd.Timestamp("2000-01-01"),
         append_dim_frequency=pd.Timedelta(days=1),
@@ -112,7 +114,7 @@ def test_append_dim_coordinate_chunk_size_varies_with_start(
         append_dim_start: Timestamp = pd.Timestamp(f"{start_year}-01-01")
 
     inst = C(
-        dims=("time",),
+        dims={ROOT: ("time",)},
         append_dim="time",
         append_dim_start=pd.Timestamp(f"{start_year}-01-01"),
         append_dim_frequency=pd.Timedelta(days=1),
@@ -135,7 +137,7 @@ def test_default_derive_coordinates_returns_spatial_ref(
 
 def test_derive_coordinates_raises_if_coords_not_returned() -> None:
     bad = BadCoordsConfig(
-        dims=("time",),
+        dims={ROOT: ("time",)},
         append_dim="time",
         append_dim_start=pd.Timestamp("2000-01-01"),
         append_dim_frequency=pd.Timedelta(days=1),

--- a/tests/common/template_config_test.py
+++ b/tests/common/template_config_test.py
@@ -37,7 +37,7 @@ class ExampleDatasetAttributes(DatasetAttributes):
 class ExampleConfig(TemplateConfig[ExampleDataVar]):
     """A minimal concrete implementation to test the happy-path logic."""
 
-    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time",)}  # noqa: RUF012
+    dims: dict[Group, tuple[Dim, ...]] = {ROOT: ("time",)}
     append_dim: AppendDim = "time"
     append_dim_start: Timestamp = pd.Timestamp("2000-01-01")
     append_dim_frequency: Timedelta = pd.Timedelta(days=1)

--- a/tests/common/test_config_models.py
+++ b/tests/common/test_config_models.py
@@ -4,11 +4,51 @@ import pytest
 from pydantic import ValidationError
 
 from reformatters.common.config_models import (
+    ROOT,
+    BaseInternalAttrs,
     DatasetAttributes,
+    DataVar,
     DataVarAttrs,
     Encoding,
+    Group,
     codecs_to_dicts,
+    var_path,
 )
+
+
+class TestGroupAndVarPath:
+    def test_root_var_path_is_bare_name(self) -> None:
+        assert var_path(ROOT, "temperature_2m") == "temperature_2m"
+
+    def test_vertical_group_var_path_is_group_slash_name(self) -> None:
+        assert var_path("pressure_level", "temperature") == "pressure_level/temperature"
+
+    def _data_var(self, group: Group = ROOT) -> DataVar:  # type: ignore[type-arg]
+        attrs = DataVarAttrs(
+            long_name="Temperature", short_name="t", units="K", step_type="instant"
+        )
+        encoding = Encoding(dtype="float32", chunks=(1,), shards=None, fill_value=0.0)
+        internal_attrs = BaseInternalAttrs(keep_mantissa_bits="no-rounding")
+        return DataVar(
+            name="temperature",
+            group=group,
+            encoding=encoding,
+            attrs=attrs,
+            internal_attrs=internal_attrs,
+        )
+
+    def test_datavar_defaults_to_root(self) -> None:
+        var = self._data_var()
+        assert var.group is ROOT
+        assert var.path == "temperature"
+
+    def test_datavar_in_vertical_group(self) -> None:
+        var = self._data_var(group="pressure_level")
+        assert var.path == "pressure_level/temperature"
+
+    def test_datavar_rejects_unknown_group(self) -> None:
+        with pytest.raises(ValidationError):
+            self._data_var(group="height_above_ground")  # ty: ignore[invalid-argument-type]
 
 
 class TestCodecsToDicts:

--- a/tests/common/test_failure_injection.py
+++ b/tests/common/test_failure_injection.py
@@ -151,11 +151,11 @@ class FailRegionJob(MaterializedRegionJob[FailDataVar, FailSourceFileCoord]):
         cls,
         primary_store: Store,
         tmp_store: Path,
-        get_template_fn: Callable[[DatetimeLike], xr.Dataset],
+        get_template_fn: Callable[[DatetimeLike], xr.DataTree],
         append_dim: AppendDim,
         all_data_vars: Sequence[FailDataVar],
         reformat_job_name: str,
-    ) -> tuple[Sequence[RegionJob[FailDataVar, FailSourceFileCoord]], xr.Dataset]:
+    ) -> tuple[Sequence[RegionJob[FailDataVar, FailSourceFileCoord]], xr.DataTree]:
         # Mirror the standard resume pattern: reprocess from the latest time already
         # in the store through the (injected) end time.
         existing_ds = xr.open_zarr(primary_store, decode_timedelta=True, chunks=None)
@@ -230,7 +230,7 @@ class FailDataset(DynamicalDataset[FailDataVar, FailSourceFileCoord]):
         return ()
 
 
-def _make_template_ds(end_time: DatetimeLike) -> xr.Dataset:
+def _make_template_ds(end_time: DatetimeLike) -> xr.DataTree:
     times = pd.date_range(_START, end_time, freq=_FREQ, inclusive="left")
     ds = xr.Dataset(
         {
@@ -261,7 +261,7 @@ def _make_template_ds(end_time: DatetimeLike) -> xr.Dataset:
     ds["time"].encoding["fill_value"] = -1
     ds["latitude"].encoding["fill_value"] = np.nan
     ds["longitude"].encoding["fill_value"] = np.nan
-    return ds
+    return xr.DataTree.from_dict({"/": ds})
 
 
 def _make_dataset(tmp_path: Path) -> FailDataset:
@@ -275,7 +275,7 @@ def _make_dataset(tmp_path: Path) -> FailDataset:
 def _run_jobs(
     dataset: FailDataset,
     all_jobs: Sequence[RegionJob[FailDataVar, FailSourceFileCoord]],
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     reformat_job_name: str,
     *,
     update_template_with_results: bool,

--- a/tests/common/test_parallel_coordination.py
+++ b/tests/common/test_parallel_coordination.py
@@ -133,9 +133,9 @@ def stub_io(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
     }
 
 
-def _template() -> xr.Dataset:
+def _template() -> xr.DataTree:
     # An empty dataset is enough — every real use of template_ds is stubbed.
-    return xr.Dataset()
+    return xr.DataTree.from_dict({"/": xr.Dataset()})
 
 
 class TestParallelSetupFirstWorker:

--- a/tests/common/test_parallel_writes.py
+++ b/tests/common/test_parallel_writes.py
@@ -168,7 +168,7 @@ class ParallelDataset(DynamicalDataset[ParallelDataVar, ParallelSourceFileCoord]
         ]
 
 
-def _create_template_ds(num_time: int = 4) -> xr.Dataset:
+def _create_template_ds(num_time: int = 4) -> xr.DataTree:
     ds = xr.Dataset(
         {
             f"var{i}": xr.Variable(
@@ -198,7 +198,7 @@ def _create_template_ds(num_time: int = 4) -> xr.Dataset:
     ds["time"].encoding["fill_value"] = -1
     ds["latitude"].encoding["fill_value"] = np.nan
     ds["longitude"].encoding["fill_value"] = np.nan
-    return ds
+    return xr.DataTree.from_dict({"/": ds})
 
 
 class TestZarr3ParallelWrites:
@@ -327,8 +327,9 @@ class TestZarr3ParallelWrites:
         # Drift the longitude (non-append) chunk on every data var (kept uniform so
         # get_jobs works). An append-axis change alone would be allowed by the guard.
         drifted_ds = _create_template_ds(num_time=4)
-        for var in drifted_ds.data_vars:
-            drifted_ds[var].encoding["chunks"] = (1, _LAT_SIZE, _LON_SIZE // 2)
+        drifted_root = drifted_ds.to_dataset()
+        for var in drifted_root.data_vars:
+            drifted_root[var].encoding["chunks"] = (1, _LAT_SIZE, _LON_SIZE // 2)
 
         all_jobs = ParallelRegionJob.get_jobs(
             tmp_store=dataset._tmp_store(),
@@ -395,7 +396,7 @@ class TestIcechunkParallelWrites:
         )
 
     def _init_store(
-        self, dataset: ParallelDataset, template_ds: xr.Dataset | None = None
+        self, dataset: ParallelDataset, template_ds: xr.DataTree | None = None
     ) -> None:
         """Write metadata to the icechunk store, matching production backfill flow."""
         if template_ds is None:
@@ -603,7 +604,7 @@ class TestResultsAggregation:
         def capturing_update(
             self: ParallelRegionJob,
             process_results: Mapping[str, Sequence[Any]],
-        ) -> xr.Dataset:
+        ) -> xr.DataTree:
             captured.append(dict(process_results))
             return original_update(self, process_results)
 
@@ -627,7 +628,7 @@ class TestResultsAggregation:
         # Each var spans every time step in the template (2 shards, 2 times each).
         for var_name in ("var0", "var1", "var2", "var3"):
             times = sorted(c.out_loc["time"] for c in merged[var_name])
-            assert times == list(template_ds["time"].values)
+            assert times == list(template_ds.to_dataset()["time"].values)
 
     def test_partial_read_failure_trims_template_to_last_successful_time(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -721,7 +722,7 @@ class TestWorkerEdgeCases:
 def _run_workers(
     dataset: ParallelDataset,
     all_jobs: Sequence,
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     *,
     workers_total: int,
     reformat_job_name: str = "test",

--- a/tests/common/test_template_utils.py
+++ b/tests/common/test_template_utils.py
@@ -382,3 +382,62 @@ def test_structural_drift_detects_dims_change() -> None:
     )
     with pytest.raises(ValueError, match=r"var0\.dims"):
         assert_no_structural_drift_from_existing_store(template, existing, "time")
+
+
+# --- multi-group (root + vertical group) structural drift ---
+
+
+def _pressure_var(
+    *,
+    chunks: tuple[int, ...] = (1, 3, 4, 2),
+    pressure_levels: tuple[float, ...] = (1000.0, 850.0),
+) -> xr.DataArray:
+    # A pressure_level group var: (time, latitude, longitude, pressure_level).
+    dims = ("time", "latitude", "longitude", "pressure_level")
+    sizes = {"time": 4, "latitude": 3, "longitude": 4, "pressure_level": 2}
+    da = xr.DataArray(
+        np.zeros(tuple(sizes[d] for d in dims), dtype=np.float32),
+        dims=dims,
+        coords={"pressure_level": list(pressure_levels)},
+    )
+    da.encoding = {"dtype": "float32", "chunks": chunks, "shards": None}
+    return da
+
+
+def _two_node_ds(
+    *,
+    root: xr.DataArray | None = None,
+    pressure: xr.DataArray | None = None,
+) -> xr.DataTree:
+    root_ds = xr.Dataset({"var0": root if root is not None else _structured_var()})
+    nodes: dict[str, xr.Dataset] = {"/": root_ds}
+    if pressure is not None:
+        nodes["/pressure_level"] = xr.Dataset({"temperature": pressure})
+    return xr.DataTree.from_dict(nodes)
+
+
+def test_structural_drift_detects_group_var_non_append_chunk_change() -> None:
+    # Drift a non-append axis (pressure_level chunk 1 -> 2) on the GROUP var; the
+    # mismatch must be reported against the group-qualified path.
+    existing = _two_node_ds(pressure=_pressure_var(chunks=(1, 3, 4, 1)))
+    template = _two_node_ds(pressure=_pressure_var(chunks=(1, 3, 4, 2)))
+    with pytest.raises(ValueError, match=r"pressure_level/temperature\.chunks"):
+        assert_no_structural_drift_from_existing_store(template, existing, "time")
+
+
+def test_structural_drift_detects_group_var_missing_from_template() -> None:
+    existing = _two_node_ds(pressure=_pressure_var())
+    template = _two_node_ds()  # pressure_level group dropped
+    with pytest.raises(
+        ValueError, match=r"pressure_level/temperature: in existing store but missing"
+    ):
+        assert_no_structural_drift_from_existing_store(template, existing, "time")
+
+
+def test_structural_drift_detects_group_coord_value_change() -> None:
+    # Same vars/chunks, but the template reorders the pressure_level coord values.
+    # A reordered vertical level would relabel existing chunks, so the guard fails.
+    existing = _two_node_ds(pressure=_pressure_var(pressure_levels=(1000.0, 850.0)))
+    template = _two_node_ds(pressure=_pressure_var(pressure_levels=(850.0, 1000.0)))
+    with pytest.raises(ValueError, match=r"coord pressure_level"):
+        assert_no_structural_drift_from_existing_store(template, existing, "time")

--- a/tests/common/test_template_utils.py
+++ b/tests/common/test_template_utils.py
@@ -295,8 +295,9 @@ def _structured_var(
     return da
 
 
-def _structured_ds(**vars_: xr.DataArray) -> xr.Dataset:
-    return xr.Dataset(dict(vars_) or {"var0": _structured_var()})
+def _structured_ds(**vars_: xr.DataArray) -> xr.DataTree:
+    ds = xr.Dataset(dict(vars_) or {"var0": _structured_var()})
+    return xr.DataTree.from_dict({"/": ds})
 
 
 def test_structural_drift_passes_for_identical_structure() -> None:

--- a/tests/common/test_zarr.py
+++ b/tests/common/test_zarr.py
@@ -165,6 +165,92 @@ def test_copy_zarr_metadata_noops_when_icechunk_only_and_no_icechunk_store(
     assert mock_copy_metadata_files.call_count == 0
 
 
+@pytest.fixture
+def multi_group_template_ds() -> xr.DataTree:
+    root = xr.Dataset(
+        coords={"time": ["2000-01-01", "2000-01-02"], "lat": [10, 20, 30]}
+    )
+    pressure = xr.Dataset(
+        coords={
+            "time": ["2000-01-01", "2000-01-02"],
+            "lat": [10, 20, 30],
+            "pressure_level": [1000.0, 850.0],
+        }
+    )
+    return xr.DataTree.from_dict({"/": root, "/pressure_level": pressure})
+
+
+@pytest.fixture
+def multi_group_store(tmp_path: Path) -> Path:
+    """A tmp store with a root node and a pressure_level child group, each carrying
+    coord chunks and a zarr.json (mirrors what to_zarr writes for a DataTree)."""
+    store_path = tmp_path / "tmp_store"
+
+    (store_path / "zarr.json").parent.mkdir(parents=True)
+    (store_path / "zarr.json").touch()
+    for coord in ("time", "lat"):
+        chunk_dir = store_path / coord / "c"
+        chunk_dir.mkdir(parents=True)
+        (chunk_dir / "0").touch()
+        (store_path / coord / "zarr.json").touch()
+
+    group = store_path / "pressure_level"
+    (group / "zarr.json").parent.mkdir(parents=True)
+    (group / "zarr.json").touch()
+    for coord in ("time", "lat", "pressure_level"):
+        chunk_dir = group / coord / "c"
+        chunk_dir.mkdir(parents=True)
+        (chunk_dir / "0").touch()
+        (group / coord / "zarr.json").touch()
+
+    return store_path
+
+
+def test_coord_chunk_globs_collects_group_nested_coord_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_group_template_ds: xr.DataTree,
+    multi_group_store: Path,
+) -> None:
+    captured: dict[str, list[Path]] = {}
+
+    def fake_copy_metadata_files(
+        files: list[Path], _store_path: Path, _store: Store
+    ) -> None:
+        captured["files"] = files
+
+    monkeypatch.setattr(zarr_module, "_copy_metadata_files", fake_copy_metadata_files)
+
+    copy_zarr_metadata(multi_group_template_ds, multi_group_store, Mock(spec=Store))
+
+    relative = {f.relative_to(multi_group_store).as_posix() for f in captured["files"]}
+    # The group's own vertical coord chunk lives under the group prefix and must be collected.
+    assert "pressure_level/pressure_level/c/0" in relative
+
+
+def test_copy_zarr_metadata_icechunk_writes_root_zarr_json_before_group(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_group_template_ds: xr.DataTree,
+    multi_group_store: Path,
+) -> None:
+    captured: dict[str, list[Path]] = {}
+
+    def fake_copy_metadata_files(
+        files: list[Path], _store_path: Path, _store: Store
+    ) -> None:
+        captured["files"] = files
+
+    monkeypatch.setattr(zarr_module, "_copy_metadata_files", fake_copy_metadata_files)
+
+    copy_zarr_metadata(
+        multi_group_template_ds, multi_group_store, Mock(spec=IcechunkStore)
+    )
+
+    order = [f.relative_to(multi_group_store).as_posix() for f in captured["files"]]
+    # Shallowest-first: a parent group's metadata is written before its child's, so
+    # icechunk never rejects a child array whose parent group does not yet exist.
+    assert order.index("zarr.json") < order.index("pressure_level/zarr.json")
+
+
 # --- sync_to_store tests ---
 
 

--- a/tests/common/test_zarr.py
+++ b/tests/common/test_zarr.py
@@ -227,6 +227,35 @@ def test_coord_chunk_globs_collects_group_nested_coord_chunk(
     assert "pressure_level/pressure_level/c/0" in relative
 
 
+def test_coord_chunk_globs_collects_scalar_coord_chunk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A scalar coord (e.g. spatial_ref) stores its single chunk as the file
+    # `spatial_ref/c`, not `spatial_ref/c/0`; the `c/**/*` glob alone would miss it.
+    template = xr.DataTree.from_dict(
+        {"/": xr.Dataset(coords={"lat": [10, 20], "spatial_ref": ((), np.array(0))})}
+    )
+    store = tmp_path / "store"
+    (store / "zarr.json").parent.mkdir(parents=True)
+    (store / "zarr.json").touch()
+    (store / "lat" / "c").mkdir(parents=True)
+    (store / "lat" / "c" / "0").touch()
+    (store / "spatial_ref").mkdir()
+    (store / "spatial_ref" / "c").touch()  # scalar chunk is a file named "c"
+
+    captured: dict[str, list[Path]] = {}
+    monkeypatch.setattr(
+        zarr_module,
+        "_copy_metadata_files",
+        lambda files, _store_path, _store: captured.__setitem__("files", files),
+    )
+    copy_zarr_metadata(template, store, Mock(spec=Store))
+
+    relative = {f.relative_to(store).as_posix() for f in captured["files"]}
+    assert "spatial_ref/c" in relative  # the scalar chunk file is collected
+    assert "lat/c/0" in relative  # and chunked coords still are
+
+
 def test_copy_zarr_metadata_icechunk_writes_root_zarr_json_before_group(
     monkeypatch: pytest.MonkeyPatch,
     multi_group_template_ds: xr.DataTree,

--- a/tests/common/test_zarr.py
+++ b/tests/common/test_zarr.py
@@ -18,12 +18,16 @@ from reformatters.common.zarr import (
 
 
 @pytest.fixture
-def template_ds() -> xr.Dataset:
-    return xr.Dataset(
-        coords={
-            "time": ["2000-01-01", "2000-01-02"],
-            "lat": [10, 20, 30],
-            "lon": [100, 110, 120],
+def template_ds() -> xr.DataTree:
+    return xr.DataTree.from_dict(
+        {
+            "/": xr.Dataset(
+                coords={
+                    "time": ["2000-01-01", "2000-01-02"],
+                    "lat": [10, 20, 30],
+                    "lon": [100, 110, 120],
+                }
+            )
         }
     )
 
@@ -63,7 +67,7 @@ def tmp_store_and_metadata_files(tmp_path: Path) -> tuple[Path, list[Path]]:
 
 def test_copy_zarr_metadata_calls_copy_metadata_files_for_all_stores(
     monkeypatch: pytest.MonkeyPatch,
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     tmp_store_and_metadata_files: tuple[Path, list[Path]],
 ) -> None:
     tmp_store, expected_metadata_files = tmp_store_and_metadata_files
@@ -104,7 +108,7 @@ def _assert_format_specific_order(files: list[Path], store: Store) -> None:
 
 def test_copy_zarr_metadata_skips_non_icechunk_stores_when_icechunk_only(
     monkeypatch: pytest.MonkeyPatch,
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     tmp_store_and_metadata_files: tuple[Path, list[Path]],
 ) -> None:
     tmp_store, expected_metadata_files = tmp_store_and_metadata_files
@@ -141,7 +145,7 @@ def test_copy_zarr_metadata_skips_non_icechunk_stores_when_icechunk_only(
 
 def test_copy_zarr_metadata_noops_when_icechunk_only_and_no_icechunk_store(
     monkeypatch: pytest.MonkeyPatch,
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     tmp_store_and_metadata_files: tuple[Path, list[Path]],
 ) -> None:
     tmp_store, _expected_metadata_files = tmp_store_and_metadata_files

--- a/tests/common/virtual_multi_group_test.py
+++ b/tests/common/virtual_multi_group_test.py
@@ -539,6 +539,66 @@ def test_two_worker_backfill_disjoint(tmp_path: Path) -> None:
     assert list(_primary_repo(dataset.store_factory).list_branches()) == ["main"]
 
 
+class _PressureProbeCoord(MultiGroupSourceFileCoord):
+    pressure_level: float
+
+    def get_url(self) -> str:
+        return MultiGroupRegionJob.messages_url
+
+
+class _PressureProbeRegionJob(MultiGroupRegionJob):
+    def representative_var(
+        self,
+        coord: MultiGroupSourceFileCoord,  # noqa: ARG002
+    ) -> DataVar[BaseInternalAttrs]:
+        # Probe the pressure_level group array, not the root var.
+        return next(v for v in self.data_vars if v.group == "pressure_level")
+
+
+def test_filter_already_present_probes_group_array(tmp_path: Path) -> None:
+    # A backfill over init 0 only writes pressure_level/temperature chunks for init 0.
+    dataset = _make_dataset(tmp_path, n_inits=2)
+    template_ds = _create_template_ds(2)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+    job = _make_region_job(template_ds, region=slice(0, 1))
+    job.process_virtual(repo, [], "main")
+
+    probe_job = _PressureProbeRegionJob(
+        tmp_store=Path("unused-tmp.zarr"),
+        template_ds=template_ds,
+        data_vars=_data_vars(),
+        append_dim="init_time",
+        region=slice(0, 2),
+        reformat_job_name="test",
+        processing_mode="backfill",
+    )
+    present = _PressureProbeCoord(
+        init_time=APPEND_DIM_START,
+        lead_time=LEAD_TIMES[0],
+        pressure_level=float(PRESSURE_LEVELS[0]),  # written by the init-0 backfill
+    )
+    absent = _PressureProbeCoord(
+        init_time=APPEND_DIM_START + APPEND_DIM_FREQ,  # init 1, not backfilled
+        lead_time=LEAD_TIMES[0],
+        pressure_level=float(PRESSURE_LEVELS[0]),
+    )
+    out_of_coords = _PressureProbeCoord(
+        init_time=APPEND_DIM_START,
+        lead_time=LEAD_TIMES[0],
+        pressure_level=123.0,  # not in PRESSURE_LEVELS -> chunk_key None -> remaining
+    )
+
+    readonly_store = repo.readonly_session("main").store
+    remaining = probe_job.filter_already_present(
+        [present, absent, out_of_coords], readonly_store
+    )
+
+    assert present not in remaining  # already in the manifest
+    assert absent in remaining  # not yet written
+    assert out_of_coords in remaining  # not a position in the dataset
+
+
 def test_virtual_operational_expands_both_groups(tmp_path: Path) -> None:
     # Per-group append-dim growth via sync_dims_to: start with empty main (0 inits),
     # then operationally expand both groups to 2 inits.

--- a/tests/common/virtual_multi_group_test.py
+++ b/tests/common/virtual_multi_group_test.py
@@ -1,0 +1,553 @@
+"""End-to-end test for a VIRTUAL icechunk dataset with a vertical-dimension group.
+
+This mirrors the single-group harness in ``virtual_region_job_test.py`` but adds a
+``pressure_level`` group so the multi-group virtual write loop is exercised: refs
+landing at a group-qualified array path (``pressure_level/temperature``), per-file
+commit atomicity *across* groups (one file's root + pressure refs commit together),
+per-group append-dim growth (each node grown on its own via ``sync_dims_to``), and a
+chunk_key that resolves a vertical-dimension position.
+
+As in the single-group file the "GRIB messages" are raw little-endian float64 blocks
+in a local file and refs point at byte ranges via a local-filesystem virtual chunk
+container (no real GRIB / no GribberishCodec), so a value round-trip catches bad chunk
+keys *and* bad byte ranges.
+"""
+
+from collections.abc import Iterator, Mapping, Sequence
+from datetime import timedelta
+from itertools import batched
+from pathlib import Path
+from typing import Any, ClassVar, Literal
+
+import dask.array
+import icechunk
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from reformatters.common import template_utils, validation
+from reformatters.common.config_models import (
+    ROOT,
+    BaseInternalAttrs,
+    DataVar,
+    DataVarAttrs,
+    Encoding,
+    Group,
+)
+from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
+from reformatters.common.region_job import CoordinateValue, SourceFileCoord
+from reformatters.common.storage import (
+    DatasetFormat,
+    IcechunkVirtualConfig,
+    StorageConfig,
+    StoreFactory,
+    manifest_append_dim_split,
+)
+from reformatters.common.template_config import TemplateConfig
+from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
+from reformatters.common.virtual_region_job import VirtualRef, VirtualRegionJob
+
+pytestmark = pytest.mark.slow
+
+N_LAT = 2
+N_LON = 3
+LEAD_TIMES = pd.timedelta_range("0h", periods=1, freq="6h")
+N_LEADS = len(LEAD_TIMES)
+PRESSURE_LEVELS = [1000, 850]
+N_LEVELS = len(PRESSURE_LEVELS)
+BLOCK_NBYTES = N_LAT * N_LON * 8  # one float64 message
+APPEND_DIM_START = pd.Timestamp("2024-01-01")
+APPEND_DIM_FREQ = pd.Timedelta("6h")
+DATASET_ID = "test-virtual-multi-group-dataset"
+
+# Per-file message layout: a root temperature_2m block followed by one block per
+# pressure level. Byte offsets are deterministic and distinct so a value round-trip
+# proves each ref landed at the right (group/name, chunk key, byte range).
+BLOCKS_PER_FILE = 1 + N_LEVELS
+FILE_NBYTES = BLOCKS_PER_FILE * BLOCK_NBYTES
+
+
+def _root_values(init_idx: int, lead_idx: int) -> np.ndarray:
+    """Deterministic root (temperature_2m) message values; distinct per (init, lead)."""
+    base = 1000.0 * init_idx + 10.0 * lead_idx
+    return (base + np.arange(N_LAT * N_LON)).reshape(N_LAT, N_LON).astype("<f8")
+
+
+def _pressure_values(init_idx: int, lead_idx: int, level_idx: int) -> np.ndarray:
+    """Deterministic pressure-level message values; distinct per (init, lead, level)."""
+    base = 1000.0 * init_idx + 10.0 * lead_idx + 100000.0 * (level_idx + 1)
+    return (base + np.arange(N_LAT * N_LON)).reshape(N_LAT, N_LON).astype("<f8")
+
+
+def _file_offset(init_idx: int, lead_idx: int) -> int:
+    return (init_idx * N_LEADS + lead_idx) * FILE_NBYTES
+
+
+def _root_offset_length(init_idx: int, lead_idx: int) -> tuple[int, int]:
+    return _file_offset(init_idx, lead_idx), BLOCK_NBYTES
+
+
+def _pressure_offset_length(
+    init_idx: int, lead_idx: int, level_idx: int
+) -> tuple[int, int]:
+    # Root block first, then one block per level.
+    block = 1 + level_idx
+    return _file_offset(init_idx, lead_idx) + block * BLOCK_NBYTES, BLOCK_NBYTES
+
+
+def _write_messages_file(path: Path, n_inits: int) -> None:
+    chunks: list[bytes] = []
+    for init_idx in range(n_inits):
+        for lead_idx in range(N_LEADS):
+            chunks.append(_root_values(init_idx, lead_idx).tobytes())
+            chunks.extend(
+                _pressure_values(init_idx, lead_idx, level_idx).tobytes()
+                for level_idx in range(N_LEVELS)
+            )
+    path.write_bytes(b"".join(chunks))
+
+
+def _create_template_ds(n_inits: int) -> xr.DataTree:
+    """Forecast-shaped virtual template with a root var plus a pressure_level group.
+
+    One chunk per message: chunk size 1 along init_time, lead_time, and pressure_level
+    so each (init, lead[, level]) is its own chunk. No shards; no compressors.
+    """
+    init_times = pd.date_range(APPEND_DIM_START, periods=n_inits, freq=APPEND_DIM_FREQ)
+    shared_coords = {
+        "init_time": ("init_time", init_times),
+        "lead_time": ("lead_time", LEAD_TIMES),
+        "latitude": ("latitude", np.arange(N_LAT, dtype="float64")),
+        "longitude": ("longitude", np.arange(N_LON, dtype="float64")),
+        "valid_time": (
+            ("init_time", "lead_time"),
+            init_times.values[:, None] + LEAD_TIMES.values[None, :],
+        ),
+    }
+    root = xr.Dataset(
+        {
+            "temperature_2m": xr.Variable(
+                ("init_time", "lead_time", "latitude", "longitude"),
+                dask.array.full(
+                    (n_inits, N_LEADS, N_LAT, N_LON),
+                    np.nan,
+                    dtype="float64",
+                    chunks=-1,
+                ),
+                encoding={
+                    "dtype": "float64",
+                    "chunks": (1, 1, N_LAT, N_LON),
+                    "fill_value": np.nan,
+                    "compressors": None,
+                    "filters": None,
+                },
+            )
+        },
+        coords=shared_coords,
+        attrs={"dataset_id": DATASET_ID, "dataset_version": "v1.0"},
+    )
+    pressure = xr.Dataset(
+        {
+            "temperature": xr.Variable(
+                ("init_time", "lead_time", "latitude", "longitude", "pressure_level"),
+                dask.array.full(
+                    (n_inits, N_LEADS, N_LAT, N_LON, N_LEVELS),
+                    np.nan,
+                    dtype="float64",
+                    chunks=-1,
+                ),
+                encoding={
+                    "dtype": "float64",
+                    "chunks": (1, 1, N_LAT, N_LON, 1),  # one chunk per level
+                    "fill_value": np.nan,
+                    "compressors": None,
+                    "filters": None,
+                },
+            )
+        },
+        # Shared coords are duplicated into the group so it can be opened on its own.
+        coords={**shared_coords, "pressure_level": ("pressure_level", PRESSURE_LEVELS)},
+    )
+
+    # Explicit time encodings so dimension-appends re-encode consistently.
+    time_encoding = {
+        "dtype": "int64",
+        "fill_value": -1,
+        "units": "seconds since 1970-01-01 00:00:00",
+        "calendar": "proleptic_gregorian",
+    }
+    lead_encoding = {"dtype": "int64", "fill_value": -1, "units": "seconds"}
+    for ds in (root, pressure):
+        ds["init_time"].encoding.update(time_encoding)
+        ds["valid_time"].encoding.update(time_encoding)
+        ds["lead_time"].encoding.update(lead_encoding)
+        ds["latitude"].encoding["fill_value"] = np.nan
+        ds["longitude"].encoding["fill_value"] = np.nan
+    pressure["pressure_level"].encoding["fill_value"] = -1
+    return xr.DataTree.from_dict({"/": root, "/pressure_level": pressure})
+
+
+# --- synthetic virtual multi-group forecast dataset ---
+
+
+class RootDataVar(DataVar[BaseInternalAttrs]):
+    encoding: Encoding = Encoding(
+        dtype="float64",
+        fill_value=np.nan,
+        chunks=(1, 1, N_LAT, N_LON),
+        shards=None,
+        compressors=(),
+        filters=None,
+    )
+    attrs: DataVarAttrs = DataVarAttrs(
+        units="K",
+        long_name="2 metre temperature",
+        short_name="2t",
+        step_type="instant",
+    )
+    internal_attrs: BaseInternalAttrs = BaseInternalAttrs(
+        keep_mantissa_bits="no-rounding"
+    )
+
+
+class PressureDataVar(DataVar[BaseInternalAttrs]):
+    group: Group = "pressure_level"
+    encoding: Encoding = Encoding(
+        dtype="float64",
+        fill_value=np.nan,
+        chunks=(1, 1, N_LAT, N_LON, 1),
+        shards=None,
+        compressors=(),
+        filters=None,
+    )
+    attrs: DataVarAttrs = DataVarAttrs(
+        units="K",
+        long_name="Temperature",
+        short_name="t",
+        step_type="instant",
+    )
+    internal_attrs: BaseInternalAttrs = BaseInternalAttrs(
+        keep_mantissa_bits="no-rounding"
+    )
+
+
+def _data_vars() -> list[DataVar[BaseInternalAttrs]]:
+    return [
+        RootDataVar(name="temperature_2m"),
+        PressureDataVar(name="temperature", group="pressure_level"),
+    ]
+
+
+class MultiGroupSourceFileCoord(SourceFileCoord):
+    init_time: Timestamp
+    lead_time: Timedelta
+
+    def get_url(self) -> str:
+        return MultiGroupRegionJob.messages_url
+
+
+class MultiGroupRegionJob(
+    VirtualRegionJob[DataVar[BaseInternalAttrs], MultiGroupSourceFileCoord]
+):
+    # Set per test by _make_dataset; every ref points at this file.
+    messages_url: ClassVar[str] = ""
+    # Whole files per yielded batch (one commit per batch).
+    backfill_batch_files: ClassVar[int] = 1
+
+    def generate_source_file_coords(
+        self,
+        processing_region_ds: xr.Dataset,
+        data_var_group: Sequence[DataVar[BaseInternalAttrs]],  # noqa: ARG002
+    ) -> Sequence[MultiGroupSourceFileCoord]:
+        return [
+            MultiGroupSourceFileCoord(init_time=pd.Timestamp(init_time), lead_time=lead)
+            for init_time in processing_region_ds["init_time"].values
+            for lead in LEAD_TIMES
+        ]
+
+    def process_virtual_refs(
+        self,
+        remaining: Sequence[MultiGroupSourceFileCoord],
+    ) -> Iterator[Sequence[tuple[MultiGroupSourceFileCoord, Sequence[VirtualRef]]]]:
+        # One source file contributes refs for BOTH the root chunk and each
+        # pressure-level chunk, all in one (coord, refs) entry so they commit
+        # together (per-file commit atomicity across groups).
+        root_var, pressure_var = _data_vars()
+        init_index = self.template_ds.to_dataset().get_index("init_time")
+        lead_index = self.template_ds.to_dataset().get_index("lead_time")
+        for group in batched(remaining, self.backfill_batch_files, strict=False):
+            batch: list[tuple[MultiGroupSourceFileCoord, Sequence[VirtualRef]]] = []
+            for coord in group:
+                init_idx = int(init_index.get_indexer(pd.Index([coord.init_time]))[0])
+                lead_idx = int(lead_index.get_indexer(pd.Index([coord.lead_time]))[0])
+
+                root_offset, root_length = _root_offset_length(init_idx, lead_idx)
+                refs: list[VirtualRef] = [
+                    VirtualRef(
+                        data_var=root_var,
+                        out_loc=coord.out_loc(),  # {init_time, lead_time}
+                        location=self.messages_url,
+                        offset=root_offset,
+                        length=root_length,
+                    )
+                ]
+                for level_idx, level in enumerate(PRESSURE_LEVELS):
+                    offset, length = _pressure_offset_length(
+                        init_idx, lead_idx, level_idx
+                    )
+                    refs.append(
+                        VirtualRef(
+                            data_var=pressure_var,
+                            # var.path routes set_virtual_refs to the group array;
+                            # the level position comes from this out_loc.
+                            out_loc={**coord.out_loc(), "pressure_level": level},
+                            location=self.messages_url,
+                            offset=offset,
+                            length=length,
+                        )
+                    )
+                batch.append((coord, refs))
+            yield batch
+
+
+class MultiGroupTemplateConfig(TemplateConfig[DataVar[BaseInternalAttrs]]):
+    dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+        ROOT: ("init_time", "lead_time", "latitude", "longitude"),
+        "pressure_level": (
+            "init_time",
+            "lead_time",
+            "latitude",
+            "longitude",
+            "pressure_level",
+        ),
+    }
+    append_dim: AppendDim = "init_time"
+    append_dim_start: Timestamp = APPEND_DIM_START
+    append_dim_frequency: Timedelta = APPEND_DIM_FREQ
+
+    @property
+    def dataset_id(self) -> str:
+        return DATASET_ID
+
+    @property
+    def version(self) -> str:
+        return "v1.0"
+
+    @property
+    def data_vars(self) -> Sequence[DataVar[BaseInternalAttrs]]:
+        return _data_vars()
+
+
+class MultiGroupDataset(
+    DynamicalDataset[DataVar[BaseInternalAttrs], MultiGroupSourceFileCoord]
+):
+    template_config: MultiGroupTemplateConfig = MultiGroupTemplateConfig()
+    region_job_class: type[MultiGroupRegionJob] = MultiGroupRegionJob
+
+    def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+        return [
+            ReformatCronJob(
+                name=f"{self.dataset_id}-update",
+                schedule="0 0 * * *",
+                pod_active_deadline=timedelta(minutes=5),
+                image=image_tag,
+                dataset_id=self.dataset_id,
+                cpu="1",
+                memory="1G",
+                shared_memory="1G",
+                ephemeral_storage="1G",
+                secret_names=self.store_factory.k8s_secret_names(),
+            ),
+            ValidationCronJob(
+                name=f"{self.dataset_id}-validate",
+                schedule="0 1 * * *",
+                pod_active_deadline=timedelta(minutes=5),
+                image=image_tag,
+                dataset_id=self.dataset_id,
+                cpu="1",
+                memory="1G",
+                shared_memory="1G",
+                ephemeral_storage="1G",
+                secret_names=self.store_factory.k8s_secret_names(),
+            ),
+        ]
+
+    def validators(self) -> Sequence[validation.DataValidator]:
+        return ()
+
+
+def _make_dataset(tmp_path: Path, *, n_inits: int = 2) -> MultiGroupDataset:
+    """Build the dataset, write the messages file, and point the region job at it.
+
+    The virtual chunk container is a local-filesystem store rooted at tmp_path;
+    refs point at tmp_path/messages.bin.
+    """
+    messages_path = tmp_path / "messages.bin"
+    _write_messages_file(messages_path, n_inits=max(n_inits, 2))
+    MultiGroupRegionJob.messages_url = f"file://{messages_path}"
+    MultiGroupRegionJob.backfill_batch_files = 1
+
+    container = icechunk.VirtualChunkContainer(
+        f"file://{tmp_path}/", icechunk.local_filesystem_store(str(tmp_path))
+    )
+    return MultiGroupDataset(
+        primary_storage_config=StorageConfig(
+            base_path=str(tmp_path), format=DatasetFormat.ICECHUNK
+        ),
+        icechunk_virtual_config=IcechunkVirtualConfig(
+            containers=(container,),
+            manifest_split=manifest_append_dim_split(split_size=2, dim="init_time"),
+        ),
+    )
+
+
+def _make_region_job(
+    template_ds: xr.DataTree,
+    *,
+    region: slice,
+    processing_mode: Literal["backfill", "update"] = "backfill",
+) -> MultiGroupRegionJob:
+    return MultiGroupRegionJob(
+        tmp_store=Path("unused-tmp.zarr"),
+        template_ds=template_ds,
+        data_vars=_data_vars(),
+        append_dim="init_time",
+        region=region,
+        reformat_job_name="test",
+        processing_mode=processing_mode,
+    )
+
+
+def _primary_repo(factory: StoreFactory) -> icechunk.Repository:
+    return factory.icechunk_repos(sort="primary-first")[0][1]
+
+
+def _assert_all_values(dataset: MultiGroupDataset, n_inits: int) -> None:
+    """Read back via DataTree and assert both groups carry their deterministic values
+    at the correct (init, lead[, level]) positions."""
+    store: Any = dataset.store_factory.primary_store()
+    tree = xr.open_datatree(store, engine="zarr", decode_timedelta=True)
+
+    root = tree.to_dataset()
+    assert root.sizes["init_time"] == n_inits
+    pressure_ds = tree["pressure_level"].to_dataset()
+    assert pressure_ds.sizes["init_time"] == n_inits
+
+    for init_idx in range(n_inits):
+        for lead_idx in range(N_LEADS):
+            np.testing.assert_array_equal(
+                root["temperature_2m"]
+                .isel(init_time=init_idx, lead_time=lead_idx)
+                .values,
+                _root_values(init_idx, lead_idx),
+            )
+            for level_idx in range(N_LEVELS):
+                np.testing.assert_array_equal(
+                    pressure_ds["temperature"]
+                    .isel(
+                        init_time=init_idx,
+                        lead_time=lead_idx,
+                        pressure_level=level_idx,
+                    )
+                    .values,
+                    _pressure_values(init_idx, lead_idx, level_idx),
+                )
+
+
+# --- chunk_key resolves a vertical-dimension position ---
+
+
+def test_chunk_key_resolves_pressure_level_position() -> None:
+    job = _make_region_job(_create_template_ds(2), region=slice(0, 2))
+    pressure_var = next(v for v in job.data_vars if v.group == "pressure_level")
+    # init index 1, lead index 0, lat/lon single full-width chunks, level index 1.
+    out_loc: Mapping[Dim, CoordinateValue] = {
+        "init_time": APPEND_DIM_START + APPEND_DIM_FREQ,
+        "lead_time": LEAD_TIMES[0],
+        "pressure_level": PRESSURE_LEVELS[1],
+    }
+    assert job.chunk_key(out_loc, pressure_var) == (1, 0, 0, 0, 1)
+
+
+# --- backfill: value round-trip + per-group growth + per-file atomicity ---
+
+
+def test_backfill_emits_refs_to_both_groups_and_reads_back(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path, n_inits=2)
+    template_ds = _create_template_ds(2)
+    # Pre-size main with full metadata (as a backfill's parallel_setup would).
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+
+    repo = _primary_repo(dataset.store_factory)
+    job = _make_region_job(template_ds, region=slice(0, 2))
+    job.process_virtual(repo, [], "main")
+
+    # (1) Refs landed at the right group/name chunk keys and byte ranges; (2) both
+    # the root and pressure_level groups grew to the expected init_time length.
+    _assert_all_values(dataset, n_inits=2)
+
+
+def test_per_file_commit_contains_both_groups(tmp_path: Path) -> None:
+    # Per-file atomicity across groups: each source file is one commit, and that
+    # commit writes both a root chunk and a pressure_level chunk for the same file.
+    dataset = _make_dataset(tmp_path, n_inits=2)
+    template_ds = _create_template_ds(2)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+
+    job = _make_region_job(template_ds, region=slice(0, 1))
+    job.process_virtual(repo, [], "main")
+
+    # One file (init 0, lead 0) -> exactly one new commit holding both groups' chunks.
+    snapshots = list(repo.ancestry(branch="main"))
+    latest = snapshots[0]
+    changed = repo.diff(from_snapshot_id=snapshots[1].id, to_snapshot_id=latest.id)
+    written = {path.removeprefix("/") for path in changed.updated_chunks}
+    assert "temperature_2m" in written
+    assert "pressure_level/temperature" in written
+
+
+def test_two_worker_backfill_disjoint(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path, n_inits=2)
+    template_ds = _create_template_ds(2)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+
+    all_jobs = MultiGroupRegionJob.get_jobs(
+        tmp_store=dataset._tmp_store(),
+        template_ds=template_ds,
+        append_dim="init_time",
+        all_data_vars=dataset.template_config.data_vars,
+        reformat_job_name="test",
+    )
+    # shards=None -> partition by chunks -> one region (one init) per job.
+    assert len(all_jobs) == 2
+
+    for worker_index in range(2):
+        dataset._process_region_jobs(
+            all_jobs=all_jobs,
+            worker_index=worker_index,
+            workers_total=2,
+            reformat_job_name="test",
+            template_ds=template_ds,
+            tmp_store=tmp_path / f"worker-{worker_index}-tmp.zarr",
+            update_template_with_results=False,
+        )
+
+    _assert_all_values(dataset, n_inits=2)
+    assert list(_primary_repo(dataset.store_factory).list_branches()) == ["main"]
+
+
+def test_virtual_operational_expands_both_groups(tmp_path: Path) -> None:
+    # Per-group append-dim growth via sync_dims_to: start with empty main (0 inits),
+    # then operationally expand both groups to 2 inits.
+    dataset = _make_dataset(tmp_path, n_inits=2)
+    template_utils.write_metadata(_create_template_ds(0), dataset.store_factory)
+    full_template = _create_template_ds(2)
+    job = _make_region_job(full_template, region=slice(0, 2), processing_mode="update")
+
+    dataset._run_virtual_operational_update([job], worker_index=0, workers_total=1)
+
+    assert list(_primary_repo(dataset.store_factory).list_branches()) == ["main"]
+    _assert_all_values(dataset, n_inits=2)

--- a/tests/common/virtual_multi_group_test.py
+++ b/tests/common/virtual_multi_group_test.py
@@ -313,7 +313,7 @@ class MultiGroupRegionJob(
 
 
 class MultiGroupTemplateConfig(TemplateConfig[DataVar[BaseInternalAttrs]]):
-    dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+    dims: dict[Group, tuple[Dim, ...]] = {
         ROOT: ("init_time", "lead_time", "latitude", "longitude"),
         "pressure_level": (
             "init_time",

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -226,7 +226,7 @@ class VirtualTestRegionJob(
 
 
 class VirtualTestTemplateConfig(TemplateConfig[VirtualTestDataVar]):
-    dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+    dims: dict[Group, tuple[Dim, ...]] = {
         ROOT: ("init_time", "lead_time", "latitude", "longitude")
     }
     append_dim: AppendDim = "init_time"

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -29,10 +29,12 @@ from zarr.core.metadata import ArrayV3Metadata
 
 from reformatters.common import template_utils, validation
 from reformatters.common.config_models import (
+    ROOT,
     BaseInternalAttrs,
     DataVar,
     DataVarAttrs,
     Encoding,
+    Group,
 )
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
@@ -224,7 +226,9 @@ class VirtualTestRegionJob(
 
 
 class VirtualTestTemplateConfig(TemplateConfig[VirtualTestDataVar]):
-    dims: tuple[Dim, ...] = ("init_time", "lead_time", "latitude", "longitude")
+    dims: dict[Group, tuple[Dim, ...]] = {  # noqa: RUF012
+        ROOT: ("init_time", "lead_time", "latitude", "longitude")
+    }
     append_dim: AppendDim = "init_time"
     append_dim_start: Timestamp = APPEND_DIM_START
     append_dim_frequency: Timedelta = APPEND_DIM_FREQ

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -92,7 +92,7 @@ def _create_template_ds(
     *,
     serializer: dict[str, Any] | None = None,
     chunks: tuple[int, ...] = (1, 1, N_LAT, N_LON),
-) -> xr.Dataset:
+) -> xr.DataTree:
     """Forecast-shaped virtual template (no shards; one chunk per message)."""
     init_times = pd.date_range(APPEND_DIM_START, periods=n_inits, freq=APPEND_DIM_FREQ)
     encoding: dict[str, Any] = {
@@ -143,7 +143,7 @@ def _create_template_ds(
     )
     ds["latitude"].encoding["fill_value"] = np.nan
     ds["longitude"].encoding["fill_value"] = np.nan
-    return ds
+    return xr.DataTree.from_dict({"/": ds})
 
 
 # --- synthetic virtual forecast dataset ---
@@ -203,8 +203,9 @@ class VirtualTestRegionJob(
         remaining: Sequence[VirtualTestSourceFileCoord],
     ) -> Iterator[Sequence[tuple[VirtualTestSourceFileCoord, Sequence[VirtualRef]]]]:
         data_var = self.data_vars[0]
-        init_index = self.template_ds.get_index("init_time")
-        lead_index = self.template_ds.get_index("lead_time")
+        template_root = self.template_ds.to_dataset()
+        init_index = template_root.get_index("init_time")
+        lead_index = template_root.get_index("lead_time")
         for group in batched(remaining, self.backfill_batch_files, strict=False):
             batch: list[tuple[VirtualTestSourceFileCoord, Sequence[VirtualRef]]] = []
             for coord in group:
@@ -308,7 +309,7 @@ def _make_dataset(tmp_path: Path, *, n_inits: int = 4) -> VirtualTestDataset:
 
 
 def _make_region_job(
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     *,
     region: slice,
     processing_mode: Literal["backfill", "update"] = "backfill",
@@ -689,10 +690,10 @@ def test_sync_dims_to_grows_then_is_noop(tmp_path: Path) -> None:
     # Derived coord (dims init_time x lead_time) expanded alongside the append dim.
     assert grown["valid_time"].sizes["init_time"] == 3
     np.testing.assert_array_equal(
-        grown["valid_time"].values, full_template["valid_time"].values[:3]
+        grown["valid_time"].values, full_template.to_dataset()["valid_time"].values[:3]
     )
     np.testing.assert_array_equal(
-        grown["init_time"].values, full_template["init_time"].values[:3]
+        grown["init_time"].values, full_template.to_dataset()["init_time"].values[:3]
     )
 
     # Already covered -> no-op (no write, session stays clean).
@@ -739,7 +740,7 @@ def test_sync_dims_to_resizes_each_store_from_its_own_size(tmp_path: Path) -> No
         ds = xr.open_zarr(repo.readonly_session("main").store, decode_timedelta=True)
         assert ds.sizes["init_time"] == 3
         np.testing.assert_array_equal(
-            ds["init_time"].values, full_template["init_time"].values[:3]
+            ds["init_time"].values, full_template.to_dataset()["init_time"].values[:3]
         )
 
 

--- a/tests/contrib/nasa/smap/level3_36km_v9/region_job_test.py
+++ b/tests/contrib/nasa/smap/level3_36km_v9/region_job_test.py
@@ -315,7 +315,9 @@ def test_operational_update_jobs(
 
     # Create a mock existing dataset with data up to 2025-09-28
     existing_end = pd.Timestamp("2025-09-28")
-    existing_ds = template_config.get_template(existing_end + pd.Timedelta("1s"))
+    existing_ds = template_config.get_template(
+        existing_end + pd.Timedelta("1s")
+    ).to_dataset()
 
     # Mock the primary store to return our existing dataset
     mock_store = Mock()

--- a/tests/contrib/nasa/smap/level3_36km_v9/template_config_test.py
+++ b/tests/contrib/nasa/smap/level3_36km_v9/template_config_test.py
@@ -13,7 +13,7 @@ def test_get_template_spatial_ref() -> None:
     template_config = NasaSmapLevel336KmV9TemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=10)
-    )
+    ).to_dataset()
     original_attrs = deepcopy(ds.spatial_ref.attrs)
 
     expected_crs = "EPSG:6933"

--- a/tests/contrib/noaa/ndvi_cdr/analysis/template_config_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/template_config_test.py
@@ -12,7 +12,7 @@ def test_get_template_spatial_ref() -> None:
     template_config = NoaaNdviCdrAnalysisTemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=10)
-    )
+    ).to_dataset()
     original_attrs = deepcopy(ds.spatial_ref.attrs)
 
     expected_crs = "EPSG:4326"

--- a/tests/contrib/uarizona/swann/template_config_test.py
+++ b/tests/contrib/uarizona/swann/template_config_test.py
@@ -11,7 +11,7 @@ def test_get_template_spatial_ref() -> None:
     template_config = UarizonaSwannAnalysisTemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=5)
-    )
+    ).to_dataset()
     original_attrs = deepcopy(ds.spatial_ref.attrs)
 
     # See https://nsidc.org/sites/default/files/documents/user-guide/nsidc-0719-v001-userguide.pdf

--- a/tests/dwd/icon_eu/forecast_5_day/region_job_test.py
+++ b/tests/dwd/icon_eu/forecast_5_day/region_job_test.py
@@ -120,7 +120,9 @@ def test_source_file_coord_out_loc(
 
 def test_region_job_source_groups() -> None:
     template_config = DwdIconEuForecast5DayTemplateConfig()
-    groups = DwdIconEuForecast5DayRegionJob.source_groups(template_config.data_vars)
+    groups = DwdIconEuForecast5DayRegionJob.source_file_var_groups(
+        template_config.data_vars
+    )
     # Each variable gets its own group (one var per GRIB file)
     assert len(groups) == len(template_config.data_vars)
     for group in groups:

--- a/tests/dwd/icon_eu/forecast_5_day/template_config_test.py
+++ b/tests/dwd/icon_eu/forecast_5_day/template_config_test.py
@@ -5,6 +5,7 @@ import pandas as pd
 import rioxarray  # noqa: F401
 from pyproj import CRS
 
+from reformatters.common.config_models import ROOT
 from reformatters.dwd.icon_eu.forecast_5_day.template_config import (
     DwdIconEuForecast5DayTemplateConfig,
 )
@@ -39,7 +40,7 @@ def test_spatial_coordinates() -> None:
 def test_template_config_attrs() -> None:
     config = DwdIconEuForecast5DayTemplateConfig()
 
-    assert config.dims == ("init_time", "lead_time", "latitude", "longitude")
+    assert config.dims[ROOT] == ("init_time", "lead_time", "latitude", "longitude")
     assert config.append_dim == "init_time"
     assert config.append_dim_start == pd.Timestamp("2026-02-10T00:00")
     assert config.append_dim_frequency == pd.Timedelta("6h")
@@ -133,7 +134,7 @@ def test_get_template_spatial_ref() -> None:
     template_config = DwdIconEuForecast5DayTemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=10)
-    )
+    ).to_dataset()
     original_attrs = deepcopy(ds.spatial_ref.attrs)
 
     # This WKT string is extracted from the ICON-EU GRIB by gdalinfo:

--- a/tests/ecmwf/aifs_ens/forecast/dynamical_dataset_test.py
+++ b/tests/ecmwf/aifs_ens/forecast/dynamical_dataset_test.py
@@ -41,12 +41,18 @@ def test_backfill_local_and_operational_update(
     monkeypatch.setattr(
         type(dataset.template_config),
         "get_template",
-        lambda self, end_time: shrink_chunks_and_shards(
-            orig_get_template(end_time).sel(
-                lead_time=slice("0h", "6h"),
-                ensemble_member=slice(0, 1),  # control (0) + first perturbed (1)
-            )
-        )[variables_to_check],
+        lambda self, end_time: xr.DataTree.from_dict(
+            {
+                "/": shrink_chunks_and_shards(
+                    orig_get_template(end_time).sel(
+                        lead_time=slice("0h", "6h"),
+                        ensemble_member=slice(
+                            0, 1
+                        ),  # control (0) + first perturbed (1)
+                    )
+                ).to_dataset()[variables_to_check]
+            }
+        ),
     )
     dataset.backfill_local(append_dim_end=pd.Timestamp("2025-07-02T06:00:00"))
 

--- a/tests/ecmwf/aifs_ens/forecast/region_job_test.py
+++ b/tests/ecmwf/aifs_ens/forecast/region_job_test.py
@@ -94,7 +94,7 @@ def test_source_file_coord_out_loc() -> None:
 
 def test_source_groups() -> None:
     config = EcmwfAifsEnsForecastTemplateConfig()
-    groups = EcmwfAifsEnsForecastRegionJob.source_groups(config.data_vars)
+    groups = EcmwfAifsEnsForecastRegionJob.source_file_var_groups(config.data_vars)
     # All vars are available from append_dim_start, so they all share date_available=None.
     assert len(groups) == 1
     assert len(groups[0]) == len(config.data_vars)
@@ -118,7 +118,7 @@ def test_generate_source_file_coords() -> None:
     )
     processing_region_ds, _ = region_job._get_region_datasets()
 
-    groups = EcmwfAifsEnsForecastRegionJob.source_groups(config.data_vars)
+    groups = EcmwfAifsEnsForecastRegionJob.source_file_var_groups(config.data_vars)
     coords = region_job.generate_source_file_coords(processing_region_ds, groups[0])
     # 2 init_times x 3 lead_times x 4 ensemble_members = 24
     assert len(coords) == 2 * 3 * 4
@@ -503,7 +503,7 @@ def test_download_file_from_ecmwf_open_data() -> None:
         init_time=[init_time],
         lead_time=[pd.Timedelta("6h")],
         ensemble_member=[1],  # first pf (perturbed) member
-    )
+    ).to_dataset()
 
     def check_data_var(data_var: EcmwfDataVar) -> None:
         for source_coord in region_job.generate_source_file_coords(test_ds, [data_var]):
@@ -522,7 +522,7 @@ def test_download_file_from_ecmwf_open_data() -> None:
 
     all_data_vars = [
         data_var
-        for group in EcmwfAifsEnsForecastRegionJob.source_groups(
+        for group in EcmwfAifsEnsForecastRegionJob.source_file_var_groups(
             template_config.data_vars
         )
         for data_var in group

--- a/tests/ecmwf/aifs_ens/forecast/template_config_test.py
+++ b/tests/ecmwf/aifs_ens/forecast/template_config_test.py
@@ -6,6 +6,7 @@ import pytest
 import rioxarray  # noqa: F401  # Registers .rio accessor on xarray objects
 import xarray as xr
 
+from reformatters.common.config_models import ROOT
 from reformatters.common.iterating import item
 from reformatters.common.template_config import SPATIAL_REF_COORDS
 from reformatters.ecmwf.aifs_ens.forecast.template_config import (
@@ -16,7 +17,7 @@ from reformatters.ecmwf.aifs_ens.forecast.template_config import (
 def test_template_config_attrs() -> None:
     config = EcmwfAifsEnsForecastTemplateConfig()
 
-    assert config.dims == (
+    assert config.dims[ROOT] == (
         "init_time",
         "lead_time",
         "ensemble_member",
@@ -200,7 +201,7 @@ def test_get_template_spatial_ref() -> None:
     template_config = EcmwfAifsEnsForecastTemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=10)
-    )
+    ).to_dataset()
 
     expected_crs = "+proj=longlat +a=6371229 +b=6371229 +no_defs +type=crs"
     calculated_spatial_ref_attrs = ds.rio.write_crs(expected_crs).spatial_ref.attrs

--- a/tests/ecmwf/aifs_single/forecast/dynamical_dataset_test.py
+++ b/tests/ecmwf/aifs_single/forecast/dynamical_dataset_test.py
@@ -40,9 +40,13 @@ def test_backfill_local_and_operational_update(
     monkeypatch.setattr(
         type(dataset.template_config),
         "get_template",
-        lambda self, end_time: orig_get_template(end_time).sel(
-            lead_time=slice("0h", "6h"),
-        )[variables_to_check],
+        lambda self, end_time: xr.DataTree.from_dict(
+            {
+                "/": orig_get_template(end_time)
+                .sel(lead_time=slice("0h", "6h"))
+                .to_dataset()[variables_to_check]
+            }
+        ),
     )
     # Backfill one 6-hour init
     dataset.backfill_local(append_dim_end=pd.Timestamp("2024-04-01T06:00:00"))

--- a/tests/ecmwf/aifs_single/forecast/region_job_test.py
+++ b/tests/ecmwf/aifs_single/forecast/region_job_test.py
@@ -109,7 +109,7 @@ def test_source_file_coord_out_loc() -> None:
 
 def test_source_groups() -> None:
     config = EcmwfAifsSingleForecastTemplateConfig()
-    groups = EcmwfAifsSingleForecastRegionJob.source_groups(config.data_vars)
+    groups = EcmwfAifsSingleForecastRegionJob.source_file_var_groups(config.data_vars)
     assert len(groups) == 2
 
     group_without_date = [
@@ -142,7 +142,7 @@ def test_generate_source_file_coords() -> None:
     processing_region_ds, output_region_ds = region_job._get_region_datasets()
     assert processing_region_ds.equals(output_region_ds)
 
-    groups = EcmwfAifsSingleForecastRegionJob.source_groups(config.data_vars)
+    groups = EcmwfAifsSingleForecastRegionJob.source_file_var_groups(config.data_vars)
 
     coords = region_job.generate_source_file_coords(processing_region_ds, groups[0])
     # 4 init_times x 3 lead_times = 12
@@ -552,7 +552,7 @@ def test_download_file_from_ecmwf_open_data() -> None:
     test_ds = full_template.sel(
         init_time=[init_time],
         lead_time=[pd.Timedelta("6h")],
-    )
+    ).to_dataset()
 
     def check_data_var(data_var: EcmwfDataVar) -> None:
         for source_coord in region_job.generate_source_file_coords(test_ds, [data_var]):
@@ -569,7 +569,7 @@ def test_download_file_from_ecmwf_open_data() -> None:
 
     all_data_vars = [
         data_var
-        for group in EcmwfAifsSingleForecastRegionJob.source_groups(
+        for group in EcmwfAifsSingleForecastRegionJob.source_file_var_groups(
             template_config.data_vars
         )
         for data_var in group

--- a/tests/ecmwf/aifs_single/forecast/template_config_test.py
+++ b/tests/ecmwf/aifs_single/forecast/template_config_test.py
@@ -6,6 +6,7 @@ import pytest
 import rioxarray  # noqa: F401  # Registers .rio accessor on xarray objects
 import xarray as xr
 
+from reformatters.common.config_models import ROOT
 from reformatters.common.iterating import item
 from reformatters.common.template_config import SPATIAL_REF_COORDS
 from reformatters.ecmwf.aifs_single.forecast.template_config import (
@@ -16,7 +17,7 @@ from reformatters.ecmwf.aifs_single.forecast.template_config import (
 def test_template_config_attrs() -> None:
     config = EcmwfAifsSingleForecastTemplateConfig()
 
-    assert config.dims == ("init_time", "lead_time", "latitude", "longitude")
+    assert config.dims[ROOT] == ("init_time", "lead_time", "latitude", "longitude")
     assert config.append_dim == "init_time"
     assert config.append_dim_start == pd.Timestamp("2024-04-01T00:00")
     assert config.append_dim_frequency == pd.Timedelta("6h")
@@ -197,7 +198,7 @@ def test_get_template_spatial_ref() -> None:
     template_config = EcmwfAifsSingleForecastTemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=10)
-    )
+    ).to_dataset()
 
     expected_crs = "+proj=longlat +a=6371229 +b=6371229 +no_defs +type=crs"
     calculated_spatial_ref_attrs = ds.rio.write_crs(expected_crs).spatial_ref.attrs

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset_test.py
@@ -44,11 +44,15 @@ def test_backfill_local_and_operational_update(
     monkeypatch.setattr(
         type(dataset.template_config),
         "get_template",
-        lambda self, end_time: shrink_chunks_and_shards(
-            orig_get_template(end_time).sel(
-                lead_time=slice("0h", "6h"), ensemble_member=slice(0, 1)
-            )
-        )[variables_to_check],
+        lambda self, end_time: xr.DataTree.from_dict(
+            {
+                "/": shrink_chunks_and_shards(
+                    orig_get_template(end_time).sel(
+                        lead_time=slice("0h", "6h"), ensemble_member=slice(0, 1)
+                    )
+                ).to_dataset()[variables_to_check]
+            }
+        ),
     )
     dataset.backfill_local(append_dim_end=pd.Timestamp("2024-04-02T00:00:00"))
 

--- a/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job_test.py
@@ -26,7 +26,7 @@ from reformatters.ecmwf.ifs_ens.forecast_15_day_0_25_degree.template_config impo
 
 def test_region_job_source_groups() -> None:
     template_config = EcmwfIfsEnsForecast15Day025DegreeTemplateConfig()
-    groups = EcmwfIfsEnsForecast15Day025DegreeRegionJob.source_groups(
+    groups = EcmwfIfsEnsForecast15Day025DegreeRegionJob.source_file_var_groups(
         template_config.data_vars
     )
     assert len(groups) == 4
@@ -59,7 +59,7 @@ def test_region_job_generate_source_file_coords_open_data() -> None:
         reformat_job_name="test",
     )
     processing_region_ds, _ = region_job._get_region_datasets()
-    groups = EcmwfIfsEnsForecast15Day025DegreeRegionJob.source_groups(
+    groups = EcmwfIfsEnsForecast15Day025DegreeRegionJob.source_file_var_groups(
         template_config.data_vars
     )
     # We are grouping by date_available and has_hour_0_values, so we should get 4 groups
@@ -147,7 +147,7 @@ def test_region_job_generate_source_file_coords_mars_date_available_vars() -> No
         reformat_job_name="test",
     )
     processing_region_ds, _ = region_job._get_region_datasets()
-    groups = EcmwfIfsEnsForecast15Day025DegreeRegionJob.source_groups(
+    groups = EcmwfIfsEnsForecast15Day025DegreeRegionJob.source_file_var_groups(
         template_config.data_vars
     )
 
@@ -577,7 +577,7 @@ def test_download_file_from_ecmwf_open_data() -> None:
         init_time=slice(init_time, None),
         lead_time=[pd.Timedelta("0h"), pd.Timedelta("3h"), pd.Timedelta("96h")],
         ensemble_member=[0],
-    )
+    ).to_dataset()
 
     def check_data_var(data_var: EcmwfDataVar) -> None:
         for source_coord in region_job.generate_source_file_coords(test_ds, [data_var]):
@@ -591,7 +591,7 @@ def test_download_file_from_ecmwf_open_data() -> None:
 
     all_data_vars = [
         data_var
-        for group in EcmwfIfsEnsForecast15Day025DegreeRegionJob.source_groups(
+        for group in EcmwfIfsEnsForecast15Day025DegreeRegionJob.source_file_var_groups(
             template_config.data_vars
         )
         for data_var in group

--- a/tests/noaa/gefs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/analysis/dynamical_dataset_test.py
@@ -6,6 +6,7 @@ import pytest
 import xarray as xr
 
 from reformatters.common import validation
+from reformatters.common.config_models import ROOT
 from reformatters.noaa.gefs.analysis.dynamical_dataset import GefsAnalysisDataset
 from tests.chunk_utils import shrink_chunks_and_shards
 from tests.common.dynamical_dataset_test import (
@@ -56,7 +57,7 @@ def test_template_config(dataset: GefsAnalysisDataset) -> None:
     """Test basic template configuration."""
     template_config = dataset.template_config
     assert template_config.dataset_id == "noaa-gefs-analysis"
-    assert template_config.dims == ("time", "latitude", "longitude")
+    assert template_config.dims[ROOT] == ("time", "latitude", "longitude")
     assert template_config.append_dim == "time"
 
 
@@ -81,7 +82,7 @@ def test_region_job_integration(dataset: GefsAnalysisDataset) -> None:
     assert len(data_vars) > 0
 
     # Test source grouping with template config variables
-    groups = region_job_class.source_groups(data_vars)
+    groups = region_job_class.source_file_var_groups(data_vars)
     assert len(groups) > 0
 
 

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -130,7 +130,7 @@ def test_get_processing_region(
 
     job = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=example_data_vars[:1],  # Single variable
         append_dim="time",
         region=slice(4, 16),  # Middle region
@@ -154,7 +154,7 @@ def test_get_processing_region_at_boundaries(
     # Test at start of dataset
     job_start = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=example_data_vars[:1],
         append_dim="time",
         region=slice(0, 8),  # Start region
@@ -167,7 +167,7 @@ def test_get_processing_region_at_boundaries(
     # Test at end of dataset
     job_end = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=example_data_vars[:1],
         append_dim="time",
         region=slice(16, 24),  # End region
@@ -228,7 +228,7 @@ def test_source_groups(example_data_vars: list[GEFSDataVar]) -> None:
         ),
     ]
 
-    groups = GefsAnalysisRegionJob.source_groups(all_vars)
+    groups = GefsAnalysisRegionJob.source_file_var_groups(all_vars)
 
     # We're grouping everything together since max_vars_per_download_group is 1
     assert len(groups) == 1
@@ -267,7 +267,7 @@ def test_generate_source_file_coords_ensemble(
 
     job = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=[var],
         append_dim="time",
         region=slice(0, 8),
@@ -342,7 +342,7 @@ def test_download_file(
 
     job = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=data_vars,
         append_dim="time",
         region=slice(0, 8),
@@ -418,7 +418,7 @@ def test_read_data(
 
     job = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=example_data_vars[:1],
         append_dim="time",
         region=slice(0, 8),
@@ -478,7 +478,7 @@ def test_apply_data_transformations(template_ds: xr.Dataset) -> None:
     tmp_store = get_local_tmp_store()
     job = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=[var_with_rounding],
         append_dim="time",
         region=slice(0, 4),
@@ -527,19 +527,25 @@ def test_operational_update_jobs(
     # Mock get_template_fn
     def mock_get_template_fn(
         end_time: pd.Timestamp | np.datetime64 | datetime | str,
-    ) -> xr.Dataset:
-        return xr.Dataset(
+    ) -> xr.DataTree:
+        return xr.DataTree.from_dict(
             {
-                "temperature_2m": xr.Variable(
-                    data=np.ones((20, 5, 10), dtype=np.float32),
-                    dims=["time", "latitude", "longitude"],
+                "/": xr.Dataset(
+                    {
+                        "temperature_2m": xr.Variable(
+                            data=np.ones((20, 5, 10), dtype=np.float32),
+                            dims=["time", "latitude", "longitude"],
+                        )
+                    },
+                    coords={
+                        "time": pd.date_range(
+                            "2000-01-01T00:00", freq="3h", periods=20
+                        ),
+                        "latitude": np.linspace(-90, 90, 5),
+                        "longitude": np.linspace(-180, 179, 10),
+                    },
                 )
-            },
-            coords={
-                "time": pd.date_range("2000-01-01T00:00", freq="3h", periods=20),
-                "latitude": np.linspace(-90, 90, 5),
-                "longitude": np.linspace(-180, 179, 10),
-            },
+            }
         )
 
     # Mock get_jobs method
@@ -585,7 +591,7 @@ def test_update_template_with_results(
     data_vars = example_data_vars[:1]
     job = GefsAnalysisRegionJob(
         tmp_store=get_local_tmp_store(),
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=example_data_vars,
         append_dim="time",
         region=slice(0, 8),
@@ -620,7 +626,7 @@ def test_download_file_fallback(
 
     job = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=data_vars,
         append_dim="time",
         region=slice(0, 1),
@@ -696,7 +702,7 @@ def test_download_file_no_fallback_for_old_data(
 
     job = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=data_vars,
         append_dim="time",
         region=slice(0, 1),
@@ -742,7 +748,7 @@ def test_download_file_fallback_permission_denied_converts_to_file_not_found(
 
     job = GefsAnalysisRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=data_vars,
         append_dim="time",
         region=slice(0, 1),

--- a/tests/noaa/gefs/analysis/template_config_test.py
+++ b/tests/noaa/gefs/analysis/template_config_test.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from reformatters.common.config_models import ROOT
 from reformatters.noaa.gefs.analysis.region_job import (
     GefsAnalysisRegionJob,
     GefsAnalysisSourceFileCoord,
@@ -59,7 +60,7 @@ def test_dataset_attributes(template_config: GefsAnalysisTemplateConfig) -> None
 
 def test_dimensions_and_append_dim(template_config: GefsAnalysisTemplateConfig) -> None:
     """Test dimension configuration."""
-    assert template_config.dims == ("time", "latitude", "longitude")
+    assert template_config.dims[ROOT] == ("time", "latitude", "longitude")
     assert template_config.append_dim == "time"
     assert template_config.append_dim_start == pd.Timestamp("2000-01-01T00:00")
     assert template_config.append_dim_frequency == pd.Timedelta("3h")

--- a/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
@@ -36,13 +36,13 @@ def get_var(name: str) -> GEFSDataVar:
 
 
 @pytest.fixture(scope="module")
-def template_ds() -> xr.Dataset:
+def template_ds() -> xr.DataTree:
     # Spans the 2022-10-18T12 transition when "s+b-b22" vars entered the s files.
     return TEMPLATE_CONFIG.get_template(pd.Timestamp("2022-10-19T00:00"))
 
 
 def make_job(
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
     data_vars: Sequence[GEFSDataVar] | None = None,
     region: slice = slice(0, 1),
     processing_mode: Literal["backfill", "update"] = "backfill",
@@ -110,7 +110,7 @@ def test_source_file_coord_rejects_pre_b22_var() -> None:
 
 
 def test_generate_source_file_coords_one_file_per_init_member_lead(
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
 ) -> None:
     data_vars = [
         get_var("temperature_2m"),  # instant
@@ -119,9 +119,11 @@ def test_generate_source_file_coords_one_file_per_init_member_lead(
     ]
     job = make_job(template_ds, data_vars=data_vars)
     # The final init (2022-10-18T18) is after the b22 transition.
-    processing_region_ds = template_ds.isel(
-        init_time=slice(-1, None), ensemble_member=slice(0, 2)
-    ).sel(lead_time=[pd.Timedelta("0h"), pd.Timedelta("3h")])
+    processing_region_ds = (
+        template_ds.isel(init_time=slice(-1, None), ensemble_member=slice(0, 2))
+        .sel(lead_time=[pd.Timedelta("0h"), pd.Timedelta("3h")])
+        .to_dataset()
+    )
 
     coords = job.generate_source_file_coords(processing_region_ds, data_vars)
 
@@ -140,7 +142,7 @@ def test_generate_source_file_coords_one_file_per_init_member_lead(
 
 
 def test_generate_source_file_coords_excludes_b22_vars_before_transition(
-    template_ds: xr.Dataset,
+    template_ds: xr.DataTree,
 ) -> None:
     data_vars = [
         get_var("temperature_2m"),
@@ -148,16 +150,18 @@ def test_generate_source_file_coords_excludes_b22_vars_before_transition(
     ]
     job = make_job(template_ds, data_vars=data_vars)
     # The first init (2020-10-01T00) is before the b22 transition.
-    processing_region_ds = template_ds.isel(
-        init_time=slice(0, 1), ensemble_member=slice(0, 1)
-    ).sel(lead_time=[pd.Timedelta("3h")])
+    processing_region_ds = (
+        template_ds.isel(init_time=slice(0, 1), ensemble_member=slice(0, 1))
+        .sel(lead_time=[pd.Timedelta("3h")])
+        .to_dataset()
+    )
 
     (coord,) = job.generate_source_file_coords(processing_region_ds, data_vars)
     assert [v.name for v in coord.data_vars] == ["temperature_2m"]
     assert coord.gefs_file_type == "s"
 
 
-def test_representative_var_uses_coords_own_file_vars(template_ds: xr.Dataset) -> None:
+def test_representative_var_uses_coords_own_file_vars(template_ds: xr.DataTree) -> None:
     job = make_job(template_ds)
     avg_then_instant = GefsForecast10DaySpatialSourceFileCoord(
         init_time=pd.Timestamp("2024-01-01T00:00"),
@@ -226,7 +230,7 @@ def _fake_discover(
 
 
 def test_process_virtual_refs_backfill_sweeps_once(
-    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     data_vars = [get_var("temperature_2m"), get_var("total_precipitation_surface")]
     job = make_job(template_ds, data_vars=data_vars)
@@ -263,7 +267,7 @@ def test_process_virtual_refs_backfill_sweeps_once(
 
 
 def test_process_virtual_refs_update_polls_until_all_ingested(
-    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     data_vars = [get_var("temperature_2m")]
     job = make_job(template_ds, data_vars=data_vars, processing_mode="update")
@@ -293,7 +297,7 @@ def test_process_virtual_refs_update_polls_until_all_ingested(
 
 
 def test_file_refs_skips_file_whose_index_points_past_eof(
-    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     data_vars = [get_var("temperature_2m")]
     job = make_job(template_ds, data_vars=data_vars)
@@ -306,7 +310,7 @@ def test_file_refs_skips_file_whose_index_points_past_eof(
 
 
 def test_process_virtual_refs_drops_files_with_stale_index(
-    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     data_vars = [get_var("temperature_2m")]
     job = make_job(template_ds, data_vars=data_vars)
@@ -323,7 +327,7 @@ def test_process_virtual_refs_drops_files_with_stale_index(
 
 
 def test_file_refs_or_skip_swallows_unexpected_errors(
-    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     job = make_job(template_ds, data_vars=[get_var("temperature_2m")])
     coord = _coord(1, [get_var("temperature_2m")])
@@ -339,7 +343,7 @@ def test_file_refs_or_skip_swallows_unexpected_errors(
 
 
 def test_file_refs_or_skip_propagates_assertion_errors(
-    template_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     job = make_job(template_ds, data_vars=[get_var("temperature_2m")])
     coord = _coord(1, [get_var("temperature_2m")])
@@ -356,7 +360,7 @@ def test_file_refs_or_skip_propagates_assertion_errors(
 
 
 @pytest.mark.slow
-def test_real_source_all_vars_resolve_and_decode(template_ds: xr.Dataset) -> None:
+def test_real_source_all_vars_resolve_and_decode(template_ds: xr.DataTree) -> None:
     """Guard against NOAA layout/index drift: list the real bucket, parse a real
     index for every variable, and decode one message to check values + grid."""
     init = pd.Timestamp("2024-01-01T00:00")
@@ -415,7 +419,7 @@ def test_operational_update_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
     (job,) = jobs
     assert isinstance(job, GefsForecast10DaySpatialRegionJob)
     assert job.processing_mode == "update"
-    init_times = template_ds.get_index("init_time")
+    init_times = template_ds.to_dataset().get_index("init_time")
     assert init_times[-1] == pd.Timestamp("2020-10-03T00:00")
     # One job spanning the 24h active window (4 init times at 6h frequency).
     assert job.region == slice(len(init_times) - 4, len(init_times))

--- a/tests/noaa/gefs/forecast_10_day_spatial/template_config_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/template_config_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 
+from reformatters.common.config_models import ROOT
 from reformatters.noaa.gefs.forecast_10_day_spatial.template_config import (
     GefsForecast10DaySpatialTemplateConfig,
 )
@@ -21,7 +22,7 @@ def test_dataset_attributes() -> None:
 
 
 def test_dims_and_append_dim() -> None:
-    assert TEMPLATE_CONFIG.dims == (
+    assert TEMPLATE_CONFIG.dims[ROOT] == (
         "init_time",
         "ensemble_member",
         "lead_time",
@@ -66,7 +67,7 @@ def test_append_dim_coordinates_range() -> None:
 
 
 def test_derive_coordinates() -> None:
-    ds = TEMPLATE_CONFIG.get_template(pd.Timestamp("2020-10-02T00:00"))
+    ds = TEMPLATE_CONFIG.get_template(pd.Timestamp("2020-10-02T00:00")).to_dataset()
     assert "spatial_ref" in ds.coords
     np.testing.assert_array_equal(
         ds["valid_time"].values,

--- a/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/forecast_35_day/dynamical_dataset_test.py
@@ -6,6 +6,7 @@ import pytest
 import xarray as xr
 
 from reformatters.common import validation
+from reformatters.common.config_models import ROOT
 from reformatters.noaa.gefs.forecast_35_day.dynamical_dataset import (
     GefsForecast35DayDataset,
 )
@@ -57,7 +58,7 @@ def test_template_config(dataset: GefsForecast35DayDataset) -> None:
     """Test basic template configuration."""
     template_config = dataset.template_config
     assert template_config.dataset_id == "noaa-gefs-forecast-35-day"
-    assert template_config.dims == (
+    assert template_config.dims[ROOT] == (
         "init_time",
         "ensemble_member",
         "lead_time",
@@ -88,7 +89,7 @@ def test_region_job_integration(dataset: GefsForecast35DayDataset) -> None:
     assert len(data_vars) > 0
 
     # Test source grouping with template config variables
-    groups = region_job_class.source_groups(data_vars)
+    groups = region_job_class.source_file_var_groups(data_vars)
     assert len(groups) > 0
 
 

--- a/tests/noaa/gefs/forecast_35_day/region_job_test.py
+++ b/tests/noaa/gefs/forecast_35_day/region_job_test.py
@@ -157,7 +157,7 @@ def test_get_processing_region(
 
     job = GefsForecast35DayRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=example_data_vars[:1],  # Single variable
         append_dim="init_time",
         region=slice(1, 2),  # Single init time
@@ -172,7 +172,7 @@ def test_get_processing_region(
 
 def test_source_groups(example_data_vars: list[GEFSDataVar]) -> None:
     """Test source groups based on GEFS file type and ensemble statistic."""
-    groups = GefsForecast35DayRegionJob.source_groups(example_data_vars)
+    groups = GefsForecast35DayRegionJob.source_file_var_groups(example_data_vars)
 
     # Both variables have the same file type, but we expect two groups due to the zero hour values
     assert len(groups) == 2
@@ -191,7 +191,7 @@ def test_generate_source_file_coords_ensemble(
 
     job = GefsForecast35DayRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=example_data_vars[:1],  # Single variable
         append_dim="init_time",
         region=slice(0, 1),  # Single init time
@@ -280,7 +280,7 @@ def test_download_file(
 
     job = GefsForecast35DayRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=data_vars,
         append_dim="init_time",
         region=slice(0, 1),
@@ -354,7 +354,7 @@ def test_download_file_fallback(
 
     job = GefsForecast35DayRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=data_vars,
         append_dim="init_time",
         region=slice(0, 1),
@@ -431,7 +431,7 @@ def test_download_file_no_fallback_for_old_data(
 
     job = GefsForecast35DayRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=data_vars,
         append_dim="init_time",
         region=slice(0, 1),
@@ -481,7 +481,7 @@ def test_read_data(
 
     job = GefsForecast35DayRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=example_data_vars[:1],
         append_dim="init_time",
         region=slice(0, 1),
@@ -550,7 +550,7 @@ def test_apply_data_transformations(template_ds: xr.Dataset) -> None:
     tmp_store = get_local_tmp_store()
     job = GefsForecast35DayRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=[var_with_rounding],
         append_dim="init_time",
         region=slice(0, 1),
@@ -603,27 +603,33 @@ def test_operational_update_jobs(
     # Mock get_template_fn
     def mock_get_template_fn(
         end_time: pd.Timestamp | np.datetime64 | datetime | str,
-    ) -> xr.Dataset:
-        return xr.Dataset(
+    ) -> xr.DataTree:
+        return xr.DataTree.from_dict(
             {
-                "temperature_2m": xr.Variable(
-                    data=np.ones((10, 8, 4, 5, 10), dtype=np.float32),
-                    dims=[
-                        "init_time",
-                        "lead_time",
-                        "ensemble_member",
-                        "latitude",
-                        "longitude",
-                    ],
+                "/": xr.Dataset(
+                    {
+                        "temperature_2m": xr.Variable(
+                            data=np.ones((10, 8, 4, 5, 10), dtype=np.float32),
+                            dims=[
+                                "init_time",
+                                "lead_time",
+                                "ensemble_member",
+                                "latitude",
+                                "longitude",
+                            ],
+                        )
+                    },
+                    coords={
+                        "init_time": pd.date_range(
+                            "2000-01-01T00:00", freq="24h", periods=10
+                        ),
+                        "lead_time": pd.timedelta_range("0h", freq="3h", periods=8),
+                        "ensemble_member": np.arange(4),
+                        "latitude": np.linspace(-90, 90, 5),
+                        "longitude": np.linspace(-180, 179, 10),
+                    },
                 )
-            },
-            coords={
-                "init_time": pd.date_range("2000-01-01T00:00", freq="24h", periods=10),
-                "lead_time": pd.timedelta_range("0h", freq="3h", periods=8),
-                "ensemble_member": np.arange(4),
-                "latitude": np.linspace(-90, 90, 5),
-                "longitude": np.linspace(-180, 179, 10),
-            },
+            }
         )
 
     # Mock get_jobs method
@@ -674,7 +680,7 @@ def test_download_file_fallback_permission_denied_converts_to_file_not_found(
 
     job = GefsForecast35DayRegionJob(
         tmp_store=tmp_store,
-        template_ds=template_ds,
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
         data_vars=data_vars,
         append_dim="init_time",
         region=slice(0, 1),
@@ -766,6 +772,8 @@ def test_download_and_read_all_vars_current(lead_time: pd.Timedelta) -> None:
                     err_msg=f"Eastern column not longitude-wrapped for {data_var.name}",
                 )
 
-    groups = list(GefsForecast35DayRegionJob.source_groups(template_config.data_vars))
+    groups = list(
+        GefsForecast35DayRegionJob.source_file_var_groups(template_config.data_vars)
+    )
     with ThreadPoolExecutor() as pool:
         list(pool.map(_download_and_check, groups))

--- a/tests/noaa/gefs/forecast_35_day/template_config_test.py
+++ b/tests/noaa/gefs/forecast_35_day/template_config_test.py
@@ -68,7 +68,7 @@ def test_spatial_ref_matches_grib(
     template_config: GefsForecast35DayTemplateConfig,
     gefs_first_message_path: Path,
 ) -> None:
-    ds = template_config.get_template(pd.Timestamp("2024-11-01T00:00"))
+    ds = template_config.get_template(pd.Timestamp("2024-11-01T00:00")).to_dataset()
 
     ds_raster = xr.open_dataset(gefs_first_message_path, engine="rasterio")
 

--- a/tests/noaa/gefs/forecast_35_day/template_config_test.py
+++ b/tests/noaa/gefs/forecast_35_day/template_config_test.py
@@ -7,6 +7,7 @@ import pytest
 import rasterio
 import xarray as xr
 
+from reformatters.common.config_models import ROOT
 from reformatters.noaa.gefs.forecast_35_day.region_job import (
     GefsForecast35DayRegionJob,
     GefsForecast35DaySourceFileCoord,
@@ -111,7 +112,7 @@ def test_dimensions_and_append_dim(
         "latitude",
         "longitude",
     )
-    assert template_config.dims == expected_dims
+    assert template_config.dims[ROOT] == expected_dims
     assert template_config.append_dim == "init_time"
     assert template_config.append_dim_start == pd.Timestamp("2020-10-01T00:00")
     assert template_config.append_dim_frequency == pd.Timedelta("24h")

--- a/tests/noaa/gfs/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/analysis/dynamical_dataset_test.py
@@ -5,6 +5,7 @@ import xarray as xr
 from numpy.testing import assert_allclose, assert_array_equal
 
 from reformatters.common import validation
+from reformatters.common.config_models import ROOT
 from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.noaa.gfs.analysis.dynamical_dataset import (
     NoaaGfsAnalysisDataset,
@@ -175,7 +176,7 @@ def test_precipitation_not_null_at_shard_boundary() -> None:
 
     # Compute shard_2_start from dataset metadata
     precip_var = next(v for v in config.data_vars if v.name == "precipitation_surface")
-    time_dim_index = config.dims.index("time")
+    time_dim_index = config.dims[ROOT].index("time")
     assert isinstance(precip_var.encoding.shards, tuple)
     time_shard_size = precip_var.encoding.shards[time_dim_index]
 

--- a/tests/noaa/gfs/analysis/template_config_test.py
+++ b/tests/noaa/gfs/analysis/template_config_test.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from reformatters.common.config_models import ROOT
 from reformatters.common.template_config import SPATIAL_REF_COORDS
 from reformatters.noaa.gfs.analysis.template_config import NoaaGfsAnalysisTemplateConfig
 
@@ -14,7 +15,7 @@ def test_get_template_spatial_ref() -> None:
     template_config = NoaaGfsAnalysisTemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=10)
-    )
+    ).to_dataset()
     original_attrs = deepcopy(ds.spatial_ref.attrs)
 
     expected_crs = "+proj=longlat +a=6371229 +b=6371229 +no_defs +type=crs"
@@ -83,7 +84,7 @@ def test_coords_property_order_and_names() -> None:
 
 def test_dims() -> None:
     cfg = NoaaGfsAnalysisTemplateConfig()
-    assert cfg.dims == ("time", "latitude", "longitude")
+    assert cfg.dims[ROOT] == ("time", "latitude", "longitude")
 
 
 def test_append_dim_configuration() -> None:

--- a/tests/noaa/gfs/forecast/template_config_test.py
+++ b/tests/noaa/gfs/forecast/template_config_test.py
@@ -47,7 +47,7 @@ def test_get_template_spatial_ref() -> None:
     template_config = NoaaGfsForecastTemplateConfig()
     ds = template_config.get_template(
         template_config.append_dim_start + pd.Timedelta(days=10)
-    )
+    ).to_dataset()
     original_attrs = deepcopy(ds.spatial_ref.attrs)
 
     expected_crs = "+proj=longlat +a=6371229 +b=6371229 +no_defs +type=crs"
@@ -59,7 +59,7 @@ def test_get_template_spatial_ref() -> None:
 @pytest.mark.slow
 def test_spatial_ref_matches_grib(gfs_first_message_path: Path) -> None:
     cfg = NoaaGfsForecastTemplateConfig()
-    ds = cfg.get_template(pd.Timestamp("2024-11-01T00:00"))
+    ds = cfg.get_template(pd.Timestamp("2024-11-01T00:00")).to_dataset()
 
     ds_raster = xr.open_dataset(gfs_first_message_path, engine="rasterio")
 

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -68,7 +68,7 @@ def test_common_region_job_source_groups() -> None:
     template_config = NoaaGfsForecastTemplateConfig()
     data_vars = template_config.data_vars
 
-    groups = NoaaGfsCommonRegionJob.source_groups(data_vars)
+    groups = NoaaGfsCommonRegionJob.source_file_var_groups(data_vars)
 
     # Should have 2 groups: instant variables (hour 0) and non-instant variables (no hour 0)
     assert len(groups) == 2
@@ -378,7 +378,9 @@ def test_download_file_from_nomads_gfs() -> None:
 
     # lead_time=6h: all vars (instant and accumulated) are present in the f006 GRIB file
     lead_time = pd.Timedelta(hours=6)
-    for group in NoaaGfsForecastRegionJob.source_groups(template_config.data_vars):
+    for group in NoaaGfsForecastRegionJob.source_file_var_groups(
+        template_config.data_vars
+    ):
         coord = NoaaGfsForecastSourceFileCoord(
             init_time=init_time,
             lead_time=lead_time,

--- a/tests/noaa/hrrr/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/analysis/dynamical_dataset_test.py
@@ -5,6 +5,7 @@ import xarray as xr
 from numpy.testing import assert_array_equal
 
 from reformatters.common import validation
+from reformatters.common.config_models import ROOT
 from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.noaa.hrrr.analysis.dynamical_dataset import (
     NoaaHrrrAnalysisDataset,
@@ -152,7 +153,7 @@ def test_precipitation_not_null_at_shard_boundary() -> None:
 
     # Compute shard_2_start from dataset metadata
     precip_var = next(v for v in config.data_vars if v.name == "precipitation_surface")
-    time_dim_index = config.dims.index("time")
+    time_dim_index = config.dims[ROOT].index("time")
     assert isinstance(precip_var.encoding.shards, tuple)
     time_shard_size = precip_var.encoding.shards[time_dim_index]
 

--- a/tests/noaa/hrrr/analysis/region_job_test.py
+++ b/tests/noaa/hrrr/analysis/region_job_test.py
@@ -344,7 +344,7 @@ def test_download_and_read_all_variables(
         reformat_job_name="test",
     )
 
-    for source_group in NoaaHrrrAnalysisRegionJob.source_groups(all_vars):
+    for source_group in NoaaHrrrAnalysisRegionJob.source_file_var_groups(all_vars):
         is_hour_0 = has_hour_0_values(source_group[0])
         lead_time = pd.Timedelta("0h") if is_hour_0 else pd.Timedelta("1h")
         coord_init_time = init_time if is_hour_0 else init_time - pd.Timedelta("1h")

--- a/tests/noaa/hrrr/analysis/template_config_test.py
+++ b/tests/noaa/hrrr/analysis/template_config_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from reformatters.common.config_models import ROOT
 from reformatters.common.download import http_download_to_disk
 from reformatters.noaa.hrrr.analysis.template_config import (
     NoaaHrrrAnalysisTemplateConfig,
@@ -53,7 +54,7 @@ def test_template_config_attrs() -> None:
     """Test basic template configuration attributes."""
     config = NoaaHrrrAnalysisTemplateConfig()
 
-    assert config.dims == ("time", "y", "x")
+    assert config.dims[ROOT] == ("time", "y", "x")
     assert config.append_dim == "time"
 
     assert config.append_dim_start == pd.Timestamp("2014-10-01T00:00")

--- a/tests/noaa/hrrr/forecast_48_hour/template_config_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour/template_config_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from reformatters.common.config_models import ROOT
 from reformatters.common.download import http_download_to_disk
 from reformatters.noaa.hrrr.forecast_48_hour.template_config import (
     NoaaHrrrForecast48HourTemplateConfig,
@@ -64,7 +65,7 @@ def test_template_config_attrs() -> None:
     config = NoaaHrrrForecast48HourTemplateConfig()
 
     # Check dimensions
-    assert config.dims == ("init_time", "lead_time", "y", "x")
+    assert config.dims[ROOT] == ("init_time", "lead_time", "y", "x")
     assert config.append_dim == "init_time"
 
     # Check date range

--- a/tests/noaa/hrrr/region_job_test.py
+++ b/tests/noaa/hrrr/region_job_test.py
@@ -95,7 +95,7 @@ def test_region_job_source_groups(
 ) -> None:
     """Test that data variables are grouped by file type."""
     # Test source grouping with available sfc variables
-    groups = NoaaHrrrRegionJob.source_groups(template_config.data_vars)
+    groups = NoaaHrrrRegionJob.source_file_var_groups(template_config.data_vars)
 
     # Two groups expected: those with hour 0 values and those without
     assert len(groups) == 2
@@ -121,7 +121,7 @@ def test_region_job_source_groups_multiple_file_types(
             break
 
     if len(mixed_vars) > 1:
-        groups = NoaaHrrrRegionJob.source_groups(mixed_vars)
+        groups = NoaaHrrrRegionJob.source_file_var_groups(mixed_vars)
         # Should have separate groups for different file types
         assert len(groups) >= 1
 
@@ -630,7 +630,7 @@ def test_download_file_from_nomads_hrrr() -> None:
 
     # lead_time=2h: all vars (instant and accumulated) are present in the f02 GRIB file
     lead_time = pd.Timedelta(hours=2)
-    for group in NoaaHrrrForecast48HourRegionJob.source_groups(
+    for group in NoaaHrrrForecast48HourRegionJob.source_file_var_groups(
         template_config.data_vars
     ):
         file_type = group[0].internal_attrs.hrrr_file_type

--- a/tests/noaa/hrrr/template_config_test.py
+++ b/tests/noaa/hrrr/template_config_test.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from reformatters.common.config_models import DatasetAttributes, Encoding
+from reformatters.common.config_models import ROOT, DatasetAttributes, Encoding
 from reformatters.common.download import http_download_to_disk
 from reformatters.noaa.hrrr.region_job import NoaaHrrrSourceFileCoord
 from reformatters.noaa.hrrr.template_config import (
@@ -34,7 +34,7 @@ def template_config(monkeypatch: pytest.MonkeyPatch) -> NoaaHrrrCommonTemplateCo
     )
 
     config = NoaaHrrrCommonTemplateConfig(
-        dims=("time", "y", "x"),
+        dims={ROOT: ("time", "y", "x")},
         append_dim="time",
         append_dim_start=pd.Timestamp("2018-07-13T12:00"),
         append_dim_frequency=pd.Timedelta("1h"),

--- a/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
@@ -105,9 +105,13 @@ def test_backfill_local_and_operational_update(
         monkeypatch.setattr(
             dataset,
             "_get_template",
-            lambda end: _set_time_shard_size(
-                orig(end).sel(time=slice(test_start, None)),
-                time_shard_size=2,
+            lambda end: xr.DataTree.from_dict(
+                {
+                    "/": _set_time_shard_size(
+                        orig(end).sel(time=slice(test_start, None)).to_dataset(),
+                        time_shard_size=2,
+                    )
+                }
             ),
         )
 

--- a/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
@@ -86,7 +86,7 @@ def test_source_file_coord_get_url_ncep() -> None:
 def test_source_groups(
     template_config: NoaaMrmsConusAnalysisHourlyTemplateConfig,
 ) -> None:
-    groups = NoaaMrmsRegionJob.source_groups(template_config.data_vars)
+    groups = NoaaMrmsRegionJob.source_file_var_groups(template_config.data_vars)
     # Each MRMS variable is its own group (one file per variable)
     assert len(groups) == len(template_config.data_vars)
     for group in groups:

--- a/tests/noaa/mrms/conus_analysis_hourly/template_config_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/template_config_test.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from reformatters.common.config_models import ROOT
 from reformatters.common.pydantic import replace
 from reformatters.noaa.mrms.conus_analysis_hourly.region_job import (
     NoaaMrmsRegionJob,
@@ -20,7 +21,7 @@ from reformatters.noaa.mrms.conus_analysis_hourly.template_config import (
 def test_template_config_attrs() -> None:
     config = NoaaMrmsConusAnalysisHourlyTemplateConfig()
 
-    assert config.dims == ("time", "latitude", "longitude")
+    assert config.dims[ROOT] == ("time", "latitude", "longitude")
     assert config.append_dim == "time"
     assert config.append_dim_start == pd.Timestamp("2014-11-01T00:00")
     assert config.append_dim_frequency == pd.Timedelta("1h")


### PR DESCRIPTION
Implements the vertical-dimension structure from `docs/plans/vertical_dimension_structure.md` (#679): datasets can mix single-level (root) variables with variables on a dense vertical dimension (`pressure_level`, `model_level`), each vertical group becoming a zarr group named after its dimension.

## Design — Decision A (DataTree is the canonical template)

The dataset template is now an `xarray.DataTree` (`get_template()` returns it; `RegionJob.template_ds` holds it). This was chosen over a flat path-keyed Dataset so the in-memory object matches the on-disk group hierarchy, coordinate scoping is structural via inheritance, and there's no unenforceable "don't `to_zarr` me raw" invariant. **A single-level dataset is a one-node tree and writes byte-identically to before** — all 15 existing templates regenerate with zero diff.

## What's in it

- **Type scheme** (`config_models.py`): `RootGroup`/`ROOT`, `VerticalGroup`, `Group`, `var_path`; `DataVar.group` (default `ROOT`) + `.path`. `Dim` gains `pressure_level`/`model_level`.
- **Template layer** (`template_config.py`): `dims` is `dict[Group, tuple]`; `all_dims`/`groups`; `update_template` builds + writes a DataTree (`write_inherited_coords=True` so groups open standalone); `get_template` returns a DataTree; structure validators (group==added dim, path uniqueness, root-var≠group-name, no orphan group, uniform append-dim chunk, encoding lengths).
- **One write path** (`template_utils.py`): a bare Dataset wraps as a one-node tree.
- **Region jobs**: `template_ds` is a DataTree; `get_jobs` walks vars by `var.path`; `source_groups` → `source_file_var_groups` (a source file may span vertical groups). Virtual write loop keys refs/probe/chunk_key by `var.path`; `sync_dims_to` grows the append dim per group node (`DataTree.to_zarr` has no `append_dim`).
- **Coordination/zarr/dataset**: thread the DataTree through; `copy_zarr_metadata` handles group-nested coords/metadata.
- **Guard**: materialized chunk-writes are not yet group-aware, so `DynamicalDataset` rejects a materialized dataset that declares a non-root var (fails loudly rather than miswriting). Group-aware materialized writes + the real **NOAA HRRR** / **DWD ICON-EU** datasets are the follow-up.

All 16 existing configs migrated to `dims = {ROOT: (...)}`.

## Tests

- New `tests/common/multi_group_template_test.py` (7) — DataTree write, standalone group open with shared coords, reindex, validators (incl. the name-collision case `pressure_level/temperature` + `model_level/temperature`).
- New `tests/common/virtual_multi_group_test.py` (5) — virtual backfill landing refs at `pressure_level/temperature`, per-group `sync_dims_to`, per-file commit atomicity across groups, two-worker + operational.
- All existing suites migrated to DataTree templates. `ty` + `ruff` clean; full suite green.

Two review passes (correctness/simplicity + comment-style conformance) were run and their findings folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)