### PR TITLE
Tolerate GRIB message padding; read at float32 to restore memory profile

### DIFF
--- a/src/reformatters/common/grib.py
+++ b/src/reformatters/common/grib.py
@@ -31,10 +31,10 @@ def grib_decimal_scale_factors(path: Path) -> list[int]:
     data = path.read_bytes()
     scale_factors: list[int] = []
     pos = 0
-    while pos < len(data):
-        assert data[pos : pos + 4] == b"GRIB", (
-            f"Expected GRIB message start at byte {pos} in {path}"
-        )
+    # Some archived source files pad after a message with junk bytes (e.g. Iowa Mesonet
+    # MRMS files from 2014-2015 append zero padding), so locate each message by its
+    # magic bytes rather than assuming messages are contiguous; GDAL scans the same way.
+    while (pos := data.find(b"GRIB", pos)) != -1:
         message_end = pos + int.from_bytes(data[pos + 8 : pos + 16])
         pos += 16
         while pos < message_end and data[pos : pos + 4] != b"7777":

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -214,6 +214,10 @@ class NoaaMrmsRegionJob(
         # Also matches gribberish's float64 decode used by virtual datasets.
         decimal_scales = grib_decimal_scale_factors(coord.downloaded_path)
         decimal_scale = decimal_scales[rasterio_band - 1]
+        # Rounding in float32 is exact only while value * 10^D stays below 2^24.
+        assert decimal_scale <= 3, (
+            f"Decimal scale factor {decimal_scale} too large to round in float32"
+        )
         np.round(raw, decimal_scale, out=raw)
         result: ArrayFloat32 = raw
 

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/region_job.py
@@ -205,7 +205,7 @@ class NoaaMrmsRegionJob(
                     f"Expected exactly 1 band, found {reader.count} in {coord.downloaded_path}"
                 )
                 rasterio_band = 1
-            raw = reader.read(rasterio_band)
+            raw = reader.read(rasterio_band, out_dtype=np.float32)
 
         # GDAL unpacks GRIB values internally in float32 arithmetic (regardless of the
         # dtype read into) whose rounding error varies by architecture (amd64 vs arm64).
@@ -215,7 +215,7 @@ class NoaaMrmsRegionJob(
         decimal_scales = grib_decimal_scale_factors(coord.downloaded_path)
         decimal_scale = decimal_scales[rasterio_band - 1]
         np.round(raw, decimal_scale, out=raw)
-        result: ArrayFloat32 = raw.astype(np.float32)
+        result: ArrayFloat32 = raw
 
         nodata_sentinel = data_var.internal_attrs.nodata_sentinel
         if nodata_sentinel is not None:

--- a/tests/common/grib_test.py
+++ b/tests/common/grib_test.py
@@ -66,8 +66,24 @@ def test_grib_decimal_scale_factors_rejects_non_integer_reference_value(
 def test_grib_decimal_scale_factors_rejects_non_grib(tmp_path: Path) -> None:
     path = tmp_path / "not_a.grib2"
     path.write_bytes(b"NOPE" + bytes(20))
-    with pytest.raises(AssertionError, match="Expected GRIB message start"):
+    with pytest.raises(AssertionError, match="No data representation sections"):
         grib_decimal_scale_factors(path)
+
+
+def test_grib_decimal_scale_factors_skips_trailing_padding(tmp_path: Path) -> None:
+    path = tmp_path / "padded.grib2"
+    path.write_bytes(_grib2_message([(0, 1)]) + bytes(500))
+    assert grib_decimal_scale_factors(path) == [1]
+
+
+def test_grib_decimal_scale_factors_skips_padding_between_messages(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "interleaved.grib2"
+    path.write_bytes(
+        _grib2_message([(0, 1)]) + bytes(500) + _grib2_message([(0, 2)]) + bytes(100)
+    )
+    assert grib_decimal_scale_factors(path) == [1, 2]
 
 
 def test_grib_decimal_scale_factors_real_negative_decimal_scale(

--- a/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/region_job_test.py
@@ -279,7 +279,7 @@ def test_read_data_pre_v12_two_band_selects_discipline_209(
         reformat_job_name="test",
     )
 
-    data = np.ones((2, 2), dtype=np.float64)
+    data = np.ones((2, 2), dtype=np.float32)
 
     class FakeReader:
         count = 2
@@ -296,7 +296,8 @@ def test_read_data_pre_v12_two_band_selects_discipline_209(
                 2: {"GRIB_DISCIPLINE": "209(Local)"},
             }[band]
 
-        def read(self, band: int) -> np.ndarray:
+        def read(self, band: int, out_dtype: np.dtype[np.float32]) -> np.ndarray:
+            assert out_dtype == np.float32
             assert band == 2
             return data
 
@@ -336,7 +337,7 @@ def test_read_data_quantizes_to_grib_decimal_precision(
     # Values as GDAL's float32 unpacking produces them on arm64 (FMA contraction):
     # a packed zero decodes to 4.4703484e-8 and 0.2 mm to 0.2 + ~5e-8.
     data = np.array(
-        [[4.4703484e-08, 0.20000004768371582], [-3.0, 12.3]], dtype=np.float64
+        [[4.4703484e-08, 0.20000004768371582], [-3.0, 12.3]], dtype=np.float32
     )
 
     class FakeReader:
@@ -348,7 +349,8 @@ def test_read_data_quantizes_to_grib_decimal_precision(
         def __exit__(self, *args: object) -> None:
             return None
 
-        def read(self, band: int) -> np.ndarray:
+        def read(self, band: int, out_dtype: np.dtype[np.float32]) -> np.ndarray:
+            assert out_dtype == np.float32
             assert band == 1
             return data
 


### PR DESCRIPTION
## Summary
The first MRMS overwrite backfill running the decimal quantization fix (#758) surfaced two issues that are failing worker pods; both are fixed here.

**1. Iowa Mesonet 2014–2015 files pad after the GRIB message.** e.g. `RadarOnly_QPE_01H_00.00_20141113-120000.grib2` is 1,505,406 bytes but its message declares 752,632 — followed by ~752KB of zero padding (no GRIB magic anywhere in it). `grib_decimal_scale_factors` asserted messages are contiguous, so every read of these files raised and nulled that hour (`ReadFailed` → NaN), while GDAL scans past the padding and decodes fine. Files from 2015-02-15 onward are clean — the blast radius was the Nov 2014 – early Feb 2015 era. The parser now locates each message by its magic bytes, matching GDAL, and still fails loudly on files with no parseable section 5.

**2. Reading at GDAL's native float64 memory-killed workers.** Backfill pods died with exit 137 during the read phase: `read_parallelism` scales with node CPUs, and the float64 read + astype roughly tripled per-read transient memory vs the pre-#758 profile. Reading at `out_dtype=float32` and rounding in place restores the original memory profile and is **bit-identical** to the float64 path and to gribberish's float64 decode — the float32 cast error is orders of magnitude below half a decimal quantum (0.05 mm / 0.005 %), and values × 10^D stay well under 2^24. Verified empirically on 2014/2015/2016/2020 source files (including the padded one): all bit-equal to gribberish, zeros exact.

## Test plan
- New tests: trailing padding, padding between messages, non-GRIB rejection message
- Updated mocked readers to the float32 read signature
- Local verification against real era-spanning MRMS files (parser + bit-parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)