### PR TITLE
Add VBDSF (direct/beam solar radiation) to NOAA HRRR

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
@@ -1,0 +1,83 @@
+{
+  "shape": [
+    1,
+    1059,
+    1799
+  ],
+  "data_type": "float32",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [
+        2160,
+        540,
+        450
+      ]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": "NaN",
+  "codecs": [
+    {
+      "name": "sharding_indexed",
+      "configuration": {
+        "chunk_shape": [
+          2160,
+          45,
+          45
+        ],
+        "codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "blosc",
+            "configuration": {
+              "typesize": 4,
+              "cname": "zstd",
+              "clevel": 3,
+              "shuffle": "shuffle",
+              "blocksize": 0
+            }
+          }
+        ],
+        "index_codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "crc32c"
+          }
+        ],
+        "index_location": "end"
+      }
+    }
+  ],
+  "attributes": {
+    "long_name": "Visible Beam Downward Solar Flux",
+    "short_name": "vbdsf",
+    "units": "W m-2",
+    "step_type": "instant",
+    "coordinates": "latitude longitude spatial_ref",
+    "_FillValue": "AAAAAAAA+H8="
+  },
+  "dimension_names": [
+    "time",
+    "y",
+    "x"
+  ],
+  "zarr_format": 3,
+  "node_type": "array",
+  "storage_transformers": []
+}

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
@@ -2030,6 +2030,89 @@
         "node_type": "array",
         "storage_transformers": []
       },
+      "visible_beam_downward_solar_flux_surface": {
+        "shape": [
+          1,
+          1059,
+          1799
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              2160,
+              540,
+              450
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+            "name": "sharding_indexed",
+            "configuration": {
+              "chunk_shape": [
+                2160,
+                45,
+                45
+              ],
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "blosc",
+                  "configuration": {
+                    "typesize": 4,
+                    "cname": "zstd",
+                    "clevel": 3,
+                    "shuffle": "shuffle",
+                    "blocksize": 0
+                  }
+                }
+              ],
+              "index_codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "crc32c"
+                }
+              ],
+              "index_location": "end"
+            }
+          }
+        ],
+        "attributes": {
+          "long_name": "Visible Beam Downward Solar Flux",
+          "short_name": "vbdsf",
+          "units": "W m-2",
+          "step_type": "instant",
+          "coordinates": "latitude longitude spatial_ref",
+          "_FillValue": "AAAAAAAA+H8="
+        },
+        "dimension_names": [
+          "time",
+          "y",
+          "x"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
       "wind_gust_surface": {
         "shape": [
           1,

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
@@ -1,0 +1,87 @@
+{
+  "shape": [
+    1,
+    49,
+    1059,
+    1799
+  ],
+  "data_type": "float32",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [
+        1,
+        49,
+        1060,
+        1800
+      ]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "codecs": [
+    {
+      "name": "sharding_indexed",
+      "configuration": {
+        "chunk_shape": [
+          1,
+          49,
+          265,
+          300
+        ],
+        "codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "blosc",
+            "configuration": {
+              "typesize": 4,
+              "cname": "zstd",
+              "clevel": 3,
+              "shuffle": "shuffle",
+              "blocksize": 0
+            }
+          }
+        ],
+        "index_codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "crc32c"
+          }
+        ],
+        "index_location": "end"
+      }
+    }
+  ],
+  "attributes": {
+    "long_name": "Visible Beam Downward Solar Flux",
+    "short_name": "vbdsf",
+    "units": "W m-2",
+    "step_type": "instant",
+    "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
+    "_FillValue": "AAAAAAAA+H8="
+  },
+  "dimension_names": [
+    "init_time",
+    "lead_time",
+    "y",
+    "x"
+  ],
+  "zarr_format": 3,
+  "node_type": "array",
+  "storage_transformers": []
+}

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
@@ -2339,6 +2339,93 @@
         "node_type": "array",
         "storage_transformers": []
       },
