### PR TITLE
Drop the std column from the point time series table when empty

### DIFF
--- a/src/scripts/validation/summary.py
+++ b/src/scripts/validation/summary.py
@@ -117,17 +117,30 @@ def _value_ts_table(stats: VariableStats, ctx: RunContext) -> list[str]:
             header += f", member={ctx.value_ts_member}"
         if stats.level_dim is not None:
             header += f", {stats.level_dim}={stats.level_value:g}"
-    return [
-        header,
-        "",
-        "| Point | min | mean | std | max |",
-        "|---|---|---|---|---|",
-        f"| P1 | {_fmt_num(stats.value_min_p1)} | {_fmt_num(stats.value_mean_p1)} "
-        f"| {_fmt_num(stats.value_std_p1)} | {_fmt_num(stats.value_max_p1)} |",
-        f"| P2 | {_fmt_num(stats.value_min_p2)} | {_fmt_num(stats.value_mean_p2)} "
-        f"| {_fmt_num(stats.value_std_p2)} | {_fmt_num(stats.value_max_p2)} |",
-        "",
-    ]
+    # std spreads over the non-time dims (lead / member); virtual and analysis stores
+    # reduce to a single value per timestep, so there is no std to show — drop the column.
+    has_std = stats.value_std_p1 is not None or stats.value_std_p2 is not None
+    if has_std:
+        rows = [
+            "| Point | min | mean | std | max |",
+            "|---|---|---|---|---|",
+            f"| P1 | {_fmt_num(stats.value_min_p1)} | {_fmt_num(stats.value_mean_p1)} "
+            f"| {_fmt_num(stats.value_std_p1)} | {_fmt_num(stats.value_max_p1)} |",
+            f"| P2 | {_fmt_num(stats.value_min_p2)} | {_fmt_num(stats.value_mean_p2)} "
+            f"| {_fmt_num(stats.value_std_p2)} | {_fmt_num(stats.value_max_p2)} |",
+        ]
+    else:
+        rows = [
+            "| Point | min | mean | max |",
+            "|---|---|---|---|",
+            _stats_row(
+                "P1", stats.value_min_p1, stats.value_mean_p1, stats.value_max_p1
+            ),
+            _stats_row(
+                "P2", stats.value_min_p2, stats.value_mean_p2, stats.value_max_p2
+            ),
+        ]
+    return [header, "", *rows, ""]
 
 
 def _temporal_table(stats: VariableStats, ctx: RunContext) -> list[str]:


### PR DESCRIPTION
The per-variable **Point time series** table always rendered a `std` column, but the std spreads over the non-time dims (lead time / ensemble member). Virtual and analysis stores reduce each timestep to a single value, so `std` is always `n/a` there — a column of `n/a`.

This renders a three-column `min / mean / max` table when neither point has a std value, and keeps the four-column `min / mean / std / max` table when std is present (materialized forecast / ensemble stores).

## Testing
- `uv run ruff check && uv run ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y29NPqgcTDZd5dQKeuUnp2)_