### PR TITLE
HRRR ops validation: exclude percent_frozen_precipitation from NaN check

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
@@ -68,5 +68,8 @@ class NoaaHrrrAnalysisDataset(
             partial(
                 validation.check_analysis_recent_nans,
                 max_expected_delay=max_expected_delay,
+                # CF-masks its -50 "no precipitation" sentinel to NaN, so the field
+                # is legitimately all/mostly NaN wherever no precipitation is falling.
+                exclude_vars=("percent_frozen_precipitation_surface",),
             ),
         )

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
@@ -73,5 +73,8 @@ class NoaaHrrrForecast48HourDataset(
             partial(
                 validation.check_forecast_recent_nans,
                 additional_skip_lead_time_0_vars=HRRR_EXPECTED_HOUR_0_NAN_VARS,
+                # CF-masks its -50 "no precipitation" sentinel to NaN, so the field
+                # is legitimately all/mostly NaN wherever no precipitation is falling.
+                exclude_vars=("percent_frozen_precipitation_surface",),
             ),
         )


### PR DESCRIPTION
## What

Add `percent_frozen_precipitation_surface` to `exclude_vars` on the operational NaN-fraction validators for both HRRR materialized datasets that carry it — `noaa-hrrr-analysis` (`check_analysis_recent_nans`) and `noaa-hrrr-forecast-48-hour` (`check_forecast_recent_nans`).

## Why

Follow-up to #759. Now that `percent_frozen_precipitation_surface` carries `missing_value=-50`, readers (including the operational validators, which CF-decode on open) mask the CPOFP `-50` "no precipitation" sentinel to NaN. Wherever no precipitation is falling — which is most of the domain most of the time — the field is legitimately all- or mostly-NaN. That trips the strict `max_nan_fraction=0.0` check:

```
Failed validation: Excessive NaN fraction (> 0.0):
- percent_frozen_precipitation_surface: 1.000000 NaN fraction
  (cron_job_name: noaa-hrrr-analysis-validate, env: prod)
```

The analysis validate cron hit `1.000000` (no precipitation anywhere in that window); the forecast-48-hour validator would fail the same way once its metadata update lands. Excluding the variable stops the check from flagging its expected, sentinel-driven NaNs while leaving the strict NaN check in force for every other variable.

## Checks

- `ruff format`, `ruff check`, `ty check` — all pass
- `pytest -k "nan or validat"` — 162 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gd2qpwonTbByYkCzaNAyt9)_