### PR TITLE
Enable ECCC HRDPS archive cron

### DIFF
--- a/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
+++ b/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
@@ -55,10 +55,6 @@ class EcccHrdpsForecastTemporalDynamicalDataset(
             memory="4G",
             ephemeral_storage="1G",  # not used
             secret_names=["source-coop-storage-options-key"],
-            # Suspended until a manual "Create Job from CronJob" run against real
-            # Source Coop credentials is verified (see reformatters#711) - remove
-            # once confirmed.
-            suspend=True,
         )
 
         return [archive_grib_files_job]

--- a/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
+++ b/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
@@ -29,9 +29,7 @@ def test_operational_kubernetes_resources(
     assert archive_grib_files_job.workers_total == 1
     assert archive_grib_files_job.parallelism == 1
     assert "source-coop-storage-options-key" in archive_grib_files_job.secret_names
-    # Suspended until a manual run against real Source Coop credentials is verified -
-    # see reformatters#711. Un-suspending is a one-line follow-up PR.
-    assert archive_grib_files_job.suspend is True
+    assert archive_grib_files_job.suspend is False
 
 
 def test_validators(dataset: EcccHrdpsForecastTemporalDynamicalDataset) -> None:


### PR DESCRIPTION
Un-suspends the `eccc-hrdps-forecast-archive-grib-files` cron now that a manual "Create Job from CronJob" run against real Source Co-Op credentials has been verified (writes to `dynamical/eccc-hrdps-grib/`).

Removes `suspend=True` (defaults back to unsuspended, matching DWD ICON-EU's archiver) so the cron runs on its schedule: 00/06/12/18 UTC inits, archived ~4h after each.

## Test plan
- [x] `uv run ruff check && ruff format --check && ty check`
- [x] `uv run pytest tests/eccc/` — updated the assertion to `suspend is False`