### PR TITLE
Suspend HRRR-spatial update/validate crons during initial backfill

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
@@ -52,6 +52,9 @@ class NoaaHrrrForecast48HourSpatialDataset(
     )
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+        # Suspended until the initial backfill completes: operational updates would
+        # race the backfill writing the same store. Unsuspend once the archive is filled.
+        suspend_until_backfilled = True
         # Run once per 6h cycle just before the first lead times publish
         # (~init+50m), polling through f48 (~init+2h on S3). The pod exits when the
         # window is fully ingested; the deadline bounds waiting on a file that never
@@ -65,6 +68,7 @@ class NoaaHrrrForecast48HourSpatialDataset(
             cpu="1.5",
             memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
+            suspend=suspend_until_backfilled,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
@@ -76,6 +80,7 @@ class NoaaHrrrForecast48HourSpatialDataset(
             cpu="1.5",
             memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
+            suspend=suspend_until_backfilled,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/tests/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset_test.py
@@ -252,6 +252,9 @@ def test_operational_kubernetes_resources(
     assert update_cron_job.pod_active_deadline < timedelta(hours=6)
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert len(update_cron_job.secret_names) > 0
+    # Suspended until the initial backfill completes; flip when un-suspending.
+    assert update_cron_job.suspend is True
+    assert validation_cron_job.suspend is True
 
 
 def test_validators(dataset: NoaaHrrrForecast48HourSpatialDataset) -> None:


### PR DESCRIPTION
## Why
The initial HRRR-spatial backfill is being re-run (fresh store, after the manifest-split fix #694). The operational `-update` cron writes the **same** icechunk store the backfill is filling, so letting it fire mid-backfill would race the backfill's writes. The `-validate` cron would also fail against an incomplete archive.

## What
Set `suspend=True` on both the update and validate CronJobs via a `suspend_until_backfilled` flag (the `CronJob` model already supports `suspend`, rendered to the manifest at `kubernetes.py:240`). The next operational deploy will apply `suspend: true` to both cronjobs, so they stay registered but don't fire.

Added test assertions (`suspend is True`) mirroring the GEFS-spatial cron test, with a comment to flip them when un-suspending.

## Un-suspending later
Once the archive is backfilled: set `suspend_until_backfilled = False`, flip the two test assertions back to `False`, and redeploy operational resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)