### PR TITLE
Unsuspend HRRR-spatial operational update and validation crons

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset.py
@@ -60,9 +60,6 @@ class NoaaHrrrForecast48HourSpatialDataset(
     )
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
-        # Suspended until the initial backfill completes: operational updates would
-        # race the backfill writing the same store. Unsuspend once the archive is filled.
-        suspend_until_backfilled = True
         # Run once per 6h cycle just before the first lead times publish
         # (~init+50m), polling through f48 (~init+2h on S3). The pod exits when the
         # window is fully ingested; the deadline bounds waiting on a file that never
@@ -76,7 +73,6 @@ class NoaaHrrrForecast48HourSpatialDataset(
             cpu="1.5",
             memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=suspend_until_backfilled,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
@@ -88,7 +84,6 @@ class NoaaHrrrForecast48HourSpatialDataset(
             cpu="1.5",
             memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=suspend_until_backfilled,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/tests/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour_spatial/dynamical_dataset_test.py
@@ -252,9 +252,6 @@ def test_operational_kubernetes_resources(
     assert update_cron_job.pod_active_deadline < timedelta(hours=6)
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert len(update_cron_job.secret_names) > 0
-    # Suspended until the initial backfill completes; flip when un-suspending.
-    assert update_cron_job.suspend is True
-    assert validation_cron_job.suspend is True
 
 
 def test_validators(dataset: NoaaHrrrForecast48HourSpatialDataset) -> None:


### PR DESCRIPTION
The initial v0.5.0 backfill completed 2026-07-02 (389/389, `main` reset to the filled archive), so the backfill-race suspension can come off. Crons revert to default unsuspended: updates at :50 past each 6h cycle (next fire picks up the 12Z/18Z runs published since the backfill's 2026-07-02T06Z cutoff), validation at :40 two hours later — by which point the first update will have brought the latest init inside the 8h freshness check. Runs on the stock published icechunk (single-writer ops needs no fork).

Deploy the operational resources after merge to apply.

Part of #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)