### PR TITLE
Restore Sentry cron check-ins + DSN fallback (Sentry restore, 1/3)

### DIFF
--- a/.github/workflows/manual-backfill.yml
+++ b/.github/workflows/manual-backfill.yml
@@ -215,5 +215,5 @@ jobs:
           echo ""
           echo "- [Manual: Get Jobs](https://github.com/${{ github.repository }}/actions/workflows/manual-get-jobs.yml)"
           echo "- [Manual: Get Pods](https://github.com/${{ github.repository }}/actions/workflows/manual-get-pods.yml)"
-          echo "- [Better Stack logs](https://telemetry.betterstack.com/team/552704/tail)"
+          echo "- [Sentry logs](https://dynamical.sentry.io/explore/logs/)"
         } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/manual-create-job-from-cronjob.yml
+++ b/.github/workflows/manual-create-job-from-cronjob.yml
@@ -110,8 +110,8 @@ jobs:
         echo ""
         echo "### Monitoring"
         echo ""
-        echo "- Better Stack heartbeats (cron status): https://uptime.betterstack.com/team/552704/monitors"
-        echo "- Better Stack logs (filter by job_name=${JOB_NAME}): https://telemetry.betterstack.com/team/552704/tail"
+        echo "- Sentry cron status: https://dynamical.sentry.io/issues/alerts/rules/crons/reformatters/${CRONJOB_NAME}/details/"
+        echo "- Sentry job logs: https://dynamical.sentry.io/explore/logs/?logsQuery=job_name%3A${JOB_NAME}"
         echo "- Manual Get Jobs: https://github.com/${{ github.repository }}/actions/workflows/manual-get-jobs.yml"
         echo "- Manual Get Pods: https://github.com/${{ github.repository }}/actions/workflows/manual-get-pods.yml"
 
@@ -125,8 +125,8 @@ jobs:
           echo ""
           echo "### Monitoring"
           echo ""
-          echo "- [Better Stack heartbeats (cron status)](https://uptime.betterstack.com/team/552704/monitors)"
-          echo "- [Better Stack logs (filter by job_name=\`${JOB_NAME}\`)](https://telemetry.betterstack.com/team/552704/tail)"
+          echo "- [Sentry cron status](https://dynamical.sentry.io/issues/alerts/rules/crons/reformatters/${CRONJOB_NAME}/details/)"
+          echo "- [Sentry job logs](https://dynamical.sentry.io/explore/logs/?logsQuery=job_name%3A${JOB_NAME})"
           echo "- [Manual Get Jobs](https://github.com/${{ github.repository }}/actions/workflows/manual-get-jobs.yml)"
           echo "- [Manual Get Pods](https://github.com/${{ github.repository }}/actions/workflows/manual-get-pods.yml)"
         } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/manual-get-jobs.yml
+++ b/.github/workflows/manual-get-jobs.yml
@@ -42,8 +42,8 @@ jobs:
         echo ""
         echo "### Monitoring"
         echo ""
-        echo "- Better Stack heartbeats: https://uptime.betterstack.com/team/552704/monitors"
-        echo "- Better Stack logs: https://telemetry.betterstack.com/team/552704/tail"
+        echo "- Sentry crons overview: https://dynamical.sentry.io/insights/crons/"
+        echo "- Sentry logs: https://dynamical.sentry.io/explore/logs/"
 
         # Write to job summary
         echo "## Kubernetes Jobs" >> $GITHUB_STEP_SUMMARY
