### PR TITLE
docs: add canonical keep_mantissa_bits guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,6 @@ Categorical / flag variables set `flag_values` (the coded values) and `flag_mean
 
 Comment vs. review note. Put intrinsic, always-true variable facts (quirks, sentinel values, what the variable physically represents if not clear in the name/long_name) in the variable's `comment` attr so they travel with the data — these get no validation-report review note. Most common variables need no `comment` unless their interpretation is unusual. Put time-windowed characteristics of a specific archive (version-boundary behavior changes, historical low-quality windows, source outages) in the validation report's `### Review notes` (see [docs/validation.md](docs/validation.md) §3e) — these get no `comment`, since they would go stale in static template metadata as the archive grows. Each fact lives in exactly one place based on its kind.
 
-#### Encoding conventions
-
 A data variable's `keep_mantissa_bits` (float32 rounding for compression, or `"no-rounding"` to keep all 23) defaults to 7, with 6 for wind, 8 for precipitation flux/rates, and 11 for pressure variables with `units="Pa"`; match an existing equivalent variable rather than re-deriving.
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,17 @@ Categorical / flag variables set `flag_values` (the coded values) and `flag_mean
 
 Comment vs. review note. Put intrinsic, always-true variable facts (quirks, sentinel values, what the variable physically represents if not clear in the name/long_name) in the variable's `comment` attr so they travel with the data — these get no validation-report review note. Most common variables need no `comment` unless their interpretation is unusual. Put time-windowed characteristics of a specific archive (version-boundary behavior changes, historical low-quality windows, source outages) in the validation report's `### Review notes` (see [docs/validation.md](docs/validation.md) §3e) — these get no `comment`, since they would go stale in static template metadata as the archive grows. Each fact lives in exactly one place based on its kind.
 
