### PR TITLE
HRRR-spatial: mask CPOFP -50 sentinel via missing_value

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/template_config.py
@@ -969,6 +969,8 @@ def _root_data_vars() -> list[NoaaHrrrDataVar]:
             short_name="cpofp",
             long_name="Percent frozen precipitation",
             units="percent",
+            comment="-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+            missing_value=-50.0,
             hour_0=False,
         ),
         _root_var(

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": -50.0,
   "codecs": [
     {
       "name": "gribberish",
@@ -38,9 +38,11 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
+    "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+    "missing_value": -50.0,
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
-    "_FillValue": "AAAAAAAA+H8="
+    "_FillValue": "AAAAAAAAScA="
   },
   "dimension_names": [
     "init_time",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_spatial/templates/latest.zarr/zarr.json
@@ -6587,7 +6587,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": -50.0,
         "codecs": [
           {
             "name": "gribberish",
@@ -6602,9 +6602,11 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
+          "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+          "missing_value": -50.0,
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
-          "_FillValue": "AAAAAAAA+H8="
+          "_FillValue": "AAAAAAAAScA="
         },
         "dimension_names": [
           "init_time",


### PR DESCRIPTION
## What

`percent_frozen_precipitation_surface` (GRIB `CPOFP`) encodes **no/undefined frozen precipitation as -50**, not a physical 0–100 percent. Source-verified against HRRR wrfsfc: at a sample init/lead, `-50.0` is the field's only negative value and covers **~96% of the domain** (everywhere there is no precipitation), with 0–100 elsewhere. This matches the GEFS reference convention.

Set `missing_value=-50.0` (and a `comment`) so CF-aware readers mask it to NaN instead of reading `-50` as a physical percent — mirroring the existing `echo_top` (`-999`) treatment in this dataset. Template regenerated (`fill_value` / `missing_value` / `_FillValue` → -50, comment added).

## Deploy

This is a metadata-only change to the committed template; the live `noaa-hrrr-forecast-48-hour-spatial` store needs its zarr metadata rewritten (no data rewrite) for readers to pick up the new `missing_value` / `fill_value`.

## Checks

- `ruff format` / `ruff check` / `ty` clean
- `tests/common/common_template_config_subclasses_test.py` + `tests/common/datasets_cf_compliance_test.py` — 243 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)