### PR TITLE
NASA IMERG: enable operational update + validate cron jobs

### DIFF
--- a/src/reformatters/nasa/imerg/dynamical_dataset.py
+++ b/src/reformatters/nasa/imerg/dynamical_dataset.py
@@ -29,10 +29,8 @@ class NasaImergAnalysisMaterializedDataset(
     max_expected_delay: ClassVar[timedelta]
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
-        # Suspended until the store is backfilled; a follow-up PR enables them.
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            suspend=True,
             schedule=self.update_schedule,
             pod_active_deadline=timedelta(minutes=60),
             image=image_tag,
@@ -50,7 +48,6 @@ class NasaImergAnalysisMaterializedDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            suspend=True,
             schedule=self.validate_schedule,
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,


### PR DESCRIPTION
The NASA IMERG Early and Late materialized stores are backfilled and validated, so this removes the `suspend=True` that shipped with the initial integration (#781). Both the update and validate cron jobs now run on their schedules, keeping the stores current and continuously validated.

Follows the dataset development guide: "Once this backfill completes, open a PR removing that [suspend] so operational updates start keeping the store current."

No other change; `suspend` defaults to `False` (matching every other dataset, none of which set it). ruff/ty and the IMERG + datasets + deploy tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)