### PR TITLE
Grow HRRR-spatial manifest split 8 -> 120 inits

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
@@ -42,12 +42,13 @@ class NoaaHrrrForecast48HourSpatialDataset(
                     _S3_LOCATION_PREFIX, icechunk.s3_store(region=_S3_BUCKET_REGION)
                 ),
             ),
-            # Each commit rewrites the touched array's whole active split, and one init
-            # touches all ~177 arrays, so per-commit manifest I/O scales with
-            # split_size x array count. Keep the split small (2 days) so backfill commits
-            # stay cheap; the largest array (a model_level var, 49 leads x 50 levels =
-            # 2450 refs/init) is then ~20k refs (~0.3 MiB) per full split.
-            manifest_split=manifest_append_dim_split(split_size=2 * 4, dim="init_time"),
+            # Per-commit cost is ~O(M^2) in M = total manifest splits on the branch
+            # (array_count x ceil(appends / split_size)): every commit scans every split
+            # of every array, so a LARGE split (few splits) keeps M -- and commit cost --
+            # low as the archive fills over a long backfill.
+            manifest_split=manifest_append_dim_split(
+                split_size=30 * 4, dim="init_time"
+            ),
         )
     )
 


### PR DESCRIPTION
## What

Grow the `noaa-hrrr-forecast-48-hour-spatial` manifest split from **8 → 120 inits** (2 → 30 days).

## Why

Per-commit cost is ~**O(M²)** in the total number of manifest splits on the branch, `M = array_count × ceil(appends / split_size)`: every icechunk commit's flush scans every split of every array. A *small* split maximizes M, so commit time accelerates as an append-only archive fills — measured ~11s → ~150s over ~1h of a fresh backfill at `split_size=8`.

#694 shrank the split to 8 to keep per-commit manifest *bytes* small, before this quadratic was understood. A large split (few splits) is the right trade for a long backfill: fewer splits → smaller M → flat commit cost.

No template change — `manifest_split` is icechunk write-time config, not zarr metadata (matches #694, which also touched only this file).

Part of #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
