### PR TITLE
Cut logs over to Sentry Logs, remove logtail (Sentry restore, 3/3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "google-crc32c>=1.8.0",
     "httpx>=0.28.1",
     "gribberish==1.5.0",
-    "logtail-python>=0.3.4",
     "croniter>=6.2.4",
 ]
 

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -12,6 +12,7 @@ with contextlib.suppress(RuntimeError):  # skip if already set
 import sentry_sdk
 import typer
 from sentry_sdk.integrations.typer import TyperIntegration
+from sentry_sdk.types import Hint, Log
 
 from reformatters.common import betterstack, monitoring
 from reformatters.common import deploy as deploy_module
@@ -231,28 +232,41 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
     ),
 ]
 
-betterstack.attach_logtail()
-
 # Register the monitors that wrap each operational cron run. Sentry first so its
 # check-in nests outside the Better Stack heartbeat, matching prior ordering.
 register_run_monitor(monitoring.monitor_cron)
 register_run_monitor(betterstack.monitor_cron_run)
 
 if Config.is_sentry_enabled:
+    cron_job_name = os.getenv("CRON_JOB_NAME")
+    job_name = os.getenv("JOB_NAME")
+    pod_name = os.getenv("POD_NAME")
+
+    def before_log(log: Log, _hint: Hint) -> Log | None:
+        if cron_job_name:
+            log["attributes"]["cron_job_name"] = cron_job_name
+        if job_name:
+            log["attributes"]["job_name"] = job_name
+        if pod_name:
+            log["attributes"]["pod_name"] = pod_name
+        return log
+
     sentry_sdk.init(
         dsn=Config.sentry_dsn,
         environment=Config.env.value,
         project_root="src/",
         in_app_include=["reformatters"],
         default_integrations=True,
+        enable_logs=True,
+        before_send_log=before_log,
         integrations=[
             TyperIntegration(),
         ],
     )
     sentry_sdk.set_tag("env", Config.env.value)
-    sentry_sdk.set_tag("cron_job_name", os.getenv("CRON_JOB_NAME"))
-    sentry_sdk.set_tag("job_name", os.getenv("JOB_NAME"))
-    sentry_sdk.set_tag("pod_name", os.getenv("POD_NAME"))
+    sentry_sdk.set_tag("cron_job_name", cron_job_name)
+    sentry_sdk.set_tag("job_name", job_name)
+    sentry_sdk.set_tag("pod_name", pod_name)
 
 
 app = typer.Typer(pretty_exceptions_show_locals=False)

--- a/src/reformatters/common/betterstack.py
+++ b/src/reformatters/common/betterstack.py
@@ -1,7 +1,6 @@
 import base64
 import itertools
 import json
-import logging
 import os
 import subprocess
 from collections.abc import Iterable, Iterator
@@ -11,7 +10,6 @@ from typing import Any, Literal, NamedTuple, cast
 
 import httpx
 from croniter import croniter
