### PR TITLE
Batch virtual backfill commits: one commit per worker

### DIFF
--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -21,7 +21,7 @@ Regions are reordered with a bit-reversal permutation (`iterating.spread_evenly`
 `RegionJob.process_worker_jobs(worker_jobs, store_factory, branch_name, worker_index)` is the single polymorphic call the coordinator (`DynamicalDataset._process_region_jobs`) drives every dataset variant through. Each variant owns its store/session lifecycle and commit cadence behind it:
 
 - **Materialized** — opens stores once and writes all of the worker's jobs in a single commit.
-- **Virtual** — commits each batch of source-file refs as its generator yields them, because a committed icechunk session is read-only (see [virtual_datasets.md](virtual_datasets.md#the-write-loop)).
+- **Virtual** — gathers the worker's not-already-present source files across all its jobs, then commits each batch its generator yields (a backfill yields once → one commit per worker, like materialized; an operational update yields per poll tick), because a committed icechunk session is read-only (see [virtual_datasets.md](virtual_datasets.md#the-write-loop)).
 
 The only fork outside this call is the coordination lifecycle: everything runs the parallel temp-branch flow below except virtual operational updates, which are single-writer (see below).
 

--- a/docs/virtual_datasets.md
+++ b/docs/virtual_datasets.md
@@ -6,14 +6,14 @@ How virtual jobs plug into worker parallelism and coordination is covered in [pa
 
 ## The write loop
 
-`VirtualRegionJob.process_virtual` runs the same loop for backfills and operational updates; only the branch differs (a temp branch for backfill, `main` for operational):
+`process_worker_jobs` gathers the not-already-present source files across all of a worker's region jobs (one readonly view, one filter pass) into `remaining`, then `VirtualRegionJob.process_virtual` runs the same write loop over that union for both backfills and operational updates; only the branch differs (a temp branch for backfill, `main` for operational):
 
-1. `generate_source_file_coords` lists candidate source files for the region.
-2. `filter_already_present` drops files whose refs are already in the manifest.
+1. `generate_source_file_coords` lists candidate source files for each of the worker's region jobs.
+2. `filter_already_present` drops files whose refs are already in the manifest; the survivors across the worker's jobs are unioned into `remaining`.
 3. `process_virtual_refs(remaining)` — a concrete `VirtualRegionJob` generator — each tick asks `discover_available` which files are ready, builds their refs with `file_refs`, and yields batches of `(source file coord, its VirtualRefs)` pairs.
 4. Each yield is committed atomically: open fresh writable sessions (a committed icechunk session is read-only), grow the append dim if needed (`sync_dims_to`), `set_virtual_refs`, commit.
 
-**The yield is the commit unit.** The loop's batching policy: operational updates yield everything that arrived since the last poll tick (typically ~one file) for per-file visibility; backfills yield everything available. A yield contains *whole* source files — never split a file across yields — and is never empty (an empty icechunk commit raises). The loop asserts each file's refs cover the representative cell `filter_already_present` probes, so a file the filter could never see as ingested fails loudly instead of being re-ingested forever.
+**The yield is the commit unit.** The loop's batching policy: a backfill sweeps once and yields everything available across the worker's jobs, so the whole worker is **one commit** — this keeps the commit count at `workers_total` rather than one-per-init, relieving shared-branch CAS contention (`jobs_per_pod` sets the batch = inits per commit, mirroring `MaterializedRegionJob`). An operational update yields everything that arrived since the last poll tick (typically ~one file) for per-file visibility. A yield contains *whole* source files — never split a file across yields — and is never empty (an empty icechunk commit raises). The loop asserts each file's refs cover the representative cell `filter_already_present` probes, so a file the filter could never see as ingested fails loudly instead of being re-ingested forever.
 
 `processing_mode` on the job selects the generator's stopping rule: `"backfill"` sweeps what exists once and exits; `"update"` polls until everything expected is ingested, with the pod's active deadline bounding how long it waits on a file that never publishes. `operational_update_jobs` implementations must construct jobs with `processing_mode="update"` (asserted by the driver).
 
@@ -41,9 +41,9 @@ How virtual jobs plug into worker parallelism and coordination is covered in [pa
 
 **Discovery utilities** (opt-in, off the base, in `virtual_source_listing.py`): `discover_available_by_obstore_listing(pending, *, store, location_prefix)` works for any obstore backend (S3, GCS, Azure, local) — a file is ready once `store` lists both its data object and its index; the caller passes the built store. A source obstore can't list (an HTTP file server whose directory index is HTML, a frontier that must be probed) gets its own discovery util in the same module and a custom `discover_available`.
 
-## Reader safety: one source file → one atomic commit
+## Reader safety: whole files, atomic commits
 
-All refs from a single source file, plus any append-dim expansion their positions require, land in one icechunk commit. A reader on `main` sees either none of a file's data or all of it. Atomicity is per *file*, not per init — readers see each lead time's data as its file is ingested, within seconds.
+Every ref from a source file, plus any append-dim expansion its positions require, lands in the same icechunk commit as the rest of that file — a reader on `main` sees either none of a file's data or all of it, never a partially-ingested file. A commit may hold one file (an operational tick) or many (a backfill worker's whole batch); atomicity is per *commit*, and each file is wholly inside one. Operational updates commit per tick, so readers see each lead time's data within seconds of its file publishing.
 
 This invariant is also what lets the filter probe a single representative cell per file: if one cell a file covers is present, the whole file is present.
 

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -252,8 +252,11 @@ class VirtualRegionJob(
         # would raise, so skip the write loop entirely.
         if remaining:
             # A worker's jobs share template_ds/processing_mode/tick_interval, so any
-            # one drives the write loop over the union of their coords.
-            jobs[0].process_virtual(
+            # one drives the write loop over the union of their coords. Poison the
+            # driver's region: the loop spans every job's region, so reading a single
+            # job's region would be a bug (see _NoRegion).
+            driver = jobs[0].model_copy(update={"region": _NO_REGION})
+            driver.process_virtual(
                 primary_repo, list(replica_repos), branch_name, remaining
             )
         return {}
@@ -507,6 +510,26 @@ class VirtualRegionJob(
             for name, coord in node.to_dataset().coords.items()
         }
         return xr.Dataset(coords=coords).isel({self.append_dim: processing_region})
+
+
+class _NoRegion:
+    """Poison `region` for the batched write-loop driver (see process_worker_jobs).
+
+    process_worker_jobs runs one write loop over the union of all its jobs'
+    coords, so the driver's own region is meaningless. process_virtual and every
+    method it calls must act on the coords passed to them, never self.region;
+    reading it would silently narrow the batch to a single job. Any access raises
+    instead, so a future edit that reintroduces region-dependence fails loudly.
+    """
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+        raise AssertionError(
+            "the batched virtual write loop read self.region; process_virtual and "
+            "the methods it calls must use the coords passed to them, not self.region"
+        )
+
+
+_NO_REGION: Final = _NoRegion()
 
 
 def _exists_many(store: IcechunkStore, keys: Sequence[str]) -> dict[str, bool]:

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from itertools import groupby
-from typing import Any, ClassVar, Final, Generic, Literal, NamedTuple
+from typing import Any, ClassVar, Final, Generic, Literal, NamedTuple, cast
 
 import icechunk
 import numpy as np
@@ -221,18 +221,41 @@ class VirtualRegionJob(
         worker_jobs: Sequence[RegionJob[DATA_VAR, SOURCE_FILE_COORD]],
         store_factory: storage.StoreFactory,
         branch_name: str,
-        worker_index: int,  # noqa: ARG003 - virtual jobs commit per batch with their own messages
+        worker_index: int,  # noqa: ARG003 - per-batch commit messages don't carry it
     ) -> dict[str, list[SourceFileResult]]:
-        """Drive each job's per-batch virtual write loop on ``branch_name``.
+        """Drive the whole worker's virtual write loop on ``branch_name``.
 
-        Always returns an empty dict of results: virtual refs live in the icechunk
-        manifest, so there is nothing to thread back to finalize.
+        Gathers the not-already-present source files across all the worker's jobs
+        against a single readonly view, then runs one write loop over their union:
+        a backfill worker's generator yields a single batch (one commit for the
+        whole worker), an update job's generator polls and commits per tick.
+        Always returns an empty dict: virtual refs live in the icechunk manifest,
+        so there is nothing to thread back to finalize.
         """
         assert worker_jobs, "process_worker_jobs requires at least one job"
+        assert all(isinstance(job, VirtualRegionJob) for job in worker_jobs)
+        jobs = cast(
+            "Sequence[VirtualRegionJob[DATA_VAR, SOURCE_FILE_COORD]]", worker_jobs
+        )
+        del worker_jobs
+
         primary_repo, replica_repos = store_factory.icechunk_primary_and_replica_repos()
-        for job in worker_jobs:
-            assert isinstance(job, VirtualRegionJob)
-            job.process_virtual(primary_repo, replica_repos, branch_name)
+        readonly_store = primary_repo.readonly_session(branch_name).store
+        remaining = [
+            coord
+            for job in jobs
+            for coord in job.filter_already_present(
+                job.source_file_coords(), readonly_store
+            )
+        ]
+        # An all-already-present worker writes nothing; an empty icechunk commit
+        # would raise, so skip the write loop entirely.
+        if remaining:
+            # A worker's jobs share template_ds/processing_mode/tick_interval, so any
+            # one drives the write loop over the union of their coords.
+            jobs[0].process_virtual(
+                primary_repo, list(replica_repos), branch_name, remaining
+            )
         return {}
 
     def process_virtual(
@@ -240,18 +263,20 @@ class VirtualRegionJob(
         primary_repo: icechunk.Repository,
         replica_repos: Sequence[icechunk.Repository],
         branch: str,
+        remaining: Sequence[SOURCE_FILE_COORD],
     ) -> None:
-        """Run the virtual write loop, committing each yielded batch atomically.
+        """Run the virtual write loop over `remaining`, committing each yielded batch atomically.
 
-        The same loop serves backfill (temp branch) and the single-writer
-        operational update ("main"); see "The write loop" in docs/virtual_datasets.md.
+        `remaining` is the pre-filtered union of the worker's not-already-present
+        source files (gathered by process_worker_jobs). The same loop serves
+        backfill (temp branch, one batch -> one commit) and the single-writer
+        operational update ("main", per-tick commits); see "The write loop" in
+        docs/virtual_datasets.md.
         """
         # A fresh writable session is opened per batch because an icechunk
         # session becomes read-only after commit. sync_dims_to grows the store
         # lazily (a no-op on the pre-sized backfill branch).
         readonly_store = primary_repo.readonly_session(branch).store
-        candidates = self.source_file_coords()
-        remaining = self.filter_already_present(candidates, readonly_store)
         # The smallest group, so the sync_dims_to shortcut below can never skip a group
         # that lags root (e.g. after a partially-applied prior grow).
         current_size = min(

--- a/tests/common/virtual_multi_group_test.py
+++ b/tests/common/virtual_multi_group_test.py
@@ -424,6 +424,18 @@ def _primary_repo(factory: StoreFactory) -> icechunk.Repository:
     return factory.icechunk_repos(sort="primary-first")[0][1]
 
 
+def _process_virtual(
+    job: MultiGroupRegionJob,
+    primary_repo: icechunk.Repository,
+    replica_repos: Sequence[icechunk.Repository] = (),
+    branch: str = "main",
+) -> None:
+    """Gather remaining coords (as process_worker_jobs does), then drive the write loop."""
+    readonly = primary_repo.readonly_session(branch).store
+    remaining = job.filter_already_present(job.source_file_coords(), readonly)
+    job.process_virtual(primary_repo, list(replica_repos), branch, remaining)
+
+
 def _assert_all_values(dataset: MultiGroupDataset, n_inits: int) -> None:
     """Read back via DataTree and assert both groups carry their deterministic values
     at the correct (init, lead[, level]) positions."""
@@ -482,7 +494,7 @@ def test_backfill_emits_refs_to_both_groups_and_reads_back(tmp_path: Path) -> No
 
     repo = _primary_repo(dataset.store_factory)
     job = _make_region_job(template_ds, region=slice(0, 2))
-    job.process_virtual(repo, [], "main")
+    _process_virtual(job, repo)
 
     # (1) Refs landed at the right group/name chunk keys and byte ranges; (2) both
     # the root and pressure_level groups grew to the expected init_time length.
@@ -497,7 +509,7 @@ def test_open_flattened_dataset_includes_group_vars(tmp_path: Path) -> None:
     template_ds = _create_template_ds(2)
     template_utils.write_metadata(template_ds, dataset.store_factory)
     repo = _primary_repo(dataset.store_factory)
-    _make_region_job(template_ds, region=slice(0, 2)).process_virtual(repo, [], "main")
+    _process_virtual(_make_region_job(template_ds, region=slice(0, 2)), repo)
 
     store = repo.readonly_session("main").store
     root_only = xr.open_zarr(store, consolidated=False, decode_timedelta=True)
@@ -517,7 +529,7 @@ def test_nan_check_covers_group_vars(tmp_path: Path) -> None:
     template_ds = _create_template_ds(2)
     template_utils.write_metadata(template_ds, dataset.store_factory)
     repo = _primary_repo(dataset.store_factory)
-    _make_region_job(template_ds, region=slice(0, 2)).process_virtual(repo, [], "main")
+    _process_virtual(_make_region_job(template_ds, region=slice(0, 2)), repo)
     store = repo.readonly_session("main").store
 
     flat = validation.open_flattened_dataset(store, consolidated=False)
@@ -538,7 +550,7 @@ def test_decode_health_covers_group_vars(tmp_path: Path) -> None:
     template_ds = _create_template_ds(2)
     template_utils.write_metadata(template_ds, dataset.store_factory)
     repo = _primary_repo(dataset.store_factory)
-    _make_region_job(template_ds, region=slice(0, 2)).process_virtual(repo, [], "main")
+    _process_virtual(_make_region_job(template_ds, region=slice(0, 2)), repo)
     store = repo.readonly_session("main").store
     job = _make_region_job(template_ds, region=slice(0, 2))
 
@@ -557,7 +569,7 @@ def test_per_file_commit_contains_both_groups(tmp_path: Path) -> None:
     repo = _primary_repo(dataset.store_factory)
 
     job = _make_region_job(template_ds, region=slice(0, 1))
-    job.process_virtual(repo, [], "main")
+    _process_virtual(job, repo)
 
     # One file (init 0, lead 0) -> exactly one new commit holding both groups' chunks.
     snapshots = list(repo.ancestry(branch="main"))
@@ -621,7 +633,7 @@ def test_filter_already_present_probes_group_array(tmp_path: Path) -> None:
     template_utils.write_metadata(template_ds, dataset.store_factory)
     repo = _primary_repo(dataset.store_factory)
     job = _make_region_job(template_ds, region=slice(0, 1))
-    job.process_virtual(repo, [], "main")
+    _process_virtual(job, repo)
 
     probe_job = _PressureProbeRegionJob(
         tmp_store=Path("unused-tmp.zarr"),

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -337,6 +337,18 @@ def _snapshot_count(repo: icechunk.Repository, branch: str = "main") -> int:
     return sum(1 for _ in repo.ancestry(branch=branch))
 
 
+def _process_virtual(
+    job: VirtualTestRegionJob,
+    primary_repo: icechunk.Repository,
+    replica_repos: Sequence[icechunk.Repository] = (),
+    branch: str = "main",
+) -> None:
+    """Gather remaining coords (as process_worker_jobs does), then drive the write loop."""
+    readonly = primary_repo.readonly_session(branch).store
+    remaining = job.filter_already_present(job.source_file_coords(), readonly)
+    job.process_virtual(primary_repo, list(replica_repos), branch, remaining)
+
+
 def _assert_store_values(store: object, n_inits: int) -> None:
     result = xr.open_zarr(store, decode_timedelta=True)
     assert result.sizes["init_time"] == n_inits
@@ -775,7 +787,7 @@ def test_process_virtual_rejects_empty_batch(tmp_path: Path) -> None:
         reformat_job_name="test",
     )
     with pytest.raises(AssertionError, match="empty batch"):
-        job.process_virtual(repo, [], "main")
+        _process_virtual(job, repo)
 
 
 def test_process_virtual_rejects_refs_missing_probe_chunk(tmp_path: Path) -> None:
@@ -813,7 +825,7 @@ def test_process_virtual_rejects_refs_missing_probe_chunk(tmp_path: Path) -> Non
         reformat_job_name="test",
     )
     with pytest.raises(AssertionError, match="do not cover representative chunk"):
-        job.process_virtual(repo, [], "main")
+        _process_virtual(job, repo)
 
 
 def test_virtual_operational_rejects_backfill_mode_job(tmp_path: Path) -> None:
@@ -904,7 +916,7 @@ def test_backfill_emits_refs_and_reads_back_values(tmp_path: Path) -> None:
 
     repo = _primary_repo(dataset.store_factory)
     job = _make_region_job(template_ds, region=slice(0, 4))
-    job.process_virtual(repo, [], "main")
+    _process_virtual(job, repo)
 
     _assert_all_values(dataset, n_inits=4)
 
@@ -916,12 +928,12 @@ def test_filter_skips_already_present_refs(tmp_path: Path) -> None:
     repo = _primary_repo(dataset.store_factory)
     job = _make_region_job(template_ds, region=slice(0, 4))
 
-    job.process_virtual(repo, [], "main")
+    _process_virtual(job, repo)
     snapshots_after_first = _snapshot_count(repo)
 
     # Second run: every candidate is already present, so the filter drops them
     # all, the generator yields nothing, and no new commit is made.
-    job.process_virtual(repo, [], "main")
+    _process_virtual(job, repo)
     assert _snapshot_count(repo) == snapshots_after_first
 
     candidates = job.generate_source_file_coords(
@@ -939,7 +951,7 @@ def test_filter_already_present_mixed_candidates(tmp_path: Path) -> None:
     template_utils.write_metadata(template_ds, dataset.store_factory)
     repo = _primary_repo(dataset.store_factory)
     # Emit only init 0's files.
-    _make_region_job(template_ds, region=slice(0, 1)).process_virtual(repo, [], "main")
+    _process_virtual(_make_region_job(template_ds, region=slice(0, 1)), repo)
 
     present = VirtualTestSourceFileCoord(
         init_time=APPEND_DIM_START, lead_time=LEAD_TIMES[0]
@@ -1039,8 +1051,56 @@ def test_yield_is_the_commit_unit(tmp_path: Path) -> None:
     VirtualTestRegionJob.backfill_batch_files = 2
     job = _make_region_job(template_ds, region=slice(0, 4))
     before = _snapshot_count(repo)
-    job.process_virtual(repo, [], "main")
+    _process_virtual(job, repo)
     assert _snapshot_count(repo) - before == 4
+
+
+def test_backfill_worker_commits_once_across_multiple_jobs(tmp_path: Path) -> None:
+    # The core of the batching change: a worker handed several region jobs (one per
+    # init, as get_jobs partitions a backfill) makes exactly ONE icechunk commit for
+    # the whole worker, not one per job, and every init reads back.
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+
+    # A single sweep over the union of all jobs' coords (as the base generator does
+    # for a backfill), so the whole worker is one commit.
+    VirtualTestRegionJob.backfill_batch_files = 4 * N_LEADS
+    worker_jobs = [
+        _make_region_job(template_ds, region=slice(i, i + 1)) for i in range(4)
+    ]
+
+    before = _snapshot_count(repo)
+    results = VirtualTestRegionJob.process_worker_jobs(
+        worker_jobs, dataset.store_factory, "main", worker_index=0
+    )
+    assert results == {}
+    assert _snapshot_count(repo) - before == 1
+    _assert_all_values(dataset, n_inits=4)
+
+
+def test_all_present_worker_makes_no_commit(tmp_path: Path) -> None:
+    # A worker whose jobs are all already present yields no remaining coords; it must
+    # skip the write loop (an empty icechunk commit would raise).
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+
+    VirtualTestRegionJob.backfill_batch_files = 4 * N_LEADS
+    worker_jobs = [
+        _make_region_job(template_ds, region=slice(i, i + 1)) for i in range(4)
+    ]
+    VirtualTestRegionJob.process_worker_jobs(
+        worker_jobs, dataset.store_factory, "main", worker_index=0
+    )
+    after_first = _snapshot_count(repo)
+
+    VirtualTestRegionJob.process_worker_jobs(
+        worker_jobs, dataset.store_factory, "main", worker_index=0
+    )
+    assert _snapshot_count(repo) == after_first
 
 
 # --- driver fork integration (operational + backfill routing) ---
@@ -1101,6 +1161,25 @@ def test_virtual_operational_single_writer_expands_main(tmp_path: Path) -> None:
     _assert_all_values(dataset, n_inits=4)
 
 
+def test_update_still_commits_per_tick(tmp_path: Path) -> None:
+    # Batching commits per worker for backfill must not collapse the update cadence:
+    # the operational update still commits once per yielded tick, so readers see each
+    # tick's files within seconds rather than waiting for the whole window.
+    dataset = _make_dataset(tmp_path)
+    template_utils.write_metadata(_create_template_ds(0), dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+    full_template = _create_template_ds(4)
+
+    # 4 inits x 2 leads = 8 files, yielded 2 at a time -> 4 ticks -> 4 commits.
+    VirtualTestRegionJob.backfill_batch_files = 2
+    job = _make_region_job(full_template, region=slice(0, 4), processing_mode="update")
+
+    before = _snapshot_count(repo)
+    dataset._run_virtual_operational_update([job], worker_index=0, workers_total=1)
+    assert _snapshot_count(repo) - before == 4
+    _assert_all_values(dataset, n_inits=4)
+
+
 def test_update_routes_virtual_to_single_writer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1143,9 +1222,7 @@ def test_validate_dataset_on_virtual_skips_shard_check(tmp_path: Path) -> None:
     template_utils.write_metadata(_create_template_ds(4), dataset.store_factory)
     repo = _primary_repo(dataset.store_factory)
     # Emit only inits 0-1; inits 2-3 stay missing (a partially-published state).
-    _make_region_job(_create_template_ds(4), region=slice(0, 2)).process_virtual(
-        repo, [], "main"
-    )
+    _process_virtual(_make_region_job(_create_template_ds(4), region=slice(0, 2)), repo)
     dataset.validate_dataset("test")  # must not raise
 
 
@@ -1158,7 +1235,7 @@ def _backfilled_store(
     """Pre-size main to the template, emit refs for `emit`, return the readonly store."""
     template_utils.write_metadata(template_ds, dataset.store_factory)
     repo = _primary_repo(dataset.store_factory)
-    _make_region_job(template_ds, region=emit).process_virtual(repo, [], "main")
+    _process_virtual(_make_region_job(template_ds, region=emit), repo)
     return repo.readonly_session("main").store
 
 
@@ -1346,7 +1423,7 @@ def test_process_virtual_writes_refs_to_replica(tmp_path: Path) -> None:
     )
 
     job = _make_region_job(_create_template_ds(4), region=slice(0, 4))
-    job.process_virtual(primary_repo, [replica_repo], "main")
+    _process_virtual(job, primary_repo, [replica_repo])
 
     for repo in (primary_repo, replica_repo):
         _assert_store_values(repo.readonly_session("main").store, n_inits=4)
@@ -1365,8 +1442,8 @@ def test_process_virtual_recovers_when_replica_ahead(tmp_path: Path) -> None:
     )
 
     # Partial commit: the replica committed (grew to 4 + refs); the primary did not.
-    _make_region_job(_create_template_ds(4), region=slice(0, 4)).process_virtual(
-        replica_repo, [], "main"
+    _process_virtual(
+        _make_region_job(_create_template_ds(4), region=slice(0, 4)), replica_repo
     )
     primary_now = xr.open_zarr(
         primary_repo.readonly_session("main").store, decode_timedelta=True
@@ -1375,8 +1452,10 @@ def test_process_virtual_recovers_when_replica_ahead(tmp_path: Path) -> None:
     _assert_store_values(replica_repo.readonly_session("main").store, n_inits=4)
 
     # Next fire catches the primary up and idempotently replays on the replica.
-    _make_region_job(_create_template_ds(4), region=slice(0, 4)).process_virtual(
-        primary_repo, [replica_repo], "main"
+    _process_virtual(
+        _make_region_job(_create_template_ds(4), region=slice(0, 4)),
+        primary_repo,
+        [replica_repo],
     )
     for repo in (primary_repo, replica_repo):
         _assert_store_values(repo.readonly_session("main").store, n_inits=4)

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -1103,6 +1103,43 @@ def test_all_present_worker_makes_no_commit(tmp_path: Path) -> None:
     assert _snapshot_count(repo) == after_first
 
 
+def test_batched_driver_region_is_poisoned(tmp_path: Path) -> None:
+    # The batched write loop spans every job's region, so a method that reads
+    # self.region would silently narrow the batch to jobs[0]. The driver's region is
+    # poisoned, so such a leak raises loudly instead of corrupting the write set.
+    class RegionReadingJob(VirtualTestRegionJob):
+        def process_virtual_refs(
+            self,
+            remaining: Sequence[VirtualTestSourceFileCoord],
+        ) -> Iterator[
+            Sequence[tuple[VirtualTestSourceFileCoord, Sequence[VirtualRef]]]
+        ]:
+            _ = self.region.start  # the leak the poison guards against
+            yield from super().process_virtual_refs(remaining)
+
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+
+    RegionReadingJob.backfill_batch_files = 4 * N_LEADS
+    worker_jobs = [
+        RegionReadingJob(
+            tmp_store=Path("unused-tmp.zarr"),
+            template_ds=template_ds,
+            data_vars=[VirtualTestDataVar(name="temperature_2m")],
+            append_dim="init_time",
+            region=slice(i, i + 1),
+            reformat_job_name="test",
+            processing_mode="backfill",
+        )
+        for i in range(4)
+    ]
+    with pytest.raises(AssertionError, match=r"self\.region"):
+        RegionReadingJob.process_worker_jobs(
+            worker_jobs, dataset.store_factory, "main", worker_index=0
+        )
+
+
 # --- driver fork integration (operational + backfill routing) ---
 
 


### PR DESCRIPTION
## What

Virtual (Icechunk) backfills committed **once per job** — and a job's region is one chunk = one init along the append dim, so the ~11.6k-init `noaa-hrrr-forecast-48-hour-spatial` archive made ~11.6k commits to a single shared branch. At higher parallelism, losing the branch-HEAD compare-and-swap race triggers an icechunk rebase + **re-flush**, so commit time climbed with worker count (measured in prod: avg commit 27s → 82s at parallelism 16, with tails to ~600s).

This makes virtual backfills commit **once per worker**, mirroring what `MaterializedRegionJob` already does. Total commits drop from `num_jobs` to `workers_total` (~`jobs_per_pod`× fewer), which is a direct, proportional cut to the CAS re-flush contention.

## How

- **`VirtualRegionJob.process_worker_jobs`** now gathers the union of not-already-present source-file coords across *all* of a worker's jobs against a single readonly view, then drives one write loop over that union (instead of looping per job, each opening its own session and committing).
- **`VirtualRegionJob.process_virtual`** takes the pre-gathered `remaining` coords as a parameter rather than recomputing them from `self`. The write/emit/commit loop is otherwise unchanged.
- **No new backfill/update branching.** The backfill-vs-update distinction stays entirely inside `process_virtual_refs`'s existing `processing_mode` logic: a backfill worker does one `discover_available` sweep → one batch → **one commit**; an update job (a single window job) polls and commits **per tick**, unchanged.
- All-already-present workers yield no `remaining` and skip the write loop (an empty icechunk commit raises).

Failure/replay granularity is now per-worker (up to `jobs_per_pod` inits replay on preemption) instead of per-init — the accepted trade; `backoffLimitPerIndex` still covers retries. `jobs_per_pod` remains the single knob bounding commit-batch size, peak memory, and replay granularity together.

## Testing

- New: `test_backfill_worker_commits_once_across_multiple_jobs` — a worker handed 4 region jobs (one per init) makes exactly **one** icechunk commit and all inits read back.
- New: `test_all_present_worker_makes_no_commit` — an all-already-present worker adds **zero** commits.
- New: `test_update_still_commits_per_tick` — an update job producing 4 ticks makes **4** commits (batching did not collapse the update cadence).
- Existing virtual + HRRR-spatial dataset tests stay green (131 + 23 passed); `ruff`/`ty` clean.

Part of #700 (virtual dataset performance optimizations), sub-issue of #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
