### PR TITLE
Retry only failed keys in _exists_many virtual chunk probe

### DIFF
--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -626,12 +626,43 @@ class _NoRegion:
 _NO_REGION: Final = _NoRegion()
 
 
-def _exists_many(store: IcechunkStore, keys: Sequence[str]) -> dict[str, bool]:
-    """Probe many chunk keys concurrently (store.exists is async)."""
+def _exists_many(
+    store: IcechunkStore, keys: Sequence[str], *, max_attempts: int = 8
+) -> dict[str, bool]:
+    """Probe many chunk keys concurrently (store.exists is async).
+
+    Transient object-store errors are retried per key: each attempt re-probes only the
+    keys that still failed, so one flaky probe never discards the successful probes or
+    forces the whole batch to be re-issued. A whole-archive scan issues enough probes
+    that a transient failure is near-certain, so retrying the failed subset (rather than
+    the entire batch) is what keeps a single blip from failing the run."""
     if not keys:
         return {}
 
-    async def _check() -> list[bool]:
-        return list(await asyncio.gather(*(store.exists(key) for key in keys)))
+    async def _check(probe_keys: Sequence[str]) -> list[bool | BaseException]:
+        return list(
+            await asyncio.gather(
+                *(store.exists(key) for key in probe_keys), return_exceptions=True
+            )
+        )
 
-    return dict(zip(keys, asyncio.run(_check()), strict=True))
+    result: dict[str, bool] = {}
+    pending: Sequence[str] = keys
+    last_exception: BaseException | None = None
+    for attempt in range(max_attempts):
+        failed: list[str] = []
+        for key, outcome in zip(pending, asyncio.run(_check(pending)), strict=True):
+            if isinstance(outcome, BaseException):
+                last_exception = outcome
+                failed.append(key)
+            else:
+                result[key] = outcome
+        if not failed:
+            return result
+        pending = failed
+        if attempt < max_attempts - 1:
+            rng = np.random.default_rng()
+            time.sleep(attempt * rng.uniform(0.8, 1.2) + 0.1)
+
+    assert last_exception is not None
+    raise last_exception

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -629,13 +629,7 @@ _NO_REGION: Final = _NoRegion()
 def _exists_many(
     store: IcechunkStore, keys: Sequence[str], *, max_attempts: int = 8
 ) -> dict[str, bool]:
-    """Probe many chunk keys concurrently (store.exists is async).
-
-    Transient object-store errors are retried per key: each attempt re-probes only the
-    keys that still failed, so one flaky probe never discards the successful probes or
-    forces the whole batch to be re-issued. A whole-archive scan issues enough probes
-    that a transient failure is near-certain, so retrying the failed subset (rather than
-    the entire batch) is what keeps a single blip from failing the run."""
+    """Probe many chunk keys concurrently."""
     if not keys:
         return {}
 
@@ -662,7 +656,8 @@ def _exists_many(
         pending = failed
         if attempt < max_attempts - 1:
             rng = np.random.default_rng()
-            time.sleep(attempt * rng.uniform(0.8, 1.2) + 0.1)
+            # First retry waits ~0.1s; back off only from the second retry onward.
+            time.sleep(max(0, attempt - 1) * rng.uniform(0.8, 1.2) + 0.1)
 
     assert last_exception is not None
     raise last_exception

--- a/src/scripts/validation/manifest_scan.py
+++ b/src/scripts/validation/manifest_scan.py
@@ -308,7 +308,9 @@ def _flush_var_probes(
     out: dict[str, dict[pd.Timestamp, bool]],
 ) -> None:
     keys = [key for _, _, key in probes]
-    present = retry(lambda: _exists_many(store, keys), max_attempts=_SCAN_MAX_RETRIES)
+    # _exists_many retries the failed subset internally, so a transient blip on one of
+    # these (up to _EXISTS_BATCH_SIZE) keys no longer re-probes the whole batch.
+    present = _exists_many(store, keys, max_attempts=_SCAN_MAX_RETRIES)
     for var_path, position, key in probes:
         out.setdefault(var_path, {})[position] = present[key]
     probes.clear()

--- a/src/scripts/validation/manifest_scan.py
+++ b/src/scripts/validation/manifest_scan.py
@@ -308,8 +308,6 @@ def _flush_var_probes(
     out: dict[str, dict[pd.Timestamp, bool]],
 ) -> None:
     keys = [key for _, _, key in probes]
-    # _exists_many retries the failed subset internally, so a transient blip on one of
-    # these (up to _EXISTS_BATCH_SIZE) keys no longer re-probes the whole batch.
     present = _exists_many(store, keys, max_attempts=_SCAN_MAX_RETRIES)
     for var_path, position, key in probes:
         out.setdefault(var_path, {})[position] = present[key]

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -15,7 +15,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from datetime import timedelta
 from itertools import batched
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, cast
 
 import dask.array
 import icechunk
@@ -58,6 +58,7 @@ from reformatters.common.types import AppendDim, Dim, Timedelta, Timestamp
 from reformatters.common.virtual_region_job import (
     VirtualRef,
     VirtualRegionJob,
+    _exists_many,
 )
 
 pytestmark = pytest.mark.slow
@@ -1683,3 +1684,29 @@ def test_serializer_threads_through_expansion_without_decoding(tmp_path: Path) -
     ]
     assert {"name": "gribberish", "configuration": {"var": "TMP"}} in codec_dicts
     assert asyncio.run(readonly.exists("temperature_2m/c/1/0/0/0")) is True
