### PR TITLE
Fix GEFS 35-day forecast resolution hour boundaries

### DIFF
--- a/src/reformatters/common/config_models.py
+++ b/src/reformatters/common/config_models.py
@@ -30,7 +30,7 @@ type SpatialResolution = Literal[
     "0.0625 degrees (~7km)",
     "0.1 degrees (~10km)",
     "0.25 degrees (~20km)",
-    "0-240 hours: 0.25 degrees (~20km), 243-840 hours: 0.5 degrees (~40km)",
+    "0-240 hours: 0.25 degrees (~20km), 246-840 hours: 0.5 degrees (~40km)",
     "2.5 km",
     "3 km",
     "4 km",

--- a/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
@@ -54,11 +54,11 @@ class GefsForecast35DayTemplateConfig(TemplateConfig[GEFSDataVar]):
             attribution="NOAA NWS NCEP GEFS data processed by dynamical.org from NOAA Open Data Dissemination archives.",
             license="CC-BY-4.0",
             spatial_domain="Global",
-            spatial_resolution="0-240 hours: 0.25 degrees (~20km), 243-840 hours: 0.5 degrees (~40km)",
+            spatial_resolution="0-240 hours: 0.25 degrees (~20km), 246-840 hours: 0.5 degrees (~40km)",
             time_domain=f"Forecasts initialized {self.append_dim_start} UTC to Present",
             time_resolution="Forecasts initialized every 24 hours",
             forecast_domain="Forecast lead time 0-840 hours (0-35 days) ahead",
-            forecast_resolution="Forecast step 0-240 hours: 3 hourly, 243-840 hours: 6 hourly",
+            forecast_resolution="Forecast step 0-240 hours: 3 hourly, 246-840 hours: 6 hourly",
         )
 
     def append_dim_coordinate_chunk_size(self) -> int:

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
@@ -7,11 +7,11 @@
     "attribution": "NOAA NWS NCEP GEFS data processed by dynamical.org from NOAA Open Data Dissemination archives.",
     "license": "CC-BY-4.0",
     "spatial_domain": "Global",
-    "spatial_resolution": "0-240 hours: 0.25 degrees (~20km), 243-840 hours: 0.5 degrees (~40km)",
+    "spatial_resolution": "0-240 hours: 0.25 degrees (~20km), 246-840 hours: 0.5 degrees (~40km)",
     "time_domain": "Forecasts initialized 2020-10-01 00:00:00 UTC to Present",
     "time_resolution": "Forecasts initialized every 24 hours",
     "forecast_domain": "Forecast lead time 0-840 hours (0-35 days) ahead",
-    "forecast_resolution": "Forecast step 0-240 hours: 3 hourly, 243-840 hours: 6 hourly"
+    "forecast_resolution": "Forecast step 0-240 hours: 3 hourly, 246-840 hours: 6 hourly"
   },
   "zarr_format": 3,
   "consolidated_metadata": {


### PR DESCRIPTION
## Summary
Corrects the hour boundaries in the GEFS 35-day forecast dataset metadata to accurately reflect when the forecast resolution changes from 3-hourly to 6-hourly intervals.

## Changes
- Updated spatial and forecast resolution descriptions from `243-840 hours` to `246-840 hours` to match the actual data structure
- Changes made in three locations:
  - `src/reformatters/noaa/gefs/forecast_35_day/template_config.py`: Updated `dataset_attributes()` method
  - `src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json`: Updated checked-in zarr metadata
  - `src/reformatters/common/config_models.py`: Updated the valid spatial resolution enum value

## Details
The GEFS forecast data transitions from 0.25-degree resolution with 3-hourly steps to 0.5-degree resolution with 6-hourly steps. The transition occurs at hour 246 (not 243), which represents 10.25 days into the forecast. This correction ensures the metadata accurately describes the dataset structure for users and downstream processing.

Note: The template metadata was regenerated to reflect these corrections.

https://claude.ai/code/session_016uSsLDF7NrdHzvxSaAUPV4