### PR TITLE
NASA IMERG: per-run V07B→V07C version boundary (fix Late gap)

### DIFF
--- a/src/reformatters/nasa/imerg/region_job.py
+++ b/src/reformatters/nasa/imerg/region_job.py
@@ -31,8 +31,11 @@ from reformatters.nasa.nasa_auth import get_earthdata_session, get_pps_session
 
 log = get_logger(__name__)
 
-# Early/Late filenames carry V07C from this granule date onward, V07B before.
-_V07C_START = pd.Timestamp("2026-03-04")
+# Filenames carry V07C from this granule time onward, V07B before.
+_V07C_START: dict[ImergRun, pd.Timestamp] = {
+    "early": pd.Timestamp("2026-03-04T00:00"),
+    "late": pd.Timestamp("2026-03-03T14:00"),
+}
 
 # The PPS NRT server (jsimpson) carries a rolling window of recent granules; older
 # granules roll off to the GES DISC archive. Pick jsimpson for granules younger than
@@ -59,7 +62,7 @@ class NasaImergAnalysisSourceFileCoord(SourceFileCoord):
 
     @property
     def version(self) -> str:
-        return "V07C" if self.time >= _V07C_START else "V07B"
+        return "V07C" if self.time >= _V07C_START[self.run] else "V07B"
 
     def _source_by_age(self) -> DownloadSource:
         age = pd.Timestamp.now() - self.time

--- a/tests/nasa/imerg/region_job_test.py
+++ b/tests/nasa/imerg/region_job_test.py
@@ -34,14 +34,24 @@ def test_variant_region_jobs_carry_run() -> None:
 
 
 def test_version_computed_from_time() -> None:
-    before = NasaImergAnalysisSourceFileCoord(
+    # The V07B->V07C switchover time differs per run.
+    early_before = NasaImergAnalysisSourceFileCoord(
         run="early", time=pd.Timestamp("2026-03-03T23:30")
     )
-    on_cutover = NasaImergAnalysisSourceFileCoord(
+    early_on = NasaImergAnalysisSourceFileCoord(
         run="early", time=pd.Timestamp("2026-03-04T00:00")
     )
-    assert before.version == "V07B"
-    assert on_cutover.version == "V07C"
+    assert early_before.version == "V07B"
+    assert early_on.version == "V07C"
+
+    late_before = NasaImergAnalysisSourceFileCoord(
+        run="late", time=pd.Timestamp("2026-03-03T13:30")
+    )
+    late_on = NasaImergAnalysisSourceFileCoord(
+        run="late", time=pd.Timestamp("2026-03-03T14:00")
+    )
+    assert late_before.version == "V07B"
+    assert late_on.version == "V07C"
 
 
 def test_gesdisc_url_early_v07c() -> None:


### PR DESCRIPTION
## Summary
Late IMERG post-backfill validation surfaced a 10-hour all-NaN gap at
2026-03-03 14:00–23:30. Root cause: the V07B→V07C filename version
switchover happens at a different time per run, but the code used one
shared constant.

- Early switches at 2026-03-04T00:00 — constant was correct, no gap.
- Late switches at 2026-03-03T14:00 — code requested V07B for 20 granules
  that exist only as V07C → 404 → NaN.

Per-run boundaries verified against the CMR granule archive
(GPM_3IMERGHHE / GPM_3IMERGHHL). The value series shows no discontinuity
across the boundary, so this was purely a fetch-version mismatch, not a
data-quality issue.

## Change
`_V07C_START` becomes a per-run `{run: Timestamp}` mapping; `version`
indexes it by run. Test extended to pin Late's 14:00 boundary.

## Follow-up (not in this PR)
After deploy, re-backfill Late's contiguous gap window with a time-range
filter: `overwrite-chunks`, `filter_start=2026-03-03T14:00:00`,
`filter_end=2026-03-04T00:00:00`, then re-verify. Early needs no re-backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)