### PR TITLE
Widen HRRR analysis update deadline + validate offset (15m -> 20m)

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
@@ -33,7 +33,7 @@ class NoaaHrrrAnalysisDataset(
             # we try S3 first to spare NOMADS, but NOMADS publishes first, by ~10 min at
             # 06z). We could of course increase this to hourly.
             schedule="57 */3 * * *",
-            pod_active_deadline=timedelta(minutes=15),  # runs take <9 min
+            pod_active_deadline=timedelta(minutes=20),  # runs take <15 min
             image=image_tag,
             dataset_id=self.dataset_id,
             cpu="7",
@@ -45,9 +45,9 @@ class NoaaHrrrAnalysisDataset(
 
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            # 15m (pod_active_deadline) after reformat at :57 = :72 = :12 of the next hour.
-            # "12 1-23/3 * * *" gives 01:12, 04:12, 07:12, ... matching reformat at 00:57, 03:57, 06:57, ...
-            schedule="12 1-23/3 * * *",
+            # 20m (pod_active_deadline) after reformat at :57 = :77 = :17 of the next hour.
+            # "17 1-23/3 * * *" gives 01:17, 04:17, 07:17, ... matching reformat at 00:57, 03:57, 06:57, ...
+            schedule="17 1-23/3 * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,


### PR DESCRIPTION
## What

Bump `noaa-hrrr-analysis` update `pod_active_deadline` 15m → 20m, and move the validate schedule `12 1-23/3 * * *` → `17 1-23/3 * * *` to keep the `validate = update_start + pod_active_deadline` convention.

## Why

The `noaa-hrrr-analysis-validate` cron intermittently raised `ValueError: Zarr validation failed: - No data found within 4:00:00 of now` ([REFORMATTERS-AY](https://dynamical.sentry.io/issues/7230544823/)).

Investigation of the 2026-07-01 22:12 failure:

- The 21:57 update pod was **preempted and restarted** mid-run (two process traces, `branch already exists, reusing`; three `Expand dataset` commits; 17m total wall clock vs. the usual 10–14m).
- Its merge to `main` landed at **22:14:07** (icechunk ancestry: `Update at 2026-07-01T22:14:06Z`).
- Validation fired at **22:12:24** — ~1m43s *before* that merge — so it read the prior cycle's committed state (latest `time` = 18:00, age 4h12m > 4h) and failed. It self-healed on the next cycle; a manual re-run passed.

The regression window opened with #681, which moved validation `:22` → `:12`, removing the buffer that absorbed a slow update. 20m puts validation at `:17`, ~2m50s after this incident's merge — enough to absorb cron jitter and a modestly worse restart.

## Note

The deadline is per-attempt (it resets on restart), so this fixes the case by pushing validation later, not by changing update behavior. An unbounded preemption could still slip past any fixed gap; the deeper lever for that is `max_expected_delay` (4h), which at the 3h update cadence tolerates barely one cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)