### PR TITLE
Better Stack heartbeats mirroring cron monitoring (Sentry migration, 3/3)

### DIFF
--- a/.github/workflows/deploy-operational-updates.yml
+++ b/.github/workflows/deploy-operational-updates.yml
@@ -80,4 +80,6 @@ jobs:
           file: deploy/Dockerfile
 
       - name: Deploy
+        env:
+          BETTERSTACK_API_KEY_RW: ${{ secrets.BETTERSTACK_API_KEY_RW }}
         run: uv run main deploy --docker-image ${{ env.IMAGE_TAG }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -132,6 +132,8 @@ jobs:
           file: deploy/Dockerfile
 
       - name: Deploy staging
+        env:
+          BETTERSTACK_API_KEY_RW: ${{ secrets.BETTERSTACK_API_KEY_RW }}
         run: >
           uv run main deploy-staging
           ${{ steps.parse.outputs.dataset_id }}

--- a/docs/ops_card.md
+++ b/docs/ops_card.md
@@ -10,6 +10,13 @@ _Requires sentry organization invitation._
 - [Issues](https://dynamical.sentry.io/issues/?statsPeriod=12h)
 - [Logs](https://dynamical.sentry.io/explore/logs/) - You can filter these by job name
 
+## Better Stack monitoring
+_Requires Better Stack (dynamical.org team) invitation._
+- **Logs** — the `reformatters` source (Live tail). Filter by the `cron_job_name` / `job_name` / `pod_name` / `env` fields.
+- **Errors** — the `reformatters` errors application (grouped exceptions).
+- **Heartbeats** — one `reformatters <dataset> <update|validate> <start|complete>` uptime monitor per cron. A missing start ping means a run didn't fire; a missing complete ping (or a `/fail`) means a run didn't finish. Period is derived from the cron schedule and grace from its `pod_active_deadline`, so heartbeats mirror the cron config automatically.
+  - Heartbeats are provisioned at deploy time; the deploy requires the `BETTERSTACK_API_KEY_RW` secret. Redeploy to reconcile them after changing a cron's schedule or deadline.
+
 ## Kubernetes cluster operations
 Accessible via manually triggered github actions. Follow link and click "run workflow". _Requires repo write permisisons._
 - [Get jobs](https://github.com/dynamical-org/reformatters/actions/workflows/manual-get-jobs.yml) - What's running now/recently and its status

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -89,6 +89,9 @@ uv run main cleanup-staging noaa-gfs-forecast 0.3.0 --force
 This deletes:
 - Kubernetes cronjobs (`stage-noaa-gfs-forecast-v0-3-0-update`, `stage-noaa-gfs-forecast-v0-3-0-validate`)
 - The remote git branch (`stage/noaa-gfs-forecast/v0.3.0`)
+- The staged version's Better Stack heartbeats
+
+Deleting heartbeats requires `BETTERSTACK_API_KEY_RW` in your environment (a read/write Better Stack Uptime API token); it is also required by `deploy-staging`. Cronjobs and the branch are deleted first, so a missing key can't leave them orphaned.
 
 The dataset store and Sentry cron monitors are **not** deleted. Clean them up manually when ready.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "httpx>=0.28.1",
     "gribberish==1.5.0",
     "logtail-python>=0.3.4",
+    "croniter>=6.2.4",
 ]
 
 [build-system]

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -13,10 +13,10 @@ import sentry_sdk
 import typer
 from sentry_sdk.integrations.typer import TyperIntegration
 
+from reformatters.common import betterstack, monitoring
 from reformatters.common import deploy as deploy_module
-from reformatters.common.betterstack import attach_logtail
 from reformatters.common.config import Config
-from reformatters.common.dynamical_dataset import DynamicalDataset
+from reformatters.common.dynamical_dataset import DynamicalDataset, register_run_monitor
 from reformatters.common.initialize_new_integration import initialize_new_integration
 from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.contrib.nasa.smap.level3_36km_v9 import NasaSmapLevel336KmV9Dataset
@@ -231,7 +231,12 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
     ),
 ]
 
-attach_logtail()
+betterstack.attach_logtail()
+
+# Register the monitors that wrap each operational cron run. Sentry first so its
+# check-in nests outside the Better Stack heartbeat, matching prior ordering.
+register_run_monitor(monitoring.monitor_cron)
+register_run_monitor(betterstack.monitor_cron_run)
 
 if Config.is_sentry_enabled:
     sentry_sdk.init(

--- a/src/reformatters/common/betterstack.py
+++ b/src/reformatters/common/betterstack.py
@@ -1,7 +1,26 @@
+import base64
+import itertools
+import json
 import logging
 import os
+import subprocess
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal, NamedTuple, cast
 
+import httpx
+from croniter import croniter
 from logtail import LogtailHandler
+
+from reformatters.common.kubernetes import (
+    BETTERSTACK_HEARTBEATS_SECRET_NAME,
+    CronJob,
+    load_secret,
+)
+from reformatters.common.logging import get_logger
+
+log = get_logger(__name__)
 
 # Every reformatters logger is a child of this one (get_logger returns a child of
 # the root named "reformatters.<module>"), so attaching here streams our records
@@ -51,3 +70,338 @@ def attach_logtail() -> None:
     handler.setLevel(logging.INFO)
     handler.addFilter(_ContextFilter())
     logger.addHandler(handler)
+
+
+# --- Heartbeats -------------------------------------------------------------
+# Each update/validate cron gets two heartbeats: a "start" ping when a run begins
+# and a "complete" ping when it finishes. The runtime ping is here; deploy-time
+# provisioning (period/grace derived from the cron schedule + deadline) is below.
+
+Step = Literal["update", "validate"]
+Role = Literal["start", "complete"]
+
+HEARTBEAT_STEPS: tuple[Step, ...] = ("update", "validate")
+HEARTBEAT_ROLES: tuple[Role, ...] = ("start", "complete")
+
+
+def cron_name_prefix(cron_name: str, step: Step) -> str:
+    """The cron name without its `-{step}` suffix; equals dataset_id for prod crons
+    and the staging-prefixed name for staging crons, so each gets its own heartbeats."""
+    return cron_name.removesuffix(f"-{step}")
+
+
+def heartbeat_key(name_prefix: str, step: Step, role: Role) -> str:
+    return f"{name_prefix}_{step}_{role}"
+
+
+def heartbeat_name(name_prefix: str, step: Step, role: Role) -> str:
+    return f"reformatters {name_prefix} {step} {role}"
+
+
+def ping(url: str, *, failed: bool = False) -> None:
+    response = httpx.post(f"{url}/fail" if failed else url, timeout=10)
+    response.raise_for_status()
+
+
+def load_heartbeat_urls() -> dict[str, str]:
+    """{name_prefix}_{step}_{role} -> heartbeat url. Empty outside prod."""
+    return {
+        key: str(url)
+        for key, url in load_secret(BETTERSTACK_HEARTBEATS_SECRET_NAME).items()
+    }
+
+
+def _safe_ping(url: str, *, failed: bool = False) -> None:
+    # Monitoring must never break a run; a dropped ping only risks a false alert.
+    try:
+        ping(url, failed=failed)
+    except httpx.HTTPError:
+        log.warning("Better Stack heartbeat ping failed", exc_info=True)
+
+
+@contextmanager
+def monitor_heartbeat(
+    cron_name: str,
+    step: Step,
+    *,
+    send_start: bool = True,
+    send_result: bool = True,
+) -> Iterator[None]:
+    """Ping this cron's Better Stack heartbeats around the wrapped run: a start ping
+    when it begins and a complete ping when it finishes (`/fail` on error). A no-op
+    for heartbeats missing from the url map (non-prod, or a not-yet-provisioned cron)."""
+    urls = load_heartbeat_urls()
+    prefix = cron_name_prefix(cron_name, step)
+    start_url = urls.get(heartbeat_key(prefix, step, "start"))
+    complete_url = urls.get(heartbeat_key(prefix, step, "complete"))
+
+    if send_start and start_url is not None:
+        _safe_ping(start_url)
+    try:
+        yield
+    except Exception:
+        if send_result and complete_url is not None:
+            _safe_ping(complete_url, failed=True)
+        raise
+    else:
+        if send_result and complete_url is not None:
+            _safe_ping(complete_url)
+
+
+@contextmanager
+def monitor_cron_run(
+    cron_job: CronJob,
+    reformat_job_name: str,  # noqa: ARG001  # RunMonitor interface; heartbeats key off the cron, not the job
+    *,
+    send_in_progress: bool = True,
+    send_result: bool = True,
+) -> Iterator[None]:
+    """A `DynamicalDataset` RunMonitor that pings this cron's Better Stack heartbeats.
+
+    A no-op for crons without an update/validate step (e.g. archive). The cron name
+    comes from the CRON_JOB_NAME env when set (staging-aware), else the cron's own name.
+    """
+    command = cron_job.command[0]
+    if command not in HEARTBEAT_STEPS:
+        yield
+        return
+    step = cast("Step", command)
+    cron_name = os.getenv("CRON_JOB_NAME") or cron_job.name
+    with monitor_heartbeat(
+        cron_name, step, send_start=send_in_progress, send_result=send_result
+    ):
+        yield
+
+
+# --- Deploy-time heartbeat provisioning -------------------------------------
+# Called from common/deploy.py at deploy time. Reconciles one start + one complete
+# uptime heartbeat per update/validate cron via the Better Stack Uptime API, and
+# writes the {key -> url} map into the k8s secret the cron pods load at runtime.
+
+_UPTIME_API = "https://uptime.betterstack.com/api/v2"
+
+# How late a cron may start before we alert.
+_START_GRACE = timedelta(minutes=10)
+
+
+class HeartbeatSpec(NamedTuple):
+    key: str
+    name: str
+    period: timedelta
+    grace: timedelta
+
+
+def provision_heartbeats(cron_jobs: Iterable[CronJob]) -> None:
+    """Reconcile heartbeats for the update/validate crons and persist their url map.
+
+    Only update/validate crons get heartbeats; other crons (e.g. archive) are skipped.
+    Requires the BETTERSTACK_API_KEY_RW env var when there is anything to provision.
+    """
+    eligible = [cj for cj in cron_jobs if cj.command[0] in HEARTBEAT_STEPS]
+    if not eligible:
+        log.info(
+            "No update/validate cron jobs to provision Better Stack heartbeats for."
+        )
+        return
+    if not os.getenv("BETTERSTACK_API_KEY_RW"):
+        raise RuntimeError(
+            "BETTERSTACK_API_KEY_RW is required to provision Better Stack "
+            "heartbeats before deploying CronJobs."
+        )
+    write_heartbeat_secret(reconcile_heartbeats(eligible))
+
+
+def schedule_period(schedule: str) -> timedelta:
+    """Largest gap between consecutive cron fire times. Using the largest (not the
+    typical) gap as the heartbeat period keeps an irregular schedule's long quiet
+    stretches from expiring the heartbeat and firing a false incident."""
+    base = datetime(2025, 1, 1, tzinfo=UTC)
+    itr = croniter(schedule, base)
+    times = [itr.get_next(datetime) for _ in range(64)]
+    return max(b - a for a, b in itertools.pairwise(times))
+
+
+def heartbeat_specs(cron_job: CronJob) -> list[HeartbeatSpec]:
+    """Two heartbeats per cron: a tight-grace start and a run-length-grace complete.
+
+    The start heartbeat detects a no-start within _START_GRACE regardless of run
+    length; the complete heartbeat's grace must cover the full run.
+    """
+    step = cast("Step", cron_job.command[0])
+    assert step in HEARTBEAT_STEPS, f"Unexpected cron command: {cron_job.command}"
+    prefix = cron_name_prefix(cron_job.name, step)
+    period = schedule_period(cron_job.schedule)
+    return [
+        HeartbeatSpec(
+            heartbeat_key(prefix, step, "start"),
+            heartbeat_name(prefix, step, "start"),
+            period,
+            _START_GRACE,
+        ),
+        HeartbeatSpec(
+            heartbeat_key(prefix, step, "complete"),
+            heartbeat_name(prefix, step, "complete"),
+            period,
+            _START_GRACE + cron_job.pod_active_deadline,
+        ),
+    ]
+
+
+def _api_client(token: str) -> httpx.Client:
+    return httpx.Client(
+        base_url=_UPTIME_API,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+
+
+def _list_heartbeats(client: httpx.Client) -> dict[str, dict[str, Any]]:
+    """name -> heartbeat attributes (including id and url), across all pages."""
+    by_name: dict[str, dict[str, Any]] = {}
+    url: str | None = "/heartbeats"
+    while url:
+        response = client.get(url)
+        response.raise_for_status()
+        body = response.json()
+        for item in body["data"]:
+            attributes = item["attributes"]
+            by_name[attributes["name"]] = {"id": item["id"], **attributes}
+        url = body.get("pagination", {}).get("next")
+    return by_name
+
+
+def _upsert_heartbeat(
+    client: httpx.Client, existing: dict[str, dict[str, Any]], spec: HeartbeatSpec
+) -> str:
+    payload = {
+        "name": spec.name,
+        "period": int(spec.period.total_seconds()),
+        "grace": int(spec.grace.total_seconds()),
+    }
+    current = existing.get(spec.name)
+    if current is None:
+        response = client.post("/heartbeats", json=payload)
+        response.raise_for_status()
+        body = response.json()["data"]
+        existing[spec.name] = {"id": body["id"], **body["attributes"]}
+        log.info(f"Created heartbeat {spec.name}")
+        return str(body["attributes"]["url"])
+
+    if current["period"] != payload["period"] or current["grace"] != payload["grace"]:
+        response = client.patch(f"/heartbeats/{current['id']}", json=payload)
+        response.raise_for_status()
+        current.update(payload)
+        log.info(f"Updated heartbeat {spec.name}")
+    return str(current["url"])
+
+
+def reconcile_heartbeats(cron_jobs: Iterable[CronJob]) -> dict[str, str]:
+    """Idempotently create/update one start + one complete heartbeat per cron job.
+
+    Returns the {name_prefix}_{step}_{role} -> url map. Requires the
+    BETTERSTACK_API_KEY_RW env var (operator-supplied at deploy).
+    """
+    token = os.environ["BETTERSTACK_API_KEY_RW"]
+    url_map: dict[str, str] = {}
+    with _api_client(token) as client:
+        existing = _list_heartbeats(client)
+        for cron_job in cron_jobs:
+            for spec in heartbeat_specs(cron_job):
+                url_map[spec.key] = _upsert_heartbeat(client, existing, spec)
+    return url_map
+
+
+def _load_existing_heartbeat_secret() -> dict[str, str]:
+    result = subprocess.run(  # noqa: S603
+        [
+            "/usr/bin/kubectl",
+            "get",
+            "secret",
+            BETTERSTACK_HEARTBEATS_SECRET_NAME,
+            "-o",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        if "not found" in result.stderr.lower():
+            return {}
+        result.check_returncode()
+
+    encoded = json.loads(result.stdout).get("data", {}).get("contents")
+    if encoded is None:
+        return {}
+    contents = json.loads(base64.b64decode(encoded).decode())
+    assert isinstance(contents, dict)
+    return contents
+
+
+def _apply_heartbeat_secret(url_map: dict[str, str]) -> None:
+    manifest = subprocess.run(  # noqa: S603
+        [
+            "/usr/bin/kubectl",
+            "create",
+            "secret",
+            "generic",
+            BETTERSTACK_HEARTBEATS_SECRET_NAME,
+            f"--from-literal=contents={json.dumps(url_map)}",
+            "--dry-run=client",
+            "-o",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    subprocess.run(
+        ["/usr/bin/kubectl", "apply", "-f", "-"],
+        input=manifest,
+        text=True,
+        check=True,
+    )
+    log.info(
+        f"Wrote {BETTERSTACK_HEARTBEATS_SECRET_NAME} secret "
+        f"with {len(url_map)} heartbeat urls"
+    )
+
+
+def write_heartbeat_secret(url_map: dict[str, str]) -> None:
+    """Merge into and persist the heartbeat URL map the cron pods load at runtime.
+
+    Merges so a single-dataset (filtered) deploy doesn't drop other datasets' urls.
+    """
+    _apply_heartbeat_secret(_load_existing_heartbeat_secret() | url_map)
+
+
+def delete_staging_heartbeats(dataset_id: str, version: str) -> None:
+    """Delete a staging version's heartbeats from Better Stack and the k8s secret."""
+    from reformatters.common import staging  # noqa: PLC0415
+
+    token = os.environ["BETTERSTACK_API_KEY_RW"]
+    remove_keys: set[str] = set()
+    remove_names: set[str] = set()
+    for step in HEARTBEAT_STEPS:
+        prefix = cron_name_prefix(
+            staging.staging_cronjob_name(dataset_id, version, step), step
+        )
+        for role in HEARTBEAT_ROLES:
+            remove_keys.add(heartbeat_key(prefix, step, role))
+            remove_names.add(heartbeat_name(prefix, step, role))
+
+    with _api_client(token) as client:
+        existing = _list_heartbeats(client)
+        for name in remove_names:
+            heartbeat = existing.get(name)
+            if heartbeat is None:
+                continue
+            client.delete(f"/heartbeats/{heartbeat['id']}").raise_for_status()
+            log.info(f"Deleted heartbeat {name}")
+
+    remaining = {
+        key: url
+        for key, url in _load_existing_heartbeat_secret().items()
+        if key not in remove_keys
+    }
+    _apply_heartbeat_secret(remaining)

--- a/src/reformatters/common/deploy.py
+++ b/src/reformatters/common/deploy.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import typer
 
-from reformatters.common import docker, kubernetes, staging
+from reformatters.common import betterstack, docker, kubernetes, staging
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.logging import get_logger
 
@@ -42,6 +42,11 @@ def deploy_operational_resources(
 
     assert len(reformat_jobs) > 0, "No cronjobs to deploy" + (
         f" for dataset_id_filter={dataset_id_filter!r}" if dataset_id_filter else ""
+    )
+
+    # Provision heartbeats (and write their secret) before the cron pods that mount it.
+    betterstack.provision_heartbeats(
+        cj for cj in reformat_jobs if isinstance(cj, kubernetes.CronJob)
     )
 
     k8s_resource_list = {
@@ -103,14 +108,17 @@ def register_commands(
         version: str,
         force: bool = False,
     ) -> None:
-        """Clean up staging resources: kubernetes cronjobs and git branch."""
+        """Clean up staging resources: Better Stack heartbeats, kubernetes cronjobs and git branch."""
         staging.find_dataset(datasets, dataset_id)  # validate dataset_id
         if not force:
             cronjob_names = staging.staging_cronjob_names(dataset_id, version)
             branch = staging.staging_branch_name(dataset_id, version)
             log.info(
-                f"Will delete cronjobs {cronjob_names} and branch {branch}. "
+                f"Will delete heartbeats, cronjobs {cronjob_names} and branch {branch}. "
                 "Run with --force to execute."
             )
             return
+        # Clean up cronjobs + branch first; delete heartbeats last so a missing
+        # BETTERSTACK_API_KEY_RW can't leave the more important resources orphaned.
         staging.cleanup_staging_resources(dataset_id, version)
+        betterstack.delete_staging_heartbeats(dataset_id, version)

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -1,11 +1,11 @@
 import json
 import subprocess
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, ExitStack, contextmanager
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Annotated, Any, Generic, Literal, Self, TypeVar
+from typing import Annotated, Any, Generic, Literal, Protocol, Self, TypeVar
 
 import icechunk
 import numpy as np
@@ -17,7 +17,6 @@ from icechunk.store import IcechunkStore
 from pydantic import Field, computed_field, model_validator
 
 from reformatters.common import (
-    monitoring,
     parallel_coordination,
     template_utils,
     validation,
@@ -790,8 +789,9 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         send_in_progress: bool = True,
         send_result: bool = True,
     ) -> Iterator[None]:
-        # Don't require operational_kubernetes_resources to be defined unless sentry reporting is enabled
-        if not Config.is_sentry_enabled:
+        # No registered monitors -> nothing to report to, and no need to require
+        # operational_kubernetes_resources to be defined.
+        if not _RUN_MONITORS:
             yield
             return
 
@@ -802,12 +802,16 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         cron_jobs = (c for c in cron_jobs if isinstance(c, cron_type))
         cron_job = item(cron_jobs)
 
-        with monitoring.monitor_cron(
-            cron_job,
-            reformat_job_name,
-            send_in_progress=send_in_progress,
-            send_result=send_result,
-        ):
+        with ExitStack() as stack:
+            for monitor in _RUN_MONITORS:
+                stack.enter_context(
+                    monitor(
+                        cron_job,
+                        reformat_job_name,
+                        send_in_progress=send_in_progress,
+                        send_result=send_result,
+                    )
+                )
             yield
 
     @model_validator(mode="after")
@@ -871,3 +875,31 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 f"materialized datasets do not yet support vertical groups: {grouped}"
             )
         return self
+
+
+class RunMonitor(Protocol):
+    """Wraps a single operational cron run to report it to a monitoring service.
+
+    The application registers monitors (see `register_run_monitor`); `DynamicalDataset._monitor`
+    enters every registered one around each update/validate run. This keeps
+    DynamicalDataset agnostic of any specific monitoring service (Better Stack,
+    Sentry, ...) — a different deployment registers whatever it uses, or nothing.
+    """
+
+    def __call__(
+        self,
+        cron_job: CronJob,
+        reformat_job_name: str,
+        *,
+        send_in_progress: bool,
+        send_result: bool,
+    ) -> AbstractContextManager[None]: ...
+
+
+_RUN_MONITORS: list[RunMonitor] = []
+
+
+def register_run_monitor(monitor: RunMonitor) -> None:
+    """Register a monitor to wrap every operational cron run. With none registered,
+    monitoring is a no-op."""
+    _RUN_MONITORS.append(monitor)

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -17,6 +17,10 @@ from reformatters.common.config import Config
 _SECRET_MOUNT_PATH = "/secrets"  # noqa: S105
 _SECRET_CONTENTS_KEY = "contents"  # noqa: S105
 
+# k8s secret holding the {dataset_id}_{step}_{role} -> heartbeat url map that
+# update/validate cron pods load at runtime (provisioned at deploy time).
+BETTERSTACK_HEARTBEATS_SECRET_NAME = "betterstack-heartbeats"  # noqa: S105
+
 
 class Job(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
@@ -39,6 +43,10 @@ class Job(pydantic.BaseModel):
     pod_annotations: dict[str, str] = pydantic.Field(default_factory=dict)
 
     secret_names: Sequence[str] = pydantic.Field(default_factory=list)
+
+    def mounted_secret_names(self) -> Sequence[str]:
+        """Secrets mounted as JSON files at /secrets/<name>.json in the pod."""
+        return self.secret_names
 
     @cached_property
     def job_name(self) -> str:
@@ -185,7 +193,7 @@ class Job(pydantic.BaseModel):
                                             "subPath": _SECRET_CONTENTS_KEY,
                                             "readOnly": True,
                                         }
-                                        for secret_name in self.secret_names
+                                        for secret_name in self.mounted_secret_names()
                                     ],
                                 ],
                             }
@@ -237,7 +245,7 @@ class Job(pydantic.BaseModel):
                                     "name": secret_name,
                                     "secret": {"secretName": secret_name},
                                 }
-                                for secret_name in self.secret_names
+                                for secret_name in self.mounted_secret_names()
                             ],
                         ],
                     },
@@ -252,6 +260,11 @@ class CronJob(Job):
     schedule: Annotated[str, pydantic.Field(min_length=1)]
     ttl: timedelta = timedelta(hours=12)
     suspend: bool = False
+
+    def mounted_secret_names(self) -> Sequence[str]:
+        # All cron pods mount the heartbeat url-map secret; runs of crons without a
+        # heartbeat (e.g. archive) simply find no matching entry and skip pinging.
+        return [*self.secret_names, BETTERSTACK_HEARTBEATS_SECRET_NAME]
 
     def as_kubernetes_object(self) -> dict[str, Any]:
         job_spec = super().as_kubernetes_object()["spec"]

--- a/tests/common/betterstack_test.py
+++ b/tests/common/betterstack_test.py
@@ -1,13 +1,18 @@
+import json
 import logging
+from datetime import timedelta
 
+import httpx
 import pytest
 from logtail import LogtailHandler
 
+from reformatters.common import betterstack, staging
 from reformatters.common.betterstack import (
     REFORMATTERS_LOGGER_NAME,
     _ContextFilter,
     attach_logtail,
 )
+from reformatters.common.kubernetes import CronJob, ReformatCronJob
 
 
 def _record() -> logging.LogRecord:
@@ -76,3 +81,339 @@ def test_attach_logtail_adds_handler_and_is_idempotent(
         for handler in logger.handlers[:]:
             if isinstance(handler, LogtailHandler):
                 logger.removeHandler(handler)
+
+
+def test_cron_name_prefix_strips_step() -> None:
+    assert (
+        betterstack.cron_name_prefix("noaa-gfs-forecast-update", "update")
+        == "noaa-gfs-forecast"
+    )
+    assert (
+        betterstack.cron_name_prefix("noaa-gfs-forecast-validate", "validate")
+        == "noaa-gfs-forecast"
+    )
+
+
+def test_heartbeat_key_and_name() -> None:
+    assert (
+        betterstack.heartbeat_key("noaa-gfs-forecast", "update", "start")
+        == "noaa-gfs-forecast_update_start"
+    )
+    assert (
+        betterstack.heartbeat_name("noaa-gfs-forecast", "update", "start")
+        == "reformatters noaa-gfs-forecast update start"
+    )
+
+
+def test_ping_posts_to_url_and_fail_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    posted: list[str] = []
+
+    def fake_post(url: str, timeout: float) -> httpx.Response:
+        posted.append(url)
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(betterstack.httpx, "post", fake_post)
+    betterstack.ping("https://hb/x")
+    betterstack.ping("https://hb/x", failed=True)
+    assert posted == ["https://hb/x", "https://hb/x/fail"]
+
+
+def test_load_heartbeat_urls_from_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(betterstack, "load_secret", lambda name: {"k": "https://u"})
+    assert betterstack.load_heartbeat_urls() == {"k": "https://u"}
+
+
+_URLS = {
+    "noaa-gfs-forecast_update_start": "https://hb/start",
+    "noaa-gfs-forecast_update_complete": "https://hb/complete",
+}
+
+
+def test_monitor_heartbeat_pings_start_then_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(betterstack, "load_heartbeat_urls", lambda: _URLS)
+    monkeypatch.setattr(
+        betterstack, "ping", lambda url, *, failed=False: calls.append((url, failed))
+    )
+    with betterstack.monitor_heartbeat("noaa-gfs-forecast-update", "update"):
+        pass
+    assert calls == [("https://hb/start", False), ("https://hb/complete", False)]
+
+
+def test_monitor_heartbeat_pings_fail_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(betterstack, "load_heartbeat_urls", lambda: _URLS)
+    monkeypatch.setattr(
+        betterstack, "ping", lambda url, *, failed=False: calls.append((url, failed))
+    )
+    with (
+        pytest.raises(ValueError, match="boom"),
+        betterstack.monitor_heartbeat("noaa-gfs-forecast-update", "update"),
+    ):
+        raise ValueError("boom")
+    assert calls == [("https://hb/start", False), ("https://hb/complete", True)]
+
+
+def test_monitor_heartbeat_noop_without_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(betterstack, "load_heartbeat_urls", dict)
+
+    def _fail(url: str, *, failed: bool = False) -> None:
+        raise AssertionError("should not ping when no urls are configured")
+
+    monkeypatch.setattr(betterstack, "ping", _fail)
+    with betterstack.monitor_heartbeat("x-update", "update"):
+        pass
+
+
+def _update_cron() -> ReformatCronJob:
+    return ReformatCronJob(
+        name="example-update",
+        schedule="0 0 * * *",
+        image="img",
+        dataset_id="example",
+        cpu="1",
+        memory="1G",
+    )
+
+
+def test_monitor_cron_run_pings_update_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CRON_JOB_NAME", raising=False)
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        betterstack,
+        "load_heartbeat_urls",
+        lambda: {
+            "example_update_start": "https://hb/start",
+            "example_update_complete": "https://hb/complete",
+        },
+    )
+    monkeypatch.setattr(
+        betterstack, "ping", lambda url, *, failed=False: calls.append((url, failed))
+    )
+    with betterstack.monitor_cron_run(_update_cron(), "job-name"):
+        pass
+    assert calls == [("https://hb/start", False), ("https://hb/complete", False)]
+
+
+def test_monitor_cron_run_noop_for_non_step_cron(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fail(url: str, *, failed: bool = False) -> None:
+        raise AssertionError("archive crons have no heartbeat step")
+
+    monkeypatch.setattr(betterstack, "ping", _fail)
+    archive = CronJob(
+        name="example-archive",
+        command=["archive-grib-files"],
+        schedule="0 0 * * *",
+        image="img",
+        dataset_id="example",
+        cpu="1",
+        memory="1G",
+        workers_total=1,
+        parallelism=1,
+    )
+    with betterstack.monitor_cron_run(archive, "job-name"):
+        pass
+
+
+def _gfs_update_cron(schedule: str, deadline_min: int) -> ReformatCronJob:
+    return ReformatCronJob(
+        name="noaa-gfs-forecast-update",
+        schedule=schedule,
+        image="img",
+        dataset_id="noaa-gfs-forecast",
+        cpu="1",
+        memory="1G",
+        pod_active_deadline=timedelta(minutes=deadline_min),
+    )
+
+
+class TestHeartbeatProvisioning:
+    @pytest.mark.parametrize(
+        ("schedule", "seconds"),
+        [
+            ("0 * * * *", 3600),
+            ("0 */6 * * *", 6 * 3600),
+            ("30 0 * * *", 24 * 3600),
+            # Irregular schedule (00:00 + 01:00): the period is the largest gap (23h),
+            # not the 1h short gap, so the long quiet stretch never false-alarms.
+            ("0 0,1 * * *", 23 * 3600),
+        ],
+    )
+    def test_schedule_period(self, schedule: str, seconds: int) -> None:
+        assert betterstack.schedule_period(schedule).total_seconds() == seconds
+
+    def test_heartbeat_specs_mirror_cron_config(self) -> None:
+        specs = betterstack.heartbeat_specs(_gfs_update_cron("0 */6 * * *", 30))
+        assert [s.key for s in specs] == [
+            "noaa-gfs-forecast_update_start",
+            "noaa-gfs-forecast_update_complete",
+        ]
+        assert all(s.period == timedelta(hours=6) for s in specs)
+        # start grace = the 10 min start margin; complete grace also covers the run.
+        assert specs[0].grace == timedelta(minutes=10)
+        assert specs[1].grace == timedelta(minutes=10) + timedelta(minutes=30)
+
+    def test_reconcile_creates_start_and_complete(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET":
+                return httpx.Response(200, json={"data": [], "pagination": {}})
+            body = json.loads(request.content)
+            created.append(body)
+            hid = str(len(created))
+            return httpx.Response(
+                201,
+                json={
+                    "data": {
+                        "id": hid,
+                        "attributes": {**body, "url": f"https://hb/{hid}"},
+                    }
+                },
+            )
+
+        monkeypatch.setattr(
+            betterstack,
+            "_api_client",
+            lambda token: httpx.Client(
+                base_url=betterstack._UPTIME_API,
+                transport=httpx.MockTransport(handler),
+            ),
+        )
+        monkeypatch.setenv("BETTERSTACK_API_KEY_RW", "tok")
+
+        url_map = betterstack.reconcile_heartbeats([_gfs_update_cron("0 * * * *", 30)])
+        assert url_map == {
+            "noaa-gfs-forecast_update_start": "https://hb/1",
+            "noaa-gfs-forecast_update_complete": "https://hb/2",
+        }
+        assert created[0]["period"] == 3600
+        assert created[0]["grace"] == 600
+        assert created[1]["grace"] == 600 + 1800
+
+    def test_reconcile_updates_only_on_drift(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        start_name = "reformatters noaa-gfs-forecast update start"
+        complete_name = "reformatters noaa-gfs-forecast update complete"
+        patched: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET":
+                return httpx.Response(
+                    200,
+                    json={
+                        "data": [
+                            {
+                                "id": "1",
+                                "attributes": {
+                                    "name": start_name,
+                                    "period": 3600,
+                                    "grace": 600,
+                                    "url": "https://hb/1",
+                                },
+                            },
+                            {
+                                "id": "2",
+                                "attributes": {
+                                    "name": complete_name,
+                                    "period": 3600,
+                                    "grace": 1,  # drifted -> should be patched
+                                    "url": "https://hb/2",
+                                },
+                            },
+                        ],
+                        "pagination": {},
+                    },
+                )
+            patched.append(request.url.path)
+            return httpx.Response(200, json={"data": {"id": "2", "attributes": {}}})
+
+        monkeypatch.setattr(
+            betterstack,
+            "_api_client",
+            lambda token: httpx.Client(
+                base_url=betterstack._UPTIME_API,
+                transport=httpx.MockTransport(handler),
+            ),
+        )
+        monkeypatch.setenv("BETTERSTACK_API_KEY_RW", "tok")
+
+        url_map = betterstack.reconcile_heartbeats([_gfs_update_cron("0 * * * *", 30)])
+        assert url_map["noaa-gfs-forecast_update_complete"] == "https://hb/2"
+        # Only the drifted complete heartbeat is patched; the matching start is left alone.
+        assert len(patched) == 1
+        assert patched[0].endswith("/heartbeats/2")
+
+    def test_write_heartbeat_secret_merges_existing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        applied: dict[str, str] = {}
+        monkeypatch.setattr(
+            betterstack,
+            "_load_existing_heartbeat_secret",
+            lambda: {"old": "https://old"},
+        )
+        monkeypatch.setattr(betterstack, "_apply_heartbeat_secret", applied.update)
+        betterstack.write_heartbeat_secret({"new": "https://new"})
+        assert applied == {"old": "https://old", "new": "https://new"}
+
+    def test_provision_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BETTERSTACK_API_KEY_RW", raising=False)
+        with pytest.raises(RuntimeError, match="BETTERSTACK_API_KEY_RW"):
+            betterstack.provision_heartbeats([_gfs_update_cron("0 * * * *", 30)])
+
+
+def test_delete_staging_heartbeats(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BETTERSTACK_API_KEY_RW", "tok")
+    update_prefix = betterstack.cron_name_prefix(
+        staging.staging_cronjob_name("gfs", "1.2.3", "update"), "update"
+    )
+    start_name = betterstack.heartbeat_name(update_prefix, "update", "start")
+    start_key = betterstack.heartbeat_key(update_prefix, "update", "start")
+
+    deleted: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": "9", "attributes": {"name": start_name, "url": "u"}}
+                    ],
+                    "pagination": {},
+                },
+            )
+        deleted.append(request.url.path)
+        return httpx.Response(204, request=request)
+
+    monkeypatch.setattr(
+        betterstack,
+        "_api_client",
+        lambda token: httpx.Client(
+            base_url=betterstack._UPTIME_API, transport=httpx.MockTransport(handler)
+        ),
+    )
+    applied: dict[str, str] = {}
+    monkeypatch.setattr(
+        betterstack,
+        "_load_existing_heartbeat_secret",
+        lambda: {start_key: "u", "other-dataset_update_start": "keep"},
+    )
+    monkeypatch.setattr(betterstack, "_apply_heartbeat_secret", applied.update)
+
+    betterstack.delete_staging_heartbeats("gfs", "1.2.3")
+
+    assert any(path.endswith("/heartbeats/9") for path in deleted)
+    # The staging key is removed from the secret; unrelated keys are kept.
+    assert start_key not in applied
+    assert applied["other-dataset_update_start"] == "keep"

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -1,5 +1,6 @@
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
@@ -11,8 +12,6 @@ import icechunk.store
 import numpy as np
 import pandas as pd
 import pytest
-import sentry_sdk
-import sentry_sdk.crons
 import xarray as xr
 from pydantic import Field, ValidationError, computed_field
 
@@ -739,106 +738,90 @@ class ExampleDatasetWithThreeCronJobs(
         ]
 
 
-def test_monitor_with_cron_job_name_filters_by_name(
+def _recording_monitor(
+    events: list[tuple[str, str]],
+) -> dynamical_dataset.RunMonitor:
+    @contextmanager
+    def monitor(
+        cron_job: CronJob,
+        reformat_job_name: str,
+        *,
+        send_in_progress: bool,
+        send_result: bool,
+    ) -> Iterator[None]:
+        events.append(("enter", cron_job.name))
+        try:
+            yield
+        except Exception:
+            events.append(("error", cron_job.name))
+            raise
+        else:
+            events.append(("ok", cron_job.name))
+
+    return monitor
+
+
+def test_monitor_noop_without_registered_monitors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When multiple cron jobs match a type (e.g. all are CronJob subclasses),
-    cron_job_name disambiguates."""
-    monkeypatch.setattr(type(Config), "is_sentry_enabled", True)
-    mock_capture = Mock()
-    monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", mock_capture)
-
-    dataset = ExampleDatasetWithThreeCronJobs()
-
-    # Without cron_job_name, filtering by base CronJob matches all 3 → should fail
-    with (
-        pytest.raises(ValueError, match="Expected exactly one item, got multiple"),
-        dataset._monitor(CronJob, "job-name"),
-    ):
-        pass
-
-    # With cron_job_name, it narrows to exactly one
-    with dataset._monitor(
-        CronJob, "job-name", cron_job_name=f"{dataset.dataset_id}-archive"
-    ):
-        pass
-
-    statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
-    assert statuses == ["in_progress", "ok"]
-
-    # Verify the monitor used the archive job's schedule
-    call_kwargs = mock_capture.call_args_list[0].kwargs
-    assert call_kwargs["monitor_config"]["schedule"]["value"] == "0 4 * * *"
-
-
-def test_monitor_with_cron_job_name_still_filters_by_type(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """cron_job_name and cron_type are both applied."""
-    monkeypatch.setattr(type(Config), "is_sentry_enabled", True)
-    mock_capture = Mock()
-    monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", mock_capture)
-
-    dataset = ExampleDatasetWithThreeCronJobs()
-
-    # ReformatCronJob filter with the update name should work
-    with dataset._monitor(
-        ReformatCronJob, "job-name", cron_job_name=f"{dataset.dataset_id}-update"
-    ):
-        pass
-
-    statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
-    assert statuses == ["in_progress", "ok"]
-
-
-def test_monitor_context_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(type(Config), "is_sentry_enabled", True)
-
-    dataset = ExampleDataset(
-        template_config=ExampleConfig(),
-        region_job_class=ExampleRegionJob,
-    )
-
-    # Mock capture_checkin to record statuses
-    mock_capture = Mock()
-    monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", mock_capture)
-
-    # Success case: should record "in_progress" then "ok"
-    with dataset._monitor(ReformatCronJob, "job-name"):
-        pass
-    statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
-    assert statuses == ["in_progress", "ok"]
-
-    # Error case: should record "in_progress" then "error"
-    mock_capture.reset_mock()
-    with pytest.raises(ValueError, match="failure"):  # noqa: SIM117
-        with dataset._monitor(ReformatCronJob, "job-name"):
-            raise ValueError("failure")
-    statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
-    assert statuses == ["in_progress", "error"]
-
-
-def test_monitor_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Test that it's ok to not define operational_kubernetes_resources if sentry reporting is disabled
-
-    # disable sentry reporting
-    monkeypatch.setattr(type(Config), "is_sentry_enabled", False)
-    dataset = ExampleDataset(
-        template_config=ExampleConfig(),
-        region_job_class=ExampleRegionJob,
-    )
-
-    # make operational_kubernetes_resources raise if called
+    # With no monitors registered, _monitor must not even look up cron jobs.
     def fail_resources(image_tag: str) -> None:
         raise RuntimeError("operational_kubernetes_resources should not be called")
 
     monkeypatch.setattr(
         ExampleDataset, "operational_kubernetes_resources", fail_resources
     )
-
-    # this should not raise
-    with dataset._monitor(ReformatCronJob, "job"):
+    dataset = ExampleDataset(
+        template_config=ExampleConfig(), region_job_class=ExampleRegionJob
+    )
+    with dataset._monitor(ReformatCronJob, "job-name"):
         pass
+
+
+def test_monitor_resolves_cron_job_and_enters_all_monitors() -> None:
+    events: list[tuple[str, str]] = []
+    dynamical_dataset.register_run_monitor(_recording_monitor(events))
+    dynamical_dataset.register_run_monitor(_recording_monitor(events))
+
+    dataset = ExampleDatasetWithThreeCronJobs()
+    # cron_job_name disambiguates among the three crons; the resolved cron reaches monitors.
+    with dataset._monitor(
+        CronJob, "job-name", cron_job_name=f"{dataset.dataset_id}-archive"
+    ):
+        pass
+
+    name = f"{dataset.dataset_id}-archive"
+    assert events == [("enter", name), ("enter", name), ("ok", name), ("ok", name)]
+
+
+def test_monitor_requires_exactly_one_matching_cron() -> None:
+    dynamical_dataset.register_run_monitor(_recording_monitor([]))
+    dataset = ExampleDatasetWithThreeCronJobs()
+    # Base CronJob with no name matches all three -> ambiguous.
+    with (
+        pytest.raises(ValueError, match="Expected exactly one item, got multiple"),
+        dataset._monitor(CronJob, "job-name"),
+    ):
+        pass
+
+
+def test_monitor_propagates_errors_to_monitors() -> None:
+    events: list[tuple[str, str]] = []
+    dynamical_dataset.register_run_monitor(_recording_monitor(events))
+
+    dataset = ExampleDataset(
+        template_config=ExampleConfig(), region_job_class=ExampleRegionJob
+    )
+    with (
+        pytest.raises(ValueError, match="failure"),
+        dataset._monitor(ReformatCronJob, "job-name"),
+    ):
+        raise ValueError("failure")
+
+    assert events == [
+        ("enter", "example-dataset-update"),
+        ("error", "example-dataset-update"),
+    ]
 
 
 def _existing_store_tree(n_time: int = 3) -> xr.DataTree:

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -9,6 +9,8 @@ import pytest
 
 from reformatters.common.config import Config, Env
 from reformatters.common.kubernetes import (
+    BETTERSTACK_HEARTBEATS_SECRET_NAME,
+    CronJob,
     Job,
     ReformatCronJob,
     ValidationCronJob,
@@ -427,3 +429,54 @@ def test_load_secret_from_kubernetes_api() -> None:
 
     assert result == secret_data
     mock_v1.read_namespaced_secret.assert_called_once_with("db-credentials", "default")
+
+
+def _cron_volume_names(cron: CronJob) -> set[str]:
+    spec = cron.as_kubernetes_object()["spec"]["jobTemplate"]["spec"]["template"][
+        "spec"
+    ]
+    return {volume["name"] for volume in spec["volumes"]}
+
+
+def test_update_cron_mounts_heartbeats_secret_alongside_dataset_secrets() -> None:
+    cron = ReformatCronJob(
+        name="weather-data-update",
+        schedule="0 * * * *",
+        image="img",
+        dataset_id="weather-data",
+        cpu="1",
+        memory="1G",
+        secret_names=["source-creds"],
+    )
+    volume_names = _cron_volume_names(cron)
+    assert BETTERSTACK_HEARTBEATS_SECRET_NAME in volume_names
+    assert "source-creds" in volume_names
+
+
+def test_validate_cron_mounts_heartbeats_secret() -> None:
+    cron = ValidationCronJob(
+        name="weather-data-validate",
+        schedule="0 * * * *",
+        image="img",
+        dataset_id="weather-data",
+        cpu="1",
+        memory="1G",
+    )
+    assert BETTERSTACK_HEARTBEATS_SECRET_NAME in _cron_volume_names(cron)
+
+
+def test_all_crons_mount_heartbeats_secret() -> None:
+    # Every cron mounts the secret (even archive, which has no heartbeat step);
+    # its runtime monitor just finds no matching entry and skips pinging.
+    cron = CronJob(
+        name="weather-data-archive",
+        schedule="0 * * * *",
+        command=["archive"],
+        image="img",
+        dataset_id="weather-data",
+        cpu="1",
+        memory="1G",
+        workers_total=1,
+        parallelism=1,
+    )
+    assert BETTERSTACK_HEARTBEATS_SECRET_NAME in _cron_volume_names(cron)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import faulthandler
 import multiprocessing
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import numpy as np
@@ -23,7 +24,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 os.environ["DYNAMICAL_ENV"] = "test"
 
 
-from reformatters.common import storage  # noqa: E402
+from reformatters.common import dynamical_dataset, storage  # noqa: E402
 
 
 def pytest_xdist_auto_num_workers(config: pytest.Config) -> int | None:
@@ -61,6 +62,15 @@ def set_local_zarr_store_base_path(
     ):
         return
     monkeypatch.setattr(storage, "_LOCAL_ZARR_STORE_BASE_PATH", tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def reset_run_monitors() -> Iterator[None]:
+    """Keep the module-level monitor registry empty by default so importing
+    __main__ (which registers prod monitors) in one test doesn't leak into others."""
+    dynamical_dataset._RUN_MONITORS.clear()
+    yield
+    dynamical_dataset._RUN_MONITORS.clear()
 
 
 @pytest.fixture

--- a/tests/deploy_test.py
+++ b/tests/deploy_test.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 import pytest
 
 from reformatters.__main__ import DYNAMICAL_DATASETS
-from reformatters.common import deploy
+from reformatters.common import betterstack, deploy
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 
@@ -56,6 +56,7 @@ class ExampleDataset2(ExampleDataset1):
 def test_deploy_operational_resources(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_run = Mock()
     monkeypatch.setattr(subprocess, "run", mock_run)
+    monkeypatch.setattr(betterstack, "provision_heartbeats", lambda cron_jobs: None)
 
     example_datasets = [
         ExampleDatasetInDevelopment(),
@@ -98,6 +99,7 @@ def test_deploy_operational_resources_dataset_id_filter(
 ) -> None:
     mock_run = Mock()
     monkeypatch.setattr(subprocess, "run", mock_run)
+    monkeypatch.setattr(betterstack, "provision_heartbeats", lambda cron_jobs: None)
 
     test_datasets: list[DynamicalDataset[Any, Any]] = [
         ExampleDataset1(),

--- a/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
+++ b/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
@@ -1,9 +1,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
-import sentry_sdk.crons
 
-from reformatters.common.config import Config
 from reformatters.eccc.hrdps.forecast.dynamical_dataset import (
     EcccHrdpsForecastTemporalDynamicalDataset,
 )
@@ -88,18 +86,14 @@ def test_archive_grib_files_passes_s3_credentials(
     assert env_vars["RCLONE_S3_PROVIDER"] == "AWS"
 
 
-def test_archive_grib_files_sends_cron_checkins(
+def test_archive_grib_files_runs(
     dataset: EcccHrdpsForecastTemporalDynamicalDataset,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(type(Config), "is_sentry_enabled", True)
-    mock_capture = Mock()
-    monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", mock_capture)
-
+    copy_mock = Mock()
     with (
         patch(
             "reformatters.eccc.hrdps.forecast.dynamical_dataset.copy_files_from_eccc_https",
-            Mock(),
+            copy_mock,
         ),
         patch(
             "reformatters.eccc.hrdps.forecast.dynamical_dataset.kubernetes.load_secret",
@@ -108,12 +102,7 @@ def test_archive_grib_files_sends_cron_checkins(
     ):
         dataset.archive_grib_files(reformat_job_name="test")
 
-    statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
-    assert statuses == ["in_progress", "ok"]
-    assert (
-        mock_capture.call_args_list[0].kwargs["monitor_slug"]
-        == f"{dataset.dataset_id}-archive-grib-files"
-    )
+    assert copy_mock.called
 
 
 def test_get_cli_has_archive_command(

--- a/uv.lock
+++ b/uv.lock
@@ -346,6 +346,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/57/2e2a65aee2a70483cb28e2b7e15a072d00a523207593b44400d4717bb100/croniter-6.2.4.tar.gz", hash = "sha256:fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189", size = 166267, upload-time = "2026-07-10T09:52:59.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/ba/d678e5bd329646ca51d3c92addbc77804e86d21f4b6b6a027218e6abb010/croniter-6.2.4-py3-none-any.whl", hash = "sha256:8ef3d544107a5c05a150a2d78f8bf5a8eb9c5c4d93405a736b824109574e3f4d", size = 46677, upload-time = "2026-07-10T09:52:58.425Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1366,6 +1378,7 @@ name = "reformatters"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "croniter" },
     { name = "dask" },
     { name = "google-crc32c" },
     { name = "gribberish" },
@@ -1409,6 +1422,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "croniter", specifier = ">=6.2.4" },
     { name = "dask", specifier = "~=2026.0" },
     { name = "google-crc32c", specifier = ">=1.8.0" },
     { name = "gribberish", specifier = "==1.5.0" },


### PR DESCRIPTION
Third of three sequenced PRs migrating observability from Sentry to Better Stack. **Stacked on #786** (base retargets as the stack merges).

## What

Better Stack uptime **heartbeats** for update/validate crons, pinged *alongside* the existing Sentry cron check-ins — so cron monitoring is double-covered during the migration and revert is just reverting this PR.

- **`common/betterstack.py`** — `monitor_heartbeat` pings a **start** heartbeat when a run begins and a **complete** heartbeat when it finishes (`/fail` on error). Best-effort (`httpx` errors are swallowed + logged) so a Better Stack outage never breaks a run.
- **`common/deploy.py`** — deploy-time provisioning that **mirrors the Sentry monitor config**: period from the cron schedule (via `croniter`), start grace = the 10-min Sentry `checkin_margin`, complete grace = margin + `pod_active_deadline`. `reconcile_heartbeats` idempotently creates/updates monitors via the Better Stack Uptime API; `write_heartbeat_secret` merges the url map into a k8s secret (so a single-dataset deploy doesn't drop others).
- **`common/kubernetes.py`** — `BETTERSTACK_HEARTBEATS_SECRET_NAME`; update/validate crons mount the url-map secret via a new `HeartbeatCronJob` base's `mounted_secret_names()`.
- **`dynamical_dataset._monitor`** — enters `monitor_heartbeat` alongside `monitoring.monitor_cron`.
- Deploy workflow passes `BETTERSTACK_API_KEY_RW` (required to provision).

## ⚠️ Deploy ordering

Deploy **this PR before #786 (errors DSN)**. Once #786 points the DSN at Better Stack, Sentry cron check-ins stop reaching Sentry, so heartbeats must already be live. Order: #785 (logging) → this (heartbeats) → #786 (errors).

## Scope notes

- **Staging heartbeats deferred** to a follow-up: `deploy_staging` passes `provision_heartbeats=False`, so staging deploys don't need the API key.
- Provisioning + runtime ping are covered by unit tests (schedule→period, spec grace mirroring, reconcile create/update via mocked API, secret merge, start/complete/fail pings). The Uptime API request/response shape is inherited from the prior heartbeats work (#685); the first prod deploy with `BETTERSTACK_API_KEY_RW` is the live check.

## Prerequisite

Add the `BETTERSTACK_API_KEY_RW` GitHub Actions secret (read/write Uptime API token).

## Revert runbook

Revert this PR — Sentry crons remain live throughout, so cron monitoring is never lost.