### PR TITLE
validation: categorical red/yellow/green availability colormap

### DIFF
--- a/src/scripts/validation/availability.py
+++ b/src/scripts/validation/availability.py
@@ -57,11 +57,12 @@ MAX_HEATMAP_COLUMNS = 1200
 _HEATMAP_DPI = 110
 _HEATMAP_WIDTH_INCHES = (14 * 80 / _HEATMAP_DPI) * 2 / 3
 
-# Availability heatmap colors: light red (missing, 0.0) -> dark green (present, 1.0). The
-# ramp is monotonically light->dark so colorblind readers can read it by lightness rather
-# than red/green hue. Green endpoint is kept from RdYlGn; the red end is lightened.
+# Availability heatmap colors, categorical by fraction available: red (none, 0.0) ->
+# yellow (partial, 0.5) -> green (full, 1.0). The yellow midpoint makes partial
+# availability read distinctly instead of as a muddy red/green blend. Green endpoint
+# kept from RdYlGn; red end lightened.
 _AVAILABILITY_CMAP = LinearSegmentedColormap.from_list(
-    "availability", ["#fa4848", plt.get_cmap("RdYlGn")(1.0)]
+    "availability", ["#fa4848", "#ffd633", plt.get_cmap("RdYlGn")(1.0)]
 )
 
 


### PR DESCRIPTION
## What

The availability heatmap used a continuous red→green colormap, so a **partially**-available cell (e.g. ~55%) rendered as a muddy **brown** that reads as "mostly unavailable." Insert a **yellow midpoint** so the scale reads categorically: **red = none, yellow = partial, green = full**. Red and green endpoints unchanged.

```
["#fa4848", plt.get_cmap("RdYlGn")(1.0)]  ->  ["#fa4848", "#ffd633", plt.get_cmap("RdYlGn")(1.0)]
```

## Why

Surfaced while reviewing GEFS availability plots — a real ~55%-available region (the pre-2022-10-18 s+b-b22 coverage of two variables) looked brown and was easy to misread as absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)