### PR TITLE
Retry NCEI 5xx errors when listing NDVI source files

### DIFF
--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/region_job.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/region_job.py
@@ -282,12 +282,20 @@ class NoaaNdviCdrAnalysisRegionJob(
         """
         ncei_url = f"{self.root_nc_url}/{year}/"
 
-        response = retry(lambda: requests.get(ncei_url, timeout=15))
+        def get_listing() -> requests.Response:
+            response = requests.get(ncei_url, timeout=15)
+            # 404 is a deterministic outcome handled below; any other non-2xx
+            # (e.g. NCEI's intermittent 500s) raises here so retry() retries it.
+            if response.status_code != 404:
+                response.raise_for_status()
+            return response
+
+        response = retry(get_listing)
         if response.status_code == 404:
             now = pd.Timestamp.now()
             if now.year == year and now.month == 1:
                 return []
-        response.raise_for_status()
+            response.raise_for_status()
 
         content = response.text
         filenames = re.findall(r"href=\"(VIIRS-Land.+nc)\"", content)

--- a/tests/contrib/noaa/ndvi_cdr/analysis/region_job_test.py
+++ b/tests/contrib/noaa/ndvi_cdr/analysis/region_job_test.py
@@ -433,6 +433,49 @@ def test_list_source_files_routing_by_year(
         mock_ncei.assert_not_called()
 
 
+def test_list_ncei_source_files_retries_on_server_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transient 5xx responses from NCEI are retried rather than failing the job."""
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+
+    call_count = 0
+
+    def mock_requests_get(url: str, **kwargs: Any) -> Mock:  # noqa: ANN401
+        nonlocal call_count
+        call_count += 1
+        mock_response = Mock()
+        if call_count < 3:
+            mock_response.status_code = 500
+
+            def raise_http_error() -> None:
+                raise requests.HTTPError(response=mock_response)
+
+            mock_response.raise_for_status = raise_http_error
+        else:
+            mock_response.status_code = 200
+            mock_response.raise_for_status = Mock()
+            mock_response.text = '<a href="VIIRS-Land_v001_JP113C1_NOAA-20_20250101_c20250103153010.nc">x</a>'
+        return mock_response
+
+    monkeypatch.setattr("requests.get", mock_requests_get)
+
+    template_config = NoaaNdviCdrAnalysisTemplateConfig()
+    region_job = NoaaNdviCdrAnalysisRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=Mock(),
+        data_vars=template_config.data_vars,
+        append_dim=template_config.append_dim,
+        region=Mock(spec=slice),
+        reformat_job_name="test",
+    )
+
+    result = region_job._list_ncei_source_files(2025)
+
+    assert call_count == 3
+    assert result == ["VIIRS-Land_v001_JP113C1_NOAA-20_20250101_c20250103153010.nc"]
+
+
 @pytest.fixture
 def mock_404_response(monkeypatch: pytest.MonkeyPatch) -> Mock:
     """Fixture to mock requests.get returning a 404 response."""


### PR DESCRIPTION
The NDVI CDR analysis operational update lists the current year's source
files from NCEI's HTML directory index. That listing was wrapped in
retry(), but retry() only retries when requests.get raises, and an HTTP
500 does not raise — it returns a Response with status_code=500. The
raise_for_status() that turned it into an exception ran outside retry(),
so NCEI's intermittent 500s failed the whole update with zero retries.

Move raise_for_status() inside the retried callable so 5xx responses are
retried, while keeping the deterministic 404 handling (empty listing in
January of the current year) outside the retry.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AaYueJgH4h7eJEpx9ciHZM