@@ -54,5 +54,5 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Monitoring" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "- [Better Stack heartbeats](https://uptime.betterstack.com/team/552704/monitors)" >> $GITHUB_STEP_SUMMARY
-        echo "- [Better Stack logs](https://telemetry.betterstack.com/team/552704/tail)" >> $GITHUB_STEP_SUMMARY
+        echo "- [Sentry crons overview](https://dynamical.sentry.io/insights/crons/)" >> $GITHUB_STEP_SUMMARY
+        echo "- [Sentry logs](https://dynamical.sentry.io/explore/logs/)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/manual-get-pods.yml
+++ b/.github/workflows/manual-get-pods.yml
@@ -42,8 +42,8 @@ jobs:
         echo ""
         echo "### Monitoring"
         echo ""
-        echo "- Better Stack heartbeats: https://uptime.betterstack.com/team/552704/monitors"
-        echo "- Better Stack logs: https://telemetry.betterstack.com/team/552704/tail"
+        echo "- Sentry crons overview: https://dynamical.sentry.io/insights/crons/"
+        echo "- Sentry logs: https://dynamical.sentry.io/explore/logs/"
 
         # Write to job summary
         echo "## Kubernetes Pods" >> $GITHUB_STEP_SUMMARY
@@ -54,5 +54,5 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Monitoring" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "- [Better Stack heartbeats](https://uptime.betterstack.com/team/552704/monitors)" >> $GITHUB_STEP_SUMMARY
-        echo "- [Better Stack logs](https://telemetry.betterstack.com/team/552704/tail)" >> $GITHUB_STEP_SUMMARY
+        echo "- [Sentry crons overview](https://dynamical.sentry.io/insights/crons/)" >> $GITHUB_STEP_SUMMARY
+        echo "- [Sentry logs](https://dynamical.sentry.io/explore/logs/)" >> $GITHUB_STEP_SUMMARY

--- a/docs/ops_card.md
+++ b/docs/ops_card.md
@@ -4,6 +4,12 @@ _Report issues to feedback@dynamical.org._
 
 For each dataset there are two workflows: `{dataset-id}-update` runs first, followed by `{dataset-id}-validate`.
 
+## Sentry monitoring
+_Requires sentry organization invitation._
+- [Crons overview](https://dynamical.sentry.io/insights/crons/) - Start here. If all green, we're good. If red, click in to see the issue and logs.
+- [Issues](https://dynamical.sentry.io/issues/?statsPeriod=12h)
+- [Logs](https://dynamical.sentry.io/explore/logs/) - You can filter these by job name
+
 ## Better Stack monitoring
 _Requires Better Stack (dynamical.org team) invitation._
 - **Logs** — the `reformatters` source (Live tail). Filter by the `cron_job_name` / `job_name` / `pod_name` / `env` fields.

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -93,7 +93,7 @@ This deletes:
 
 Deleting heartbeats requires `BETTERSTACK_API_KEY_RW` in your environment (a read/write Better Stack Uptime API token); it is also required by `deploy-staging`. Cronjobs and the branch are deleted first, so a missing key can't leave them orphaned.
 
-The dataset store is **not** deleted. Clean it up manually when ready.
+The dataset store and Sentry cron monitors are **not** deleted. Clean them up manually when ready.
 
 ## Constraints
 

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -13,7 +13,7 @@ import sentry_sdk
 import typer
 from sentry_sdk.integrations.typer import TyperIntegration
 
-from reformatters.common import betterstack
+from reformatters.common import betterstack, monitoring
 from reformatters.common import deploy as deploy_module
 from reformatters.common.config import Config
 from reformatters.common.dynamical_dataset import DynamicalDataset, register_run_monitor
@@ -233,13 +233,14 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
 
 betterstack.attach_logtail()
 
-# Register the monitor that wraps each operational cron run.
+# Register the monitors that wrap each operational cron run. Sentry first so its
+# check-in nests outside the Better Stack heartbeat, matching prior ordering.
+register_run_monitor(monitoring.monitor_cron)
 register_run_monitor(betterstack.monitor_cron_run)
 
-if Config.is_error_tracking_enabled:
-    # Better Stack Errors ingests via the Sentry SDK (Sentry-protocol compatible).
+if Config.is_sentry_enabled:
     sentry_sdk.init(
-        dsn=Config.errors_dsn,
+        dsn=Config.sentry_dsn,
         environment=Config.env.value,
         project_root="src/",
         in_app_include=["reformatters"],
@@ -247,7 +248,6 @@ if Config.is_error_tracking_enabled:
         integrations=[
             TyperIntegration(),
         ],
-        before_send=betterstack.group_error_fingerprint,
     )
     sentry_sdk.set_tag("env", Config.env.value)
     sentry_sdk.set_tag("cron_job_name", os.getenv("CRON_JOB_NAME"))

--- a/src/reformatters/common/betterstack.py
+++ b/src/reformatters/common/betterstack.py
@@ -7,14 +7,11 @@ import subprocess
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
+from typing import Any, Literal, NamedTuple, cast
 
 import httpx
 from croniter import croniter
 from logtail import LogtailHandler
-
-if TYPE_CHECKING:
-    from sentry_sdk.types import Event, Hint
 
 from reformatters.common.kubernetes import (
     BETTERSTACK_HEARTBEATS_SECRET_NAME,
@@ -73,36 +70,6 @@ def attach_logtail() -> None:
     handler.setLevel(logging.INFO)
     handler.addFilter(_ContextFilter())
     logger.addHandler(handler)
-
-
-# --- Error grouping ---------------------------------------------------------
-# Better Stack Errors groups by the rendered message. Our messages interpolate
-# unique data (source file paths, timestamps, coordinates), so message grouping
-# splits one failure mode into thousands of single-occurrence groups — e.g. a
-# backfill over a gappy archive emits one expected FileNotFoundError per missing
-# file. Fingerprinting on exception type + originating in-app code location
-# collapses each failure mode back to a single group.
-
-
-def group_error_fingerprint(event: Event, hint: Hint) -> Event:  # noqa: ARG001  # sentry before_send signature; hint unused
-    """Sentry `before_send`: fingerprint by exception type + innermost in-app
-    frame instead of the message. Events without an exception (bare log records)
-    keep default grouping."""
-    values = (event.get("exception") or {}).get("values")
-    if not values:
-        return event
-
-    exception = values[-1]
-    frames = (exception.get("stacktrace") or {}).get("frames") or []
-    in_app_frames = [frame for frame in frames if frame.get("in_app")]
-    culprit_frames = in_app_frames or frames
-
-    fingerprint = [str(exception.get("type", "Error"))]
-    if culprit_frames:
-        culprit = culprit_frames[-1]  # innermost: where the exception was raised
-        fingerprint += [str(culprit.get("module")), str(culprit.get("function"))]
-    event["fingerprint"] = fingerprint
-    return event
 
 
 # --- Heartbeats -------------------------------------------------------------

--- a/src/reformatters/common/config.py
+++ b/src/reformatters/common/config.py
@@ -10,11 +10,16 @@ class Env(StrEnum):
     test = "test"
 
 
+def _errors_dsn() -> str | None:
+    # Prefer the Better Stack Errors DSN (Sentry-protocol compatible); fall back to
+    # the Sentry DSN so unsetting BETTERSTACK_ERRORS_DSN reverts error tracking to Sentry.
+    return os.getenv("BETTERSTACK_ERRORS_DSN") or os.getenv("DYNAMICAL_SENTRY_DSN")
+
+
 class DynamicalConfig(pydantic.BaseModel):
     env: Env = Env(os.getenv("DYNAMICAL_ENV", "dev"))
 
-    # Sentry-protocol DSN for the Better Stack Errors application.
-    errors_dsn: str | None = os.getenv("BETTERSTACK_ERRORS_DSN")
+    sentry_dsn: str | None = _errors_dsn()
 
     @property
     def is_test(self) -> bool:
@@ -29,8 +34,8 @@ class DynamicalConfig(pydantic.BaseModel):
         return self.env == Env.prod
 
     @property
-    def is_error_tracking_enabled(self) -> bool:
-        return self.errors_dsn is not None
+    def is_sentry_enabled(self) -> bool:
+        return self.sentry_dsn is not None
 
 
 Config = DynamicalConfig()

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -882,8 +882,8 @@ class RunMonitor(Protocol):
 
     The application registers monitors (see `register_run_monitor`); `DynamicalDataset._monitor`
     enters every registered one around each update/validate run. This keeps
-    DynamicalDataset agnostic of any specific monitoring service (e.g. Better Stack)
-    — a different deployment registers whatever it uses, or nothing.
+    DynamicalDataset agnostic of any specific monitoring service (Better Stack,
+    Sentry, ...) — a different deployment registers whatever it uses, or nothing.
     """
 
     def __call__(

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -104,6 +104,15 @@ class Job(pydantic.BaseModel):
                                 "env": [
                                     {"name": "DYNAMICAL_ENV", "value": "prod"},
                                     {
+                                        "name": "DYNAMICAL_SENTRY_DSN",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "DYNAMICAL_SENTRY_DSN",
+                                                "name": "sentry",
+                                            }
+                                        },
+                                    },
+                                    {
                                         "name": "BETTERSTACK_SOURCE_TOKEN",
                                         "valueFrom": {
                                             "secretKeyRef": {

--- a/src/reformatters/common/monitoring.py
+++ b/src/reformatters/common/monitoring.py
@@ -1,0 +1,57 @@
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Literal
+
+import sentry_sdk
+import sentry_sdk.crons
+
+from reformatters.common.config import Config
+from reformatters.common.iterating import digest
+from reformatters.common.kubernetes import CronJob
+
+
+@contextmanager
+def monitor_cron(
+    cron_job: CronJob,
+    reformat_job_name: str,
+    *,
+    send_in_progress: bool = True,
+    send_result: bool = True,
+) -> Iterator[None]:
+    """Send Sentry cron check-ins for `cron_job` around the wrapped block, so a
+    missed or overrunning run alerts, not just a raised exception."""
+    if not Config.is_sentry_enabled:
+        yield
+        return
+
+    # Use the actual cronjob name from k8s env when available. This ensures
+    # staging cronjobs report to their own Sentry monitor, not production's.
+    monitor_slug = os.getenv("CRON_JOB_NAME") or cron_job.name
+
+    def capture_checkin(status: Literal["ok", "in_progress", "error"]) -> None:
+        sentry_sdk.crons.capture_checkin(
+            monitor_slug=monitor_slug,
+            check_in_id=digest([reformat_job_name], length=32),
+            status=status,
+            monitor_config={
+                "schedule": {"type": "crontab", "value": cron_job.schedule},
+                "timezone": "UTC",
+                "checkin_margin": 10,
+                "max_runtime": int(cron_job.pod_active_deadline.total_seconds() / 60),
+                "failure_issue_threshold": 1,
+                "recovery_threshold": 1,
+            },
+        )
+
+    if send_in_progress:
+        capture_checkin("in_progress")
+    try:
+        yield
+    except Exception:
+        if send_result:
+            capture_checkin("error")
+        raise
+    else:
+        if send_result:
+            capture_checkin("ok")

--- a/src/reformatters/common/staging.py
+++ b/src/reformatters/common/staging.py
@@ -131,5 +131,6 @@ def cleanup_staging_resources(
         log.info(f"Could not delete branch {branch}: {result.stderr.strip()}")
 
     log.info(
-        f"Cleanup complete. Dataset store was NOT deleted for cronjobs: {cronjob_names}"
+        "Cleanup complete. Dataset store and Sentry cron monitors were NOT deleted. "
+        f"Manually delete Sentry monitors: {cronjob_names}"
     )

--- a/src/scripts/generate_manual_workflows.py
+++ b/src/scripts/generate_manual_workflows.py
@@ -154,8 +154,8 @@ echo "Job Name: ${JOB_NAME}"
 echo ""
 echo "### Monitoring"
 echo ""
-echo "- Better Stack heartbeats (cron status): https://uptime.betterstack.com/team/552704/monitors"
-echo "- Better Stack logs (filter by job_name=${JOB_NAME}): https://telemetry.betterstack.com/team/552704/tail"
+echo "- Sentry cron status: https://dynamical.sentry.io/issues/alerts/rules/crons/reformatters/${CRONJOB_NAME}/details/"
+echo "- Sentry job logs: https://dynamical.sentry.io/explore/logs/?logsQuery=job_name%3A${JOB_NAME}"
 echo "- Manual Get Jobs: https://github.com/${{ github.repository }}/actions/workflows/manual-get-jobs.yml"
 echo "- Manual Get Pods: https://github.com/${{ github.repository }}/actions/workflows/manual-get-pods.yml"
 
@@ -169,8 +169,8 @@ echo "- Manual Get Pods: https://github.com/${{ github.repository }}/actions/wor
   echo ""
   echo "### Monitoring"
   echo ""
-  echo "- [Better Stack heartbeats (cron status)](https://uptime.betterstack.com/team/552704/monitors)"
-  echo "- [Better Stack logs (filter by job_name=\`${JOB_NAME}\`)](https://telemetry.betterstack.com/team/552704/tail)"
+  echo "- [Sentry cron status](https://dynamical.sentry.io/issues/alerts/rules/crons/reformatters/${CRONJOB_NAME}/details/)"
+  echo "- [Sentry job logs](https://dynamical.sentry.io/explore/logs/?logsQuery=job_name%3A${JOB_NAME})"
   echo "- [Manual Get Jobs](https://github.com/${{ github.repository }}/actions/workflows/manual-get-jobs.yml)"
   echo "- [Manual Get Pods](https://github.com/${{ github.repository }}/actions/workflows/manual-get-pods.yml)"
 } >> $GITHUB_STEP_SUMMARY
@@ -428,7 +428,7 @@ uv run main "${DATASET_ID}" backfill-kubernetes "${ARGS[@]}"
   echo ""
   echo "- [Manual: Get Jobs](https://github.com/${{ github.repository }}/actions/workflows/manual-get-jobs.yml)"
   echo "- [Manual: Get Pods](https://github.com/${{ github.repository }}/actions/workflows/manual-get-pods.yml)"
-  echo "- [Better Stack logs](https://telemetry.betterstack.com/team/552704/tail)"
+  echo "- [Sentry logs](https://dynamical.sentry.io/explore/logs/)"
 } >> $GITHUB_STEP_SUMMARY
 """
                         ),
@@ -488,8 +488,8 @@ echo "$OUTPUT"
 echo ""
 echo "### Monitoring"
 echo ""
-echo "- Better Stack heartbeats: https://uptime.betterstack.com/team/552704/monitors"
-echo "- Better Stack logs: https://telemetry.betterstack.com/team/552704/tail"
+echo "- Sentry crons overview: https://dynamical.sentry.io/insights/crons/"
+echo "- Sentry logs: https://dynamical.sentry.io/explore/logs/"
 
 # Write to job summary
 echo "## Kubernetes Jobs" >> $GITHUB_STEP_SUMMARY
@@ -500,8 +500,8 @@ echo '```' >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "### Monitoring" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "- [Better Stack heartbeats](https://uptime.betterstack.com/team/552704/monitors)" >> $GITHUB_STEP_SUMMARY
-echo "- [Better Stack logs](https://telemetry.betterstack.com/team/552704/tail)" >> $GITHUB_STEP_SUMMARY
+echo "- [Sentry crons overview](https://dynamical.sentry.io/insights/crons/)" >> $GITHUB_STEP_SUMMARY
+echo "- [Sentry logs](https://dynamical.sentry.io/explore/logs/)" >> $GITHUB_STEP_SUMMARY
 """
                         ),
                     },
@@ -560,8 +560,8 @@ echo "$OUTPUT"
 echo ""
 echo "### Monitoring"
 echo ""
-echo "- Better Stack heartbeats: https://uptime.betterstack.com/team/552704/monitors"
-echo "- Better Stack logs: https://telemetry.betterstack.com/team/552704/tail"
+echo "- Sentry crons overview: https://dynamical.sentry.io/insights/crons/"
+echo "- Sentry logs: https://dynamical.sentry.io/explore/logs/"
 
 # Write to job summary
 echo "## Kubernetes Pods" >> $GITHUB_STEP_SUMMARY
@@ -572,8 +572,8 @@ echo '```' >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "### Monitoring" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "- [Better Stack heartbeats](https://uptime.betterstack.com/team/552704/monitors)" >> $GITHUB_STEP_SUMMARY
-echo "- [Better Stack logs](https://telemetry.betterstack.com/team/552704/tail)" >> $GITHUB_STEP_SUMMARY
+echo "- [Sentry crons overview](https://dynamical.sentry.io/insights/crons/)" >> $GITHUB_STEP_SUMMARY
+echo "- [Sentry logs](https://dynamical.sentry.io/explore/logs/)" >> $GITHUB_STEP_SUMMARY
 """
                         ),
                     },

--- a/tests/common/betterstack_test.py
+++ b/tests/common/betterstack_test.py
@@ -1,12 +1,10 @@
 import json
 import logging
 from datetime import timedelta
-from typing import cast
 
 import httpx
 import pytest
 from logtail import LogtailHandler
-from sentry_sdk.types import Event, Hint
 
 from reformatters.common import betterstack, staging
 from reformatters.common.betterstack import (
@@ -83,78 +81,6 @@ def test_attach_logtail_adds_handler_and_is_idempotent(
         for handler in logger.handlers[:]:
             if isinstance(handler, LogtailHandler):
                 logger.removeHandler(handler)
-
-
-def _exception_event(
-    exc_type: str, message: str, frames: list[dict[str, object]]
-) -> Event:
-    return cast(
-        "Event",
-        {
-            "exception": {
-                "values": [
-                    {
-                        "type": exc_type,
-                        "value": message,
-                        "stacktrace": {"frames": frames},
-                    }
-                ]
-            }
-        },
-    )
-
-
-_HINT = cast("Hint", {})
-
-
-def test_group_error_fingerprint_collapses_varied_messages() -> None:
-    frames: list[dict[str, object]] = [
-        {"module": "obstore._store", "function": "get", "in_app": False},
-        {
-            "module": "reformatters.common.download",
-            "function": "http_download_to_disk",
-            "in_app": True,
-        },
-    ]
-    first = betterstack.group_error_fingerprint(
-        _exception_event(
-            "FileNotFoundError", "Object at hrrr.20161124/...t16z", frames
-        ),
-        _HINT,
-    )
-    second = betterstack.group_error_fingerprint(
-        _exception_event(
-            "FileNotFoundError", "Object at hrrr.20190630/...t18z", frames
-        ),
-        _HINT,
-    )
-    # Same failure mode, different interpolated path -> identical fingerprint.
-    assert first["fingerprint"] == second["fingerprint"]
-    # Fingerprints on the innermost in-app frame, not the noisy library frame.
-    assert first["fingerprint"] == [
-        "FileNotFoundError",
-        "reformatters.common.download",
-        "http_download_to_disk",
-    ]
-
-
-def test_group_error_fingerprint_separates_distinct_types() -> None:
-    frames: list[dict[str, object]] = [
-        {"module": "reformatters.x", "function": "f", "in_app": True}
-    ]
-    not_found = betterstack.group_error_fingerprint(
-        _exception_event("FileNotFoundError", "a", frames), _HINT
-    )
-    value_error = betterstack.group_error_fingerprint(
-        _exception_event("ValueError", "a", frames), _HINT
-    )
-    assert not_found["fingerprint"] != value_error["fingerprint"]
-
-
-def test_group_error_fingerprint_leaves_non_exception_events() -> None:
-    event = cast("Event", {"message": "just a log line"})
-    result = betterstack.group_error_fingerprint(event, _HINT)
-    assert "fingerprint" not in result
 
 
 def test_cron_name_prefix_strips_step() -> None:

--- a/tests/common/monitoring_test.py
+++ b/tests/common/monitoring_test.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+from unittest.mock import Mock
+
+import pytest
+import sentry_sdk.crons
+
+from reformatters.common.config import Config
+from reformatters.common.kubernetes import CronJob
+from reformatters.common.monitoring import monitor_cron
+
+_CRON_JOB = CronJob(
+    command=["archive-grib-files"],
+    workers_total=1,
+    parallelism=1,
+    name="example-archive-grib-files",
+    schedule="0 4 * * *",
+    pod_active_deadline=timedelta(hours=2),
+    image="test-image:tag",
+    dataset_id="example",
+    cpu="1",
+    memory="1G",
+)
+
+
+def test_monitor_cron_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(Config), "is_sentry_enabled", True)
+    mock_capture = Mock()
+    monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", mock_capture)
+
+    with monitor_cron(_CRON_JOB, "job-name"):
+        pass
+    statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
+    assert statuses == ["in_progress", "ok"]
+
+    call_kwargs = mock_capture.call_args_list[0].kwargs
+    assert call_kwargs["monitor_config"]["schedule"]["value"] == "0 4 * * *"
+    assert call_kwargs["monitor_config"]["max_runtime"] == 120
+
+    mock_capture.reset_mock()
+    with pytest.raises(ValueError, match="failure"):  # noqa: SIM117
+        with monitor_cron(_CRON_JOB, "job-name"):
+            raise ValueError("failure")
+    statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
+    assert statuses == ["in_progress", "error"]
+
+
+def test_monitor_cron_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(type(Config), "is_sentry_enabled", False)
+    mock_capture = Mock()
+    monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", mock_capture)
+
+    # Should not raise, and should not call out to sentry at all.
+    with monitor_cron(_CRON_JOB, "job-name"):
+        pass
+    mock_capture.assert_not_called()

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -1,4 +1,6 @@
-from reformatters.common.config import DynamicalConfig, Env
+import pytest
+
+from reformatters.common.config import DynamicalConfig, Env, _errors_dsn
 
 
 class TestEnv:
@@ -32,10 +34,29 @@ class TestDynamicalConfig:
         assert config.is_dev is False
         assert config.is_test is False
 
-    def test_error_tracking_enabled_when_dsn_set(self) -> None:
-        config = DynamicalConfig(env=Env.dev, errors_dsn="https://example.com/dsn")
-        assert config.is_error_tracking_enabled is True
+    def test_sentry_enabled_when_dsn_set(self) -> None:
+        config = DynamicalConfig(env=Env.dev, sentry_dsn="https://example.com/dsn")
+        assert config.is_sentry_enabled is True
 
-    def test_error_tracking_disabled_when_dsn_none(self) -> None:
-        config = DynamicalConfig(env=Env.dev, errors_dsn=None)
-        assert config.is_error_tracking_enabled is False
+    def test_sentry_disabled_when_dsn_none(self) -> None:
+        config = DynamicalConfig(env=Env.dev, sentry_dsn=None)
+        assert config.is_sentry_enabled is False
+
+
+class TestErrorsDsn:
+    def test_prefers_betterstack_over_sentry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BETTERSTACK_ERRORS_DSN", "https://betterstack/dsn")
+        monkeypatch.setenv("DYNAMICAL_SENTRY_DSN", "https://sentry/dsn")
+        assert _errors_dsn() == "https://betterstack/dsn"
+
+    def test_falls_back_to_sentry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BETTERSTACK_ERRORS_DSN", raising=False)
+        monkeypatch.setenv("DYNAMICAL_SENTRY_DSN", "https://sentry/dsn")
+        assert _errors_dsn() == "https://sentry/dsn"
+
+    def test_none_when_neither_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BETTERSTACK_ERRORS_DSN", raising=False)
+        monkeypatch.delenv("DYNAMICAL_SENTRY_DSN", raising=False)
+        assert _errors_dsn() is None

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -78,6 +78,15 @@ def test_as_kubernetes_object_comprehensive() -> None:
                         "env": [
                             {"name": "DYNAMICAL_ENV", "value": "prod"},
                             {
+                                "name": "DYNAMICAL_SENTRY_DSN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "DYNAMICAL_SENTRY_DSN",
+                                        "name": "sentry",
+                                    }
+                                },
+                            },
+                            {
                                 "name": "BETTERSTACK_SOURCE_TOKEN",
                                 "valueFrom": {
                                     "secretKeyRef": {


### PR DESCRIPTION
Revert of #788, first of three PRs migrating observability back to Sentry (tracking: dynamical-org/meta#145).

Restores:
- `common/monitoring.py` Sentry cron check-ins, registered **alongside** the Better Stack heartbeat monitor (heartbeats keep feeding the public status page until dynamical-org/meta#147 replaces it)
- `DYNAMICAL_SENTRY_DSN` env from the `sentry` k8s secret; `errors_dsn` prefers `BETTERSTACK_ERRORS_DSN` with Sentry as fallback (errors keep flowing to Better Stack until 2/3 cuts them over)
- `dynamical.sentry.io` links in docs/workflows

All ~34 Sentry cron monitors are still active in the `dynamical` org, so check-ins resume against existing slugs.

**Deploy prerequisite (before merge):**
`kubectl create secret generic sentry --from-literal=DYNAMICAL_SENTRY_DSN=<reformatters DSN>` — secretKeyRef is non-optional; a missing secret blocks pod start.

Next: 2/3 revert of #786 (errors → Sentry), 3/3 revert of #785 (logs → Sentry Logs, remove logtail).