### PR TITLE
Push ifs-ens update later so late ENS leads have disseminated

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
@@ -29,9 +29,10 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            # ECMWF uploads the first file at 07:40 UTC and the last one by ~07:45 UTC.
-            # (Ensemble stats get uploaded 15-20 mins later, but we don't process those.)
-            schedule="50 7 * * *",
+            # Gating lead group f360 typically lands ~08:00-08:09 UTC (recent days;
+            # wxopticon external-ecmwf-ifs-ens-long-aws p99 08:26); pod spin-up adds
+            # a head start before late-lead downloads, so fire at 08:05.
+            schedule="5 8 * * *",
             suspend=False,
             pod_active_deadline=timedelta(minutes=35),  # runs take <26 min
             image=image_tag,
@@ -46,7 +47,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="25 8 * * *",  # 35m (pod_active_deadline) after reformat at 07:50
+            schedule="40 8 * * *",  # 35m (pod_active_deadline) after reformat at 08:05
             suspend=False,
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,


### PR DESCRIPTION
## Problem

`ecmwf-ifs-ens-forecast-15-day-0-25-degree` validation has been failing intermittently with **excessive NaN fraction** (e.g. `pressure_surface: 0.36`, most surface/pressure vars `0.02–0.05`).

Root cause is **"too early," not origin overload**. Update job logs show only `404 NoSuchKey` on the late ENS lead index/grib (`...-360h-enfo-ef.*`), with `retries: 0` (404 isn't retried) — **zero 503s**. A failed download marks the coord `DownloadFailed` and leaves `fill_value` (NaN); for recent (<48h) 404s this is logged at `info`, so the update completes "successfully" with holes and the NaN-fraction validator fails ~20 min later.

The update fired at **07:50 UTC**, but the gating lead group **f360 (15d)** finishes disseminating to `s3://ecmwf-forecasts` later than that. Workers that reach the late-lead coords before the files land 404 → NaN — intermittent, hitting on days where dissemination runs into the tail.

## Evidence

f360 enfo-ef `Last-Modified` (the last file), last 5 days:

| date | grib2 | index |
|------|-------|-------|
| 06-25 | 08:06:47 | 08:07:22 |
| 06-26 | 08:08:25 | 08:08:34 |
| 06-27 | 08:00:49 | 08:00:57 |
| 06-28 | 07:59:25 | 07:59:27 |
| 06-29 | 08:00:40 | 08:00:45 |

wxopticon `external-ecmwf-ifs-ens-long-aws` (85 leads, 365-day / 543 inits) — f360 group completion after init: **p50 07:46, p95 07:47, p99 08:26**. The old 07:50 fire sat right at p50/p95, so it won most days and lost in the upper-~5% tail.

## Change

- update `50 7` → **`5 8`** (08:05 UTC)
- validate `25 8` → **`40 8`** (08:05 + 35m `pod_active_deadline`)

08:05 covers recent days; pod spin-up gives extra head start before workers reach the late leads. It intentionally does **not** cover the full p99 tail (08:26) to limit the freshness cost — the upcoming validation-failure rerun and wxopticon availability webhook will handle the rare tail day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)