### PR TITLE
DWD archive: raise rclone list timeout to 200s

### DIFF
--- a/src/reformatters/dwd/archive_gribs/list_files.py
+++ b/src/reformatters/dwd/archive_gribs/list_files.py
@@ -41,6 +41,7 @@ def list_files(
     checkers: int,
     rclone_args: Sequence[str] = (),
     env_vars: dict[str, Any] | None = None,
+    timeout_seconds: float = 200,
 ) -> list[PurePosixPath]:
     """List files recursively.
 
@@ -62,6 +63,9 @@ def list_files(
             For more info, see the rclone docs: https://rclone.org/docs/#checkers-int
         rclone_args: Additional args to be passed to `rclone lsf`.
         env_vars: Additional environment variables to give to `rclone`.
+        timeout_seconds: Kill the `rclone` subprocess if it runs longer than this. Scoped to a
+            single init directory, so list operation latency (not total bucket size) sets the
+            duration; the default is generous because the pod deadline is hours.
 
     Returns:
         paths: A sorted list of all the files found in `path`. Returns an empty list if the
@@ -86,7 +90,7 @@ def list_files(
             text=True,
             capture_output=True,
             env=env_vars,
-            timeout=120,
+            timeout=timeout_seconds,
         )
     except subprocess.CalledProcessError as e:
         if (


### PR DESCRIPTION
## Problem

The `archive-grib-files` job for `dwd-icon-eu-forecast-5-day` failed with `TimeoutExpired` on the destination S3 listing ([sentry](https://dynamical.sentry.io/issues/7602704126/)):

```
TimeoutExpired: Command '('/usr/bin/rclone', 'lsf',
  ':s3:us-west-2.opendata.source.coop/dynamical/dwd-icon-grib/icon-eu/regular-lat-lon/2026-07-10T00',
  '--fast-list', '--recursive', '--files-only', '--checkers=32')' timed out after 120 seconds
```

The `120s` timeout in `list_files` was hardcoded, and `retry(max_attempts=3)` just burned three attempts against the same too-tight ceiling.

## Note on cause

This listing is scoped to a **single init directory** (`.../regular-lat-lon/2026-07-10T00/`), so total bucket growth does not inflate it — a single init dir holds a fixed set (variables × lead times for one run). The timeout is driven by list operation latency, not archive size.

## Change

Make `timeout_seconds` a parameter of `list_files`, defaulting to `200s`. The pod deadline is hours, so there's ample headroom. No CLI/config plumbing added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)