+      "visible_beam_downward_solar_flux_surface": {
+        "shape": [
+          1,
+          49,
+          1059,
+          1799
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              1,
+              49,
+              1060,
+              1800
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": 0.0,
+        "codecs": [
+          {
+            "name": "sharding_indexed",
+            "configuration": {
+              "chunk_shape": [
+                1,
+                49,
+                265,
+                300
+              ],
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "blosc",
+                  "configuration": {
+                    "typesize": 4,
+                    "cname": "zstd",
+                    "clevel": 3,
+                    "shuffle": "shuffle",
+                    "blocksize": 0
+                  }
+                }
+              ],
+              "index_codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "crc32c"
+                }
+              ],
+              "index_location": "end"
+            }
+          }
+        ],
+        "attributes": {
+          "long_name": "Visible Beam Downward Solar Flux",
+          "short_name": "vbdsf",
+          "units": "W m-2",
+          "step_type": "instant",
+          "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
+          "_FillValue": "AAAAAAAA+H8="
+        },
+        "dimension_names": [
+          "init_time",
+          "lead_time",
+          "y",
+          "x"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
       "wind_gust_surface": {
         "shape": [
           1,

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -323,9 +323,6 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=128,
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     hrrr_file_type="sfc",
-                    # HRRR f00 VBDSF (the analysis-time record) is not properly diagnosed
-                    # and contains non-physical spikes (>9000 W m-2); use the f01 value.
-                    hour_0_values_override=False,
                 ),
             ),
             NoaaHrrrDataVar(

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -308,6 +308,24 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                 ),
             ),
             NoaaHrrrDataVar(
+                name="visible_beam_downward_solar_flux_surface",
+                encoding=encoding,
+                attrs=DataVarAttrs(
+                    short_name="vbdsf",
+                    long_name="Visible Beam Downward Solar Flux",
+                    units="W m-2",
+                    step_type="instant",
+                ),
+                internal_attrs=NoaaHrrrInternalAttrs(
+                    grib_element="VBDSF",
+                    grib_description='0[-] SFC="Ground or water surface"',
+                    grib_index_level="surface",
+                    index_position=128,
+                    keep_mantissa_bits=default_keep_mantissa_bits,
+                    hrrr_file_type="sfc",
+                ),
+            ),
+            NoaaHrrrDataVar(
                 name="downward_long_wave_radiation_flux_surface",
                 encoding=encoding,
                 attrs=DataVarAttrs(

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -323,6 +323,9 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=128,
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     hrrr_file_type="sfc",
+                    # HRRR f00 VBDSF (the analysis-time record) is not properly diagnosed
+                    # and contains non-physical spikes (>9000 W m-2); use the f01 value.
+                    hour_0_values_override=False,
                 ),
             ),
             NoaaHrrrDataVar(

--- a/tests/noaa/hrrr/analysis/region_job_test.py
+++ b/tests/noaa/hrrr/analysis/region_job_test.py
@@ -310,6 +310,7 @@ _PRE_V3_UNAVAILABLE = {
     "downward_long_wave_radiation_flux_surface",
     "relative_humidity_2m",
     "snowfall_surface",
+    "visible_beam_downward_solar_flux_surface",
 }
 
 


### PR DESCRIPTION
## What

Adds `visible_beam_downward_solar_flux_surface` (GRIB element **VBDSF** — Visible Beam Downward Solar Flux, the direct/beam shortwave irradiance) to the shared materialized HRRR data-variable config (`NoaaHrrrCommonTemplateConfig.get_data_vars`). Because that method is shared, both materialized HRRR datasets gain the variable:

- `noaa-hrrr-forecast-48-hour`
- `noaa-hrrr-analysis`

The new `DataVar` is placed right after the existing DSWRF entry (`downward_short_wave_radiation_flux_surface`) and mirrors its internal pattern (`units="W m-2"`, `step_type="instant"`, `hrrr_file_type="sfc"`, `keep_mantissa_bits=7`). The f00 (analysis-time) VBDSF record is not properly diagnosed in the source (non-physical spikes >9000 W m-2), so it carries `hour_0_values_override=False` — the same treatment as the other unreliable-at-f00 instant surface fields.

## Why

Customer solar use case: DSWRF already provides **global** (total) surface downward shortwave irradiance; VBDSF adds the **direct/beam** component, which downstream solar models need alongside the global value.

## Consistency

Name and externally-visible attrs exactly match the existing HRRR **virtual** dataset's VBDSF (`short_name="vbdsf"`, `long_name="Visible Beam Downward Solar Flux"`, `units="W m-2"`, no `standard_name`), so the two HRRR products stay in sync. Per AGENTS.md, VBDSF (a visible-band beam flux) has no exact CF standard name, so `standard_name` is left unset — it is already listed in `ALLOWED_MISSING_STANDARD_NAME` in the CF compliance test. The virtual dataset is not touched (it already ships this variable).

## Verification

Verified on the canonical Python 3.14.6 toolchain: `update-template` for both datasets produces **zero diff** vs. the checked-in metadata; `ruff` / `ty check` / `pytest` (`common_template_config_subclasses_test` + `datasets_cf_compliance_test`, 259 passed) all pass; and a decode of real source GRIB confirmed physically sensible values. See the verification comment below for full detail, including the f00 fix.

## Scope

Template metadata only. Post-merge work — history backfill, validation (incl. the VBDSF version-boundary note), and catalog docs — is tracked in #750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZY5VagHhMYq9D6WXVXxvq