### PR TITLE
Shrink HRRR-spatial manifest split 120 → 8 inits

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
@@ -42,13 +42,12 @@ class NoaaHrrrForecast48HourSpatialDataset(
                     _S3_LOCATION_PREFIX, icechunk.s3_store(region=_S3_BUCKET_REGION)
                 ),
             ),
-            # One month of inits (4 cycles/day) per manifest split. Each commit rewrites
-            # only the touched array's active split, so this caps commit cost: the
-            # largest array (a model_level var, 49 leads x 50 levels = 2450 refs/init)
-            # reaches ~294k refs (~4.7 MiB) per split (120 inits) at month end.
-            manifest_split=manifest_append_dim_split(
-                split_size=30 * 4, dim="init_time"
-            ),
+            # Each commit rewrites the touched array's whole active split, and one init
+            # touches all ~177 arrays, so per-commit manifest I/O scales with
+            # split_size x array count. Keep the split small (2 days) so backfill commits
+            # stay cheap; the largest array (a model_level var, 49 leads x 50 levels =
+            # 2450 refs/init) is then ~20k refs (~0.3 MiB) per full split.
+            manifest_split=manifest_append_dim_split(split_size=2 * 4, dim="init_time"),
         )
     )
 


### PR DESCRIPTION
## Why
Instrumenting the virtual write loop (#692) showed the HRRR-spatial backfill is bottlenecked on the **icechunk commit**, not source I/O. Per-batch timings:

```
discover ≈ 6s   build ≈ 0.7s    emit ≈ 15–21s   commit ≈ 5s (partial split) → 27s (full split)
```

- `build`/`discover` are small and flat → **not** an S3-source problem.
- `commit` time tracks init **size / split fullness** (5s→27s), deterministically (the two full-init commits were 24.8s and 27.5s) → it's **manifest rewrite I/O**, not primarily OCC contention. On each commit, every one of the ~177 arrays whose active split changed has its split manifest **downloaded, merged, and re-uploaded**; bytes ∝ split fullness.
- `commit` serializes on the shared backfill branch, so at 120 inits/split (~5 MiB for the largest array) the full archive projected to **~50h**.

Per-commit manifest I/O scales with **`split_size × array_count`**. HRRR has ~177 arrays (vs ~22 for GEFS) **and** used a 4× larger split than GEFS (120 vs 28) — ~34× more per-commit manifest work, which is why GEFS backfilled wide fine and HRRR stalled.

## What
Drop `manifest_split` from `30 * 4` (120 inits) to `2 * 4` (8 inits) — ~15× less manifest I/O per commit. The largest array's full split goes from ~4.7 MiB to ~0.3 MiB, so commits get cheap; read manifests stay tiny (more manifest objects, but each read loads only the one relevant split).

`emit` (~20s, O(refs)) is unaffected, but it runs in each worker's own session so it parallelizes — it isn't the serial bottleneck.

## Notes
- **Takes effect on a fresh store only** — icechunk can't re-split existing manifests in place. Plan: merge → delete the half-built store → clean backfill.
- This is the quick unblock. The deeper fix (per-worker branches / cooperative writes to remove the serial-commit bottleneck entirely) is still open for discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)