### PR TITLE
Fix GEFS NOMADS redirect and IMERG publish-latency error noise

### DIFF
--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -312,8 +312,13 @@ class MaterializedRegionJob(
                 two_days_ago = pd.Timestamp.now() - pd.Timedelta(hours=48)
                 is_not_found = isinstance(e, FileNotFoundError) or (
                     isinstance(e, httpx.HTTPStatusError)
-                    and e.response.status_code
-                    in (HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)
+                    and (
+                        e.response.status_code
+                        in (HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)
+                        # Some sources (e.g. NOMADS) redirect instead of 404ing when
+                        # a file isn't published yet.
+                        or e.response.is_redirect
+                    )
                 )
                 if (
                     is_not_found

--- a/src/reformatters/nasa/imerg/analysis_early/region_job.py
+++ b/src/reformatters/nasa/imerg/analysis_early/region_job.py
@@ -1,6 +1,9 @@
+import pandas as pd
+
 from reformatters.nasa.imerg.imerg_config_models import ImergRun
 from reformatters.nasa.imerg.region_job import NasaImergAnalysisMaterializedRegionJob
 
 
 class NasaImergAnalysisEarlyRegionJob(NasaImergAnalysisMaterializedRegionJob):
     run: ImergRun = "early"
+    publish_latency = pd.Timedelta(hours=4.6)

--- a/src/reformatters/nasa/imerg/analysis_late/region_job.py
+++ b/src/reformatters/nasa/imerg/analysis_late/region_job.py
@@ -1,6 +1,9 @@
+import pandas as pd
+
 from reformatters.nasa.imerg.imerg_config_models import ImergRun
 from reformatters.nasa.imerg.region_job import NasaImergAnalysisMaterializedRegionJob
 
 
 class NasaImergAnalysisLateRegionJob(NasaImergAnalysisMaterializedRegionJob):
     run: ImergRun = "late"
+    publish_latency = pd.Timedelta(hours=14.7)

--- a/src/reformatters/nasa/imerg/region_job.py
+++ b/src/reformatters/nasa/imerg/region_job.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Literal, assert_never
+from typing import ClassVar, Literal, assert_never
 from urllib.parse import urlparse
 
 import numpy as np
@@ -121,6 +121,12 @@ class NasaImergAnalysisMaterializedRegionJob(
 ):
     run: ImergRun
 
+    # How long after its nominal time a granule typically takes to fully publish
+    # (all grids populated, not just the file existing). Operational updates stay
+    # behind this so they don't repeatedly request a granule whose fields (e.g.
+    # precipitationQualityIndex) haven't landed yet. See src/scripts/imerg_latency_probe.py.
+    publish_latency: ClassVar[pd.Timedelta]
+
     def generate_source_file_coords(
         self,
         processing_region_ds: xr.Dataset,
@@ -200,7 +206,7 @@ class NasaImergAnalysisMaterializedRegionJob(
     ]:
         existing_ds = xr.open_zarr(primary_store)
         append_dim_start = existing_ds[append_dim].max()
-        append_dim_end = pd.Timestamp.now()
+        append_dim_end = pd.Timestamp.now() - cls.publish_latency
         template_ds = get_template_fn(append_dim_end)
 
         jobs = cls.get_jobs(

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -1206,6 +1206,15 @@ class TestDownloadErrorLogging:
         )
         assert levels == [logging.INFO]
 
+    def test_httpx_302_recent_logs_info(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(hours=1))
+        levels = self._download_and_get_log_levels(
+            job, _make_http_status_error(302), monkeypatch, caplog
+        )
+        assert levels == [logging.INFO]
+
     def test_httpx_500_recent_logs_exception(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/nasa/imerg/dynamical_dataset_test.py
+++ b/tests/nasa/imerg/dynamical_dataset_test.py
@@ -8,6 +8,9 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from reformatters.common import validation
 from reformatters.nasa.imerg.analysis_early import NasaImergAnalysisEarlyDataset
+from reformatters.nasa.imerg.analysis_early.region_job import (
+    NasaImergAnalysisEarlyRegionJob,
+)
 from reformatters.nasa.imerg.analysis_late import NasaImergAnalysisLateDataset
 from reformatters.nasa.imerg.dynamical_dataset import (
     NasaImergAnalysisMaterializedDataset,
@@ -105,8 +108,11 @@ def test_backfill_local_and_operational_update(
     assert south["precipitation_quality_index_surface"].values[0] < 100
 
     # Operational update adds the 01:00 granule through the jsimpson (PPS) path.
+    # `now` is offset ahead by the run's publish latency buffer so the granule
+    # arriving at 01:00 falls inside the requested append_dim_end.
     update_end = pd.Timestamp("1998-01-01T01:30")
-    monkeypatch.setattr(pd.Timestamp, "now", classmethod(lambda *a, **k: update_end))
+    mocked_now = update_end + NasaImergAnalysisEarlyRegionJob.publish_latency
+    monkeypatch.setattr(pd.Timestamp, "now", classmethod(lambda *a, **k: mocked_now))
     dataset.update("test-update")
     updated = xr.open_zarr(dataset.store_factory.primary_store(), chunks=None)
     assert_array_equal(

--- a/tests/nasa/imerg/region_job_test.py
+++ b/tests/nasa/imerg/region_job_test.py
@@ -33,6 +33,14 @@ def test_variant_region_jobs_carry_run() -> None:
     assert NasaImergAnalysisLateRegionJob.model_fields["run"].default == "late"
 
 
+def test_variant_region_jobs_carry_publish_latency() -> None:
+    # Late publishes later than Early; operational updates must stay behind both.
+    assert (
+        NasaImergAnalysisEarlyRegionJob.publish_latency
+        < NasaImergAnalysisLateRegionJob.publish_latency
+    )
+
+
 def test_version_computed_from_time() -> None:
     # The V07B->V07C switchover time differs per run.
     early_before = NasaImergAnalysisSourceFileCoord(


### PR DESCRIPTION
## What

Fixes the two highest-volume error patterns in Better Stack for the `reformatters` app.

**1. GEFS 35-day: NOMADS 302 redirects logged as exceptions (~1.1K occurrences)**

`noaa-gefs-forecast-35-day-update` requests f840 (35-day) output for all 31 ensemble members at the 00Z cycle, per the dataset's own template. NOAA doesn't always produce that full extended-range tail for every perturbed member on every cycle, and NOMADS signals "not found" for these files via a 302 redirect rather than a 404. `materialized_region_job.py`'s not-found classifier only recognized `FileNotFoundError` and HTTP 403/404, so every one of these expected gaps was logged via `log.exception` (shipped to error tracking) instead of `log.info`.

Fix: treat an `httpx.HTTPStatusError` whose response `is_redirect` the same as 403/404 in the classifier — a redirect surviving `raise_for_status()` despite `follow_redirects=True` already means httpx couldn't resolve it to a real resource, so on NOMADS it's functionally "not found."

**2. IMERG Late: precipitationQualityIndex RasterioIOError (584 occurrences, top volume)**

`nasa-imerg-analysis-late-update` requests granules up to `pd.Timestamp.now()` with no publish-latency buffer. The Late run's `precipitationQualityIndex` grid isn't populated in the trailing granule until ~14.7h (p95) after nominal time (`analysis_late/dynamical_dataset.py`'s own comment documents this), so the update job kept trying to read a field that wasn't written yet, every run, on the same trailing granule — which also cascaded into `nasa-imerg-analysis-late-validate` failing with "No data found within 18:00:00 of now" since the store never advanced.

Fix: add a `publish_latency: ClassVar[pd.Timedelta]` to `NasaImergAnalysisMaterializedRegionJob` (mirroring `VirtualRegionJob.operational_update_window`), set per run (Early: 4.6h, Late: 14.7h — the p95 figures already measured by `src/scripts/imerg_latency_probe.py`), and subtract it from `append_dim_end` in `operational_update_jobs`.

## Other errors triaged (no code change)

- SMAP 404 for very recent dates and IMERG jsimpson `ConnectionResetError` — both transient/self-healing (source hasn't published yet / server-side network flakiness), already retried, and within each dataset's tolerated staleness window. Resolved as noise in Better Stack rather than code changes.

## Test plan

- [x] `uv run ruff format && uv run ruff check --fix && uv run ty check` clean
- [x] Added `test_httpx_302_recent_logs_info` to `TestDownloadErrorLogging` (mirrors existing 403/404 cases)
- [x] Added `test_variant_region_jobs_carry_publish_latency`; updated the existing `test_backfill_local_and_operational_update` integration test to account for the new latency buffer
- [x] Full test suite: `uv run pytest` — 1893 passed, 10 skipped

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013g8BeQ81opdTTmS5QYHpjF

---
_Generated by [Claude Code](https://claude.ai/code/session_013g8BeQ81opdTTmS5QYHpjF)_