### PR TITLE
Cut error tracking over to Sentry (Sentry restore, 2/3)

### DIFF
--- a/src/reformatters/common/config.py
+++ b/src/reformatters/common/config.py
@@ -10,16 +10,10 @@ class Env(StrEnum):
     test = "test"
 
 
-def _errors_dsn() -> str | None:
-    # Prefer the Better Stack Errors DSN (Sentry-protocol compatible); fall back to
-    # the Sentry DSN so unsetting BETTERSTACK_ERRORS_DSN reverts error tracking to Sentry.
-    return os.getenv("BETTERSTACK_ERRORS_DSN") or os.getenv("DYNAMICAL_SENTRY_DSN")
-
-
 class DynamicalConfig(pydantic.BaseModel):
     env: Env = Env(os.getenv("DYNAMICAL_ENV", "dev"))
 
-    sentry_dsn: str | None = _errors_dsn()
+    sentry_dsn: str | None = os.getenv("DYNAMICAL_SENTRY_DSN")
 
     @property
     def is_test(self) -> bool:

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -131,15 +131,6 @@ class Job(pydantic.BaseModel):
                                         },
                                     },
                                     {
-                                        "name": "BETTERSTACK_ERRORS_DSN",
-                                        "valueFrom": {
-                                            "secretKeyRef": {
-                                                "key": "BETTERSTACK_ERRORS_DSN",
-                                                "name": "betterstack",
-                                            }
-                                        },
-                                    },
-                                    {
                                         "name": "JOB_NAME",
                                         "valueFrom": {
                                             "fieldRef": {

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -1,6 +1,4 @@
-import pytest
-
-from reformatters.common.config import DynamicalConfig, Env, _errors_dsn
+from reformatters.common.config import DynamicalConfig, Env
 
 
 class TestEnv:
@@ -41,22 +39,3 @@ class TestDynamicalConfig:
     def test_sentry_disabled_when_dsn_none(self) -> None:
         config = DynamicalConfig(env=Env.dev, sentry_dsn=None)
         assert config.is_sentry_enabled is False
-
-
-class TestErrorsDsn:
-    def test_prefers_betterstack_over_sentry(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("BETTERSTACK_ERRORS_DSN", "https://betterstack/dsn")
-        monkeypatch.setenv("DYNAMICAL_SENTRY_DSN", "https://sentry/dsn")
-        assert _errors_dsn() == "https://betterstack/dsn"
-
-    def test_falls_back_to_sentry(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("BETTERSTACK_ERRORS_DSN", raising=False)
-        monkeypatch.setenv("DYNAMICAL_SENTRY_DSN", "https://sentry/dsn")
-        assert _errors_dsn() == "https://sentry/dsn"
-
-    def test_none_when_neither_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("BETTERSTACK_ERRORS_DSN", raising=False)
-        monkeypatch.delenv("DYNAMICAL_SENTRY_DSN", raising=False)
-        assert _errors_dsn() is None

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -105,15 +105,6 @@ def test_as_kubernetes_object_comprehensive() -> None:
                                 },
                             },
                             {
-                                "name": "BETTERSTACK_ERRORS_DSN",
-                                "valueFrom": {
-                                    "secretKeyRef": {
-                                        "key": "BETTERSTACK_ERRORS_DSN",
-                                        "name": "betterstack",
-                                    }
-                                },
-                            },
-                            {
                                 "name": "JOB_NAME",
                                 "valueFrom": {
                                     "fieldRef": {


### PR DESCRIPTION
Revert of #786, second of three (tracking: dynamical-org/meta#145). Stacked on #801.

Drops the `BETTERSTACK_ERRORS_DSN` preference and its env wiring — `sentry_sdk` reports to the real Sentry DSN (`DYNAMICAL_SENTRY_DSN`, restored in #801). Better Stack heartbeats are untouched.

**Merge after** #801 has deployed and Sentry cron check-ins are confirmed green.
Verify after deploy: induce a test error in dev → issue appears in the Sentry `reformatters` project with env/cron tags.