### PR TITLE
Handle connection reset errors as missing files in IMERG

### DIFF
--- a/src/reformatters/nasa/imerg/region_job.py
+++ b/src/reformatters/nasa/imerg/region_job.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import numpy as np
 import pandas as pd
 import rasterio
+import requests
 import xarray as xr
 from zarr.abc.store import Store
 
@@ -157,7 +158,15 @@ class NasaImergAnalysisMaterializedRegionJob(
                 f"No IMERG granule found for {coord.run} {coord.time}"
             )
 
-        return retry(_download, max_attempts=6)
+        try:
+            return retry(_download, max_attempts=6)
+        except requests.ConnectionError as e:
+            # jsimpson resets the connection for a not-yet-published granule
+            # instead of returning 404. Convert to a missing-file error so a
+            # persistent connection failure is handled like an absent granule.
+            raise FileNotFoundError(
+                f"Connection failed for IMERG granule {coord.run} {coord.time}"
+            ) from e
 
     def read_data(
         self,

--- a/tests/nasa/imerg/region_job_test.py
+++ b/tests/nasa/imerg/region_job_test.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pandas as pd
 import pytest
+import requests
 import xarray as xr
 
 from reformatters.common.pydantic import replace
@@ -123,6 +124,30 @@ def _job() -> NasaImergAnalysisEarlyRegionJob:
         region=slice(0, 1),
         reformat_job_name="test",
     )
+
+
+def test_download_file_connection_reset_raises_file_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # jsimpson resets the connection for not-yet-published granules; the base job
+    # treats a missing recent granule as expected, so a persistent connection
+    # failure must surface as FileNotFoundError rather than ConnectionError.
+    monkeypatch.setattr("reformatters.common.retry.time.sleep", lambda _seconds: None)
+    session = MagicMock()
+    session.get.side_effect = requests.ConnectionError("Connection reset by peer")
+    monkeypatch.setattr(
+        "reformatters.nasa.imerg.region_job.get_pps_session", lambda: session
+    )
+    monkeypatch.setattr(
+        "reformatters.nasa.imerg.region_job.get_earthdata_session", lambda: session
+    )
+
+    job = _job()
+    coord = NasaImergAnalysisSourceFileCoord(
+        run="early", time=pd.Timestamp.now().floor("30min") - pd.Timedelta(hours=6)
+    )
+    with pytest.raises(FileNotFoundError):
+        job.download_file(coord)
 
 
 def test_read_data_masks_exact_sentinel_and_scales(


### PR DESCRIPTION
## Summary
Convert persistent connection reset errors from the jsimpson server into `FileNotFoundError` exceptions when downloading IMERG granules. This ensures that connection failures for not-yet-published granules are handled consistently with missing files, rather than surfacing as connection errors.

## Changes
- **src/reformatters/nasa/imerg/region_job.py**: Wrap the retry logic in `download_file()` with a try-except block that catches `requests.ConnectionError` and re-raises it as `FileNotFoundError`. This handles the case where jsimpson resets connections for granules that haven't been published yet, treating it the same as a 404 response.

- **tests/nasa/imerg/region_job_test.py**: Add `test_download_file_connection_reset_raises_file_not_found()` to verify that connection reset errors are properly converted to `FileNotFoundError` when downloading IMERG files. The test mocks both PPS and Earthdata sessions to simulate the connection reset behavior.

## Implementation Details
The jsimpson server resets connections instead of returning HTTP 404 for granules that haven't been published yet. Since the base job class treats missing recent granules as expected behavior, connection failures must be converted to `FileNotFoundError` to avoid surfacing as unexpected errors. The conversion happens after all retry attempts are exhausted, preserving the original exception as the cause.

https://claude.ai/code/session_01JVxEnm23n1ztoNCehNMRsA