### PR TITLE
Fix virtual backfill OOM: cap download concurrency, add memory headroom

### DIFF
--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import time
 from collections.abc import Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -60,8 +59,11 @@ class VirtualRegionJob(
 
     # When polling, pace each discovery sweep to at most one per tick.
     tick_interval: ClassVar[Timedelta] = pd.Timedelta("1s")
-    # Concurrent file downloads while building refs. High concurrency for small .idx files.
-    download_concurrency: ClassVar[int] = (os.cpu_count() or 1) * 16
+    # Concurrent file downloads while building refs; small .idx files, so IO-bound.
+    # Hardcoded, not scaled from os.cpu_count(): under a cgroup CPU limit that returns the
+    # node's core count rather than the pod's allocation, oversubscribing threads on a
+    # large shared node exhausts pod memory.
+    download_concurrency: ClassVar[int] = 64
 
     # ----- Overridable methods -----
     # A dataset implements file_refs and generate_source_file_coords (from

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -60,9 +60,6 @@ class VirtualRegionJob(
     # When polling, pace each discovery sweep to at most one per tick.
     tick_interval: ClassVar[Timedelta] = pd.Timedelta("1s")
     # Concurrent file downloads while building refs; small .idx files, so IO-bound.
-    # Hardcoded, not scaled from os.cpu_count(): under a cgroup CPU limit that returns the
-    # node's core count rather than the pod's allocation, oversubscribing threads on a
-    # large shared node exhausts pod memory.
     download_concurrency: ClassVar[int] = 64
 
     # ----- Overridable methods -----

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
@@ -63,10 +63,8 @@ class NoaaHrrrForecast48HourSpatialDataset(
             pod_active_deadline=timedelta(hours=1, minutes=40),
             image=image_tag,
             dataset_id=self.dataset_id,
-            # Builds chunk refs (no data decode); peak scales with download_concurrency.
-            # 4G is headroom over the bounded working set.
             cpu="1.5",
-            memory="4G",
+            memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
@@ -76,9 +74,8 @@ class NoaaHrrrForecast48HourSpatialDataset(
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
-            # Decodes GRIB to probe health, so heavier than the ref-building update.
             cpu="1.5",
-            memory="4G",
+            memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
         )
 

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
@@ -63,9 +63,10 @@ class NoaaHrrrForecast48HourSpatialDataset(
             pod_active_deadline=timedelta(hours=1, minutes=40),
             image=image_tag,
             dataset_id=self.dataset_id,
-            # Single-threaded ingest, ~0.7 GiB peak per init measured locally.
+            # Builds chunk refs (no data decode); peak scales with download_concurrency.
+            # 4G is headroom over the bounded working set.
             cpu="1.5",
-            memory="2G",
+            memory="4G",
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
@@ -75,8 +76,9 @@ class NoaaHrrrForecast48HourSpatialDataset(
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
+            # Decodes GRIB to probe health, so heavier than the ref-building update.
             cpu="1.5",
-            memory="2G",
+            memory="4G",
             secret_names=self.store_factory.k8s_secret_names(),
         )
 


### PR DESCRIPTION
## Problem
HRRR-spatial backfill pods were `OOMKilled` once scaled to parallelism 200.

Root cause: `VirtualRegionJob.download_concurrency` was `(os.cpu_count() or 1) * 16`. In Kubernetes `os.cpu_count()` returns the **node's** core count, not the pod's cgroup CPU allocation (a CFS quota, which `os.cpu_count()` / `os.sched_getaffinity` do not reflect). So a 1.5-CPU pod landing on, e.g., a 32-core node spun up `32 * 16 = 512` concurrent download threads instead of the intended ~32. At parallelism 4 this survived (few pods per node); at 200, many such pods packed onto each node and exhausted node memory.

## Fix
- **Cap `download_concurrency` to a hardcoded `64`** — ref-building is IO-bound on small `.idx` files, so it needs concurrency but not node-scaled concurrency. Node-independent, so it can't oversubscribe on large shared nodes. (There is no easy stdlib way to read the cgroup CPU *quota*; affinity-based APIs still return node cores.)
- **Raise HRRR-spatial `update`/`validate` memory `2G -> 4G`** for headroom (backfill inherits the update cron's resources; the validate/decode-health job decodes GRIB and is heavier than ref-building).

## Notes
- The concurrency fix is in common code and benefits every virtual dataset.
- `update_template` not needed (no metadata change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)