-from logtail import LogtailHandler
 
 from reformatters.common.kubernetes import (
     BETTERSTACK_HEARTBEATS_SECRET_NAME,
@@ -21,56 +19,6 @@ from reformatters.common.kubernetes import (
 from reformatters.common.logging import get_logger
 
 log = get_logger(__name__)
-
-# Every reformatters logger is a child of this one (get_logger returns a child of
-# the root named "reformatters.<module>"), so attaching here streams our records
-# to Better Stack without the chatter other libraries log to the root.
-REFORMATTERS_LOGGER_NAME = "reformatters"
-
-# Kubernetes context injected as env vars by common/kubernetes.py, emitted as
-# structured fields so Better Stack surfaces them as queryable tags. cron_job_name
-# is not derivable from pod metadata, so it must travel with the log.
-_CONTEXT_FIELD_ENV_VARS = {
-    "cron_job_name": "CRON_JOB_NAME",
-    "job_name": "JOB_NAME",
-    "pod_name": "POD_NAME",
-    "env": "DYNAMICAL_ENV",
-}
-
-
-class _ContextFilter(logging.Filter):
-    def __init__(self) -> None:
-        super().__init__()
-        self._context = {
-            field: value
-            for field, env_var in _CONTEXT_FIELD_ENV_VARS.items()
-            if (value := os.getenv(env_var)) is not None
-        }
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        for field, value in self._context.items():
-            setattr(record, field, value)
-        return True
-
-
-def attach_logtail() -> None:
-    """Stream reformatters logs to the Better Stack source when the source token
-    and ingesting host are set. Idempotent; a no-op when they are absent (local
-    runs) so the only way logs stop reaching Better Stack is unsetting the env."""
-    token = os.getenv("BETTERSTACK_SOURCE_TOKEN")
-    host = os.getenv("BETTERSTACK_INGESTING_HOST")
-    if not (token and host):
-        return
-
-    logger = logging.getLogger(REFORMATTERS_LOGGER_NAME)
-    if any(isinstance(handler, LogtailHandler) for handler in logger.handlers):
-        return
-
-    handler = LogtailHandler(source_token=token, host=f"https://{host}")
-    handler.setLevel(logging.INFO)
-    handler.addFilter(_ContextFilter())
-    logger.addHandler(handler)
-
 
 # --- Heartbeats -------------------------------------------------------------
 # Each update/validate cron gets two heartbeats: a "start" ping when a run begins

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -113,24 +113,6 @@ class Job(pydantic.BaseModel):
                                         },
                                     },
                                     {
-                                        "name": "BETTERSTACK_SOURCE_TOKEN",
-                                        "valueFrom": {
-                                            "secretKeyRef": {
-                                                "key": "BETTERSTACK_SOURCE_TOKEN",
-                                                "name": "betterstack",
-                                            }
-                                        },
-                                    },
-                                    {
-                                        "name": "BETTERSTACK_INGESTING_HOST",
-                                        "valueFrom": {
-                                            "secretKeyRef": {
-                                                "key": "BETTERSTACK_INGESTING_HOST",
-                                                "name": "betterstack",
-                                            }
-                                        },
-                                    },
-                                    {
                                         "name": "JOB_NAME",
                                         "valueFrom": {
                                             "fieldRef": {

--- a/tests/common/betterstack_test.py
+++ b/tests/common/betterstack_test.py
@@ -1,86 +1,11 @@
 import json
-import logging
 from datetime import timedelta
 
 import httpx
 import pytest
-from logtail import LogtailHandler
 
 from reformatters.common import betterstack, staging
-from reformatters.common.betterstack import (
-    REFORMATTERS_LOGGER_NAME,
-    _ContextFilter,
-    attach_logtail,
-)
 from reformatters.common.kubernetes import CronJob, ReformatCronJob
-
-
-def _record() -> logging.LogRecord:
-    return logging.LogRecord(
-        name="reformatters.test",
-        level=logging.INFO,
-        pathname=__file__,
-        lineno=1,
-        msg="hello",
-        args=(),
-        exc_info=None,
-    )
-
-
-def test_context_filter_sets_fields_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("CRON_JOB_NAME", "gfs-update")
-    monkeypatch.setenv("JOB_NAME", "gfs-backfill")
-    monkeypatch.setenv("POD_NAME", "gfs-worker-0")
-    monkeypatch.setenv("DYNAMICAL_ENV", "prod")
-
-    record = _record()
-    assert _ContextFilter().filter(record) is True
-    assert record.__dict__["cron_job_name"] == "gfs-update"
-    assert record.__dict__["job_name"] == "gfs-backfill"
-    assert record.__dict__["pod_name"] == "gfs-worker-0"
-    assert record.__dict__["env"] == "prod"
-
-
-def test_context_filter_omits_unset_fields(monkeypatch: pytest.MonkeyPatch) -> None:
-    for env_var in ("CRON_JOB_NAME", "JOB_NAME", "POD_NAME", "DYNAMICAL_ENV"):
-        monkeypatch.delenv(env_var, raising=False)
-
-    record = _record()
-    _ContextFilter().filter(record)
-    assert not hasattr(record, "cron_job_name")
-
-
-def test_attach_logtail_noop_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("BETTERSTACK_SOURCE_TOKEN", raising=False)
-    monkeypatch.delenv("BETTERSTACK_INGESTING_HOST", raising=False)
-
-    logger = logging.getLogger(REFORMATTERS_LOGGER_NAME)
-    before = list(logger.handlers)
-    attach_logtail()
-    assert logger.handlers == before
-
-
-def test_attach_logtail_adds_handler_and_is_idempotent(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("BETTERSTACK_SOURCE_TOKEN", "test-token")
-    monkeypatch.setenv("BETTERSTACK_INGESTING_HOST", "s1.example.betterstackdata.com")
-
-    logger = logging.getLogger(REFORMATTERS_LOGGER_NAME)
-    added = [h for h in logger.handlers if isinstance(h, LogtailHandler)]
-    for handler in added:
-        logger.removeHandler(handler)
-
-    try:
-        attach_logtail()
-        attach_logtail()
-        logtail_handlers = [h for h in logger.handlers if isinstance(h, LogtailHandler)]
-        assert len(logtail_handlers) == 1
-        assert any(isinstance(f, _ContextFilter) for f in logtail_handlers[0].filters)
-    finally:
-        for handler in logger.handlers[:]:
-            if isinstance(handler, LogtailHandler):
-                logger.removeHandler(handler)
 
 
 def test_cron_name_prefix_strips_step() -> None:

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -87,24 +87,6 @@ def test_as_kubernetes_object_comprehensive() -> None:
                                 },
                             },
                             {
-                                "name": "BETTERSTACK_SOURCE_TOKEN",
-                                "valueFrom": {
-                                    "secretKeyRef": {
-                                        "key": "BETTERSTACK_SOURCE_TOKEN",
-                                        "name": "betterstack",
-                                    }
-                                },
-                            },
-                            {
-                                "name": "BETTERSTACK_INGESTING_HOST",
-                                "valueFrom": {
-                                    "secretKeyRef": {
-                                        "key": "BETTERSTACK_INGESTING_HOST",
-                                        "name": "betterstack",
-                                    }
-                                },
-                            },
-                            {
                                 "name": "JOB_NAME",
                                 "valueFrom": {
                                     "fieldRef": {

--- a/uv.lock
+++ b/uv.lock
@@ -679,19 +679,6 @@ wheels = [
 ]
 
 [[package]]
-name = "logtail-python"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "msgpack" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/23/72bf3f603892679942815fa5436379a3f09329a54008ff6370b73ad66218/logtail_python-0.4.0.tar.gz", hash = "sha256:1483cb71aad89fb1fae4c1c55be3397914057986257e5b24f4359b96e6dff30b", size = 43980, upload-time = "2026-07-01T16:13:45.286Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/50/b096cab715c33781b6b5564c43317f897c3222c66654793653044239d0d5/logtail_python-0.4.0-py2.py3-none-any.whl", hash = "sha256:d9ecf4841965cfced09d747aa4ec62be586cd208d43a6af0c85a6cbd9e8f28e7", size = 9063, upload-time = "2026-07-01T16:13:44.2Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -743,36 +730,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "msgpack"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
-    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
-    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
-    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
-    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
-    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
-    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
-    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
-    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
 ]
 
 [[package]]
@@ -1385,7 +1342,6 @@ dependencies = [
     { name = "httpx" },
     { name = "icechunk" },
     { name = "kubernetes" },
-    { name = "logtail-python" },
     { name = "numba" },
     { name = "numcodecs" },
     { name = "numpy" },
@@ -1429,7 +1385,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "icechunk", git = "https://github.com/aldenks/icechunk?subdirectory=icechunk-python&branch=expose-commit-max-concurrent-nodes-2.1.1" },
     { name = "kubernetes", specifier = ">=36.0.1,<37" },
-    { name = "logtail-python", specifier = ">=0.3.4" },
     { name = "numba", specifier = "~=0.62" },
     { name = "numcodecs", specifier = "~=0.16" },
     { name = "numpy", specifier = "~=2.3" },


### PR DESCRIPTION
Revert of #785 (with conflict resolution), third of three (tracking: dynamical-org/meta#145). Stacked on #802.

- Restores Sentry log ingestion: `enable_logs=True` + `before_send_log` stamping `cron_job_name`/`job_name`/`pod_name` as log attributes.
- Removes logtail: `attach_logtail`/`_ContextFilter` from `common/betterstack.py` (heartbeat half untouched — it still feeds the public status page), `logtail-python` dep, and the `BETTERSTACK_SOURCE_TOKEN`/`BETTERSTACK_INGESTING_HOST` env wiring.
- Conflicts vs a plain revert: `betterstack.py`/`betterstack_test.py` kept (heartbeats), only the logging halves removed; `croniter` kept in `pyproject.toml`.

**Merge after** #802 has deployed and errors are confirmed in Sentry.
Verify after deploy: a known log line is searchable in Sentry Logs with the `cron_job_name` attribute.

After the confidence window: `kubectl delete secret betterstack` (fully unwired by #802 + this PR) and delete the Better Stack errors app + logs source.