### PR TITLE
Align all virtual metadata writers so refresh commits only on real drift

### DIFF
--- a/docs/virtual_datasets.md
+++ b/docs/virtual_datasets.md
@@ -55,7 +55,7 @@ Single-writer is what makes lazy append-dim expansion safe: `main` grows exactly
 
 Each update fire first refreshes metadata from the checked-in template, trimmed to each group's committed extent (`VirtualRegionJob.refresh_metadata`): template attrs and coordinate-value fixes deploy operationally — matching materialized updates, which rewrite metadata every fire — while the append dim is never sized past ingested data. Byte-identical metadata is skipped, so an in-sync store adds no commit. Structural changes are rejected by the same drift guard materialized updates use — changing structure still requires a backfill.
 
-Virtual stores carry no consolidated metadata in the root zarr.json — nothing updates it as the append dim grows, so readers list the live metadata instead. The refresh renders unconsolidated and strips any consolidated block it finds.
+Virtual stores carry no consolidated metadata in the root zarr.json — nothing updates it as the append dim grows, so readers list the live metadata instead. Every virtual metadata writer renders unconsolidated (`VirtualRegionJob.consolidated_metadata = False` covers backfill setup/finalize; appends and the refresh pass `consolidated=False` directly), so their outputs are byte-identical and the refresh only commits on real template drift. Appends write only variables spanning the append dim: overwriting the rest would delete chunks that equal their fill_value (e.g. `spatial_ref`), since appends write with `write_empty_chunks=False`.
 
 Crash recovery is automatic: committed refs are durable and the filter skips them on the next cron fire; uncommitted refs and expansions vanish and are re-discovered.
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -429,6 +429,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             template_ds=template_ds,
             tmp_store=tmp_store,
             icechunk_repos=icechunk_repos,
+            consolidated=self.region_job_class.consolidated_metadata,
         )
 
         # 2. Process jobs. Each region job variant owns its own store/session
@@ -473,6 +474,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 setup_info=setup_info,
                 workers_total=workers_total,
                 update_template_with_results=update_template_with_results,
