### PR TITLE
Fix GRIB decimal precision rounding in MRMS data

### DIFF
--- a/src/reformatters/common/grib.py
+++ b/src/reformatters/common/grib.py
@@ -9,6 +9,25 @@ def grib_decimal_scale_factors(path: Path) -> list[int]:
     an integer reference value R, which together guarantee its values are exact
     multiples of 10^-D.
     """
+    # A GRIB2 file is a sequence of messages. Byte layout behind the offsets below
+    # (0-based from the message or section start; multi-byte integers big-endian):
+    #
+    #   Section 0 (indicator, fixed 16 bytes):
+    #     [0:4]    b"GRIB"
+    #     [8:16]   total message length
+    #   Sections 1-7 (sections 4-7 repeat per field within a message):
+    #     [0:4]    section length
+    #     [4]      section number
+    #   Section 5 (data representation), following that 5-byte section header:
+    #     [5:9]    number of data points
+    #     [9:11]   data representation template number
+    #     [11:15]  reference value R (IEEE float32)
+    #     [15:17]  binary scale factor E (sign-and-magnitude int16)
+    #     [17:19]  decimal scale factor D (sign-and-magnitude int16)
+    #   End section: the literal bytes b"7777" terminate each message.
+    #
+    # R/E/D sit at the same octets in all common templates (5.0 simple, 5.2/5.3
+    # complex, 5.40 JPEG2000, 5.41 PNG), so no branching on template is needed.
     data = path.read_bytes()
     scale_factors: list[int] = []
     pos = 0

--- a/src/reformatters/common/grib.py
+++ b/src/reformatters/common/grib.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+
+def grib_decimal_scale_factors(path: Path) -> list[int]:
+    """Decimal scale factor D from each GRIB2 data representation section (section 5)
+    in the file, in field order (GDAL/rasterio band order). A GRIB2 field's values are
+    (R + X * 2^E) / 10^D; each field's binary scale factor E is asserted to be 0, so
+    its values are exact multiples of 10^-D.
+    """
+    data = path.read_bytes()
+    scale_factors: list[int] = []
+    pos = 0
+    while pos < len(data):
+        assert data[pos : pos + 4] == b"GRIB", (
+            f"Expected GRIB message start at byte {pos} in {path}"
+        )
+        message_end = pos + int.from_bytes(data[pos + 8 : pos + 16])
+        pos += 16
+        while pos < message_end and data[pos : pos + 4] != b"7777":
+            section_length = int.from_bytes(data[pos : pos + 4])
+            if data[pos + 4] == 5:
+                binary_scale = _sign_and_magnitude_int(data[pos + 15 : pos + 17])
+                assert binary_scale == 0, (
+                    f"Binary scale factor {binary_scale} != 0 in {path}; "
+                    "values are not multiples of 10^-D"
+                )
+                scale_factors.append(_sign_and_magnitude_int(data[pos + 17 : pos + 19]))
+            pos += section_length
+        pos = message_end
+
+    assert scale_factors, f"No data representation sections found in {path}"
+    return scale_factors
+
+
+def _sign_and_magnitude_int(raw: bytes) -> int:
+    """GRIB2 signed integers use a sign bit plus magnitude, not two's complement."""
+    value = int.from_bytes(raw)
+    sign_bit = 1 << (len(raw) * 8 - 1)
+    return -(value & ~sign_bit) if value & sign_bit else value

--- a/src/reformatters/common/grib.py
+++ b/src/reformatters/common/grib.py
@@ -1,11 +1,13 @@
+import struct
 from pathlib import Path
 
 
 def grib_decimal_scale_factors(path: Path) -> list[int]:
     """Decimal scale factor D from each GRIB2 data representation section (section 5)
     in the file, in field order (GDAL/rasterio band order). A GRIB2 field's values are
-    (R + X * 2^E) / 10^D; each field's binary scale factor E is asserted to be 0, so
-    its values are exact multiples of 10^-D.
+    (R + X * 2^E) / 10^D; each field is asserted to have binary scale factor E == 0 and
+    an integer reference value R, which together guarantee its values are exact
+    multiples of 10^-D.
     """
     data = path.read_bytes()
     scale_factors: list[int] = []
@@ -19,6 +21,11 @@ def grib_decimal_scale_factors(path: Path) -> list[int]:
         while pos < message_end and data[pos : pos + 4] != b"7777":
             section_length = int.from_bytes(data[pos : pos + 4])
             if data[pos + 4] == 5:
