### PR TITLE
Better Stack error tracking via Sentry-compatible DSN (Sentry migration, 2/3)

### DIFF
--- a/src/reformatters/common/config.py
+++ b/src/reformatters/common/config.py
@@ -10,10 +10,16 @@ class Env(StrEnum):
     test = "test"
 
 
+def _errors_dsn() -> str | None:
+    # Prefer the Better Stack Errors DSN (Sentry-protocol compatible); fall back to
+    # the Sentry DSN so unsetting BETTERSTACK_ERRORS_DSN reverts error tracking to Sentry.
+    return os.getenv("BETTERSTACK_ERRORS_DSN") or os.getenv("DYNAMICAL_SENTRY_DSN")
+
+
 class DynamicalConfig(pydantic.BaseModel):
     env: Env = Env(os.getenv("DYNAMICAL_ENV", "dev"))
 
-    sentry_dsn: str | None = os.getenv("DYNAMICAL_SENTRY_DSN")
+    sentry_dsn: str | None = _errors_dsn()
 
     @property
     def is_test(self) -> bool:

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -123,6 +123,15 @@ class Job(pydantic.BaseModel):
                                         },
                                     },
                                     {
+                                        "name": "BETTERSTACK_ERRORS_DSN",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "BETTERSTACK_ERRORS_DSN",
+                                                "name": "betterstack",
+                                            }
+                                        },
+                                    },
+                                    {
                                         "name": "JOB_NAME",
                                         "valueFrom": {
                                             "fieldRef": {

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -1,4 +1,6 @@
-from reformatters.common.config import DynamicalConfig, Env
+import pytest
+
+from reformatters.common.config import DynamicalConfig, Env, _errors_dsn
 
 
 class TestEnv:
@@ -39,3 +41,22 @@ class TestDynamicalConfig:
     def test_sentry_disabled_when_dsn_none(self) -> None:
         config = DynamicalConfig(env=Env.dev, sentry_dsn=None)
         assert config.is_sentry_enabled is False
+
+
+class TestErrorsDsn:
+    def test_prefers_betterstack_over_sentry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BETTERSTACK_ERRORS_DSN", "https://betterstack/dsn")
+        monkeypatch.setenv("DYNAMICAL_SENTRY_DSN", "https://sentry/dsn")
+        assert _errors_dsn() == "https://betterstack/dsn"
+
+    def test_falls_back_to_sentry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BETTERSTACK_ERRORS_DSN", raising=False)
+        monkeypatch.setenv("DYNAMICAL_SENTRY_DSN", "https://sentry/dsn")
+        assert _errors_dsn() == "https://sentry/dsn"
+
+    def test_none_when_neither_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BETTERSTACK_ERRORS_DSN", raising=False)
+        monkeypatch.delenv("DYNAMICAL_SENTRY_DSN", raising=False)
+        assert _errors_dsn() is None

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -103,6 +103,15 @@ def test_as_kubernetes_object_comprehensive() -> None:
                                 },
                             },
                             {
+                                "name": "BETTERSTACK_ERRORS_DSN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "BETTERSTACK_ERRORS_DSN",
+                                        "name": "betterstack",
+                                    }
+                                },
+                            },
+                            {
                                 "name": "JOB_NAME",
                                 "valueFrom": {
                                     "fieldRef": {


### PR DESCRIPTION
Second of three sequenced PRs migrating observability from Sentry to Better Stack. **Stacked on #785** (base retargets to `main` once #785 merges).

## What

Point the Sentry SDK at a Better Stack **Errors** application. Better Stack's error tracking is Sentry-protocol compatible, so this is a DSN swap — no SDK/instrumentation changes.

- **`config.py`** — `_errors_dsn()` resolves `BETTERSTACK_ERRORS_DSN` first, else `DYNAMICAL_SENTRY_DSN`. `is_sentry_enabled` semantics unchanged.
- **`kubernetes.py`** — inject `BETTERSTACK_ERRORS_DSN` from the `betterstack` secret; `DYNAMICAL_SENTRY_DSN` (from the `sentry` secret) stays wired as the fallback.

## Validation

Verified end-to-end against the live `reformatters` errors application: a test `ValueError` grouped into Errors, tagged `dev`, with the Sentry fallback DSN correctly ignored when `BETTERSTACK_ERRORS_DSN` is set. `ruff` / `ty` clean; config + kubernetes tests green.

## Secret step

Add the DSN to the existing `betterstack` secret:

    kubectl patch secret betterstack -p '{"stringData":{"BETTERSTACK_ERRORS_DSN":"<dsn>"}}'

## Revert runbook

Remove the `BETTERSTACK_ERRORS_DSN` key from the `betterstack` secret → the SDK falls back to the real Sentry DSN on the next cron cycle. No code change, no redeploy.