### PR TITLE
GEFS: skip 80m vars in reforecast era (fix #749 backfill KeyError)

### DIFF
--- a/src/reformatters/noaa/gefs/analysis/region_job.py
+++ b/src/reformatters/noaa/gefs/analysis/region_job.py
@@ -95,8 +95,6 @@ class GefsAnalysisRegionJob(
 
         times = filter_available_times(times)
 
-        # Variables added after the reforecast (e.g. 80m fields) have no source data
-        # in the reforecast era; skip those times so they remain fill value.
         available_from = item(
             {var.internal_attrs.available_from for var in data_var_group}
         )

--- a/src/reformatters/noaa/gefs/analysis/region_job.py
+++ b/src/reformatters/noaa/gefs/analysis/region_job.py
@@ -95,6 +95,14 @@ class GefsAnalysisRegionJob(
 
         times = filter_available_times(times)
 
+        # Variables added after the reforecast (e.g. 80m fields) have no source data
+        # in the reforecast era; skip those times so they remain fill value.
+        available_from = item(
+            {var.internal_attrs.available_from for var in data_var_group}
+        )
+        if available_from is not None:
+            times = times[times >= available_from]
+
         var_has_hour_0_values = item({has_hour_0_values(var) for var in data_var_group})
 
         # If var doesn't have hour 0 values we have to go back one forecast

--- a/src/reformatters/noaa/gefs/common_gefs_template_config.py
+++ b/src/reformatters/noaa/gefs/common_gefs_template_config.py
@@ -15,7 +15,11 @@ from reformatters.common.zarr import (
     BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE,
     BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE,
 )
-from reformatters.noaa.gefs.gefs_config_models import GEFSDataVar, GEFSInternalAttrs
+from reformatters.noaa.gefs.gefs_config_models import (
+    GEFS_REFORECAST_END,
+    GEFSDataVar,
+    GEFSInternalAttrs,
+)
 
 
 def get_shared_template_dimension_coordinates() -> dict[str, Any]:
@@ -309,6 +313,7 @@ def get_shared_data_var_configs(
                 grib_index_level="80 m above ground",
                 gefs_file_type="b",
                 index_position=351,
+                available_from=GEFS_REFORECAST_END,
                 keep_mantissa_bits=keep_mantissa_bits_default,
             ),
         ),
@@ -328,6 +333,7 @@ def get_shared_data_var_configs(
                 grib_index_level="80 m above ground",
                 gefs_file_type="b",
                 index_position=353,
+                available_from=GEFS_REFORECAST_END,
                 keep_mantissa_bits=10,
             ),
         ),
@@ -347,6 +353,7 @@ def get_shared_data_var_configs(
                 grib_index_level="80 m above ground",
                 gefs_file_type="b",
                 index_position=354,
+                available_from=GEFS_REFORECAST_END,
                 keep_mantissa_bits=6,
             ),
         ),
@@ -366,6 +373,7 @@ def get_shared_data_var_configs(
                 grib_description='80[m] HTGL="Specified height level above ground"',
                 gefs_file_type="b",
                 index_position=355,
+                available_from=GEFS_REFORECAST_END,
                 keep_mantissa_bits=6,
             ),
         ),

--- a/src/reformatters/noaa/gefs/gefs_config_models.py
+++ b/src/reformatters/noaa/gefs/gefs_config_models.py
@@ -22,8 +22,6 @@ GEFS_B22_TRANSITION_DATE = pd.Timestamp("2022-10-18T12:00")
 
 class GEFSInternalAttrs(NoaaInternalAttrs):
     gefs_file_type: GEFSFileType
-    # Earliest valid time the variable exists in the source archive; times before it
-    # are skipped and left as fill value (e.g. 80m fields absent from the reforecast).
     available_from: Timestamp | None = None
 
 

--- a/src/reformatters/noaa/gefs/gefs_config_models.py
+++ b/src/reformatters/noaa/gefs/gefs_config_models.py
@@ -22,6 +22,9 @@ GEFS_B22_TRANSITION_DATE = pd.Timestamp("2022-10-18T12:00")
 
 class GEFSInternalAttrs(NoaaInternalAttrs):
     gefs_file_type: GEFSFileType
