### PR TITLE
Skip empty grib index in HRRR-spatial file_refs

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/region_job.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/region_job.py
@@ -123,6 +123,10 @@ class NoaaHrrrForecast48HourSpatialRegionJob(
         finally:
             index_path.unlink()
 
+        if not index_lines:
+            log.warning(f"Skipping {coord.get_url()}: empty or unparseable grib index")
+            return []
+
         lookup = self._message_lookup(coord.data_vars, whole_hours(coord.lead_time))
         # Each message's end byte is the next message's start; the last is the file end.
         starts = [start for start, *_ in index_lines]

--- a/tests/noaa/hrrr/forecast_48_hour_spatial/region_job_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour_spatial/region_job_test.py
@@ -225,6 +225,16 @@ def test_file_refs_skips_stale_index_past_eof(
     assert job.file_refs(_coord("sfc", data_vars), file_size=1200) == []
 
 
+def test_file_refs_skips_empty_index(
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _fake_index(monkeypatch, tmp_path, "")
+    data_vars = [get_var("temperature_2m")]
+    job = make_job(template_ds, data_vars=data_vars)
+    # empty/unparseable index -> no messages -> skip.
+    assert job.file_refs(_coord("sfc", data_vars), file_size=9000) == []
+
+
 def test_file_refs_lead_0_instant_uses_anl_window(
     template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Bug

Sentry #7588124478: `ValueError: zip() argument 2 is longer than argument 1` raised in `NoaaHrrrForecast48HourSpatialRegionJob.file_refs`.

## Root cause

When the downloaded grib `.idx` is empty or unparseable, `parse_grib_index_lines` returns `[]`. Then:

```python
starts = [start for start, *_ in index_lines]   # []  (length 0)
ends = [*starts[1:], file_size]                  # [file_size]  (length 1)
zip(index_lines, ends, strict=True)              # ValueError: lengths mismatch (0 vs 1)
```

`strict=True` requires both iterables to be the same length, so the mismatch raises. The exception was caught downstream by `_file_refs_or_skip` (it isn't an `AssertionError`) and the file was skipped, but it surfaced in Sentry with a cryptic message.

## Fix

Guard the empty-index case with an explicit, clearly-logged skip before building `starts`/`ends`, matching the style of the existing stale-index skip a few lines below.

## Test

Added `test_file_refs_skips_empty_index` mirroring `test_file_refs_skips_stale_index_past_eof`: uses the `_fake_index` helper with an empty string to produce zero index lines and asserts `file_refs(...)` returns `[]`.

Fixes Sentry #7588124478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)