+
+
+def test_exists_many_retries_only_failed_keys() -> None:
+    """A transient error on one key re-probes only that key, not the whole batch."""
+    calls: dict[str, int] = {}
+
+    class FlakyStore:
+        async def exists(self, key: str) -> bool:
+            calls[key] = calls.get(key, 0) + 1
+            if key == "b" and calls[key] == 1:
+                raise RuntimeError("transient")
+            return key != "c"  # "c" is genuinely absent
+
+    result = _exists_many(cast("icechunk.IcechunkStore", FlakyStore()), ["a", "b", "c"])
+    assert result == {"a": True, "b": True, "c": False}
+    # "a"/"c" succeeded on the first attempt and are not re-probed; only "b" retries.
+    assert calls == {"a": 1, "b": 2, "c": 1}
+
+
+def test_exists_many_raises_after_exhausting_attempts() -> None:
+    class DeadStore:
+        async def exists(self, _key: str) -> bool:
+            raise RuntimeError("object store down")
+
+    with pytest.raises(RuntimeError, match="object store down"):
+        _exists_many(cast("icechunk.IcechunkStore", DeadStore()), ["a"], max_attempts=2)


### PR DESCRIPTION
## Problem
A whole-archive virtual manifest scan (`availability` on a virtual store, and the completeness gate in `run-all`) issues enough `store.exists` probes — `manifest_scan` flushes batches of up to `_EXISTS_BATCH_SIZE` (20,000) keys — that a transient object-store error during the run is near-certain. `_exists_many` gathered the whole batch with `asyncio.gather` **without** `return_exceptions`, so a single failed probe raised and the surrounding `retry()` re-issued the **entire** batch. Re-firing thousands of concurrent probes tends to hit another transient failure, so the retries can keep failing and eventually exhaust — killing a multi-hour run. (Observed: a full `noaa-hrrr-forecast-48-hour-virtual` run died ~2h in on a single `HTTP connect timeout` while probing `pressure_level/relative_humidity`.)

## Change
- `_exists_many` now gathers with `return_exceptions=True` and retries **only the keys that failed**, with backoff, up to `max_attempts`. A transient blip on one key no longer discards the successful probes or re-issues the whole batch.
- `manifest_scan._flush_var_probes` calls `_exists_many(store, keys, max_attempts=_SCAN_MAX_RETRIES)` directly instead of wrapping it in an outer whole-batch `retry(...)`.
- The write path (`filter_already_present` → `_exists_many`) gets the same per-key resilience for free.

## Testing
- New unit tests: `_exists_many` re-probes only the failed key (not the whole batch) and returns correct results; and raises after exhausting attempts when a key keeps failing.
- `uv run ruff check && uv run ty check` clean; `pytest -k "manifest or exists or completeness or decode_health"` → 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y29NPqgcTDZd5dQKeuUnp2)_