+    # Earliest valid time the variable exists in the source archive; times before it
+    # are skipped and left as fill value (e.g. 80m fields absent from the reforecast).
+    available_from: Timestamp | None = None
 
 
 class GEFSDataVar(DataVar[GEFSInternalAttrs]):

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -26,6 +26,7 @@ from reformatters.noaa.gefs.analysis.region_job import (
 )
 from reformatters.noaa.gefs.analysis.template_config import GefsAnalysisTemplateConfig
 from reformatters.noaa.gefs.gefs_config_models import (
+    GEFS_REFORECAST_END,
     GEFSDataVar,
     GEFSInternalAttrs,
 )
@@ -284,6 +285,39 @@ def test_generate_source_file_coords_ensemble(
     for coord in coords:
         assert isinstance(coord, GefsAnalysisSourceFileCoord)
         assert coord.ensemble_member == 0  # Control member for analysis
+
+
+def test_generate_source_file_coords_skips_times_before_available_from(
+    template_ds: xr.Dataset,
+) -> None:
+    """A variable with available_from gets no source coords for earlier times.
+
+    The 80m fields are absent from the GEFS v12 reforecast, so reforecast-era times
+    must be skipped and left as fill value rather than building a nonexistent source URL.
+    """
+    template_config = GefsAnalysisTemplateConfig()
+    wind_u_80m = next(v for v in template_config.data_vars if v.name == "wind_u_80m")
+    assert wind_u_80m.internal_attrs.available_from == GEFS_REFORECAST_END
+
+    job = GefsAnalysisRegionJob(
+        tmp_store=get_local_tmp_store(),
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
+        data_vars=[wind_u_80m],
+        append_dim="time",
+        region=slice(0, template_ds.sizes["time"]),
+        reformat_job_name="test-job",
+    )
+
+    # The fixture's times are all in the reforecast era (2000); none are fetchable.
+    assert job.generate_source_file_coords(template_ds, [wind_u_80m]) == []
+
+    # From the reforecast end onward the 80m fields exist, so coords are generated.
+    post_reforecast_ds = template_ds.assign_coords(
+        time=pd.date_range(
+            GEFS_REFORECAST_END, freq="3h", periods=template_ds.sizes["time"]
+        )
+    )
+    assert len(job.generate_source_file_coords(post_reforecast_ds, [wind_u_80m])) > 0
 
 
 def test_source_file_coord_url_generation(example_data_vars: list[GEFSDataVar]) -> None:

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -290,7 +290,7 @@ def test_generate_source_file_coords_ensemble(
 def test_generate_source_file_coords_skips_times_before_available_from(
     template_ds: xr.Dataset,
 ) -> None:
-    """A variable with available_from gets no source coords for earlier times.
+    """A job straddling the reforecast end yields coords only from available_from onward.
 
     The 80m fields are absent from the GEFS v12 reforecast, so reforecast-era times
     must be skipped and left as fill value rather than building a nonexistent source URL.
@@ -299,25 +299,26 @@ def test_generate_source_file_coords_skips_times_before_available_from(
     wind_u_80m = next(v for v in template_config.data_vars if v.name == "wind_u_80m")
     assert wind_u_80m.internal_attrs.available_from == GEFS_REFORECAST_END
 
+    # 24 six-hourly times straddling the reforecast end: the first 12 are reforecast-era
+    # (before available_from) and skipped, the last 12 are at/after it and generate coords.
+    straddle_ds = template_ds.assign_coords(
+        time=pd.date_range("2019-12-29T00:00", freq="6h", periods=24)
+    )
+    assert (straddle_ds["time"].values < GEFS_REFORECAST_END).sum() == 12
+
     job = GefsAnalysisRegionJob(
         tmp_store=get_local_tmp_store(),
-        template_ds=xr.DataTree.from_dict({"/": template_ds}),
+        template_ds=xr.DataTree.from_dict({"/": straddle_ds}),
         data_vars=[wind_u_80m],
         append_dim="time",
-        region=slice(0, template_ds.sizes["time"]),
+        region=slice(0, straddle_ds.sizes["time"]),
         reformat_job_name="test-job",
     )
 
-    # The fixture's times are all in the reforecast era (2000); none are fetchable.
-    assert job.generate_source_file_coords(template_ds, [wind_u_80m]) == []
+    coords = job.generate_source_file_coords(straddle_ds, [wind_u_80m])
 
-    # From the reforecast end onward the 80m fields exist, so coords are generated.
-    post_reforecast_ds = template_ds.assign_coords(
-        time=pd.date_range(
-            GEFS_REFORECAST_END, freq="3h", periods=template_ds.sizes["time"]
-        )
-    )
-    assert len(job.generate_source_file_coords(post_reforecast_ds, [wind_u_80m])) > 0
+    assert len(coords) == 12
+    assert all(coord.init_time >= GEFS_REFORECAST_END for coord in coords)
 
 
 def test_source_file_coord_url_generation(example_data_vars: list[GEFSDataVar]) -> None:


### PR DESCRIPTION
## What

Follow-up fix to #749 (which added `wind_u_80m`, `wind_v_80m`, `temperature_80m`, `pressure_80m` to the shared NOAA GEFS config).

The four 80m fields **do not exist in the GEFS v12 reforecast archive** (init times `2000-01-01` → `2020-01-01`). `noaa-gefs-analysis` spans that era, so its backfill built a reforecast source URL for these vars and hit `KeyError: '80 m above ground'` in `gefs_config_models.get_url` (the reforecast branch looks the level up in `GEFS_REFORECAST_LEVELS_SHORT`, which has no 80m entry). The existing `wind_u_100m` survives only because `"100 m above ground"` is in that dict and the reforecast `ugrd_hgt` file carries 100m.

## Source verification (real files)

- Reforecast `ugrd_hgt` `.idx` (`s3://noaa-gefs-retrospective/.../2019010100/c00/Days:1-10/`) contains **only** `10 m` and `100 m above ground` — no 80m. There are no height-above-ground temperature/pressure files at all (`tmp_*` = 2m/sfc/hybr/pres; `pres_*` = sfc/msl/hybr). Same file set at the 2000 start of the archive.
- Pre-v12 b-file (`s3://noaa-gefs-pds/gefs.20200101/00/pgrb2b/...f06.idx`) **does** contain `TMP/PRES/UGRD/VGRD` at `80 m above ground`, from the very start of the pre-v12 window (`2020-01-01`).

So 80m is available from `GEFS_REFORECAST_END` (2020-01-01) onward, and absent only in the reforecast era.

## Change

- Add `available_from: Timestamp | None = None` to `GEFSInternalAttrs` (mirrors the existing MRMS `available_from` mechanism).
- Set `available_from=GEFS_REFORECAST_END` on the four 80m vars.
- `GefsAnalysisRegionJob.generate_source_file_coords` skips times before `available_from`, so reforecast-era chunks stay at fill value (`NaN`) instead of constructing a nonexistent source URL.

`available_from` is an internal attr, so **the checked-in templates are unchanged** (verified: `update-template` for all three GEFS datasets produces zero diff). `noaa-gefs-forecast-35-day` starts `2020-10-01`, entirely after `available_from`, so it is unaffected.

## Testing

- New fast unit test `test_generate_source_file_coords_skips_times_before_available_from`: reforecast-era times yield no coords for `wind_u_80m`; times from `GEFS_REFORECAST_END` onward do.
- `tests/noaa/gefs/`, `common_template_config_subclasses_test.py`, `datasets_cf_compliance_test.py` pass (the 2 pre-existing `nasa-smap` round-trip failures are unrelated and also fail on `main`). `ruff` / `ty` clean.

## Follow-up

After merge: re-run the `noaa-gefs-analysis` 80m backfill (full history; reforecast era now NaN, `2020-01-01`+ populated). The `noaa-gefs-forecast-35-day` 80m backfill is unaffected by this change and is being run separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
