### PR TITLE
Quiet-log recent "not published yet" gaps for requests-based downloads

### DIFF
--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 import httpx
 import numpy as np
 import obstore
+import requests
 
 from reformatters.common.logging import get_logger
 
@@ -32,6 +33,15 @@ The main functions which have (effectively) interchangeable interfaces are
 `http_download_to_disk` which uses obstore and
 `httpx_download_to_disk` which uses httpx and supports redirects and cookies.
 """
+
+
+def http_status_code(e: Exception) -> int | None:
+    """HTTP status code from an httpx or requests error response, else None."""
+    if isinstance(e, httpx.HTTPStatusError):
+        return e.response.status_code
+    if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
+        return e.response.status_code
+    return None
 
 
 def download_to_disk(

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -35,15 +35,6 @@ The main functions which have (effectively) interchangeable interfaces are
 """
 
 
-def http_status_code(e: Exception) -> int | None:
-    """HTTP status code from an httpx or requests error response, else None."""
-    if isinstance(e, httpx.HTTPStatusError):
-        return e.response.status_code
-    if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
-        return e.response.status_code
-    return None
-
-
 def download_to_disk(
     store: ObjectStore,
     path: str,
@@ -367,3 +358,12 @@ def httpx_download_to_disk(
         raise
 
     return local_path
+
+
+def http_status_code(e: Exception) -> int | None:
+    """HTTP status code from an httpx or requests error response, else None."""
+    if isinstance(e, httpx.HTTPStatusError):
+        return e.response.status_code
+    if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
+        return e.response.status_code
+    return None

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -9,15 +9,14 @@ from multiprocessing.shared_memory import SharedMemory
 from pathlib import Path
 from typing import Any, ClassVar, Generic, cast
 
-import httpx
 import numpy as np
 import pandas as pd
-import requests
 import xarray as xr
 from zarr.abc.store import Store
 
 from reformatters.common import storage, template_utils
 from reformatters.common.binary_rounding import round_float32_inplace
+from reformatters.common.download import http_status_code
 from reformatters.common.iterating import split_groups
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import replace
@@ -37,15 +36,6 @@ from reformatters.common.types import ArrayND
 from reformatters.common.zarr import copy_data_var
 
 log = get_logger(__name__)
-
-
-def _http_status_code(e: Exception) -> int | None:
-    """HTTP status code from an httpx or requests error response, else None."""
-    if isinstance(e, httpx.HTTPStatusError):
-        return e.response.status_code
-    if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
-        return e.response.status_code
-    return None
 
 
 class MaterializedRegionJob(
@@ -321,7 +311,7 @@ class MaterializedRegionJob(
                 append_dim_coord = coord.append_dim_coord
                 two_days_ago = pd.Timestamp.now() - pd.Timedelta(hours=48)
                 is_not_found = isinstance(e, FileNotFoundError) or (
-                    _http_status_code(e) in (HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)
+                    http_status_code(e) in (HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)
                 )
                 if (
                     is_not_found

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar, Generic, cast
 import httpx
 import numpy as np
 import pandas as pd
+import requests
 import xarray as xr
 from zarr.abc.store import Store
 
@@ -36,6 +37,15 @@ from reformatters.common.types import ArrayND
 from reformatters.common.zarr import copy_data_var
 
 log = get_logger(__name__)
+
+
+def _http_status_code(e: Exception) -> int | None:
+    """HTTP status code from an httpx or requests error response, else None."""
+    if isinstance(e, httpx.HTTPStatusError):
+        return e.response.status_code
+    if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
+        return e.response.status_code
+    return None
 
 
 class MaterializedRegionJob(
@@ -311,9 +321,7 @@ class MaterializedRegionJob(
                 append_dim_coord = coord.append_dim_coord
                 two_days_ago = pd.Timestamp.now() - pd.Timedelta(hours=48)
                 is_not_found = isinstance(e, FileNotFoundError) or (
-                    isinstance(e, httpx.HTTPStatusError)
-                    and e.response.status_code
-                    in (HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)
+                    _http_status_code(e) in (HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)
                 )
                 if (
                     is_not_found

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -11,6 +11,7 @@ import httpx
 import numpy as np
 import pandas as pd
 import pytest
+import requests
 import xarray as xr
 
 from reformatters.common import template_utils, validation
@@ -1144,6 +1145,14 @@ def _make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
     )
 
 
+def _make_requests_http_error(status_code: int) -> requests.exceptions.HTTPError:
+    response = requests.Response()
+    response.status_code = status_code
+    return requests.exceptions.HTTPError(
+        f"{status_code} Client Error", response=response
+    )
+
+
 class TestDownloadErrorLogging:
     """Test that download errors for recent files use quiet logging for expected errors."""
 
@@ -1239,6 +1248,42 @@ class TestDownloadErrorLogging:
         job = self._make_job(pd.Timestamp.now() - pd.Timedelta(days=5))
         levels = self._download_and_get_log_levels(
             job, FileNotFoundError("missing"), monkeypatch, caplog
+        )
+        assert levels == [logging.ERROR]
+
+    def test_requests_404_recent_logs_info(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(hours=1))
+        levels = self._download_and_get_log_levels(
+            job, _make_requests_http_error(404), monkeypatch, caplog
+        )
+        assert levels == [logging.INFO]
+
+    def test_requests_403_recent_logs_info(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(hours=1))
+        levels = self._download_and_get_log_levels(
+            job, _make_requests_http_error(403), monkeypatch, caplog
+        )
+        assert levels == [logging.INFO]
+
+    def test_requests_500_recent_logs_exception(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(hours=1))
+        levels = self._download_and_get_log_levels(
+            job, _make_requests_http_error(500), monkeypatch, caplog
+        )
+        assert levels == [logging.ERROR]
+
+    def test_requests_404_old_logs_exception(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(days=5))
+        levels = self._download_and_get_log_levels(
+            job, _make_requests_http_error(404), monkeypatch, caplog
         )
         assert levels == [logging.ERROR]
 

--- a/tests/common/test_download.py
+++ b/tests/common/test_download.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 import httpx
 import obstore.store
 import pytest
+import requests
 
 from reformatters.common import download as download_module
 from reformatters.common.download import (
@@ -14,11 +15,44 @@ from reformatters.common.download import (
     download_to_disk,
     get_local_path,
     http_download_to_disk,
+    http_status_code,
     http_store,
     httpx_download_to_disk,
     s3_download_to_disk,
     s3_store,
 )
+
+
+def _httpx_error(status_code: int) -> httpx.HTTPStatusError:
+    return httpx.HTTPStatusError(
+        message=f"Client error '{status_code}'",
+        request=httpx.Request("GET", "https://example.com/file"),
+        response=httpx.Response(status_code),
+    )
+
+
+def _requests_error(status_code: int) -> requests.exceptions.HTTPError:
+    response = requests.Response()
+    response.status_code = status_code
+    return requests.exceptions.HTTPError(
+        f"{status_code} Client Error", response=response
+    )
+
+
+def test_http_status_code_httpx() -> None:
+    assert http_status_code(_httpx_error(404)) == 404
+
+
+def test_http_status_code_requests() -> None:
+    assert http_status_code(_requests_error(403)) == 403
+
+
+def test_http_status_code_requests_without_response() -> None:
+    assert http_status_code(requests.exceptions.HTTPError("no response")) is None
+
+
+def test_http_status_code_other_exception() -> None:
+    assert http_status_code(FileNotFoundError("missing")) is None
 
 
 def test_get_local_path_basic() -> None:


### PR DESCRIPTION
Fixes #799.

## Problem

`MaterializedRegionJob._call_download_file` has a "quiet path" that downgrades a download failure to `log.info` (instead of `log.exception`) when a recent append_dim value (`< 48h` old) fails with `FileNotFoundError` or a 403/404 — this exists so normal "not published yet" publish-latency gaps don't fire error-level alerts.

That check only recognized `httpx.HTTPStatusError`. NASA download modules (`contrib/nasa/smap/level3_36km_v9`, `nasa/imerg`) use `requests.Session` objects via `nasa_auth`, whose `raise_for_status()` raises `requests.exceptions.HTTPError`. So every NASA dataset hitting a normal publish-latency gap fell through to `log.exception`, spamming error tracking (e.g. the SMAP L3 404s triaged in Better Stack, where the source has known multi-day publish latency).

## Change

- Extract HTTP status extraction into a `_http_status_code` helper that returns the status code from either an `httpx.HTTPStatusError` or a `requests.exceptions.HTTPError` (with a non-None response), else `None`.
- Use it in the `is_not_found` check so 403/404 from `requests`-based downloads take the quiet path too. The 48h recency gate is unchanged.

## Tests

Added `requests`-based cases mirroring the existing httpx ones in `TestDownloadErrorLogging`: recent 403/404 → `INFO`, recent 500 → `ERROR`, old 404 → `ERROR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LuGrEciyDXeZRB8Kz4Dmx

---
_Generated by [Claude Code](https://claude.ai/code/session_011LuGrEciyDXeZRB8Kz4Dmx)_