### PR TITLE
Mask HRRR pressure-level dew point missing sentinel to NaN

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/template_config.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/template_config.py
@@ -443,6 +443,7 @@ def _pressure_var(
     units: str,
     standard_name: str | None = None,
     comment: str | None = None,
+    missing_value: float | None = None,
 ) -> NoaaHrrrDataVar:
     return _data_var(
         name,
@@ -457,6 +458,7 @@ def _pressure_var(
         units=units,
         standard_name=standard_name,
         comment=comment,
+        missing_value=missing_value,
         hour_0=None,
     )
 
@@ -1833,6 +1835,12 @@ def _pressure_data_vars() -> list[NoaaHrrrDataVar]:
             long_name="Dew point temperature",
             units="degree_Celsius",
             standard_name="dew_point_temperature",
+            # HRRR omits dew point at the highest isobaric levels (always 50 hPa, and
+            # 75 hPa in some cycles); those GRIB cells decode to 0 K, which the
+            # Kelvin->Celsius filter turns into -273.15. Absolute zero is physically
+            # impossible for a dew point, so it is a safe missing sentinel that
+            # CF-aware readers mask to NaN.
+            missing_value=-273.15,
         ),
         _pressure_var(
             "graupel",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/pressure_level/dew_point_temperature/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/pressure_level/dew_point_temperature/zarr.json
@@ -25,7 +25,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": -273.15,
   "codecs": [
     {
       "name": "scale_offset",
@@ -47,9 +47,10 @@
     "short_name": "dpt",
     "standard_name": "dew_point_temperature",
     "units": "degree_Celsius",
+    "missing_value": -273.15,
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
-    "_FillValue": "AAAAAAAA+H8="
+    "_FillValue": "ZmZmZmYSccA="
   },
   "dimension_names": [
     "init_time",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/zarr.json
@@ -7337,7 +7337,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": -273.15,
         "codecs": [
           {
             "name": "scale_offset",
@@ -7359,9 +7359,10 @@
           "short_name": "dpt",
           "standard_name": "dew_point_temperature",
           "units": "degree_Celsius",
+          "missing_value": -273.15,
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
-          "_FillValue": "AAAAAAAA+H8="
+          "_FillValue": "ZmZmZmYSccA="
         },
         "dimension_names": [
           "init_time",


### PR DESCRIPTION
## Problem

In `noaa-hrrr-forecast-48-hour-virtual`, HRRR does not report dew point at the highest isobaric levels — always 50 hPa, and 75 hPa in some cycles. Those GRIB cells decode to 0 K, and the Kelvin→Celsius read filter (`ScaleOffset(offset=-273.15)`) turns them into **-273.15 °C**. That absolute-zero value currently surfaces as real-looking data, so anything that reduces over the vertical column (mean profiles, lapse rates, dewpoint depression, RH-from-dewpoint) is silently corrupted — it looks fine to code but is physically absurd.

## Fix

Declare `-273.15` as the pressure-level `dew_point_temperature`'s CF `missing_value` (with matching `_FillValue` / `fill_value`), so CF-aware readers (xarray's default `mask_and_scale`) mask it to `NaN` on read. This follows the existing sentinel pattern in this config (e.g. `echo_top`'s `-999`). Absolute zero can never be a valid dew point, so the sentinel is unambiguous and real values — including genuinely cold upper-level dew points near -81 °C — are preserved untouched.

- Adds a `missing_value` parameter to `_pressure_var` (it previously had none).
- Sets `missing_value=-273.15` on the pressure-level `dew_point_temperature`.
- Regenerates `templates/latest.zarr` (`update-template`): `fill_value` `NaN → -273.15`, adds `missing_value: -273.15`, `_FillValue` base64 updated to the float64 encoding of `-273.15`.

## Scope

Checked the other groups — the fix is correctly limited to the pressure-level dew point:

- **model_level:** has no dew-point variable (only `temperature`) — N/A.
- **surface/2m** (`dew_point_temperature_2m`): zero sentinels across the full CONUS grid over three sampled inits (~1.9M points each) — the surface always has a valid dew point, so no change.
- **Not applied to the other moisture fields** (relative humidity, specific humidity, mixing ratios): those decode missing as `0`, which is a legitimate physical value there, so masking would destroy real data. Dew point is special precisely because its sentinel maps to a physically impossible temperature.

## Verification

- Synthetic zarr-v3 array with the real codec chain (`ScaleOffset` + CF attrs): present `-273.15` → `NaN`, real values preserved.
- Real staging data: sentinel appears only at 50/75 hPa; masking turns exactly those to `NaN` and leaves the physical -81 °C at 100 hPa unchanged.
- `uv run pytest` on the template / CF-compliance / HRRR-virtual suites (274 tests) passes; `ruff check`, `ruff format --check`, and `ty` are clean.

## Note (separate, out of scope)

While scoping this I found a value of exactly `-81.02521362304685 °C` appearing 36× in the 2m field, identical to the 100 hPa value — likely a secondary GRIB packing floor. Unlike `-273.15` it is ambiguous (that value is physically real at 100 hPa), so it is intentionally not touched here and would need its own investigation.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Gxiz1eWxK8cy4gt3LAm9n)_