+                (reference_value,) = struct.unpack(">f", data[pos + 11 : pos + 15])
+                assert reference_value == round(reference_value), (
+                    f"Non-integer reference value {reference_value} in {path}; "
+                    "values are not multiples of 10^-D"
+                )
                 binary_scale = _sign_and_magnitude_int(data[pos + 15 : pos + 17])
                 assert binary_scale == 0, (
                     f"Binary scale factor {binary_scale} != 0 in {path}; "

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -207,10 +207,11 @@ class NoaaMrmsRegionJob(
                 rasterio_band = 1
             raw = reader.read(rasterio_band)
 
-        # GDAL unpacks GRIB values in float32 arithmetic whose rounding error varies by
-        # architecture (FMA contraction on arm64 decodes packed zeros to ~4.5e-8 instead
-        # of 0). Field values are exact multiples of 10^-D, so rounding to D decimals
-        # restores them and matches gribberish's float64 decode used by virtual datasets.
+        # GDAL unpacks GRIB values internally in float32 arithmetic (regardless of the
+        # dtype read into) whose rounding error varies by architecture (amd64 vs arm64).
+        # These fields' values are exact multiples of 10^-D (enforced by
+        # grib_decimal_scale_factors), so rounding to D decimals restores them exactly.
+        # Also matches gribberish's float64 decode used by virtual datasets.
         decimal_scale = grib_decimal_scale_factors(coord.downloaded_path)[
             rasterio_band - 1
         ]

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -212,9 +212,8 @@ class NoaaMrmsRegionJob(
         # These fields' values are exact multiples of 10^-D (enforced by
         # grib_decimal_scale_factors), so rounding to D decimals restores them exactly.
         # Also matches gribberish's float64 decode used by virtual datasets.
-        decimal_scale = grib_decimal_scale_factors(coord.downloaded_path)[
-            rasterio_band - 1
-        ]
+        decimal_scales = grib_decimal_scale_factors(coord.downloaded_path)
+        decimal_scale = decimal_scales[rasterio_band - 1]
         np.round(raw, decimal_scale, out=raw)
         result: ArrayFloat32 = raw.astype(np.float32)
 

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -14,6 +14,7 @@ from zarr.abc.store import Store
 from reformatters.common.binary_rounding import round_float32_inplace
 from reformatters.common.deaccumulation import deaccumulate_to_rates_inplace
 from reformatters.common.download import http_download_to_disk
+from reformatters.common.grib import grib_decimal_scale_factors
 from reformatters.common.logging import get_logger
 from reformatters.common.materialized_region_job import MaterializedRegionJob
 from reformatters.common.pydantic import replace
@@ -204,7 +205,17 @@ class NoaaMrmsRegionJob(
                     f"Expected exactly 1 band, found {reader.count} in {coord.downloaded_path}"
                 )
                 rasterio_band = 1
-            result: ArrayFloat32 = reader.read(rasterio_band, out_dtype=np.float32)
+            raw = reader.read(rasterio_band)
+
+        # GDAL unpacks GRIB values in float32 arithmetic whose rounding error varies by
+        # architecture (FMA contraction on arm64 decodes packed zeros to ~4.5e-8 instead
+        # of 0). Field values are exact multiples of 10^-D, so rounding to D decimals
+        # restores them and matches gribberish's float64 decode used by virtual datasets.
+        decimal_scale = grib_decimal_scale_factors(coord.downloaded_path)[
+            rasterio_band - 1
+        ]
+        np.round(raw, decimal_scale, out=raw)
+        result: ArrayFloat32 = raw.astype(np.float32)
 
         nodata_sentinel = data_var.internal_attrs.nodata_sentinel
         if nodata_sentinel is not None:

--- a/tests/common/grib_test.py
+++ b/tests/common/grib_test.py
@@ -1,0 +1,67 @@
+import struct
+from pathlib import Path
+
+import pytest
+
+from reformatters.common.grib import grib_decimal_scale_factors
+
+
+def _sign_and_magnitude_bytes(value: int) -> bytes:
+    return ((0x8000 | -value) if value < 0 else value).to_bytes(2)
+
+
+def _grib2_message(fields: list[tuple[int, int]]) -> bytes:
+    """Minimal GRIB2 message with a (binary_scale, decimal_scale) section 5 per field."""
+    body = (21).to_bytes(4) + bytes([1]) + bytes(16)  # section 1
+    for binary_scale, decimal_scale in fields:
+        body += (9).to_bytes(4) + bytes([4]) + bytes(4)  # section 4
+        section5_payload = (
+            (4).to_bytes(4)  # number of data points
+            + (41).to_bytes(2)  # data representation template (PNG packing)
+            + struct.pack(">f", -30.0)  # reference value R
+            + _sign_and_magnitude_bytes(binary_scale)
+            + _sign_and_magnitude_bytes(decimal_scale)
+            + bytes([16, 0])  # bits per value, original field type
+        )
+        body += (5 + len(section5_payload)).to_bytes(4) + bytes([5]) + section5_payload
+        body += (5).to_bytes(4) + bytes([7])  # section 7
+    header = b"GRIB" + bytes(2) + bytes([0, 2]) + (16 + len(body) + 4).to_bytes(8)
+    return header + body + b"7777"
+
+
+def test_grib_decimal_scale_factors_single_field(tmp_path: Path) -> None:
+    path = tmp_path / "single.grib2"
+    path.write_bytes(_grib2_message([(0, 1)]))
+    assert grib_decimal_scale_factors(path) == [1]
+
+
+def test_grib_decimal_scale_factors_multiple_messages_and_fields(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "multi.grib2"
+    path.write_bytes(_grib2_message([(0, 2), (0, 0)]) + _grib2_message([(0, -1)]))
+    assert grib_decimal_scale_factors(path) == [2, 0, -1]
+
+
+def test_grib_decimal_scale_factors_rejects_nonzero_binary_scale(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "binary_scaled.grib2"
+    path.write_bytes(_grib2_message([(-2, 1)]))
+    with pytest.raises(AssertionError, match="Binary scale factor"):
+        grib_decimal_scale_factors(path)
+
+
+def test_grib_decimal_scale_factors_rejects_non_grib(tmp_path: Path) -> None:
+    path = tmp_path / "not_a.grib2"
+    path.write_bytes(b"NOPE" + bytes(20))
+    with pytest.raises(AssertionError, match="Expected GRIB message start"):
+        grib_decimal_scale_factors(path)
+
+
+def test_grib_decimal_scale_factors_real_negative_decimal_scale(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "neg_d.grib2"
+    path.write_bytes(_grib2_message([(0, -3)]))
+    assert grib_decimal_scale_factors(path) == [-3]

--- a/tests/common/grib_test.py
+++ b/tests/common/grib_test.py
@@ -10,7 +10,9 @@ def _sign_and_magnitude_bytes(value: int) -> bytes:
     return ((0x8000 | -value) if value < 0 else value).to_bytes(2)
 
 
-def _grib2_message(fields: list[tuple[int, int]]) -> bytes:
+def _grib2_message(
+    fields: list[tuple[int, int]], reference_value: float = -30.0
+) -> bytes:
     """Minimal GRIB2 message with a (binary_scale, decimal_scale) section 5 per field."""
     body = (21).to_bytes(4) + bytes([1]) + bytes(16)  # section 1
     for binary_scale, decimal_scale in fields:
@@ -18,7 +20,7 @@ def _grib2_message(fields: list[tuple[int, int]]) -> bytes:
         section5_payload = (
             (4).to_bytes(4)  # number of data points
             + (41).to_bytes(2)  # data representation template (PNG packing)
-            + struct.pack(">f", -30.0)  # reference value R
+            + struct.pack(">f", reference_value)
             + _sign_and_magnitude_bytes(binary_scale)
             + _sign_and_magnitude_bytes(decimal_scale)
             + bytes([16, 0])  # bits per value, original field type
@@ -49,6 +51,15 @@ def test_grib_decimal_scale_factors_rejects_nonzero_binary_scale(
     path = tmp_path / "binary_scaled.grib2"
     path.write_bytes(_grib2_message([(-2, 1)]))
     with pytest.raises(AssertionError, match="Binary scale factor"):
+        grib_decimal_scale_factors(path)
+
+
+def test_grib_decimal_scale_factors_rejects_non_integer_reference_value(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "fractional_r.grib2"
+    path.write_bytes(_grib2_message([(0, 1)], reference_value=-30.5))
+    with pytest.raises(AssertionError, match="Non-integer reference value"):
         grib_decimal_scale_factors(path)
 
 

--- a/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
@@ -279,7 +279,7 @@ def test_read_data_pre_v12_two_band_selects_discipline_209(
         reformat_job_name="test",
     )
 
-    data = np.ones((2, 2), dtype=np.float32)
+    data = np.ones((2, 2), dtype=np.float64)
 
     class FakeReader:
         count = 2
@@ -296,12 +296,15 @@ def test_read_data_pre_v12_two_band_selects_discipline_209(
                 2: {"GRIB_DISCIPLINE": "209(Local)"},
             }[band]
 
-        def read(self, band: int, out_dtype: np.dtype[np.float32]) -> np.ndarray:
-            assert out_dtype == np.float32
+        def read(self, band: int) -> np.ndarray:
             assert band == 2
             return data
 
     monkeypatch.setattr("rasterio.open", lambda *_args, **_kwargs: FakeReader())
+    monkeypatch.setattr(
+        "reformatters.noaa.mrms.conus_analysis_hourly.region_job.grib_decimal_scale_factors",
+        lambda _path: [1, 1],
+    )
 
     result = region_job.read_data(
         NoaaMrmsSourceFileCoord(
@@ -316,6 +319,60 @@ def test_read_data_pre_v12_two_band_selects_discipline_209(
     )
 
     np.testing.assert_array_equal(result, data)
+
+
+def test_read_data_quantizes_to_grib_decimal_precision(
+    monkeypatch: pytest.MonkeyPatch,
+    template_config: NoaaMrmsConusAnalysisHourlyTemplateConfig,
+) -> None:
+    region_job = NoaaMrmsRegionJob.model_construct(
+        template_ds=Mock(),
+        data_vars=[],
+        append_dim="time",
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+
+    # Values as GDAL's float32 unpacking produces them on arm64 (FMA contraction):
+    # a packed zero decodes to 4.4703484e-8 and 0.2 mm to 0.2 + ~5e-8.
+    data = np.array(
+        [[4.4703484e-08, 0.20000004768371582], [-3.0, 12.3]], dtype=np.float64
+    )
+
+    class FakeReader:
+        count = 1
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self, band: int) -> np.ndarray:
+            assert band == 1
+            return data
+
+    monkeypatch.setattr("rasterio.open", lambda *_args, **_kwargs: FakeReader())
+    monkeypatch.setattr(
+        "reformatters.noaa.mrms.conus_analysis_hourly.region_job.grib_decimal_scale_factors",
+        lambda _path: [1],
+    )
+
+    result = region_job.read_data(
+        NoaaMrmsSourceFileCoord(
+            time=pd.Timestamp("2024-01-15T12:00"),
+            product="MultiSensor_QPE_01H_Pass2",
+            level="00.00",
+            fallback_products=(),
+            data_var_name="precipitation_surface",
+            downloaded_path=Path("fake.grib2"),
+        ),
+        next(v for v in template_config.data_vars if v.name == "precipitation_surface"),
+    )
+
+    assert result.dtype == np.float32
+    expected = np.array([[0.0, 0.2], [-3.0, 12.3]], dtype=np.float32)
+    np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Fixes precision loss when reading GRIB2 data through GDAL/rasterio. GDAL unpacks GRIB values using float32 arithmetic, which introduces architecture-dependent rounding errors (e.g., on arm64, packed zeros decode to ~4.5e-8 instead of 0). Since GRIB field values are exact multiples of 10^-D (where D is the decimal scale factor), we can restore precision by rounding to D decimal places before converting to float32.

## Key Changes
- **New module** `src/reformatters/common/grib.py`: Extracts decimal scale factors from GRIB2 files by parsing section 5 (data representation) headers. Validates that binary scale factors are zero (ensuring values are exact multiples of 10^-D).
- **Updated** `src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py`: 
  - Changed `reader.read()` call to not pass `out_dtype` parameter (GDAL now returns float64)
  - Added rounding step using the extracted decimal scale factor before converting to float32
  - This ensures decoded values match the precision of gribberish's float64 decode used by virtual datasets
- **New tests** `tests/common/grib_test.py`: Comprehensive test coverage for GRIB2 parsing including single/multiple fields, negative scales, and error cases
- **Updated test** `tests/noaa/mrms/conus_analysis_hourly/region_job_test.py`:
  - Fixed dtype in existing test from float32 to float64
  - Added new test `test_read_data_quantizes_to_grib_decimal_precision` validating the rounding behavior

## Implementation Details
- GRIB2 uses sign-and-magnitude encoding for signed integers (not two's complement), handled by `_sign_and_magnitude_int()`
- The solution is architecture-agnostic: rounding to the decimal scale factor works regardless of how GDAL's float32 unpacking behaves
- Maintains backward compatibility with existing code paths

https://claude.ai/code/session_01YVoAgQxtwjvu86nMfowU9a