### PR TITLE
Document virtual backfill commit-latency model and measured validation

### DIFF
--- a/docs/virtual_datasets.md
+++ b/docs/virtual_datasets.md
@@ -59,6 +59,8 @@ Crash recovery is automatic: committed refs are durable and the filter skips the
 
 Virtual backfills use the standard parallel temp-branch flow (see [parallel_processing.md](parallel_processing.md#icechunk-stores)). Worker 0 pre-sizes the full template on the branch, so every worker's `sync_dims_to` is a no-op and parallel workers write disjoint refs with no resize conflicts. Jobs partition by chunks along the append dim (virtual arrays have no shards).
 
+Commit latency ≈ `(1 + rebase_attempts) × flush cost`. A flush read-modify-writes every manifest window the session's refs touch (manifests are immutable), and every lost branch-HEAD CAS race re-runs the flush, so rebase attempts scale with parallelism. Keeping each worker's refs within its own few windows — contiguous append-dim assignment — is what bounds flush cost: measured on the HRRR-spatial backfill, commits held flat (~10–30s at parallelism 10) from empty to full archive, where scattered (spread) assignment touched most windows of every array per flush and commits grew ~40s → 1000s+ as windows filled. Icechunk stamps `rebase_attempts` into each snapshot's metadata (`repo.ancestry`) — read it to distinguish contention from flush cost when commits are slow.
+
 Two operational rules when backfilling a live virtual dataset:
 
 - **Suspend the dataset's `-update` CronJob for the duration of the backfill.** Finalize resets `main` to the temp branch only if `main` hasn't moved since setup; an operational fire committing to `main` mid-backfill would make finalize skip the reset (with a warning), discarding the backfill's work.


### PR DESCRIPTION
One paragraph in the Backfill section of docs/virtual_datasets.md: commit latency ≈ (1 + rebase_attempts) × flush cost, flush = RMW of touched manifest windows, contiguous assignment bounds it (measured flat ~10–30s commits across the whole HRRR-spatial backfill vs ~40s → 1000s+ under scattered assignment), and how to read rebase_attempts from snapshot metadata when diagnosing. Companion to #708; part of #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)