### PR TITLE
Validation plots: readable year ticks + robust precip color scale

### DIFF
--- a/src/scripts/validation/availability.py
+++ b/src/scripts/validation/availability.py
@@ -131,17 +131,20 @@ def _downsample_columns(grid: np.ndarray, max_columns: int) -> np.ndarray:
 def _heatmap_xticks(
     positions: np.ndarray, n_columns: int
 ) -> tuple[list[int], list[str]]:
-    """Ticks on the heatmap's downsampled column axis: one per calendar-year start
-    (labeled with the year) when the archive spans multiple years, else 8 evenly spaced
-    date ticks."""
+    """Ticks on the heatmap's downsampled column axis: round-year starts (labeled with
+    the year) when the archive spans multiple years, thinned to a "nice" year step from
+    {1, 2, 5, 10, 20} so at most ~12 labels are drawn; else 8 evenly spaced date ticks."""
     positions_dt = pd.DatetimeIndex(positions)
     years = positions_dt.year.to_numpy()
     span = max(1, len(positions) - 1)
     if years[-1] > years[0]:
-        year_range = range(int(years[0]), int(years[-1]) + 1)
-        position_idx = np.array([np.searchsorted(years, year) for year in year_range])
+        first_year, last_year = int(years[0]), int(years[-1])
+        n_years = last_year - first_year + 1
+        step = next((s for s in (1, 2, 5, 10, 20) if n_years / s <= 12), 20)
+        tick_years = [y for y in range(first_year, last_year + 1) if y % step == 0]
+        position_idx = np.array([np.searchsorted(years, year) for year in tick_years])
         columns = np.round(position_idx / span * (n_columns - 1)).astype(int)
-        return columns.tolist(), [str(year) for year in year_range]
+        return columns.tolist(), [str(year) for year in tick_years]
     columns = np.unique(np.linspace(0, n_columns - 1, 8).astype(int))
     column_to_position = np.linspace(0, len(positions) - 1, n_columns).astype(int)
     labels = [str(p)[:10] for p in positions_dt[column_to_position[columns]]]

--- a/src/scripts/validation/compare_spatial.py
+++ b/src/scripts/validation/compare_spatial.py
@@ -142,6 +142,37 @@ def _compute_spatial_stats(
     return data_clean, ref_clean
 
 
+def _spatial_color_range(
+    var: str,
+    data: xr.DataArray,
+    ref_data: xr.DataArray | None,
+    data_clean: np.ndarray,
+    ref_clean: np.ndarray,
+) -> tuple[float, float]:
+    """Shared (vmin, vmax) for the reference and validation maps."""
+    if ref_data is not None:
+        vmin = min(float(data.min()), float(ref_data.min()))
+        vmax = max(float(data.max()), float(ref_data.max()))
+    else:
+        vmin = float(data.min()) if data_clean.size else 0.0
+        vmax = float(data.max()) if data_clean.size else 1.0
+
+    if var == "precipitation_surface":
+        # Precip's heavy right tail lets a few extreme cells wash out all spatial detail
+        # under a raw-max scale; clip vmax to the 99th percentile, falling back to the
+        # raw max for a near-constant field to avoid a degenerate vmin == vmax range.
+        combined_clean = (
+            np.concatenate([data_clean, ref_clean])
+            if ref_data is not None
+            else data_clean
+        )
+        if combined_clean.size:
+            p99 = float(np.quantile(combined_clean, 0.99))
+            if p99 > vmin:
+                vmax = p99
+    return vmin, vmax
+
+
 def _draw_spatial_triplet(
     ax_ref: Axes,
     ax_val: Axes,
@@ -156,12 +187,7 @@ def _draw_spatial_triplet(
     ref_title: str,
 ) -> None:
     """Draw reference map, validation map, and histogram onto provided axes."""
-    if ref_data is not None:
-        vmin = min(float(data.min()), float(ref_data.min()))
-        vmax = max(float(data.max()), float(ref_data.max()))
-    else:
-        vmin = float(data.min()) if data_clean.size else 0.0
-        vmax = float(data.max()) if data_clean.size else 1.0
+    vmin, vmax = _spatial_color_range(var, data, ref_data, data_clean, ref_clean)
 
     # Reference map
     if ref_data is not None:

--- a/tests/scripts/validation/availability_test.py
+++ b/tests/scripts/validation/availability_test.py
@@ -8,6 +8,7 @@ import xarray as xr
 
 from scripts.validation.availability import (
     HEATMAP_FILENAME,
+    _heatmap_xticks,
     run_value_availability,
     write_availability_artifacts,
 )
@@ -269,3 +270,24 @@ def test_run_value_availability_sentinel_masked_unregistered_store(
     stats = ctx.stats["percent_frozen_precipitation_surface"]
     assert stats.positions_total is None
     assert "percent_frozen_precipitation_surface" not in ctx.availability
+
+
+def test_heatmap_xticks_thins_long_archive() -> None:
+    """A ~28-year span ticks on round years thinned to a nice step (5 here), not one
+    label per year, so labels stay readable."""
+    positions = pd.date_range("1998-01-01", "2026-01-01", freq="D").to_numpy()
+    columns, labels = _heatmap_xticks(positions, n_columns=500)
+
+    years = [int(label) for label in labels]
+    assert len(labels) <= 12
+    assert all(year % 5 == 0 for year in years)
+    assert years == sorted(years)
+    assert columns == sorted(columns)
+    assert len(set(columns)) == len(columns)  # thinned, so columns don't collide
+
+
+def test_heatmap_xticks_short_archive_ticks_every_year() -> None:
+    positions = pd.date_range("2020-01-01", "2021-12-31", freq="D").to_numpy()
+    _, labels = _heatmap_xticks(positions, n_columns=500)
+
+    assert labels == ["2020", "2021"]


### PR DESCRIPTION
Two small validation-report plotting improvements, surfaced while validating the NASA IMERG datasets (28-year global precipitation archive).

## Availability heatmap — year-tick thinning
The multi-year branch previously emitted one x-tick per calendar year, so a multi-decade archive rendered ~28 overlapping labels. Now it ticks on round years, auto-thinned to the smallest step in `{1, 2, 5, 10, 20}` that yields ≤12 labels (e.g. 1998–2026 → step 5 → 2000, 2005, …, 2025). Short (<1yr) archives are unchanged; ≤2yr still ticks every year.

## compare-spatial — robust color scale for precipitation
`precipitation_surface` is heavily right-skewed, so a raw-`max` vmax washed out all spatial structure. vmax now uses the 99th percentile (shared across the validation and reference maps, with a fallback to raw max for near-constant fields). Gated to `precipitation_surface` only — every other variable and dataset keeps the existing raw min/max range.

Tests added for the tick thinning (long vs short archive); `tests/scripts/validation/` green (49 passed), ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)