### PR TITLE
Add CF attributes to HRRR virtual vertical coordinates

### DIFF
--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -103,10 +103,6 @@ class CoordinateAttrs(FrozenBaseModel):
     standard_name: Annotated[str, pydantic.Field(min_length=1)] | None = None
     # Must follow CF Conventions if CF defines a standard name for this coordinate
     axis: CfAxis | None = None
-    # CF Conventions §4.3: for a vertical (Z) coordinate, the direction of
-    # increasing values, "up" or "down". Recommended when the sense can't be
-    # inferred from the units (e.g. pressure, where "down" means toward higher
-    # pressure / lower altitude).
     positive: Literal["up", "down"] | None = None
     units: TimestampUnits | TimedeltaUnits | str | None
     statistics_approximate: StatisticsApproximate | None

--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -103,6 +103,11 @@ class CoordinateAttrs(FrozenBaseModel):
     standard_name: Annotated[str, pydantic.Field(min_length=1)] | None = None
     # Must follow CF Conventions if CF defines a standard name for this coordinate
     axis: CfAxis | None = None
+    # CF Conventions §4.3: for a vertical (Z) coordinate, the direction of
+    # increasing values, "up" or "down". Recommended when the sense can't be
+    # inferred from the units (e.g. pressure, where "down" means toward higher
+    # pressure / lower altitude).
+    positive: Literal["up", "down"] | None = None
     units: TimestampUnits | TimedeltaUnits | str | None
     statistics_approximate: StatisticsApproximate | None
     comment: Annotated[str, pydantic.Field(min_length=1)] | None = None

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/template_config.py
@@ -243,6 +243,7 @@ class NoaaHrrrForecast48HourVirtualTemplateConfig(NoaaHrrrCommonTemplateConfig):
                     standard_name="model_level_number",
                     units="1",
                     axis="Z",
