### PR TITLE
HRRR VBDSF: keep f00 analysis-time record (address #746 review)

### DIFF
--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -323,9 +323,6 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=128,
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     hrrr_file_type="sfc",
-                    # HRRR f00 VBDSF (the analysis-time record) is not properly diagnosed
-                    # and contains non-physical spikes (>9000 W m-2); use the f01 value.
-                    hour_0_values_override=False,
                 ),
             ),
             NoaaHrrrDataVar(


### PR DESCRIPTION
## What

Addresses the review discussion on #746. Per @aldenks's decision:

> so keep hour 0 in and remove this override and this comment. This will show up in the validation report

This removes the `hour_0_values_override=False` (and its explanatory comment) from the `visible_beam_downward_solar_flux_surface` (VBDSF) data-variable config in `NoaaHrrrCommonTemplateConfig`. With `step_type="instant"`, VBDSF now retains its analysis-time (f00) record: the forecast dataset keeps lead-0 and the analysis dataset pulls VBDSF from f00.

## Why

The earlier override NaN'd out f00 to avoid the non-physical spikes in HRRR's analysis-time VBDSF record. Investigation on the thread showed the f00 field is ~99.9% physically sensible, with only a sparse set (~500–1,300 cells per low-sun init) of impossible high-sun outliers. The maintainer's call is to keep the data in and document this f00 diagnostic artifact in the dataset's validation report `### Review notes` during the step-3 validation pass, rather than discard lead-0 for every forecast.

The pre-HRRRv3 availability of VBDSF (a separate concern) is unchanged — the `_PRE_V3_UNAVAILABLE` test still lists it.

## Verification

- `update-template` for both `noaa-hrrr-forecast-48-hour` and `noaa-hrrr-analysis` → zero diff vs. checked-in metadata (the override is an internal attr, not serialized).
- `ruff format` / `ruff check` / `ty check` all clean.
- `pytest` for `common_template_config_subclasses_test`, `datasets_cf_compliance_test`, and `noaa/hrrr/analysis/region_job_test` (not slow) → 271 passed.

## Notes

Targets the #746 branch (`claude/hrrr-add-vbdsf`) so the diff is just this one fix; merging it into that branch updates #746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LL3bgCvpEaqT7Jn2B7VKTX)_