### PR TITLE
Make IMERG download fall through to a valid granule per candidate

### DIFF
--- a/src/reformatters/nasa/imerg/region_job.py
+++ b/src/reformatters/nasa/imerg/region_job.py
@@ -32,6 +32,9 @@ from reformatters.nasa.nasa_auth import get_earthdata_session, get_pps_session
 
 log = get_logger(__name__)
 
+# Leading bytes of every HDF5 file; used to reject non-granule response bodies.
+_HDF5_MAGIC = b"\x89HDF\r\n\x1a\n"
+
 # Filenames carry V07C from this granule time onward, V07B before.
 _V07C_START: dict[ImergRun, pd.Timestamp] = {
     "early": pd.Timestamp("2026-03-04T00:00"),
@@ -140,33 +143,40 @@ class NasaImergAnalysisMaterializedRegionJob(
                     if source == "jsimpson"
                     else get_earthdata_session()
                 )
-                response = session.get(
-                    url, timeout=30, stream=True, allow_redirects=True
-                )
-                if response.status_code == 404:
-                    log.warning(f"File not found at {url}, trying next candidate")
+                try:
+                    response = session.get(
+                        url, timeout=30, stream=True, allow_redirects=True
+                    )
+                    if response.status_code == 404:
+                        log.warning(f"File not found at {url}, trying next candidate")
+                        continue
+                    response.raise_for_status()
+                    local_path = get_local_path(
+                        self.template_ds.attrs["dataset_id"], path=urlparse(url).path
+                    )
+                    local_path.parent.mkdir(parents=True, exist_ok=True)
+                    with open(local_path, "wb") as f:
+                        f.writelines(response.iter_content(chunk_size=8192))
+                except requests.ConnectionError:
+                    # jsimpson resets the connection for a not-yet-published
+                    # granule rather than returning 404; fall through to the
+                    # next candidate (e.g. the GES DISC archive).
+                    log.warning(f"Connection failed for {url}, trying next candidate")
                     continue
-                response.raise_for_status()
-                local_path = get_local_path(
-                    self.template_ds.attrs["dataset_id"], path=urlparse(url).path
-                )
-                local_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(local_path, "wb") as f:
-                    f.writelines(response.iter_content(chunk_size=8192))
+                with open(local_path, "rb") as f:
+                    is_hdf5 = f.read(len(_HDF5_MAGIC)) == _HDF5_MAGIC
+                if not is_hdf5:
+                    # GES DISC serves an HTML/JSON error body (not a 404) for a
+                    # not-yet-published granule; skip it rather than handing a
+                    # non-HDF5 file to the reader.
+                    log.warning(f"Non-HDF5 body from {url}, trying next candidate")
+                    continue
                 return local_path
             raise FileNotFoundError(
                 f"No IMERG granule found for {coord.run} {coord.time}"
             )
 
-        try:
-            return retry(_download, max_attempts=6)
-        except requests.ConnectionError as e:
-            # jsimpson resets the connection for a not-yet-published granule
-            # instead of returning 404. Convert to a missing-file error so a
-            # persistent connection failure is handled like an absent granule.
-            raise FileNotFoundError(
-                f"Connection failed for IMERG granule {coord.run} {coord.time}"
-            ) from e
+        return retry(_download, max_attempts=6)
 
     def read_data(
         self,

--- a/tests/nasa/imerg/dynamical_dataset_test.py
+++ b/tests/nasa/imerg/dynamical_dataset_test.py
@@ -12,6 +12,7 @@ from reformatters.nasa.imerg.analysis_late import NasaImergAnalysisLateDataset
 from reformatters.nasa.imerg.dynamical_dataset import (
     NasaImergAnalysisMaterializedDataset,
 )
+from reformatters.nasa.imerg.region_job import _HDF5_MAGIC
 from reformatters.nasa.imerg.template_config import (
     GRID_LAT_SIZE,
     GRID_LON_SIZE,
@@ -50,7 +51,8 @@ def _patch_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.raise_for_status = lambda: None
-    mock_response.iter_content = lambda chunk_size: [b"fake_hdf5"]
+    # download_file checks the leading bytes are HDF5 before accepting the body.
+    mock_response.iter_content = lambda chunk_size: [_HDF5_MAGIC + b"fake_hdf5"]
     mock_session = Mock()
     mock_session.get.return_value = mock_response
 

--- a/tests/nasa/imerg/region_job_test.py
+++ b/tests/nasa/imerg/region_job_test.py
@@ -18,6 +18,7 @@ from reformatters.nasa.imerg.analysis_late.region_job import (
     NasaImergAnalysisLateRegionJob,
 )
 from reformatters.nasa.imerg.region_job import (
+    _HDF5_MAGIC,
     _JSIMPSON_MAX_AGE,
     NasaImergAnalysisSourceFileCoord,
 )
@@ -118,7 +119,9 @@ def test_candidate_urls_old_prefers_gesdisc() -> None:
 def _job() -> NasaImergAnalysisEarlyRegionJob:
     return NasaImergAnalysisEarlyRegionJob(
         tmp_store=Path("unused.zarr"),
-        template_ds=xr.DataTree(),
+        template_ds=xr.DataTree(
+            xr.Dataset(attrs={"dataset_id": "nasa-imerg-analysis-early"})
+        ),
         data_vars=list(NasaImergAnalysisEarlyTemplateConfig().data_vars),
         append_dim="time",
         region=slice(0, 1),
@@ -126,28 +129,79 @@ def _job() -> NasaImergAnalysisEarlyRegionJob:
     )
 
 
-def test_download_file_connection_reset_raises_file_not_found(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # jsimpson resets the connection for not-yet-published granules; the base job
-    # treats a missing recent granule as expected, so a persistent connection
-    # failure must surface as FileNotFoundError rather than ConnectionError.
-    monkeypatch.setattr("reformatters.common.retry.time.sleep", lambda _seconds: None)
-    session = MagicMock()
-    session.get.side_effect = requests.ConnectionError("Connection reset by peer")
-    monkeypatch.setattr(
-        "reformatters.nasa.imerg.region_job.get_pps_session", lambda: session
-    )
-    monkeypatch.setattr(
-        "reformatters.nasa.imerg.region_job.get_earthdata_session", lambda: session
-    )
+def _fake_response(body: bytes) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.iter_content.return_value = [body]
+    return response
 
-    job = _job()
-    coord = NasaImergAnalysisSourceFileCoord(
+
+def _recent_coord() -> NasaImergAnalysisSourceFileCoord:
+    return NasaImergAnalysisSourceFileCoord(
         run="early", time=pd.Timestamp.now().floor("30min") - pd.Timedelta(hours=6)
     )
+
+
+def _patch_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    pps: MagicMock,
+    earthdata: MagicMock,
+) -> None:
+    monkeypatch.setattr("reformatters.common.retry.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("reformatters.common.download.DOWNLOAD_DIR", tmp_path)
+    monkeypatch.setattr(
+        "reformatters.nasa.imerg.region_job.get_pps_session", lambda: pps
+    )
+    monkeypatch.setattr(
+        "reformatters.nasa.imerg.region_job.get_earthdata_session", lambda: earthdata
+    )
+
+
+def test_download_file_falls_through_connection_error_to_archive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # jsimpson resets the connection for a not-yet-published granule; the GES DISC
+    # archive candidate must still be tried rather than the whole attempt aborting.
+    jsimpson = MagicMock()
+    jsimpson.get.side_effect = requests.ConnectionError("Connection reset by peer")
+    gesdisc = MagicMock()
+    gesdisc.get.return_value = _fake_response(_HDF5_MAGIC + b"granule-bytes")
+    _patch_sessions(monkeypatch, tmp_path, pps=jsimpson, earthdata=gesdisc)
+
+    path = _job().download_file(_recent_coord())
+
+    assert path.read_bytes().startswith(_HDF5_MAGIC)
+    assert jsimpson.get.called
+    assert gesdisc.get.called
+
+
+def test_download_file_rejects_non_hdf5_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # GES DISC returns an HTML/JSON error body (not a 404) for a not-yet-published
+    # granule; a non-HDF5 body must never be handed to the reader as a granule.
+    session = MagicMock()
+    session.get.return_value = _fake_response(b"<html>not found</html>")
+    _patch_sessions(monkeypatch, tmp_path, pps=session, earthdata=session)
+
     with pytest.raises(FileNotFoundError):
-        job.download_file(coord)
+        _job().download_file(_recent_coord())
+
+
+def test_download_file_all_sources_connection_error_raises_file_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # When every candidate fails to connect, the exhausted loop reports a missing
+    # file, which the base job's recency gate treats as expected for recent granules.
+    session = MagicMock()
+    session.get.side_effect = requests.ConnectionError("Connection reset by peer")
+    _patch_sessions(monkeypatch, tmp_path, pps=session, earthdata=session)
+
+    with pytest.raises(FileNotFoundError):
+        _job().download_file(_recent_coord())
 
 
 def test_read_data_masks_exact_sentinel_and_scales(


### PR DESCRIPTION
## Summary

The IMERG download candidate loop only advanced to the next source on a literal HTTP 404, so two "not-really-available" signals leaked out as hard errors during operational updates (which reach up to the present and therefore always attempt the last ~14 h of not-yet-published late granules):

- **A jsimpson connection reset** — its way of signalling a not-yet-published granule — aborted the loop *before* the GES DISC archive candidate was tried, so an older granule that GES DISC actually has was reported missing (Sentry `REFORMATTERS-GY`).
- **GES DISC returns an HTML/JSON error body at HTTP 200** (not a 404) for a not-yet-published granule. That body was written to disk and returned as if it were the granule, then failed at read time with `rasterio ... No such file or directory` on the HDF5 subdataset (Sentry `REFORMATTERS-GF`, 400 occurrences).

## Changes

In IMERG `download_file`:
- Handle a connection error **per candidate** — fall through to the next source (e.g. the GES DISC archive) instead of aborting the whole attempt.
- **Validate the downloaded body's HDF5 magic bytes** before accepting it; a non-HDF5 body is skipped like a 404, so a bogus response never reaches the reader.
- Only when every candidate is exhausted do we raise `FileNotFoundError`, which the base job's recency gate already keeps quiet for genuinely recent granules.

This eliminates the read-time failure at its source and lets a jsimpson reset fall through to the archive that has the granule.

## Testing

- `uv run ruff format && uv run ruff check && uv run ty check` — clean
- `uv run pytest tests/nasa/imerg/` (non-slow) — 18 passed
- Added tests: connection-error fall-through to the archive, non-HDF5-body rejection, and all-sources-connection-error → `FileNotFoundError`.

Fixes REFORMATTERS-GY
Fixes REFORMATTERS-GF

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVxEnm23n1ztoNCehNMRsA)_