### PR TITLE
Push aifs-ens update later (H+7h00m) so more leads have disseminated

### DIFF
--- a/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
@@ -27,10 +27,11 @@ class EcmwfAifsEnsForecastDataset(
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            # AIFS-ENS publishes the last file ~H+6h00m to H+6h40m after init across
-            # normal cycles (sample of 11 v2 cycles 2026-05-12 through 05-14).
-            # Run at H+6h43m for a 3 min margin past the worst-observed last-file lag.
-            schedule="43 */6 * * *",
+            # AIFS-ENS full completion (wxopticon external-ecmwf-aifs-ens-aws, 365d):
+            # last file p50 H+5h56m, p95 H+7h11m. Fire at H+7h00m (01/07/13/19 UTC);
+            # late leads download last, so they land before the run reaches them.
+            # The rare p99 (H+13h+) tail is left to validation-failure reruns.
+            schedule="0 1,7,13,19 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -44,8 +45,8 @@ class EcmwfAifsEnsForecastDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            # Validation runs 30 minutes after each update run: 01:13, 07:13, 13:13, and 19:13.
-            schedule="13 1-23/6 * * *",
+            # Validation runs 30 minutes after each update run: 01:30, 07:30, 13:30, and 19:30.
+            schedule="30 1,7,13,19 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,


### PR DESCRIPTION
## Problem

`ecmwf-aifs-ens-forecast` NaN validation has been failing intermittently — both observed failures (2026-06-25, 2026-06-29; Sentry 7557792174) are the **12z cycle** (validated at 19:13). NaN fractions reached 0.4–0.71 across ~16 variables.

## Diagnosis: "too early," not S3 throttling

Checked the same two angles as the IFS-ENS fix (#691):

- **Not 503/overload** — zero real `503`/`SlowDown`/`ServiceUnavailable` in update or validation logs. Every download failure is `404 NoSuchKey`. (The only "503" string matches were substrings of NaN fractions like `0.587592`.)
- **Too early** — on 06-29 at 18:48–18:52 a broad swath of leads (18h through 360h) was still missing; the run finalized with holes → high NaN fraction. The gating 360h file landed at **18:52:57 (H+6h52m)**, *after* the 18:43 run (H+6h43m) had given up.

S3 `Last-Modified` for the 360h-pf file:

| cycle | 360h landed | H+ |
|---|---|---|
| 06-26 12z | 18:26:58 | H+6h26m ✓ |
| 06-27 12z | 18:20:50 | H+6h20m ✓ |
| **06-29 12z** | **18:52:57** | **H+6h52m** ✗ |
| 06-28 06z/12z/18z | — | H+9–14h (ECMWF-wide incident) |

## wxopticon ground truth

`external-ecmwf-aifs-ens-aws` (365d, 105 inits), full completion: last file **p50 H+5h56m, p95 H+7h11m, p99 H+13h33m**. The old H+6h43m fire sat between p50 and p95 — catching the typical case but missing the slow ~15–20% tail, which is exactly the intermittent failures.

## Change

- update fire: `43 */6` → `0 1,7,13,19` (**H+6h43m → H+7h00m**, 01/07/13/19 UTC)
- validation: `13 1-23/6` → `30 1,7,13,19` (+30 min)

Late leads download last, so firing at H+7h00m the run reaches them after p95. The rare p99 (H+13h+) tail — e.g. the 06-28 ECMWF-wide dissemination incident — is left to the planned validation-failure reruns + wxopticon availability webhook rather than further delaying every cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)