+#### Encoding conventions
+
+`keep_mantissa_bits` (on a data variable's `internal_attrs`) sets how many of a float32's 23 mantissa bits survive before compression — lower rounds harder and compresses better but coarsens the data; `"no-rounding"` keeps all 23 (used by virtual datasets, whose bytes are never rewritten, and any variable that must stay exact). Pick it per the physical precision the variable needs, not the source's stored precision. Defaults by variable kind:
+
+- **7** — general default for most variables.
+- **6** — wind components / speeds.
+- **8** — precipitation flux and rates.
+- **11** — pressure variables with `units="Pa"`.
+
+Match an existing equivalent variable's value across datasets rather than re-deriving. Existing datasets predate this table and are not all consistent with it (e.g. some carry pressure at 10); leave them as-is unless separately asked to reconcile.
+
 
 ### RegionJob
 Base class: `src/reformatters/common/region_job.py`, commented example subclasses: `src/reformatters/example_{materialized|virtual}/region_job.py`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Categorical / flag variables set `flag_values` (the coded values) and `flag_mean
 
 Comment vs. review note. Put intrinsic, always-true variable facts (quirks, sentinel values, what the variable physically represents if not clear in the name/long_name) in the variable's `comment` attr so they travel with the data — these get no validation-report review note. Most common variables need no `comment` unless their interpretation is unusual. Put time-windowed characteristics of a specific archive (version-boundary behavior changes, historical low-quality windows, source outages) in the validation report's `### Review notes` (see [docs/validation.md](docs/validation.md) §3e) — these get no `comment`, since they would go stale in static template metadata as the archive grows. Each fact lives in exactly one place based on its kind.
 
-A data variable's `keep_mantissa_bits` (float32 rounding for compression, or `"no-rounding"` to keep all 23) defaults to 7, with 6 for wind, 8 for precipitation flux/rates, and 11 for pressure variables with `units="Pa"`; match an existing equivalent variable rather than re-deriving.
+Set each data variable's `keep_mantissa_bits` (float32 rounding for compression, or `"no-rounding"` to keep all 23) by convention: use 7 unless the variable is wind (6), a precipitation flux/rate (8), or a pressure variable with `units="Pa"` (11); match an existing equivalent variable rather than re-deriving.
 
 
 ### RegionJob

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,14 +82,7 @@ Comment vs. review note. Put intrinsic, always-true variable facts (quirks, sent
 
 #### Encoding conventions
 
-`keep_mantissa_bits` (on a data variable's `internal_attrs`) sets how many of a float32's 23 mantissa bits survive before compression — lower rounds harder and compresses better but coarsens the data; `"no-rounding"` keeps all 23 (used by virtual datasets, whose bytes are never rewritten, and any variable that must stay exact). Pick it per the physical precision the variable needs, not the source's stored precision. Defaults by variable kind:
-
-- **7** — general default for most variables.
-- **6** — wind components / speeds.
-- **8** — precipitation flux and rates.
-- **11** — pressure variables with `units="Pa"`.
-
-Match an existing equivalent variable's value across datasets rather than re-deriving. Existing datasets predate this table and are not all consistent with it (e.g. some carry pressure at 10); leave them as-is unless separately asked to reconcile.
+A data variable's `keep_mantissa_bits` (float32 rounding for compression, or `"no-rounding"` to keep all 23) defaults to 7, with 6 for wind, 8 for precipitation flux/rates, and 11 for pressure variables with `units="Pa"`; match an existing equivalent variable rather than re-deriving.
 
 
 ### RegionJob

--- a/docs/add_new_variable.md
+++ b/docs/add_new_variable.md
@@ -9,7 +9,7 @@ How to add a new data variable to an existing dataset.
 1b. Add a new `DataVar` to your dataset’s `TemplateConfig.data_vars` (usually in `src/reformatters/<provider>/<model>/<variant>/template_config.py`).
    - **Name + externally visible attrs**: match existing naming/attrs used in this repo where possible; otherwise follow CF Conventions. Variable names generally follow the format `<long name>_<level>`.
    - **Internal attrs**: derive from `gdalinfo` output on a representative source file (and GRIB index if relevant)
-   - **Encoding**: match existing variables, setting `keep_mantissa_bits` to 7 by default, 6 for wind variables, 8 for precipitation and 10 for pressure variables with units `pa`.
+   - **Encoding**: match existing variables. Set `keep_mantissa_bits` per the defaults-by-variable-kind table in the [Encoding conventions](../AGENTS.md#encoding-conventions) section of AGENTS.md.
 
 1c. Regenerate the checked-in Zarr template metadata:
 

--- a/docs/add_new_variable.md
+++ b/docs/add_new_variable.md
@@ -9,7 +9,7 @@ How to add a new data variable to an existing dataset.
 1b. Add a new `DataVar` to your dataset’s `TemplateConfig.data_vars` (usually in `src/reformatters/<provider>/<model>/<variant>/template_config.py`).
    - **Name + externally visible attrs**: match existing naming/attrs used in this repo where possible; otherwise follow CF Conventions. Variable names generally follow the format `<long name>_<level>`.
    - **Internal attrs**: derive from `gdalinfo` output on a representative source file (and GRIB index if relevant)
-   - **Encoding**: match existing variables. Set `keep_mantissa_bits` per the defaults-by-variable-kind table in the [Encoding conventions](../AGENTS.md#encoding-conventions) section of AGENTS.md.
+   - **Encoding**: match existing variables, and follow the `keep_mantissa_bits` guidance in AGENTS.md.
 
 1c. Regenerate the checked-in Zarr template metadata:
 

--- a/docs/dataset_integration_guide.md
+++ b/docs/dataset_integration_guide.md
@@ -76,7 +76,7 @@ Set `dataset_id` and `name` in `dataset_attributes` following the id/name conven
 
 Read the [chunk/shard layout tool](./chunk_shard_layout_tool.md) docs and use the tool to find chunk and shard sizes for your data variables.
 
-Set each data variable's `keep_mantissa_bits` per the defaults-by-variable-kind table in the [Encoding conventions](../AGENTS.md#encoding-conventions) section of AGENTS.md.
+Follow the `keep_mantissa_bits` guidance in AGENTS.md when setting each data variable's encoding.
 
 Using the information in the `TemplateConfig`, `reformatters` writes the Zarr metadata for your dataset to `src/reformatters/$DATASET_PATH/templates/latest.zarr`. Run this command in your terminal to create or update the template based on the your `TemplateConfig` subclass:
 

--- a/docs/dataset_integration_guide.md
+++ b/docs/dataset_integration_guide.md
@@ -76,6 +76,8 @@ Set `dataset_id` and `name` in `dataset_attributes` following the id/name conven
 
 Read the [chunk/shard layout tool](./chunk_shard_layout_tool.md) docs and use the tool to find chunk and shard sizes for your data variables.
 
+Set each data variable's `keep_mantissa_bits` per the defaults-by-variable-kind table in the [Encoding conventions](../AGENTS.md#encoding-conventions) section of AGENTS.md.
+
 Using the information in the `TemplateConfig`, `reformatters` writes the Zarr metadata for your dataset to `src/reformatters/$DATASET_PATH/templates/latest.zarr`. Run this command in your terminal to create or update the template based on the your `TemplateConfig` subclass:
 
 ```bash


### PR DESCRIPTION
Document the per-variable-kind keep_mantissa_bits defaults (8 for
precipitation flux/rates, 11 for Pa pressure variables) in a new
"Encoding conventions" section of AGENTS.md, and point the add-new-variable
and dataset-integration guides at it instead of duplicating the numbers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013j97ygxFcoKjnATcMsdUBo