+                consolidated=self.region_job_class.consolidated_metadata,
             )
 
     def _run_virtual_operational_update(

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -49,9 +49,10 @@ def parallel_setup(
     template_ds: xr.DataTree,
     tmp_store: Path,
     icechunk_repos: list[tuple[str, icechunk.Repository]],
+    consolidated: bool,
 ) -> SetupInfo:
     if is_first:
-        template_utils.write_metadata(template_ds, tmp_store)
+        template_utils.write_metadata(template_ds, tmp_store, consolidated=consolidated)
 
         # On retry, reuse snapshots from the prior attempt's ready.json so
         # original_snapshot stays stable. This keeps finalize's
@@ -158,6 +159,7 @@ def finalize(
     setup_info: SetupInfo,
     workers_total: int,
     update_template_with_results: bool,
+    consolidated: bool,
 ) -> None:
     if update_template_with_results:
         assert len(all_jobs) > 0
@@ -166,7 +168,9 @@ def finalize(
         updated_template = template_ds
     # Ensure tmp_store has written metadata. Virtual workers (besides worker 0)
     # do not otherwise write to tmp_store.
-    template_utils.write_metadata(updated_template, tmp_store)
+    template_utils.write_metadata(
+        updated_template, tmp_store, consolidated=consolidated
+    )
 
     now = pd.Timestamp.now(tz="UTC")
     commit_message = f"Update at {now.strftime('%Y-%m-%dT%H:%M:%SZ')}"

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -136,6 +136,9 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     # in docs/parallel_processing.md.
     worker_assignment: ClassVar[Literal["spread", "contiguous"]] = "spread"
 
+    # Whether setup/finalize metadata writes embed zarr consolidated metadata.
+    consolidated_metadata: ClassVar[bool] = True
+
     @classmethod
     def source_file_var_groups(
         cls,

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -62,6 +62,11 @@ class VirtualRegionJob(
     # (scattered regions rewrite most windows every flush), see docs/parallel_processing.md.
     worker_assignment: ClassVar[Literal["spread", "contiguous"]] = "contiguous"
 
+    # Virtual stores carry no consolidated metadata so every metadata writer
+    # (setup/finalize, appends, refresh) produces byte-identical documents,
+    # see "Metadata refresh" in docs/virtual_datasets.md.
+    consolidated_metadata: ClassVar[bool] = False
+
     # Updates wait for source files as the provider publishes them, backfills check once
     processing_mode: Literal["backfill", "update"] = "backfill"
 
@@ -538,6 +543,16 @@ class VirtualRegionJob(
                     continue
                 slice_ds = node.to_dataset().isel(
                     {self.append_dim: slice(current_size, needed_append_dim_size)}
+                )
+                # to_zarr(append_dim=...) overwrites variables without the append dim,
+                # deleting chunks that equal fill_value (e.g. spatial_ref) since it
+                # writes with write_empty_chunks=False. Append only what grows.
+                slice_ds = slice_ds.drop_vars(
+                    [
+                        name
+                        for name, variable in slice_ds.variables.items()
+                        if self.append_dim not in variable.dims
+                    ]
                 )
                 slice_ds.to_zarr(
                     store,

--- a/tests/common/test_parallel_coordination.py
+++ b/tests/common/test_parallel_coordination.py
@@ -154,9 +154,12 @@ class TestParallelSetupFirstWorker:
             template_ds=ds,
             tmp_store=tmp_path,
             icechunk_repos=[],
+            consolidated=True,
         )
 
-        stub_io["write_metadata"].assert_called_once_with(ds, tmp_path)
+        stub_io["write_metadata"].assert_called_once_with(
+            ds, tmp_path, consolidated=True
+        )
         # Single-worker: no ready.json is written.
         assert factory.files == {}
         assert result == {}
@@ -175,6 +178,7 @@ class TestParallelSetupFirstWorker:
             template_ds=_template(),
             tmp_store=tmp_path,
             icechunk_repos=[],
+            consolidated=True,
         )
 
         assert result == {}
@@ -201,6 +205,7 @@ class TestParallelSetupFirstWorker:
             template_ds=ds,
             tmp_store=tmp_path,
             icechunk_repos=repos,  # ty: ignore[invalid-argument-type]
+            consolidated=True,
         )
 
         # Each repo had create_branch called with the main snapshot captured.
@@ -265,6 +270,7 @@ class TestParallelSetupFirstWorker:
             template_ds=_template(),
             tmp_store=tmp_path,
             icechunk_repos=repos,  # ty: ignore[invalid-argument-type]
+            consolidated=True,
         )
 
         # setdefault must preserve the prior-attempt snapshot, not refresh from main.
@@ -292,6 +298,7 @@ class TestParallelSetupFirstWorker:
             template_ds=_template(),
             tmp_store=tmp_path,
             icechunk_repos=[("primary", primary_repo)],  # ty: ignore[invalid-argument-type]
+            consolidated=True,
         )
 
         assert primary_repo.create_branch_calls == [
@@ -321,6 +328,7 @@ class TestParallelSetupFirstWorker:
             template_ds=_template(),
             tmp_store=tmp_path,
             icechunk_repos=repos,  # ty: ignore[invalid-argument-type]
+            consolidated=True,
         )
 
         assert primary_repo.create_branch_calls == []
@@ -342,6 +350,7 @@ class TestParallelSetupLaterWorker:
             template_ds=_template(),
             tmp_store=tmp_path,
             icechunk_repos=[],
+            consolidated=True,
         )
         assert result == {}
         stub_io["write_metadata"].assert_not_called()
@@ -374,6 +383,7 @@ class TestParallelSetupLaterWorker:
             template_ds=_template(),
             tmp_store=tmp_path,
             icechunk_repos=[],
+            consolidated=True,
         )
 
         assert result == payload
@@ -469,6 +479,7 @@ class TestFinalize:
             setup_info={},
             workers_total=1,
             update_template_with_results=False,
+            consolidated=True,
         )
 
         # No metadata copies, no commits, and no replicas/primary stores queried.
@@ -509,6 +520,7 @@ class TestFinalize:
             setup_info=setup_info,
             workers_total=1,
             update_template_with_results=False,
+            consolidated=True,
         )
 
         # Replica processed before primary per primary-last order.
