### PR TITLE
Disable Karpenter consolidation for reformat/update pods

### DIFF
--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -36,6 +36,8 @@ class Job(pydantic.BaseModel):
     pod_active_deadline: timedelta = timedelta(hours=6)
     ttl: timedelta = timedelta(days=1)
 
+    pod_annotations: dict[str, str] = pydantic.Field(default_factory=dict)
+
     secret_names: Sequence[str] = pydantic.Field(default_factory=list)
 
     @cached_property
@@ -81,6 +83,7 @@ class Job(pydantic.BaseModel):
                     ]
                 },
                 "template": {
+                    "metadata": {"annotations": self.pod_annotations},
                     "spec": {
                         "containers": [
                             {
@@ -210,7 +213,7 @@ class Job(pydantic.BaseModel):
                                 for secret_name in self.secret_names
                             ],
                         ],
-                    }
+                    },
                 },
                 "ttlSecondsAfterFinished": int(self.ttl.total_seconds()),
             },
@@ -250,6 +253,8 @@ class ReformatCronJob(CronJob):
     # Operational updates expect a single worker
     workers_total: int = 1
     parallelism: int = 1
+    # A mid-run eviction restarts the whole job, so opt out of consolidation.
+    pod_annotations: dict[str, str] = {"karpenter.sh/do-not-disrupt": "true"}
 
 
 class ValidationCronJob(CronJob):

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -10,6 +10,8 @@ import pytest
 from reformatters.common.config import Config, Env
 from reformatters.common.kubernetes import (
     Job,
+    ReformatCronJob,
+    ValidationCronJob,
     _load_secret_from_kubernetes_api,
     load_secret,
 )
@@ -58,6 +60,7 @@ def test_as_kubernetes_object_comprehensive() -> None:
             ]
         },
         "template": {
+            "metadata": {"annotations": {}},
             "spec": {
                 "containers": [
                     {
@@ -161,12 +164,53 @@ def test_as_kubernetes_object_comprehensive() -> None:
                     {"name": "aws-creds", "secret": {"secretName": "aws-creds"}},
                     {"name": "db-creds", "secret": {"secretName": "db-creds"}},
                 ],
-            }
+            },
         },
         "ttlSecondsAfterFinished": 86400,  # default 24 hours
     }
 
     assert k8s_obj["spec"] == expected_spec
+
+
+def test_do_not_disrupt_annotation_only_on_reformat_jobs() -> None:
+    reformat = ReformatCronJob(
+        name="weather-data-update",
+        schedule="0 * * * *",
+        image="img:v1",
+        dataset_id="weather_data",
+        cpu="1",
+        memory="1Gi",
+    )
+    validate = ValidationCronJob(
+        name="weather-data-validate",
+        schedule="0 * * * *",
+        image="img:v1",
+        dataset_id="weather_data",
+        cpu="1",
+        memory="1Gi",
+    )
+    backfill = Job(
+        command=["backfill-kubernetes"],
+        image="img:v1",
+        dataset_id="weather_data",
+        cpu="1",
+        memory="1Gi",
+        workers_total=1,
+        parallelism=1,
+    )
+
+    def pod_template(obj: dict[str, Any], *, cron: bool) -> dict[str, Any]:
+        spec = obj["spec"]["jobTemplate"]["spec"] if cron else obj["spec"]
+        return spec["template"]
+
+    def annotations(obj: dict[str, Any], *, cron: bool) -> dict[str, str]:
+        return pod_template(obj, cron=cron)["metadata"]["annotations"]
+
+    assert annotations(reformat.as_kubernetes_object(), cron=True) == {
+        "karpenter.sh/do-not-disrupt": "true"
+    }
+    assert annotations(validate.as_kubernetes_object(), cron=True) == {}
+    assert annotations(backfill.as_kubernetes_object(), cron=False) == {}
 
 
 def test_kubernetes_job_name() -> None:


### PR DESCRIPTION
## Problem

`noaa-hrrr-analysis-validate` fired repeated Sentry alerts ("No data found within 4:00:00 of now"). Traced via kubectl + sentry-cli:

- Update pods run on **spot** nodes with `restartPolicy: Never`.
- On the 2026-07-15 12:57Z run, Karpenter **voluntary consolidation** evicted the running update pod mid-job (`Killing` → `Evicted pod: Underutilized`).
- Workers aren't checkpointed, so the replacement pod re-ran the entire region job from scratch — wall-clock doubled (12m → 24m).
- The update then finished at 13:21Z, **after** the validation cronjob started at 13:17Z, so validation ran against stale data and alerted until the update completed.

This is voluntary disruption (consolidation), not spot reclaim or the pod deadline — and it's preventable.

## Change

Add a `pod_annotations` hook on `Job` (empty by default, applied to the pod template) and set `karpenter.sh/do-not-disrupt: "true"` on `ReformatCronJob` (the `-update` jobs). Karpenter won't voluntarily evict a running update.

Scoped to reformat/update jobs only — **backfill and validation pods are unaffected** (they keep an empty annotations map).

- Involuntary spot reclaim is unaffected (already handled by the existing `podFailurePolicy` `Ignore` on `DisruptionTarget`).
- `pod_active_deadline` still bounds hung pods.

## Test

Added `test_do_not_disrupt_annotation_only_on_reformat_jobs` (asserts the annotation is present on `ReformatCronJob` and empty on `ValidationCronJob` / backfill `Job`) and updated the comprehensive fixture. `ruff`, `ty`, and `pytest tests/common/test_kubernetes.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)