### PR TITLE
Vectorize per-var chunk index resolution to fix virtual emit hotspot

### DIFF
--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -357,11 +357,8 @@ class VirtualRegionJob(
 
         Groups items by var.path and, per group, resolves every labeled dim's
         position with one vectorized pandas.Index.get_indexer call over the whole
-        group, rather than one call per item. Recomputed fresh every call rather
-        than cached across calls -- profiling showed that's already fast enough
-        (microseconds per ref for a large backfill batch, tens of milliseconds for
-        a whole small operational-update poll tick), so there's no cross-call state
-        to keep consistent. chunk_key is a batch-of-one wrapper around this.
+        group, rather than one call per item. chunk_key is a batch-of-one wrapper
+        around this.
         """
         order = sorted(range(len(items)), key=lambda i: items[i][1].path)
         results: list[tuple[int, ...] | None] = [None] * len(items)

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -127,7 +127,7 @@ class VirtualRegionJob(
         """
         group = zarr.open_group(store, mode="r")
         rep_vars = [self.representative_var(coord) for coord in candidates]
-        indices = self._resolve_chunk_indices(
+        indices = self._resolve_chunk_keys(
             [
                 (coord.out_loc(), var)
                 for coord, var in zip(candidates, rep_vars, strict=True)
@@ -310,7 +310,7 @@ class VirtualRegionJob(
     def _emit_refs(
         self, stores: Sequence[IcechunkStore], refs: Sequence[VirtualRef]
     ) -> None:
-        indices = self._resolve_chunk_indices(
+        indices = self._resolve_chunk_keys(
             [(ref.out_loc, ref.data_var) for ref in refs]
         )
         specs_by_var: dict[str, list[VirtualChunkSpec]] = {}
@@ -344,12 +344,12 @@ class VirtualRegionJob(
         """Map a source message's coordinate labels to its zarr chunk index.
 
         Returns None if a label is not in the template's coords (the filter treats
-        that as "remaining"). A batch of one through _resolve_chunk_indices, which
+        that as "remaining"). A batch of one through _resolve_chunk_keys, which
         holds the actual chunk-index math -- see there.
         """
-        return self._resolve_chunk_indices([(out_loc, var)])[0]
+        return self._resolve_chunk_keys([(out_loc, var)])[0]
 
-    def _resolve_chunk_indices(
+    def _resolve_chunk_keys(
         self, items: Sequence[tuple[Mapping[Dim, CoordinateValue], DataVar[Any]]]
     ) -> list[tuple[int, ...] | None]:
         """Map each (out_loc, var) pair to its zarr chunk index, or None if a label

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -2,9 +2,11 @@ import asyncio
 import time
 from collections.abc import Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from itertools import groupby
 from typing import Any, ClassVar, Final, Generic, Literal, NamedTuple
 
 import icechunk
+import numpy as np
 import pandas as pd
 import xarray as xr
 import zarr
@@ -124,10 +126,15 @@ class VirtualRegionJob(
         would trigger a download + decode.
         """
         group = zarr.open_group(store, mode="r")
+        rep_vars = [self.representative_var(coord) for coord in candidates]
+        indices = self._resolve_chunk_indices(
+            [
+                (coord.out_loc(), var)
+                for coord, var in zip(candidates, rep_vars, strict=True)
+            ]
+        )
         keyed: list[tuple[SOURCE_FILE_COORD, str | None]] = []
-        for coord in candidates:
-            var = self.representative_var(coord)
-            index = self.chunk_key(coord.out_loc(), var)
+        for coord, var, index in zip(candidates, rep_vars, indices, strict=True):
             if index is None:
                 keyed.append((coord, None))
                 continue
@@ -303,9 +310,11 @@ class VirtualRegionJob(
     def _emit_refs(
         self, stores: Sequence[IcechunkStore], refs: Sequence[VirtualRef]
     ) -> None:
+        indices = self._resolve_chunk_indices(
+            [(ref.out_loc, ref.data_var) for ref in refs]
+        )
         specs_by_var: dict[str, list[VirtualChunkSpec]] = {}
-        for ref in refs:
-            index = self.chunk_key(ref.out_loc, ref.data_var)
+        for ref, index in zip(refs, indices, strict=True):
             assert index is not None, (
                 f"ref {ref.data_var.name} {dict(ref.out_loc)} did not resolve to a "
                 "chunk index after expansion"
@@ -335,42 +344,78 @@ class VirtualRegionJob(
         """Map a source message's coordinate labels to its zarr chunk index.
 
         Returns None if a label is not in the template's coords (the filter treats
-        that as "remaining").
+        that as "remaining"). A batch of one through _resolve_chunk_indices, which
+        holds the actual chunk-index math -- see there.
         """
-        # Geometry comes from the checked-in template, not in-code DataVar.encoding
-        # which could drift. Index by var.path so a vertical-group var resolves to its
-        # group node (its DataArray carries the vertical coord, absent from the root).
-        template_var = self.template_ds[var.path]
-        dims = tuple(str(d) for d in template_var.dims)
-        chunks = template_var.encoding["chunks"]
-        assert len(chunks) == len(dims)
-        labels = {str(dim): label for dim, label in out_loc.items()}
+        return self._resolve_chunk_indices([(out_loc, var)])[0]
 
-        index: list[int] = []
-        for dim, chunk_size in zip(dims, chunks, strict=True):
-            if dim in labels:
-                position = int(
-                    template_var.get_index(dim).get_indexer(pd.Index([labels[dim]]))[0]
-                )
-                if position < 0:
-                    return None  # label not in coords -> not yet a position in this dataset
-            else:
-                # A dim absent from out_loc must be single-chunk, else all refs
-                # collapse to chunk 0 along it.
-                assert chunk_size >= template_var.sizes[dim], (
-                    f"dim {dim} is absent from out_loc but spans multiple chunks "
-                    f"(size {template_var.sizes[dim]}, chunk {chunk_size}); out_loc "
-                    "must locate every multi-chunk dim."
-                )
-                position = 0
-            chunk_index, remainder = divmod(position, chunk_size)
-            assert remainder == 0, (
-                f"{dim}={labels.get(dim)} maps to position {position}, which is not "
-                f"on a chunk boundary (chunk size {chunk_size}); a virtual chunk must "
-                "be exactly one GRIB message."
+    def _resolve_chunk_indices(
+        self, items: Sequence[tuple[Mapping[Dim, CoordinateValue], DataVar[Any]]]
+    ) -> list[tuple[int, ...] | None]:
+        """Map each (out_loc, var) pair to its zarr chunk index, or None if a label
+        isn't in the template's coords yet (the filter treats that as "remaining").
+
+        Groups items by var.path and, per group, resolves every labeled dim's
+        position with one vectorized pandas.Index.get_indexer call over the whole
+        group, rather than one call per item. Recomputed fresh every call rather
+        than cached across calls -- profiling showed that's already fast enough
+        (microseconds per ref for a large backfill batch, tens of milliseconds for
+        a whole small operational-update poll tick), so there's no cross-call state
+        to keep consistent. chunk_key is a batch-of-one wrapper around this.
+        """
+        order = sorted(range(len(items)), key=lambda i: items[i][1].path)
+        results: list[tuple[int, ...] | None] = [None] * len(items)
+
+        for var_path, idx_group in groupby(order, key=lambda i: items[i][1].path):
+            idxs = list(idx_group)
+            template_var = self.template_ds[var_path]
+            dims = tuple(str(d) for d in template_var.dims)
+            chunks = tuple(template_var.encoding["chunks"])
+            assert len(chunks) == len(dims)
+
+            group_labels = [
+                {str(dim): label for dim, label in items[i][0].items()} for i in idxs
+            ]
+            labeled_dims = set(group_labels[0])
+            assert all(set(labels) == labeled_dims for labels in group_labels), (
+                f"every ref for {var_path} must label the same set of dims"
             )
-            index.append(chunk_index)
-        return tuple(index)
+
+            n = len(idxs)
+            chunk_indices = np.zeros((n, len(dims)), dtype=np.int64)
+            present = np.ones(n, dtype=bool)
+            for dim_i, (dim, chunk_size) in enumerate(zip(dims, chunks, strict=True)):
+                if dim in labeled_dims:
+                    labels = pd.Index([lbl[dim] for lbl in group_labels])
+                    positions = template_var.get_index(dim).get_indexer(labels)
+                    present &= positions >= 0
+                    chunk_idx, remainder = np.divmod(
+                        np.where(positions >= 0, positions, 0), chunk_size
+                    )
+                    assert np.all(remainder[positions >= 0] == 0), (
+                        f"a ref's {dim} label does not fall on a chunk boundary "
+                        f"(chunk size {chunk_size}); a virtual chunk must be exactly "
+                        "one GRIB message."
+                    )
+                else:
+                    # A dim absent from out_loc must be single-chunk, else all refs
+                    # collapse to chunk 0 along it.
+                    size = int(template_var.sizes[dim])
+                    assert chunk_size >= size, (
+                        f"dim {dim} is absent from out_loc but spans multiple chunks "
+                        f"(size {size}, chunk {chunk_size}); out_loc must locate every "
+                        "multi-chunk dim."
+                    )
+                    chunk_idx = np.zeros(n, dtype=np.int64)
+                chunk_indices[:, dim_i] = chunk_idx
+
+            for local_i, item_i in enumerate(idxs):
+                results[item_i] = (
+                    tuple(int(v) for v in chunk_indices[local_i])
+                    if present[local_i]
+                    else None  # label not in coords -> not yet a position in this dataset
+                )
+        return results
 
     def sync_dims_to(
         self, stores: Sequence[IcechunkStore], needed_append_dim_size: int

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -587,10 +587,10 @@ def test_chunk_key_separate_job_instances_do_not_share_cache() -> None:
     assert job_chunk1.chunk_key(out_loc_init2, var) == (2, 0, 0, 0)
 
 
-def test_resolve_chunk_indices_matches_chunk_key_and_batches_lookups(
+def test_resolve_chunk_keys_matches_chunk_key_and_batches_lookups(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # _resolve_chunk_indices (used by _emit_refs and filter_already_present) must
+    # _resolve_chunk_keys (used by _emit_refs and filter_already_present) must
     # return exactly what calling chunk_key once per item would, while touching the
     # template only once per var per call regardless of how many items (or labeled
     # dims) share that var -- not once per item.
@@ -614,7 +614,7 @@ def test_resolve_chunk_indices_matches_chunk_key_and_batches_lookups(
         return original_getitem(self, key)
 
     monkeypatch.setattr(xr.DataTree, "__getitem__", counting_getitem)
-    results = job._resolve_chunk_indices([(out_loc, var) for out_loc in out_locs])
+    results = job._resolve_chunk_keys([(out_loc, var) for out_loc in out_locs])
 
     assert results == expected
     # One template lookup for the whole group (dims/chunks/sizes and both labeled
@@ -622,7 +622,7 @@ def test_resolve_chunk_indices_matches_chunk_key_and_batches_lookups(
     assert call_count == 1
 
 
-def test_resolve_chunk_indices_rejects_inconsistent_labeled_dims() -> None:
+def test_resolve_chunk_keys_rejects_inconsistent_labeled_dims() -> None:
     # Every ref for a given var must label the same set of dims -- if it didn't,
     # peeking at the first item's labels to decide which dims to vectorize over
     # would silently miscompute the rest. Fail loudly instead.
@@ -633,11 +633,11 @@ def test_resolve_chunk_indices_rejects_inconsistent_labeled_dims() -> None:
         ({"init_time": APPEND_DIM_START + APPEND_DIM_FREQ}, var),
     ]
     with pytest.raises(AssertionError, match="must label the same set of dims"):
-        job._resolve_chunk_indices(items)
+        job._resolve_chunk_keys(items)
 
 
-def test_resolve_chunk_indices_multi_var_interleaved_preserves_order() -> None:
-    # _resolve_chunk_indices groups items by var.path internally, then must scatter
+def test_resolve_chunk_keys_multi_var_interleaved_preserves_order() -> None:
+    # _resolve_chunk_keys groups items by var.path internally, then must scatter
     # results back into the caller's original order. With items for only one var, a
     # stable sort leaves order unchanged, so a bug that swapped which item's result
     # went where (e.g. writing to the group-local index instead of the original
@@ -679,13 +679,13 @@ def test_resolve_chunk_indices_multi_var_interleaved_preserves_order() -> None:
         (out_loc(2), var_a),  # -> (2, 0, 0, 0)
         (out_loc(0), var_b),  # -> (0, 0, 0, 0)
     ]
-    results = job._resolve_chunk_indices(items)
+    results = job._resolve_chunk_keys(items)
 
     assert results == [(1, 0, 0, 0), (0, 0, 0, 0), (2, 0, 0, 0), (0, 0, 0, 0)]
     assert results == [job.chunk_key(out_loc, var) for out_loc, var in items]
 
 
-def test_resolve_chunk_indices_mixed_present_and_absent_in_one_group() -> None:
+def test_resolve_chunk_keys_mixed_present_and_absent_in_one_group() -> None:
     # Within a single var's vectorized group, an absent label must not corrupt a
     # neighboring present item's resolved index (np.where clamps the absent
     # position to 0 before divmod so it never raises, and the boundary assert only
@@ -706,7 +706,7 @@ def test_resolve_chunk_indices_mixed_present_and_absent_in_one_group() -> None:
             var,
         ),
     ]
-    results = job._resolve_chunk_indices(items)
+    results = job._resolve_chunk_keys(items)
 
     assert results == [(0, 0, 0, 0), None, (2, 1, 0, 0)]
     assert results == [job.chunk_key(out_loc, v) for out_loc, v in items]

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -431,6 +431,211 @@ def test_chunk_key_uses_template_geometry_not_datavar_encoding() -> None:
     assert job.chunk_key(out_loc, misconfigured_var) == (0, 1, 0, 0)
 
 
+def _create_ensemble_template_ds(
+    n_inits: int, *, ensemble_members: tuple[int, ...] = (0, 1, 2)
+) -> xr.DataTree:
+    """Like _create_template_ds, but with a plain-int labeled dim (ensemble_member)
+    in place of lead_time, to exercise non-Timestamp/Timedelta label lookups."""
+    init_times = pd.date_range(APPEND_DIM_START, periods=n_inits, freq=APPEND_DIM_FREQ)
+    encoding: dict[str, Any] = {
+        "dtype": "float64",
+        "chunks": (1, 1, N_LAT, N_LON),
+        "fill_value": np.nan,
+        "compressors": None,
+        "filters": None,
+    }
+    ds = xr.Dataset(
+        {
+            "temperature_2m": xr.Variable(
+                ("init_time", "ensemble_member", "latitude", "longitude"),
+                dask.array.full(
+                    (n_inits, len(ensemble_members), N_LAT, N_LON),
+                    np.nan,
+                    dtype="float64",
+                    chunks=-1,
+                ),
+                encoding=encoding,
+            )
+        },
+        coords={
+            "init_time": ("init_time", init_times),
+            "ensemble_member": ("ensemble_member", np.array(ensemble_members)),
+            "latitude": ("latitude", np.arange(N_LAT, dtype="float64")),
+            "longitude": ("longitude", np.arange(N_LON, dtype="float64")),
+        },
+        attrs={"dataset_id": DATASET_ID, "dataset_version": "v1.0"},
+    )
+    ds["init_time"].encoding.update(
+        {
+            "dtype": "int64",
+            "fill_value": -1,
+            "units": "seconds since 1970-01-01 00:00:00",
+            "calendar": "proleptic_gregorian",
+        }
+    )
+    ds["ensemble_member"].encoding["fill_value"] = -1
+    ds["latitude"].encoding["fill_value"] = np.nan
+    ds["longitude"].encoding["fill_value"] = np.nan
+    return xr.DataTree.from_dict({"/": ds})
+
+
+def test_chunk_key_int_labeled_dim_resolves_and_handles_absent_label() -> None:
+    # Non-Timestamp/Timedelta labeled dim: dict-based lookups must hash/compare
+    # int coordinate labels consistently, not just datetime-like ones.
+    template_ds = _create_ensemble_template_ds(4, ensemble_members=(0, 1, 2))
+    job = _make_region_job(template_ds, region=slice(0, 4))
+    var = job.data_vars[0]
+
+    present: Mapping[Dim, CoordinateValue] = {
+        "init_time": APPEND_DIM_START + APPEND_DIM_FREQ,
+        "ensemble_member": 2,
+    }
+    assert job.chunk_key(present, var) == (1, 2, 0, 0)
+
+    absent: Mapping[Dim, CoordinateValue] = {
+        "init_time": APPEND_DIM_START,
+        "ensemble_member": 99,  # not in the template's ensemble_member coord
+    }
+    assert job.chunk_key(absent, var) is None
+
+    # Repeat the present lookup to prove any cache built on first use is stable.
+    assert job.chunk_key(present, var) == (1, 2, 0, 0)
+
+
+def test_chunk_key_repeated_calls_same_var_different_out_loc() -> None:
+    # A cache keyed on var.path alone (ignoring out_loc) would return stale
+    # results; each distinct out_loc must resolve independently and correctly.
+    job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
+    var = job.data_vars[0]
+
+    for init_idx in range(4):
+        for lead_idx, lead in enumerate(LEAD_TIMES):
+            out_loc: Mapping[Dim, CoordinateValue] = {
+                "init_time": APPEND_DIM_START + init_idx * APPEND_DIM_FREQ,
+                "lead_time": lead,
+            }
+            assert job.chunk_key(out_loc, var) == (init_idx, lead_idx, 0, 0)
+
+    # And querying an already-seen out_loc again still gives the same answer.
+    out_loc = {
+        "init_time": APPEND_DIM_START + 2 * APPEND_DIM_FREQ,
+        "lead_time": LEAD_TIMES[1],
+    }
+    assert job.chunk_key(out_loc, var) == (2, 1, 0, 0)
+    assert job.chunk_key(out_loc, var) == (2, 1, 0, 0)
+
+
+def test_chunk_key_two_datavars_same_path_different_encoding_in_sequence() -> None:
+    # Any per-var.path geometry cache must key strictly off the template, not
+    # off whichever DataVar object happened to populate it first.
+    job = _make_region_job(
+        _create_template_ds(4, chunks=(1, 1, N_LAT, N_LON)), region=slice(0, 4)
+    )
+    correct_var = job.data_vars[0]
+    misconfigured_var = VirtualTestDataVar(
+        name="temperature_2m",
+        encoding=Encoding(
+            dtype="float64",
+            fill_value=np.nan,
+            chunks=(1, 2, N_LAT, N_LON),  # disagrees with the template's (1, 1, ...)
+            shards=None,
+            compressors=None,
+            filters=None,
+        ),
+    )
+    out_loc: Mapping[Dim, CoordinateValue] = {
+        "init_time": APPEND_DIM_START,
+        "lead_time": LEAD_TIMES[1],
+    }
+    # correct_var first (populates any cache), then misconfigured_var: both must
+    # resolve against the template's chunk size of 1, not either var's own encoding.
+    assert job.chunk_key(out_loc, correct_var) == (0, 1, 0, 0)
+    assert job.chunk_key(out_loc, misconfigured_var) == (0, 1, 0, 0)
+    # And again in the opposite order, to rule out order-dependent cache seeding.
+    job2 = _make_region_job(
+        _create_template_ds(4, chunks=(1, 1, N_LAT, N_LON)), region=slice(0, 4)
+    )
+    assert job2.chunk_key(out_loc, misconfigured_var) == (0, 1, 0, 0)
+    assert job2.chunk_key(out_loc, correct_var) == (0, 1, 0, 0)
+
+
+def test_chunk_key_separate_job_instances_do_not_share_cache() -> None:
+    # Two jobs over different templates (different init_time chunk sizes) must
+    # not cross-contaminate any var.path-keyed cache.
+    job_chunk1 = _make_region_job(
+        _create_template_ds(4, chunks=(1, 1, N_LAT, N_LON)), region=slice(0, 4)
+    )
+    job_chunk2 = _make_region_job(
+        _create_template_ds(4, chunks=(2, 1, N_LAT, N_LON)), region=slice(0, 4)
+    )
+    var = job_chunk1.data_vars[0]
+    out_loc: Mapping[Dim, CoordinateValue] = {
+        "init_time": APPEND_DIM_START,
+        "lead_time": LEAD_TIMES[0],
+    }
+    # Warm job_chunk1's cache first.
+    assert job_chunk1.chunk_key(out_loc, var) == (0, 0, 0, 0)
+    # job_chunk2's init_time chunk size is 2: init index 2 lands at the start of
+    # chunk index 1, distinct from job_chunk1's chunk index 2 for the same position.
+    out_loc_init2: Mapping[Dim, CoordinateValue] = {
+        "init_time": APPEND_DIM_START + 2 * APPEND_DIM_FREQ,
+        "lead_time": LEAD_TIMES[0],
+    }
+    assert job_chunk2.chunk_key(out_loc_init2, job_chunk2.data_vars[0]) == (1, 0, 0, 0)
+    # Re-querying job_chunk1 for the same position must still use its own
+    # (1, 1, ...) chunking, unaffected by job_chunk2's lookups in between.
+    assert job_chunk1.chunk_key(out_loc_init2, var) == (2, 0, 0, 0)
+
+
+def test_resolve_chunk_indices_matches_chunk_key_and_batches_lookups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # _resolve_chunk_indices (used by _emit_refs and filter_already_present) must
+    # return exactly what calling chunk_key once per item would, while touching the
+    # template only once per var per call regardless of how many items (or labeled
+    # dims) share that var -- not once per item.
+    job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
+    var = job.data_vars[0]
+    out_locs: list[Mapping[Dim, CoordinateValue]] = [
+        {
+            "init_time": APPEND_DIM_START + init_idx * APPEND_DIM_FREQ,
+            "lead_time": LEAD_TIMES[0],
+        }
+        for init_idx in range(4)
+    ]
+    expected = [job.chunk_key(out_loc, var) for out_loc in out_locs]
+
+    call_count = 0
+    original_getitem = xr.DataTree.__getitem__
+
+    def counting_getitem(self: xr.DataTree, key: str) -> xr.DataTree | xr.DataArray:
+        nonlocal call_count
+        call_count += 1
+        return original_getitem(self, key)
+
+    monkeypatch.setattr(xr.DataTree, "__getitem__", counting_getitem)
+    results = job._resolve_chunk_indices([(out_loc, var) for out_loc in out_locs])
+
+    assert results == expected
+    # One template lookup for the whole group (dims/chunks/sizes and both labeled
+    # dims' positions all reuse it), not one per item (4).
+    assert call_count == 1
+
+
+def test_resolve_chunk_indices_rejects_inconsistent_labeled_dims() -> None:
+    # Every ref for a given var must label the same set of dims -- if it didn't,
+    # peeking at the first item's labels to decide which dims to vectorize over
+    # would silently miscompute the rest. Fail loudly instead.
+    job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
+    var = job.data_vars[0]
+    items: list[tuple[Mapping[Dim, CoordinateValue], VirtualTestDataVar]] = [
+        ({"init_time": APPEND_DIM_START, "lead_time": LEAD_TIMES[0]}, var),
+        ({"init_time": APPEND_DIM_START + APPEND_DIM_FREQ}, var),
+    ]
+    with pytest.raises(AssertionError, match="must label the same set of dims"):
+        job._resolve_chunk_indices(items)
+
+
 def test_needed_append_dim_size() -> None:
     job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
     refs = [

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -636,6 +636,82 @@ def test_resolve_chunk_indices_rejects_inconsistent_labeled_dims() -> None:
         job._resolve_chunk_indices(items)
 
 
+def test_resolve_chunk_indices_multi_var_interleaved_preserves_order() -> None:
+    # _resolve_chunk_indices groups items by var.path internally, then must scatter
+    # results back into the caller's original order. With items for only one var, a
+    # stable sort leaves order unchanged, so a bug that swapped which item's result
+    # went where (e.g. writing to the group-local index instead of the original
+    # item index) wouldn't be caught. Two vars with DIFFERENT init_time chunk sizes,
+    # interleaved and queried at the SAME position, produce genuinely different
+    # correct answers -- exactly what's needed to catch a reassembly bug.
+    template_ds = _create_template_ds(4, chunks=(1, 1, N_LAT, N_LON))
+    ds = template_ds.to_dataset()
+    ds["dewpoint_2m"] = ds["temperature_2m"].copy(deep=False)
+    ds["dewpoint_2m"].encoding = {
+        **ds["temperature_2m"].encoding,
+        "chunks": (2, 1, N_LAT, N_LON),
+    }
+    template_ds = xr.DataTree.from_dict({"/": ds})
+
+    var_a = VirtualTestDataVar(name="temperature_2m")  # init_time chunk size 1
+    var_b = VirtualTestDataVar(name="dewpoint_2m")  # init_time chunk size 2
+    job = VirtualTestRegionJob(
+        tmp_store=Path("unused-tmp.zarr"),
+        template_ds=template_ds,
+        data_vars=[var_a, var_b],
+        append_dim="init_time",
+        region=slice(0, 4),
+        reformat_job_name="test",
+    )
+
+    def out_loc(init_idx: int) -> Mapping[Dim, CoordinateValue]:
+        return {
+            "init_time": APPEND_DIM_START + init_idx * APPEND_DIM_FREQ,
+            "lead_time": LEAD_TIMES[0],
+        }
+
+    # Interleaved, not grouped by var -- init index 2 lands on a chunk boundary for
+    # both vars (chunk sizes 1 and 2), so it's safe to query for both while still
+    # giving different chunk indices (2 vs. 1).
+    items = [
+        (out_loc(2), var_b),  # -> (1, 0, 0, 0)
+        (out_loc(0), var_a),  # -> (0, 0, 0, 0)
+        (out_loc(2), var_a),  # -> (2, 0, 0, 0)
+        (out_loc(0), var_b),  # -> (0, 0, 0, 0)
+    ]
+    results = job._resolve_chunk_indices(items)
+
+    assert results == [(1, 0, 0, 0), (0, 0, 0, 0), (2, 0, 0, 0), (0, 0, 0, 0)]
+    assert results == [job.chunk_key(out_loc, var) for out_loc, var in items]
+
+
+def test_resolve_chunk_indices_mixed_present_and_absent_in_one_group() -> None:
+    # Within a single var's vectorized group, an absent label must not corrupt a
+    # neighboring present item's resolved index (np.where clamps the absent
+    # position to 0 before divmod so it never raises, and the boundary assert only
+    # checks the present subset), and must land as None at exactly its own slot.
+    job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
+    var = job.data_vars[0]
+    items: list[tuple[Mapping[Dim, CoordinateValue], VirtualTestDataVar]] = [
+        ({"init_time": APPEND_DIM_START, "lead_time": LEAD_TIMES[0]}, var),
+        (
+            {"init_time": pd.Timestamp("2030-01-01"), "lead_time": LEAD_TIMES[0]},
+            var,
+        ),  # not in the template's coords
+        (
+            {
+                "init_time": APPEND_DIM_START + 2 * APPEND_DIM_FREQ,
+                "lead_time": LEAD_TIMES[1],
+            },
+            var,
+        ),
+    ]
+    results = job._resolve_chunk_indices(items)
+
+    assert results == [(0, 0, 0, 0), None, (2, 1, 0, 0)]
+    assert results == [job.chunk_key(out_loc, v) for out_loc, v in items]
+
+
 def test_needed_append_dim_size() -> None:
     job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
     refs = [


### PR DESCRIPTION
## Summary
- `chunk_key` re-derived each variable's dims/chunks/sizes from `template_ds` and reran `pandas.Index.get_indexer` on every single ref during virtual backfill/update emit — measured at ~260us/ref in production, dominating the `emit` phase (~21.5s for ~80k refs).
- Adds `_resolve_chunk_indices`, used by the two hot loops (`_emit_refs`, `filter_already_present`). It groups refs by `var.path` and resolves each labeled dim's positions with **one vectorized `pandas.Index.get_indexer` call over the whole group**, instead of one call per ref — the same pandas call the original code made, just handed an array instead of a single-element `Index`.
- `chunk_key` is now a thin batch-of-one wrapper around `_resolve_chunk_indices` (`return self._resolve_chunk_indices([(out_loc, var)])[0]`) — there's a single implementation of the chunk-index math instead of two that could silently drift apart. Its only production caller, `_assert_probe_chunk_covered`, invokes it roughly once per source file (not per ref, confirmed by the short-circuiting `and` before the `chunk_key` call), so the ~90us of extra groupby/array-construction overhead for a batch of one is negligible there (worst case ~100ms total across a whole backfill, against the ~21.5s this eliminates).
- No caching, anywhere. Measured (see benchmark below) that recomputing per-var geometry fresh on every call — rather than persisting anything across calls, whether on the job instance or in a batch-scoped closure — is already fast enough that there's no cache lifetime/staleness to reason about.

### Why no caching
Two earlier iterations of this PR added caching (first as `cached_property` state on the frozen job instance, then as batch-scoped closures/dicts) and both added real complexity — hidden mutable state, memoization lifetime questions — for a win that, once vectorized, mostly wasn't needed. Measurements:
- **Backfill-shaped** (one big batch, 80k refs / 177 vars): `_resolve_chunk_indices` alone (no cache) gets to ~2.3-3.5us/item, matching what the cached versions achieved — vectorizing did nearly all the work, not memoization.
- **Operational-update-shaped** (50 small poll ticks, ~2 refs/var/tick): recomputing geometry fresh every tick costs ~49ms/tick; adding full persistent caching (geometry + label index) only brings that down to ~34ms/tick — a ~15ms difference against a ~1.3s commit overhead, i.e. noise either way.

So the simplest version — recompute, don't cache, and don't duplicate the algorithm — is also the fast-enough version.

## Test plan
- [x] `uv run pytest tests/common/virtual_region_job_test.py tests/common/virtual_multi_group_test.py -q` — 51 passed
- [x] `uv run pytest -m "not slow" -q` — 1508 passed in 27.5s (this test file is `pytest.mark.slow`, so fast-suite runtime is unaffected)
- [x] `uv run ruff format && uv run ruff check --fix && uv run ty check` — all clean
- [x] Microbenchmark: `_resolve_chunk_indices` ~2.3-3.5us/item for a large batch (vs. ~250us/item unbatched); `chunk_key`'s batch-of-one wrapper ~340us/call, acceptable given its low call volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)