### PR TITLE
DWD ICON-EU: tolerate rare single-cell deaccumulation noise for aswdir_s

### DIFF
--- a/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
@@ -182,6 +182,7 @@ class DwdIconEuForecast5DayRegionJob(
             optional_kwargs: dict[str, Any] = {
                 "invalid_below_threshold_rate": attrs.deaccumulation_invalid_below_threshold_rate,
                 "expected_clamp_fraction": attrs.deaccumulation_expected_clamp_fraction,
+                "expected_invalid_fraction": attrs.deaccumulation_expected_invalid_fraction,
             }
             optional_kwargs = {
                 k: v for k, v in optional_kwargs.items() if v is not None

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/template_config.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/template_config.py
@@ -46,6 +46,8 @@ class DwdIconEuInternalAttrs(BaseInternalAttrs):
             to tolerate the larger negative noise produced by lossy-compressed radiation fields.
         deaccumulation_expected_clamp_fraction (float | None): Override for the fraction of values
             expected to be clamped to 0.
+        deaccumulation_expected_invalid_fraction (float | None): Override for the fraction of
+            values expected to fall below `deaccumulation_invalid_below_threshold_rate`.
         deaccumulation_type (AccumulationType): Whether the source values are cumulative totals
             ("accumulated", default) or running-mean rates whose averaging window grows from
             forecast start ("running_mean", used for ICON-EU averaged radiation fields).
@@ -56,6 +58,7 @@ class DwdIconEuInternalAttrs(BaseInternalAttrs):
     scale_factor: float | None = None
     deaccumulation_invalid_below_threshold_rate: float | None = None
     deaccumulation_expected_clamp_fraction: float | None = None
+    deaccumulation_expected_invalid_fraction: float | None = None
     deaccumulation_type: AccumulationType = "accumulated"
 
 
@@ -386,6 +389,9 @@ class DwdIconEuForecast5DayTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                     deaccumulation_invalid_below_threshold_rate=RADIATION_INVALID_BELOW_THRESHOLD,
                     # GRIB precision jitter in the running mean drives nighttime clamping to ~20%.
                     deaccumulation_expected_clamp_fraction=0.25,
+                    # GRIB precision jitter occasionally pushes a lone grid cell just past the
+                    # threshold; a handful of cells out of tens of millions is not a data issue.
+                    deaccumulation_expected_invalid_fraction=1e-6,
                     deaccumulation_type="running_mean",
                 ),
             ),

--- a/tests/dwd/icon_eu/forecast_5_day/region_job_test.py
+++ b/tests/dwd/icon_eu/forecast_5_day/region_job_test.py
@@ -232,6 +232,7 @@ def test_region_job_apply_data_transformations_deaccumulation_optional_kwargs(
             window_reset_frequency=reset_freq,
             deaccumulation_invalid_below_threshold_rate=-50.0,
             deaccumulation_expected_clamp_fraction=0.25,
+            deaccumulation_expected_invalid_fraction=1e-6,
             deaccumulation_type="running_mean",
         ),
     )
@@ -253,6 +254,7 @@ def test_region_job_apply_data_transformations_deaccumulation_optional_kwargs(
         accumulation_type="running_mean",
         invalid_below_threshold_rate=-50.0,
         expected_clamp_fraction=0.25,
+        expected_invalid_fraction=1e-6,
     )
 
 


### PR DESCRIPTION
## What

Fixes [REFORMATTERS-D2](https://dynamical.sentry.io/issues/REFORMATTERS-D2) (513 occurrences since March, still ongoing).

`dwd-icon-eu-forecast-5-day`'s `downward_direct_short_wave_radiation_flux_surface` (`aswdir_s`) deaccumulation intermittently fails with `ValueError: Found 1 values (0.0%) below threshold, expected at most 0.0%`. GRIB precision jitter occasionally pushes a single grid cell just under the deaccumulation threshold — 1 cell out of the ~84M in a region (93 lead times × 657 latitudes × 1377 longitudes) is `1.2e-8` of the array, but `expected_invalid_fraction` defaults to `0.0`, so any nonzero count trips it.

This variable already has an analogous override for a different kind of GRIB noise (`deaccumulation_expected_clamp_fraction=0.25`, "GRIB precision jitter in the running mean drives nighttime clamping to ~20%"). This PR adds the missing `deaccumulation_expected_invalid_fraction` counterpart (mirroring the existing `expected_clamp_fraction` plumbing end to end) and sets it to `1e-6` for `aswdir_s` — generous enough to absorb this single-cell noise while still catching a real systemic problem.

Note: while investigating this issue, I found that Sentry's default exception fingerprinting groups **every** dataset's validation failure into one bucket (`REFORMATTERS-D2`'s "latest event" was this radiation noise, but the same issue also aggregated an unrelated one-time MRMS backfill event with 35-94% invalid precipitation values from 2026-07-21, which appears to already be resolved/complete — no recurrence since). I've resolved the umbrella Sentry issue and left a comment; worth considering a fingerprint rule so future unrelated validation failures don't keep landing in the same bucket (same problem exists for `REFORMATTERS-AY`, also resolved with a comment).

## Test plan

- [x] `uv run ruff format && uv run ruff check --fix && uv run ty check` clean on the touched files
- [x] Extended the existing `test_region_job_apply_data_transformations_deaccumulation_optional_kwargs` test to cover the new `expected_invalid_fraction` kwarg
- [x] `uv run pytest tests/dwd/icon_eu/` — 33 passed

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01M1FfmFACxhdckvWdYTN8y7)_