@@ -552,6 +564,7 @@ class TestFinalize:
             setup_info=setup_info,
             workers_total=1,
             update_template_with_results=False,
+            consolidated=True,
         )
 
         # First pass was skipped — no session, no reset, no icechunk_only copy.
@@ -578,6 +591,7 @@ class TestFinalize:
             setup_info={},
             workers_total=1,
             update_template_with_results=False,
+            consolidated=True,
         )
         stub_io["copy_zarr_metadata"].assert_not_called()
         # Even without update_template_with_results, finalize writes template
@@ -608,6 +622,7 @@ class TestFinalize:
             setup_info={},
             workers_total=1,
             update_template_with_results=True,
+            consolidated=True,
         )
         job.update_template_with_results.assert_called_once_with(merged)
         assert stub_io["copy_zarr_metadata"].call_count == 1
@@ -633,6 +648,7 @@ class TestFinalize:
             setup_info={},
             workers_total=1,
             update_template_with_results=False,
+            consolidated=True,
         )
         assert "job" in factory.files  # not cleared
 
@@ -647,5 +663,6 @@ class TestFinalize:
             setup_info={},
             workers_total=2,
             update_template_with_results=False,
+            consolidated=True,
         )
         assert "job" not in factory.files  # cleared

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -10,6 +10,7 @@ expansion without the decode-only codec ever being invoked.
 """
 
 import asyncio
+import json
 from collections.abc import Iterator, Mapping, Sequence
 from datetime import timedelta
 from itertools import batched
@@ -25,6 +26,7 @@ import xarray as xr
 import zarr
 from gribberish.zarr import GribberishCodec
 from pydantic import ValidationError, computed_field
+from zarr.core.buffer import default_buffer_prototype
 from zarr.core.metadata import ArrayV3Metadata
 
 from reformatters.common import template_utils, validation
@@ -129,6 +131,9 @@ def _create_template_ds(
                 ("init_time", "lead_time"),
                 init_times.values[:, None] + LEAD_TIMES.values[None, :],
             ),
+            # Like prod spatial_ref: value equals fill_value, so any writer using
+            # write_empty_chunks=False deletes the chunk instead of writing it.
+            "spatial_ref": ((), np.int64(0)),
         },
         attrs={"dataset_id": DATASET_ID, "dataset_version": "v1.0"},
     )
@@ -148,6 +153,7 @@ def _create_template_ds(
     )
     ds["latitude"].encoding["fill_value"] = np.nan
     ds["longitude"].encoding["fill_value"] = np.nan
+    ds["spatial_ref"].encoding.update({"dtype": "int64", "fill_value": 0})
     return xr.DataTree.from_dict({"/": ds})
 
 
@@ -338,6 +344,12 @@ def _primary_repo(factory: StoreFactory) -> icechunk.Repository:
 
 def _snapshot_count(repo: icechunk.Repository, branch: str = "main") -> int:
     return sum(1 for _ in repo.ancestry(branch=branch))
+
+
+def _main_store_bytes(factory: StoreFactory, key: str) -> bytes | None:
+    store = _primary_repo(factory).readonly_session("main").store
+    buffer = asyncio.run(store.get(key, prototype=default_buffer_prototype()))
+    return None if buffer is None else bytes(buffer.to_bytes())
 
 
 def _process_virtual(
@@ -1543,11 +1555,57 @@ def test_virtual_operational_second_fire_sees_no_new_work(tmp_path: Path) -> Non
     fire()
     repo = _primary_repo(dataset.store_factory)
     snapshots_after_first = _snapshot_count(repo)
+    # The first fire's append must not delete spatial_ref (value == fill_value),
+    # or the next fire's refresh would restore it and commit every fire.
+    spatial_ref_chunk = _main_store_bytes(dataset.store_factory, "spatial_ref/c")
+    assert spatial_ref_chunk is not None
 
     # No new data and no template drift -> no new commits: the metadata refresh's
     # unconsolidated render is byte-identical to what appends leave in the store.
     fire()
     assert _snapshot_count(repo) == snapshots_after_first
+    assert (
+        _main_store_bytes(dataset.store_factory, "spatial_ref/c") == spatial_ref_chunk
+    )
+
+
+def test_virtual_backfill_then_fire_leaves_metadata_stable(tmp_path: Path) -> None:
+    # The prod sequence that exposed writer misalignment: a backfill through
+    # parallel_setup/finalize, then an operational fire whose refresh should
+    # find nothing to fix.
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    # Seed with consolidated metadata (as older code wrote) to prove the
+    # backfill's own metadata writes remove it.
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+
+    all_jobs = VirtualTestRegionJob.get_jobs(
+        tmp_store=dataset._tmp_store(),
+        template_ds=template_ds,
+        append_dim="init_time",
+        all_data_vars=dataset.template_config.data_vars,
+        reformat_job_name="test",
+    )
+    dataset._process_region_jobs(
+        all_jobs=all_jobs,
+        worker_index=0,
+        workers_total=1,
+        reformat_job_name="test",
+        template_ds=template_ds,
+        tmp_store=tmp_path / "worker-tmp.zarr",
+        update_template_with_results=False,
+    )
+
+    root_metadata = _main_store_bytes(dataset.store_factory, "zarr.json")
+    assert root_metadata is not None
+    assert json.loads(root_metadata).get("consolidated_metadata") is None
+    assert _main_store_bytes(dataset.store_factory, "spatial_ref/c") is not None
+
+    repo = _primary_repo(dataset.store_factory)
+    snapshots_after_backfill = _snapshot_count(repo)
+    job = _make_region_job(template_ds, region=slice(0, 4), processing_mode="update")
+    dataset._run_virtual_operational_update([job], worker_index=0, workers_total=1)
+    assert _snapshot_count(repo) == snapshots_after_backfill
 
 
 def test_serializer_threads_through_expansion_without_decoding(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

The first prod fire after #713 (HRRR-spatial, 2026-07-06 18:50Z) made **two** `Refresh metadata from template` commits instead of the expected zero. Icechunk snapshot diffs pinpointed two writer misalignments — in both cases the refresh behaved as designed and repaired drift another writer introduced:

1. **Backfill setup/finalize embedded consolidated metadata.** `parallel_setup`/`finalize` rendered the tmp store with `write_metadata`'s default `consolidated=True`, writing a 286KB consolidated block into the root zarr.json that the refresh (which renders `consolidated=False`) then stripped — one spurious commit after every backfill.

2. **Appends deleted the `spatial_ref` chunk.** `sync_dims_to` passed the whole node dataset to `to_zarr(append_dim=...)`, which *overwrites* variables lacking the append dim. spatial_ref's value (int64 `0`) equals its fill_value, so the overwrite deleted the chunk (appends write with `write_empty_chunks=False`) — in prod, on every fire since the store launched. Harmless to readers (missing chunk reads back as fill `0`, the intended value), but the refresh restored it each fire: a permanent one-commit-per-fire ping-pong.

## Fix

- `RegionJob.consolidated_metadata: ClassVar[bool] = True`, overridden `False` on `VirtualRegionJob` (same pattern as `worker_assignment`), threaded through `parallel_setup`/`finalize`. Materialized datasets are unchanged: they keep consolidated metadata, rewritten fresh each fire from the same render that feeds plain-zarr replicas, where it genuinely pays. Virtual stores now have no consolidated metadata from any writer, per the convention in docs/virtual_datasets.md.
- `sync_dims_to` drops variables that don't span the append dim before the append write. Appends now touch only what grows — which also stops pointlessly rewriting the 2D latitude/longitude chunks on every append.

## Tests

- The harness template gains a prod-like `spatial_ref` (scalar int64, value == fill_value). With it, `test_virtual_operational_second_fire_sees_no_new_work` fails on unfixed code (verified) — the harness previously had no coord whose value equals its fill, which is why this slipped through.
- New `test_virtual_backfill_then_fire_leaves_metadata_stable` covers the exact prod sequence: backfill through `parallel_setup`/`finalize`, assert no consolidated block and spatial_ref intact on main, then an operational fire that must add zero commits. Fails on unfixed code (verified).

After this lands, the steady state is what #713 claimed: a fire on an in-sync store commits nothing but ingested data. Until then each fire adds one benign refresh commit restoring spatial_ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)