### PR TITLE
Fix deploy workflows: remove dangling env: left by #805

### DIFF
--- a/.github/workflows/deploy-operational-updates.yml
+++ b/.github/workflows/deploy-operational-updates.yml
@@ -80,5 +80,4 @@ jobs:
           file: deploy/Dockerfile
 
       - name: Deploy
-        env:
         run: uv run main deploy --docker-image ${{ env.IMAGE_TAG }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -132,7 +132,6 @@ jobs:
           file: deploy/Dockerfile
 
       - name: Deploy staging
-        env:
         run: >
           uv run main deploy-staging
           ${{ steps.parse.outputs.dataset_id }}


### PR DESCRIPTION
#805 removed the only key under the Deploy steps's `env:` block in both deploy workflows, leaving a bare `env:` that fails workflow parsing (the #805 deploy run had zero jobs). Removes the empty blocks; YAML validated.