### PR TITLE
HRRR materialized: CF missing_value for percent_frozen_precipitation

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -21,7 +21,7 @@
       "separator": "/"
     }
   },
-  "fill_value": "NaN",
+  "fill_value": -50.0,
   "codecs": [
     {
       "name": "sharding_indexed",
@@ -68,9 +68,11 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
+    "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+    "missing_value": -50.0,
     "step_type": "instant",
     "coordinates": "latitude longitude spatial_ref",
-    "_FillValue": "AAAAAAAA+H8="
+    "_FillValue": "AAAAAAAAScA="
   },
   "dimension_names": [
     "time",

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
@@ -931,7 +931,7 @@
             "separator": "/"
           }
         },
-        "fill_value": "NaN",
+        "fill_value": -50.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -978,9 +978,11 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
+          "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+          "missing_value": -50.0,
           "step_type": "instant",
           "coordinates": "latitude longitude spatial_ref",
-          "_FillValue": "AAAAAAAA+H8="
+          "_FillValue": "AAAAAAAAScA="
         },
         "dimension_names": [
           "time",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": 0.0,
+  "fill_value": -50.0,
   "codecs": [
     {
       "name": "sharding_indexed",
@@ -71,9 +71,11 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
+    "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+    "missing_value": -50.0,
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
-    "_FillValue": "AAAAAAAA+H8="
+    "_FillValue": "AAAAAAAAScA="
   },
   "dimension_names": [
     "init_time",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
@@ -1192,7 +1192,7 @@
             "separator": "/"
           }
         },
-        "fill_value": 0.0,
+        "fill_value": -50.0,
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1240,9 +1240,11 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
+          "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+          "missing_value": -50.0,
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
-          "_FillValue": "AAAAAAAA+H8="
+          "_FillValue": "AAAAAAAAScA="
         },
         "dimension_names": [
           "init_time",

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -12,6 +12,7 @@ from reformatters.common.config_models import (
     Encoding,
     StatisticsApproximate,
 )
+from reformatters.common.pydantic import replace
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import (
     Array1D,
@@ -349,12 +350,14 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
             ),
             NoaaHrrrDataVar(
                 name="percent_frozen_precipitation_surface",
-                encoding=encoding,
+                encoding=replace(encoding, fill_value=-50.0),
                 attrs=DataVarAttrs(
                     short_name="cpofp",
                     long_name="Percent frozen precipitation",
                     units="percent",
                     step_type="instant",
+                    comment="-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+                    missing_value=-50.0,
                 ),
                 internal_attrs=NoaaHrrrInternalAttrs(
                     grib_element="CPOFP",


### PR DESCRIPTION
## What

Give `percent_frozen_precipitation_surface` CF-compliant sentinel handling in the two **materialized** HRRR datasets (`noaa-hrrr-forecast-48-hour` and `noaa-hrrr-analysis`), mirroring what the HRRR forecast **virtual** dataset already does.

```python
encoding=replace(encoding, fill_value=-50.0),
attrs=DataVarAttrs(
    ...,
    comment="-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
    missing_value=-50.0,
),
```

The change is in the shared `NoaaHrrrCommonTemplateConfig.get_data_vars`, so both materialized datasets pick it up; templates were regenerated with `update-template`.

## Why

HRRR CPOFP encodes "no / undefined frozen precipitation" as a discrete `-50`. The materialized datasets passed this through unmasked and undocumented, so the field mean reads ~-47 and CF-aware readers see the sentinel as real data.

Verified against the store (`s3://us-west-2.opendata.source.coop/dynamical/noaa-hrrr-forecast-48-hour/v0.1.0.zarr`) across full CONUS fields: `-50` is a discrete value (nothing in the open interval `(-50, 0)`) covering ~97–98% of the domain where no precipitation is falling; the remaining cells carry valid frozen-fraction values 0–100 (winter field mean ~55%). Setting `missing_value` = `fill_value` = `-50.0` lets CF-aware readers mask it to NaN, matching the virtual dataset and satisfying the `missing_value == fill_value` model validator.

This surfaced during a validation pass of `noaa-hrrr-forecast-48-hour`; it was the one intrinsic-metadata item found (per AGENTS.md, an always-true variable fact like a sentinel belongs in `comment`/`missing_value`, not a validation-report note).

## Scope / notes

- `missing_value` is metadata-only — no chunk rewrite. Applying it to the already-backfilled stores is a metadata update from an image containing this commit, not a re-backfill.
- Affects both materialized datasets that share the common data var (forecast-48-hour and analysis).

## Checks

- `ruff format`, `ruff check`, `ty check` — all pass
- `pytest tests/common/common_template_config_subclasses_test.py tests/common/datasets_cf_compliance_test.py` — 259 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gd2qpwonTbByYkCzaNAyt9)_