### PR TITLE
Fix availability fraction bool arithmetic on analysis datasets

### DIFF
--- a/src/scripts/validation/availability.py
+++ b/src/scripts/validation/availability.py
@@ -236,7 +236,11 @@ def _compute_nulls_for_point(
         check_mask = null_mask.isel(lead_time=slice(1, None))
 
     time_dim = next(d for d in ("time", "init_time") if d in da_point.dims)
-    null_frac = check_mask.mean(dim=[d for d in non_time_dims if d in check_mask.dims])
+    # On an analysis dataset the point series has no non-time dims, and mean over an
+    # empty dim list keeps the mask's bool dtype; cast so callers can do arithmetic.
+    null_frac = check_mask.mean(
+        dim=[d for d in non_time_dims if d in check_mask.dims]
+    ).astype(np.float64)
 
     if check_mask.any():
         unavailable = null_frac[time_dim].where(null_frac > 0, drop=True)

--- a/tests/scripts/validation/availability_test.py
+++ b/tests/scripts/validation/availability_test.py
@@ -99,6 +99,32 @@ def test_run_value_availability_flags_missing_position(tmp_path: Path) -> None:
     assert "temperature_2m" in ctx.loaded_point_data
 
 
+def test_run_value_availability_analysis_dataset_fraction_is_float(
+    tmp_path: Path,
+) -> None:
+    """An analysis point series has no non-time dims, so the null-fraction mean is an
+    identity op that keeps bool dtype; bool arithmetic then reports fully-missing
+    positions as fraction 0.5 instead of 0.0."""
+    time = pd.date_range("2020-01-01", periods=6, freq="h")
+    lat = np.array([10.0, 20.0])
+    lon = np.array([30.0, 40.0])
+    values = np.ones((time.size, lat.size, lon.size))
+    values[2, :, :] = np.nan  # missing at both points
+    values[4, 0, 0] = np.nan  # missing at point 1 only
+    ds = xr.Dataset(
+        {"temperature_2m": (("time", "latitude", "longitude"), values)},
+        coords={"time": time, "latitude": lat, "longitude": lon},
+    )
+    ds["temperature_2m"].attrs["step_type"] = "instant"
+    ctx = _ctx(ds, tmp_path)
+    ctx.variables = ["temperature_2m"]
+
+    run_value_availability(ctx)
+
+    series = ctx.availability["temperature_2m"]
+    np.testing.assert_allclose(series.fraction, [1, 1, 0, 1, 0.5, 1])
+
+
 def test_run_value_availability_exempts_accum_hour_zero(tmp_path: Path) -> None:
     ctx = _ctx(_forecast_dataset(), tmp_path)
     run_value_availability(ctx)


### PR DESCRIPTION
## Summary
The availability heatmap rendered fully-missing eras brown (the colormap midpoint) instead of light red. Root cause: on an **analysis** dataset the per-point series has no non-time dims, so `check_mask.mean(dim=[])` in `_compute_nulls_for_point` is an identity op that keeps the mask's **bool** dtype; `null_p1.values + null_p2.values` is then logical-or, and `1 - True/2 = 0.5` for both fully-missing and half-missing positions. Forecast datasets average over `lead_time` and get floats, which is why existing tests passed.

Fix: cast the null fraction to float64 at its source. Adds an analysis-shaped regression test asserting fully-missing → 0.0 and one-point-missing → 0.5.

(The published MRMS report's heatmap was recolored by hand as a one-off; the next validation run will render correctly from this fix.)

## Test plan
- New `test_run_value_availability_analysis_dataset_fraction_is_float`
- Existing availability tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)