### PR TITLE
Authorize virtual chunk access in icechunk_utils

### DIFF
--- a/src/scripts/icechunk_utils.py
+++ b/src/scripts/icechunk_utils.py
@@ -11,6 +11,7 @@ import httpx
 import icechunk
 
 from reformatters.common.kubernetes import load_secret
+from scripts.validation.utils import anonymous_virtual_credentials
 
 DEFAULT_STAC_CATALOG_URL = "https://stac.dynamical.org/catalog.json"
 
@@ -43,7 +44,10 @@ def open_repo(s3_uri: str, auth: AuthMode) -> icechunk.Repository:
             storage = icechunk.s3_storage(
                 bucket=bucket, prefix=prefix, **load_storage_options()
             )
-    return icechunk.Repository.open(storage)
+    return icechunk.Repository.open(
+        storage,
+        authorize_virtual_chunk_access=anonymous_virtual_credentials(storage),
+    )
 
 
 def load_icechunk_repos_from_stac(catalog_url: str) -> list[str]:

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -253,7 +253,7 @@ def var_slug(var: str) -> str:
     return var.replace("/", "__")
 
 
-def _anonymous_virtual_credentials(
+def anonymous_virtual_credentials(
     storage: icechunk.Storage,
 ) -> dict[str, Any] | None:
     """Anonymous read credentials for a virtual store's persisted chunk containers.
@@ -290,7 +290,7 @@ def open_icechunk_readonly(url: str) -> icechunk.IcechunkStore:
     )
     repo = icechunk.Repository.open(
         storage,
-        authorize_virtual_chunk_access=_anonymous_virtual_credentials(storage),
+        authorize_virtual_chunk_access=anonymous_virtual_credentials(storage),
     )
     return repo.readonly_session("main").store
 
@@ -496,7 +496,7 @@ def is_virtual_store(url: str) -> bool:
     storage = icechunk.s3_storage(
         bucket=bucket, prefix=prefix, anonymous=True, region="us-west-2"
     )
-    return _anonymous_virtual_credentials(storage) is not None
+    return anonymous_virtual_credentials(storage) is not None
 
 
 def extract_variable_metadata(ds: xr.Dataset, var: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

`src/scripts/icechunk_utils.py` (expire / garbage-collect / count / list) opened repos with a bare `icechunk.Repository.open(storage)`. On a **virtual** store — e.g. the HRRR/GEFS spatial datasets — the repo config carries virtual chunk containers pointing at source buckets. Without `authorize_virtual_chunk_access`, icechunk falls back to the default AWS credential chain for those containers and dies with a profile-provider credentials error, before it can even read `main`.

This wires in `authorize_virtual_chunk_access` using anonymous per-container credentials (all dynamical source buckets are public S3), reusing the existing validation helper. The helper returns `None` for materialized repos, so this is a no-op there.

## Changes

- `open_repo()` now passes `authorize_virtual_chunk_access=anonymous_virtual_credentials(storage)`.
- Promoted `_anonymous_virtual_credentials` → `anonymous_virtual_credentials` in `scripts/validation/utils.py` since it's now shared across modules (updated its two in-file callers).

## Testing

- `ruff format`, `ruff check`, `ty check` all pass.
- Ran `expire` end-to-end against `s3://dynamical-noaa-hrrr/noaa-hrrr-forecast-48-hour-spatial/v0.5.0.icechunk` with real (prod) credentials — repo opens and snapshots expire successfully.

> Note: running these commands locally still requires `DYNAMICAL_ENV=prod` so `load_secret` pulls the storage-options secret from the cluster; that's unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)