### PR TITLE
docs: point add-new-variable step 4 at the STAC catalog

### DIFF
--- a/docs/add_new_variable.md
+++ b/docs/add_new_variable.md
@@ -44,6 +44,13 @@ An operational update that publishes while the backfill runs makes the backfill'
 
 Follow [docs/validation.md](validation.md) — it walks through running `run-all`, reading `validation_summary.md`, inspecting every plot, and the full data quality checklist. When validating a new variable it is often useful to restrict with `--variable <name>` to iterate faster.
 
-## 4. Update dataset catalog documentation
+## 4. Refresh the STAC catalog
 
-Update the dataset catalog docs on `dynamical.org` by rebuilding (`npm run build`) and merging updates to main in `https://github.com/dynamical-org/dynamical.org`.
+The dataset catalog on dynamical.org is built from the STAC catalog at `https://stac.dynamical.org/catalog.json`, maintained in [`dynamical-org/dynamical-stac`](https://github.com/dynamical-org/dynamical-stac). That STAC is the source of truth — you don't edit the website; you update the STAC and the site reflects the change on its next deploy.
+
+The STAC generator derives each collection's variables by opening the dataset's Icechunk store, so once the backfill (step 2) has written the new variable no `src/catalog.py` edit is needed (that's only for adding a whole new dataset). Just regenerate the committed output in `dynamical-stac` and merge:
+
+```bash
+./scripts/generate   # opens each store on S3; picks up the new variable
+git add stac/        # commit the regenerated collection.json
+```


### PR DESCRIPTION
## What & why

Rewrites step 4 of `docs/add_new_variable.md`. The old text described updating the dataset catalog by editing the **website** (`dynamical.org`, `npm run build`). That's wrong: the catalog on dynamical.org is **built from the STAC catalog** (`https://stac.dynamical.org/catalog.json`, repo `dynamical-org/dynamical-stac`), which is the source of truth. You don't edit the website — you update the STAC and the site reflects it on its next deploy.

Since the STAC generator (`./scripts/generate`) derives each collection's variables by opening the dataset's Icechunk store, a **new variable** needs no `src/catalog.py` edit — just a regenerate-and-commit after the backfill (step 2) has written it.

Verified against the actual `dynamical-stac` flow while completing the GFS 80m integration (#748 / #751): regenerating picked up the four new 80m variables into the GFS collections automatically ([dynamical-stac#53](https://github.com/dynamical-org/dynamical-stac/pull/53)).

## Related

Follow-up to #748 / #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxv5Wc8bwWAaGCtm9KdGBC