+                    positive="up",
                     statistics_approximate=StatisticsApproximate(
                         min=int(dim_coords["model_level"].min()),
                         max=int(dim_coords["model_level"].max()),

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/template_config.py
@@ -222,6 +222,7 @@ class NoaaHrrrForecast48HourVirtualTemplateConfig(NoaaHrrrCommonTemplateConfig):
                     standard_name="air_pressure",
                     units="hPa",
                     axis="Z",
+                    positive="down",
                     statistics_approximate=StatisticsApproximate(
                         min=int(dim_coords["pressure_level"].min()),
                         max=int(dim_coords["pressure_level"].max()),
@@ -239,6 +240,7 @@ class NoaaHrrrForecast48HourVirtualTemplateConfig(NoaaHrrrCommonTemplateConfig):
                 ),
                 attrs=CoordinateAttrs(
                     long_name="Hybrid model level number",
+                    standard_name="model_level_number",
                     units="1",
                     axis="Z",
                     statistics_approximate=StatisticsApproximate(

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/model_level/model_level/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/model_level/model_level/zarr.json
@@ -40,6 +40,7 @@
     "long_name": "Hybrid model level number",
     "standard_name": "model_level_number",
     "axis": "Z",
+    "positive": "up",
     "units": "1",
     "statistics_approximate": {
       "min": 1,

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/model_level/model_level/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/model_level/model_level/zarr.json
@@ -38,6 +38,7 @@
   ],
   "attributes": {
     "long_name": "Hybrid model level number",
+    "standard_name": "model_level_number",
     "axis": "Z",
     "units": "1",
     "statistics_approximate": {

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/pressure_level/pressure_level/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/pressure_level/pressure_level/zarr.json
@@ -40,6 +40,7 @@
     "long_name": "Pressure level",
     "standard_name": "air_pressure",
     "axis": "Z",
+    "positive": "down",
     "units": "hPa",
     "statistics_approximate": {
       "min": 50,

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/zarr.json
@@ -5455,6 +5455,7 @@
           "long_name": "Hybrid model level number",
           "standard_name": "model_level_number",
           "axis": "Z",
+          "positive": "up",
           "units": "1",
           "statistics_approximate": {
             "min": 1,

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/zarr.json
@@ -5453,6 +5453,7 @@
         ],
         "attributes": {
           "long_name": "Hybrid model level number",
+          "standard_name": "model_level_number",
           "axis": "Z",
           "units": "1",
           "statistics_approximate": {
@@ -7813,6 +7814,7 @@
           "long_name": "Pressure level",
           "standard_name": "air_pressure",
           "axis": "Z",
+          "positive": "down",
           "units": "hPa",
           "statistics_approximate": {
             "min": 50,

--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -270,6 +270,42 @@ def test_cf_ensemble_member_recognized(
         )
 
 
+# Dimension coordinates that carry a vertical level. CF requires axis="Z" on
+# each, axis="Z" is reserved for these names, and (see
+# test_metadata_consistency_across_datasets) each name presents identical
+# attributes across every dataset that defines it.
+VERTICAL_LEVEL_COORD_NAMES = frozenset({"pressure_level", "model_level"})
+
+
+@pytest.mark.parametrize(
+    "dataset", IMPLEMENTED_DATASETS, ids=[d.dataset_id for d in IMPLEMENTED_DATASETS]
+)
+def test_cf_vertical_level_coordinates(
+    dataset: DynamicalDataset[Any, Any],
+) -> None:
+    """
+    A pressure_level / model_level dimension coordinate must carry axis="Z",
+    and axis="Z" must not appear on any other coordinate.
+    """
+    errors: list[str] = []
+    for coord in dataset.template_config.coords:
+        is_vertical = coord.name in VERTICAL_LEVEL_COORD_NAMES
+        has_z_axis = coord.attrs.axis == "Z"
+        if is_vertical and not has_z_axis:
+            errors.append(
+                f"Coordinate '{coord.name}' must have axis='Z', got {coord.attrs.axis!r}."
+            )
+        if has_z_axis and not is_vertical:
+            errors.append(
+                f"Coordinate '{coord.name}' has axis='Z' but only "
+                f"{sorted(VERTICAL_LEVEL_COORD_NAMES)} may use it."
+            )
+    assert not errors, (
+        f"Vertical-level coordinate errors in dataset '{dataset.dataset_id}':\n\n"
+        + "\n\n".join(errors)
+    )
+
+
 @pytest.mark.parametrize(
     "dataset", IMPLEMENTED_DATASETS, ids=[d.dataset_id for d in IMPLEMENTED_DATASETS]
 )
@@ -890,6 +926,25 @@ def test_metadata_consistency_across_datasets() -> None:
     conflicts.extend(
         _check_consistency(by_coord_name, ["long_name", "standard_name", "units"])
     )
+
+    # Vertical-level dimension coordinates must additionally agree on axis and
+    # positive across datasets. axis isn't checked for coordinates in general
+    # because latitude/longitude legitimately carry axis on geographic datasets
+    # but not as 2D aux coords on projected ones; long_name/standard_name/units
+    # are already covered by the by_coord_name check above.
+    by_vertical_coord_name: dict[str, dict[str, dict[str, str | None]]] = {}
+    for dataset in IMPLEMENTED_DATASETS:
+        for coord_config in dataset.template_config.coords:
+            if coord_config.name not in VERTICAL_LEVEL_COORD_NAMES:
+                continue
+            by_vertical_coord_name.setdefault(coord_config.name, {})[
+                dataset.dataset_id
+            ] = {
+                "axis": coord_config.attrs.axis,
+                "positive": coord_config.attrs.positive,
+            }
+
+    conflicts.extend(_check_consistency(by_vertical_coord_name, ["axis", "positive"]))
 
     assert not conflicts, (
         "Metadata inconsistencies found across datasets:\n\n" + "\n\n".join(conflicts)

--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -948,9 +948,6 @@ def test_metadata_consistency_across_datasets() -> None:
                 "positive": coord_config.attrs.positive,
             }
 
-    # axis is not checked here — it's dimension-specific (see
-    # test_cf_dimension_coordinate_axis) and latitude/longitude legitimately
-    # carry it on geographic but not projected datasets.
     conflicts.extend(
         _check_consistency(
             by_coord_name, ["long_name", "standard_name", "units", "positive"]

--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -278,6 +278,8 @@ def test_cf_ensemble_member_recognized(
 # on a projected grid, valid_time, spatial_ref) must likewise declare no axis.
 DIM_EXPECTED_AXIS: dict[str, str | None] = {
     "time": "T",
+    # init_time/lead_time are identified by standard_name (forecast_reference_time /
+    # forecast_period), not axis; CF reserves axis="T" for the single time axis.
     "init_time": None,
     "lead_time": None,
     "ensemble_member": None,

--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -2,7 +2,7 @@ import json
 import xml.etree.ElementTree as ET
 from difflib import get_close_matches
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import cf_xarray  # noqa: F401 - needed for ds.cf accessor
 import pytest
@@ -10,6 +10,7 @@ import xarray as xr
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.types import Dim
 from tests.dataset_helpers import IMPLEMENTED_DATASETS
 
 # Downloaded from https://codes.ecmwf.int/parameter-database/api/v1/param/?format=json
@@ -270,39 +271,60 @@ def test_cf_ensemble_member_recognized(
         )
 
 
-# Dimension coordinates that carry a vertical level. CF requires axis="Z" on
-# each, axis="Z" is reserved for these names, and (see
-# test_metadata_consistency_across_datasets) each name presents identical
-# attributes across every dataset that defines it.
-VERTICAL_LEVEL_COORD_NAMES = frozenset({"pressure_level", "model_level"})
+# The CF axis attribute every dimension coordinate must carry, keyed by
+# dimension name. None means the dimension is not one of the CF X/Y/Z/T axes
+# (forecast time components, ensemble realization, statistic) and must declare
+# no axis. Coordinates that are not dimensions (e.g. HRRR's 2D latitude/longitude
+# on a projected grid, valid_time, spatial_ref) must likewise declare no axis.
+DIM_EXPECTED_AXIS: dict[str, str | None] = {
+    "time": "T",
+    "init_time": None,
+    "lead_time": None,
+    "ensemble_member": None,
+    "latitude": "Y",
+    "longitude": "X",
+    "x": "X",
+    "y": "Y",
+    "statistic": None,
+    "pressure_level": "Z",
+    "model_level": "Z",
+}
+# Force a decision here whenever a new dimension is added to the Dim type.
+assert set(DIM_EXPECTED_AXIS) == set(get_args(Dim.__value__))
 
 
 @pytest.mark.parametrize(
     "dataset", IMPLEMENTED_DATASETS, ids=[d.dataset_id for d in IMPLEMENTED_DATASETS]
 )
-def test_cf_vertical_level_coordinates(
+def test_cf_dimension_coordinate_axis(
     dataset: DynamicalDataset[Any, Any],
 ) -> None:
     """
-    A pressure_level / model_level dimension coordinate must carry axis="Z",
-    and axis="Z" must not appear on any other coordinate.
+    Every dimension coordinate carries exactly the CF axis its dimension
+    requires (and dimensions that are not CF axes declare none). Coordinates
+    that are not dimensions — e.g. 2D latitude/longitude on a projected grid —
+    must not declare an axis at all.
     """
+    dataset_dims = {
+        dim for dims in dataset.template_config.dims.values() for dim in dims
+    }
     errors: list[str] = []
     for coord in dataset.template_config.coords:
-        is_vertical = coord.name in VERTICAL_LEVEL_COORD_NAMES
-        has_z_axis = coord.attrs.axis == "Z"
-        if is_vertical and not has_z_axis:
+        axis = coord.attrs.axis
+        if coord.name in dataset_dims:
+            expected = DIM_EXPECTED_AXIS[coord.name]
+            if axis != expected:
+                errors.append(
+                    f"Dimension coordinate '{coord.name}' must have axis={expected!r}, "
+                    f"got {axis!r}."
+                )
+        elif axis is not None:
             errors.append(
-                f"Coordinate '{coord.name}' must have axis='Z', got {coord.attrs.axis!r}."
-            )
-        if has_z_axis and not is_vertical:
-            errors.append(
-                f"Coordinate '{coord.name}' has axis='Z' but only "
-                f"{sorted(VERTICAL_LEVEL_COORD_NAMES)} may use it."
+                f"Non-dimension coordinate '{coord.name}' must not declare an axis, "
+                f"got axis={axis!r}."
             )
     assert not errors, (
-        f"Vertical-level coordinate errors in dataset '{dataset.dataset_id}':\n\n"
-        + "\n\n".join(errors)
+        f"CF axis errors in dataset '{dataset.dataset_id}':\n\n" + "\n\n".join(errors)
     )
 
 
@@ -921,30 +943,17 @@ def test_metadata_consistency_across_datasets() -> None:
                 "long_name": coord_config.attrs.long_name,
                 "standard_name": coord_config.attrs.standard_name,
                 "units": coord_config.attrs.units,
-            }
-
-    conflicts.extend(
-        _check_consistency(by_coord_name, ["long_name", "standard_name", "units"])
-    )
-
-    # Vertical-level dimension coordinates must additionally agree on axis and
-    # positive across datasets. axis isn't checked for coordinates in general
-    # because latitude/longitude legitimately carry axis on geographic datasets
-    # but not as 2D aux coords on projected ones; long_name/standard_name/units
-    # are already covered by the by_coord_name check above.
-    by_vertical_coord_name: dict[str, dict[str, dict[str, str | None]]] = {}
-    for dataset in IMPLEMENTED_DATASETS:
-        for coord_config in dataset.template_config.coords:
-            if coord_config.name not in VERTICAL_LEVEL_COORD_NAMES:
-                continue
-            by_vertical_coord_name.setdefault(coord_config.name, {})[
-                dataset.dataset_id
-            ] = {
-                "axis": coord_config.attrs.axis,
                 "positive": coord_config.attrs.positive,
             }
 
-    conflicts.extend(_check_consistency(by_vertical_coord_name, ["axis", "positive"]))
+    # axis is not checked here — it's dimension-specific (see
+    # test_cf_dimension_coordinate_axis) and latitude/longitude legitimately
+    # carry it on geographic but not projected datasets.
+    conflicts.extend(
+        _check_consistency(
+            by_coord_name, ["long_name", "standard_name", "units", "positive"]
+        )
+    )
 
     assert not conflicts, (
         "Metadata inconsistencies found across datasets:\n\n" + "\n\n".join(conflicts)


### PR DESCRIPTION
## What

Makes the `pressure_level` and `model_level` dimension coordinates of the
`noaa-hrrr-forecast-48-hour-virtual` dataset fully CF compliant, and adds
cross-dataset test coverage enforcing correct CF axes and consistent vertical-level metadata.

**Metadata**
- **`pressure_level`**: add `positive="down"` (pressure increases toward lower
  altitude; CF §4.3). Already carries `standard_name="air_pressure"`, `units="hPa"`, `axis="Z"`.
- **`model_level`**: add `standard_name="model_level_number"` (CF standard name
  for a dimensionless model-level index) and `positive="up"`. Keeps `units="1"`, `axis="Z"`.
  - Direction confirmed empirically against the live store: `model_level=1` sits at
    ~455 m geopotential height (−0.5 °C) and `model_level=50` at ~27 km (−53.9 °C),
    i.e. level 1 = near-surface, increasing upward — matching the WRF/ARW native-level
    convention (level 1 lowest) in NOAA's WRFNAT reference.

**Tests** (`tests/common/datasets_cf_compliance_test.py`)
- `test_cf_dimension_coordinate_axis`: every dimension coordinate must carry
  exactly the CF axis its dimension requires (`DIM_EXPECTED_AXIS`, keyed by the
  `Dim` type and asserted complete so a new dimension forces a decision), and
  non-dimension coordinates (e.g. HRRR's 2D projected lat/lon) must declare no
  axis. This subsumes the vertical `axis="Z"` rules (only `pressure_level`/`model_level`
  map to `Z`) and covers all X/Y/Z/T dimensions.
- Extend `test_metadata_consistency_across_datasets` so coordinates also agree on
  `positive` across datasets (`long_name`/`standard_name`/`units` were already covered).

## How

- Add an optional `positive: Literal["up", "down"] | None` field to
  `CoordinateAttrs` (CF §4.3) in `common/config_models.py`.
- Set the new attrs in the HRRR virtual `template_config.py`.
- Regenerate the committed template
  (`uv run main noaa-hrrr-forecast-48-hour-virtual update-template`);
  the metadata deltas land in `templates/latest.zarr`.

## Testing

- `uv run ruff check` / `ruff format --check` — clean
- `uv run ty check` — clean
- `uv run pytest tests/common/datasets_cf_compliance_test.py tests/common/common_template_config_subclasses_test.py` — 259 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)