### PR TITLE
Bump noaa-hrrr-forecast-48-hour-spatial version 0.1.0 -> 0.2.0

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/template_config.py
@@ -103,7 +103,7 @@ class NoaaHrrrForecast48HourSpatialTemplateConfig(NoaaHrrrCommonTemplateConfig):
     def dataset_attributes(self) -> DatasetAttributes:
         return DatasetAttributes(
             dataset_id="noaa-hrrr-forecast-48-hour-spatial",
-            dataset_version="0.1.0",
+            dataset_version="0.2.0",
             name="NOAA HRRR forecast, 48 hour, spatial",
             description="Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.",
             attribution="NOAA NWS NCEP HRRR data processed by dynamical.org from NOAA Open Data Dissemination archives.",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/model_level/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/model_level/zarr.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "dataset_id": "noaa-hrrr-forecast-48-hour-spatial",
-    "dataset_version": "0.1.0",
+    "dataset_version": "0.2.0",
     "name": "NOAA HRRR forecast, 48 hour, spatial",
     "description": "Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.",
     "attribution": "NOAA NWS NCEP HRRR data processed by dynamical.org from NOAA Open Data Dissemination archives.",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/pressure_level/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/pressure_level/zarr.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "dataset_id": "noaa-hrrr-forecast-48-hour-spatial",
-    "dataset_version": "0.1.0",
+    "dataset_version": "0.2.0",
     "name": "NOAA HRRR forecast, 48 hour, spatial",
     "description": "Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.",
     "attribution": "NOAA NWS NCEP HRRR data processed by dynamical.org from NOAA Open Data Dissemination archives.",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/zarr.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "dataset_id": "noaa-hrrr-forecast-48-hour-spatial",
-    "dataset_version": "0.1.0",
+    "dataset_version": "0.2.0",
     "name": "NOAA HRRR forecast, 48 hour, spatial",
     "description": "Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.",
     "attribution": "NOAA NWS NCEP HRRR data processed by dynamical.org from NOAA Open Data Dissemination archives.",
@@ -4731,7 +4731,7 @@
       "model_level": {
         "attributes": {
           "dataset_id": "noaa-hrrr-forecast-48-hour-spatial",
-          "dataset_version": "0.1.0",
+          "dataset_version": "0.2.0",
           "name": "NOAA HRRR forecast, 48 hour, spatial",
           "description": "Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.",
           "attribution": "NOAA NWS NCEP HRRR data processed by dynamical.org from NOAA Open Data Dissemination archives.",
@@ -7047,7 +7047,7 @@
       "pressure_level": {
         "attributes": {
           "dataset_id": "noaa-hrrr-forecast-48-hour-spatial",
-          "dataset_version": "0.1.0",
+          "dataset_version": "0.2.0",
           "name": "NOAA HRRR forecast, 48 hour, spatial",
           "description": "Weather forecasts from the High-Resolution Rapid Refresh (HRRR) model operated by NOAA NWS NCEP.",
           "attribution": "NOAA NWS NCEP HRRR data processed by dynamical.org from NOAA Open Data Dissemination archives.",


### PR DESCRIPTION
## What

Bump `noaa-hrrr-forecast-48-hour-spatial` dataset version **0.1.0 → 0.2.0** and regenerate the template.

## Why

The store path is `.../{dataset_id}/v{version}.icechunk`, so bumping the version routes the (still-in-progress) initial virtual backfill to a **fresh store** rather than reusing the partially written `v0.1.0` archive — no manual store cleanup required before relaunching.

Template regenerated (`update-template`); the only change is the `dataset_version` attribute on the root and both vertical groups. Template subclass + CF-compliance tests green (241 passed).

Part of #700 / #513 (first virtual dataset backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
