### PR TITLE
Render per-variable plots with availability last

### DIFF
--- a/src/scripts/validation/render.py
+++ b/src/scripts/validation/render.py
@@ -22,11 +22,13 @@ def _extract_per_var_html(html: str) -> list[str]:
     return re.findall(r"<h3><code>([^<]+)</code></h3>", html)
 
 
+# Order mirrors the per-variable text/table sections: value time series, spatial,
+# temporal, then availability last.
 _PLOT_TYPES = (
-    ("availability", "availability over append dim"),
     ("value_timeseries", "full-period value time series"),
     ("spatial", "spatial comparison"),
     ("temporal", "time series comparison"),
+    ("availability", "availability over append dim"),
 )
 
 


### PR DESCRIPTION
In the per-variable sections of the HTML report, order the four plot images as value time series → spatial → temporal → availability, mirroring the order of the text/table sections just above them. Availability was previously rendered first.

## Testing
- `uv run ruff check && uv run ty check` clean; `pytest tests/scripts/validation/render_test.py` → 4 passed (the tests assert each plot is present, not its position, so they're unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y29NPqgcTDZd5dQKeuUnp2)_