### PR TITLE
EXPLORATION (DONT MERGE): Add ECMWF ECDS extended-range spike: prototype retrieval client, docs, and tests

### DIFF
--- a/docs/plans/ecmwf_extended_range_request_measurements.json
+++ b/docs/plans/ecmwf_extended_range_request_measurements.json
@@ -1,96 +1,158 @@
 {
-  "generated_at": "2026-07-28T18:05:00Z",
+  "generated_at": "2026-07-28T21:48:00Z",
   "environment": {
     "authenticated_ecds_access": true,
     "accepted_s2s_terms": true,
-    "credential_source": ".cdsapirc"
+    "credential_source": ".cdsapirc",
+    "signed_result_urls_persisted_in_report": false
   },
-  "observations": [
-    {
-      "id": "recent_smoke_2m_temperature",
-      "request_id": "1699ae8a-eb95-4f03-afc0-1339a72fcf50",
-      "status": "failed",
-      "variable": "2m_temperature",
-      "members": 1,
-      "steps": [
-        24,
-        48,
-        72
-      ],
-      "error_category": "ambiguous_backend_parameter_mapping"
+  "verdict": {
+    "ecds_transport_and_source_contract": "go",
+    "revised_1_5_degree_product": "conditional_go",
+    "original_0_25_degree_product": "no_go"
+  },
+  "source_contract": {
+    "first_verified_initialization": "2023-06-28T00:00:00Z",
+    "grid_shape": [
+      121,
+      240
+    ],
+    "resolution_degrees": 1.5,
+    "latitude_bounds": [
+      90.0,
+      -90.0
+    ],
+    "longitude_bounds": [
+      -180.0,
+      178.5
+    ],
+    "control_members": 1,
+    "perturbed_members": 100,
+    "daily_leads": 46,
+    "maximum_lead_hours": 1104
+  },
+  "request_summary": {
+    "accepted_jobs_downloaded_and_inventory_valid": 27,
+    "accepted_job_failures": 0,
+    "pre_job_http_502_submissions": 1,
+    "downloaded_bytes_all_acceptance_cases": 7128215624,
+    "download_seconds_total": 410.54932024894515,
+    "download_seconds_max": 154.79949450001004,
+    "queue_seconds": {
+      "min": 11.705325,
+      "median": 64.28604,
+      "p95": 216.431367,
+      "max": 299.645518,
+      "mean": 87.56604644444444
     },
-    {
-      "id": "recent_smoke_wind_u_10m",
-      "request_id": "4f5026a6-90f3-4469-9fb4-4cfef9f44dab",
-      "status": "downloaded",
-      "variable": "10_m_u_component_of_wind",
-      "members": 1,
-      "steps": [
-        24,
-        48,
-        72
-      ],
-      "queue_seconds": 12.824365,
-      "server_processing_seconds": 4.511008,
-      "download_seconds": 0.826459,
-      "downloaded_bytes": 174786,
-      "grib_messages": 3,
-      "http_range_resume": true,
-      "partial_bytes_before_resume": 87393
+    "server_processing_seconds": {
+      "min": 2.884146,
+      "median": 12.592311,
+      "p95": 71.636,
+      "max": 201.414532,
+      "mean": 25.576666962962964
     }
-  ],
-  "planned_matrix": [
-    {
-      "id": "recent_smoke",
+  },
+  "acceptance_matrix": {
+    "representative_shards": {
       "status": "completed",
-      "variables": 1,
-      "members": 1,
-      "steps": [
-        24,
-        48,
-        72
+      "count": 10,
+      "dates": [
+        "2023-06-28",
+        "2024-06-27",
+        "2026-07-23",
+        "2026-07-24"
       ]
     },
-    {
-      "id": "recent_surface_all_members",
-      "status": "pending"
+    "all_member_single_lead_surface": {
+      "status": "completed",
+      "members": 100
     },
-    {
-      "id": "recent_pressure_all_members",
-      "status": "pending",
+    "all_member_three_level_pressure": {
+      "status": "completed",
+      "members": 100,
       "levels_hpa": [
         500,
         700,
         850
       ]
     },
-    {
-      "id": "recent_complete_sharded",
-      "status": "pending"
+    "full_candidate_initialization": {
+      "status": "completed",
+      "date": "2026-07-24",
+      "shards": 14,
+      "source_variables": 17,
+      "field_level_outputs": 27,
+      "members": 101,
+      "leads": 46,
+      "source_bytes": 6985939316,
+      "grib_messages": 125442
     },
-    {
-      "id": "archive_start_complete_sharded",
-      "status": "pending"
+    "duplicate_request": {
+      "status": "completed",
+      "byte_identical": true,
+      "sha256": "85abedb05adcffcb405879ef136cb8e019dad5d8713f382625ac23900dafaad9"
     },
-    {
-      "id": "completed_request_rerun",
-      "status": "pending"
+    "interrupted_download_resume": {
+      "status": "completed",
+      "http_206_append": true,
+      "http_200_restart": true
     },
-    {
-      "id": "interrupted_download_resume",
-      "status": "completed"
-    },
-    {
-      "id": "intermediate_smoke",
-      "status": "pending"
-    },
-    {
-      "id": "second_recent_smoke",
-      "status": "pending"
-    },
-    {
-      "id": "transient_poll_failure",
-      "status": "simulated_only"
+    "transient_failure": {
+      "status": "completed",
+      "failure": "HTTP 502 before request ID",
+      "recovery": "resubmission succeeded"
     }
+  },
+  "development_zarr": {
+    "status": "completed",
+    "complete": true,
+    "source_bytes": 6985939316,
+    "zarr_bytes": 8958032476,
+    "message_count": 125442,
+    "transformation_seconds": 784.0782916249882,
+    "rerun_transformation_seconds": 772.1013115830137,
+    "file_count": 13703,
+    "deterministic_tree_sha1": "215e037503e6ffc413ce38b87cb545616331753b",
+    "field_level_outputs": 27,
+    "members": 101,
+    "leads": 46,
+    "ensemble_chunk_size": 10,
+    "regional_query_shape": [
+      1,
+      46,
+      101,
+      21,
+      17
+    ],
+    "variables_without_missing_values": 25,
+    "land_only_missing_fraction": 0.6618457300275482,
+    "land_only_variables": [
+      "runoff_surface",
+      "soil_moisture_0_20cm"
+    ]
+  },
+  "storage_projection": {
+    "assumed_initializations_through_2026_07_24": 1123,
+    "projected_initial_archive_bytes": 10059870470548,
+    "projected_annual_growth_bytes": 3269681853740,
+    "storage_price_usd_per_decimal_gb_month": 0.015,
+    "projected_initial_monthly_storage_usd": 150.89805705822,
+    "projected_added_monthly_storage_usd_per_year": 49.045227806099994,
+    "excluded": [
+      "replicas",
+      "Icechunk metadata",
+      "requests",
+      "compute",
+      "staging overlap",
+      "missing initialization dates",
+      "compression changes across model cycles"
+    ]
+  },
+  "remaining_decisions": [
+    "Confirm that a 1.5 degree product meets the product need.",
+    "Confirm attribution presentation and unattended request rate with ECMWF.",
+    "Run a bounded multi-initialization throughput test before pricing the backfill.",
+    "Clamp measured soil-moisture and cloud-cover packing artifacts in production."
   ]
 }

--- a/docs/plans/ecmwf_extended_range_request_measurements.json
+++ b/docs/plans/ecmwf_extended_range_request_measurements.json
@@ -1,20 +1,96 @@
 {
-  "generated_at": "2026-07-28T00:00:00Z",
+  "generated_at": "2026-07-28T18:05:00Z",
   "environment": {
-    "authenticated_ecds_access": false,
-    "reason": "Neither ECDS_API_ENDPOINT nor ECDS_API_KEY was exposed to the process, and no CDS/ECDS credential file was available. No request was submitted."
+    "authenticated_ecds_access": true,
+    "accepted_s2s_terms": true,
+    "credential_source": ".cdsapirc"
   },
-  "observations": [],
+  "observations": [
+    {
+      "id": "recent_smoke_2m_temperature",
+      "request_id": "1699ae8a-eb95-4f03-afc0-1339a72fcf50",
+      "status": "failed",
+      "variable": "2m_temperature",
+      "members": 1,
+      "steps": [
+        24,
+        48,
+        72
+      ],
+      "error_category": "ambiguous_backend_parameter_mapping"
+    },
+    {
+      "id": "recent_smoke_wind_u_10m",
+      "request_id": "4f5026a6-90f3-4469-9fb4-4cfef9f44dab",
+      "status": "downloaded",
+      "variable": "10_m_u_component_of_wind",
+      "members": 1,
+      "steps": [
+        24,
+        48,
+        72
+      ],
+      "queue_seconds": 12.824365,
+      "server_processing_seconds": 4.511008,
+      "download_seconds": 0.826459,
+      "downloaded_bytes": 174786,
+      "grib_messages": 3,
+      "http_range_resume": true,
+      "partial_bytes_before_resume": 87393
+    }
+  ],
   "planned_matrix": [
-    {"id": "recent_smoke", "status": "blocked_credentials", "variables": 1, "members": 1, "steps": [24, 48, 72]},
-    {"id": "recent_surface_all_members", "status": "blocked_credentials"},
-    {"id": "recent_pressure_all_members", "status": "blocked_credentials", "levels_hpa": [500, 700, 850]},
-    {"id": "recent_complete_sharded", "status": "blocked_credentials"},
-    {"id": "archive_start_complete_sharded", "status": "blocked_credentials"},
-    {"id": "completed_request_rerun", "status": "blocked_credentials"},
-    {"id": "interrupted_download_resume", "status": "simulated_only"},
-    {"id": "intermediate_smoke", "status": "blocked_credentials"},
-    {"id": "second_recent_smoke", "status": "blocked_credentials"},
-    {"id": "transient_poll_failure", "status": "simulated_only"}
+    {
+      "id": "recent_smoke",
+      "status": "completed",
+      "variables": 1,
+      "members": 1,
+      "steps": [
+        24,
+        48,
+        72
+      ]
+    },
+    {
+      "id": "recent_surface_all_members",
+      "status": "pending"
+    },
+    {
+      "id": "recent_pressure_all_members",
+      "status": "pending",
+      "levels_hpa": [
+        500,
+        700,
+        850
+      ]
+    },
+    {
+      "id": "recent_complete_sharded",
+      "status": "pending"
+    },
+    {
+      "id": "archive_start_complete_sharded",
+      "status": "pending"
+    },
+    {
+      "id": "completed_request_rerun",
+      "status": "pending"
+    },
+    {
+      "id": "interrupted_download_resume",
+      "status": "completed"
+    },
+    {
+      "id": "intermediate_smoke",
+      "status": "pending"
+    },
+    {
+      "id": "second_recent_smoke",
+      "status": "pending"
+    },
+    {
+      "id": "transient_poll_failure",
+      "status": "simulated_only"
+    }
   ]
 }

--- a/docs/plans/ecmwf_extended_range_request_measurements.json
+++ b/docs/plans/ecmwf_extended_range_request_measurements.json
@@ -1,0 +1,20 @@
+{
+  "generated_at": "2026-07-28T00:00:00Z",
+  "environment": {
+    "authenticated_ecds_access": false,
+    "reason": "Neither ECDS_API_ENDPOINT nor ECDS_API_KEY was exposed to the process, and no CDS/ECDS credential file was available. No request was submitted."
+  },
+  "observations": [],
+  "planned_matrix": [
+    {"id": "recent_smoke", "status": "blocked_credentials", "variables": 1, "members": 1, "steps": [24, 48, 72]},
+    {"id": "recent_surface_all_members", "status": "blocked_credentials"},
+    {"id": "recent_pressure_all_members", "status": "blocked_credentials", "levels_hpa": [500, 700, 850]},
+    {"id": "recent_complete_sharded", "status": "blocked_credentials"},
+    {"id": "archive_start_complete_sharded", "status": "blocked_credentials"},
+    {"id": "completed_request_rerun", "status": "blocked_credentials"},
+    {"id": "interrupted_download_resume", "status": "simulated_only"},
+    {"id": "intermediate_smoke", "status": "blocked_credentials"},
+    {"id": "second_recent_smoke", "status": "blocked_credentials"},
+    {"id": "transient_poll_failure", "status": "simulated_only"}
+  ]
+}

--- a/docs/plans/ecmwf_extended_range_spike.md
+++ b/docs/plans/ecmwf_extended_range_spike.md
@@ -2,7 +2,7 @@
 
 ## Executive summary
 
-**Recommendation: CONDITIONAL GO, with no fixed-price production commitment until the authenticated acceptance gate below passes.** The repository has most of the expensive transformation machinery, and a durable asynchronous retrieval prototype demonstrates the required local control flow under simulated responses. This run could not answer the primary source question, however: the environment had no CDS/ECDS credential, so it submitted no live request and downloaded no GRIB. Consequently there are **no measured bytes, queue times, success rate, transformation costs, or end-to-end development Zarr from ECDS**. Documentation is not a substitute for those decision criteria.
+**Recommendation: CONDITIONAL GO, with no fixed-price production commitment until the full acceptance gate below passes.** Authenticated submission, one-shot polling, persisted result discovery, GRIB download, and HTTP Range resume now work against live ECDS. A three-message control-forecast smoke file was 174,786 bytes; its observed queue time was 12.8 seconds and server processing time was 4.5 seconds. The official `2m_temperature` example failed in the backend because its parameter name was ambiguous, while `10_m_u_component_of_wind` succeeded. The full surface/pressure/member matrix and an end-to-end development Zarr remain untested.
 
 The minimum acceptance gate is three real dates (near June 2023, intermediate, and recent), one complete proposed initialization, ten total request shards, interruption/retry exercises, a strict GRIB inventory, and an end-to-end Zarr. A fixed implementation price should wait for that run. If it fails because operational ECDS retrieval is unreliable, seek a quote for scheduled dissemination rather than making the public dataset depend on manual recovery.
 
@@ -31,9 +31,11 @@ There is also an important completeness gap: failed individual downloads can rem
 
 ### Observed in this run
 
-* Neither `ECDS_API_ENDPOINT` nor `ECDS_API_KEY` was exposed to the process, and no CDS credential file was present. No authenticated request was attempted. This was rechecked after the environment secrets were identified by name.
-* The checked-in prototype defaults to the process endpoint for the live `s2s-forecasts` collection. The retrieve endpoint and response body still require an authenticated smoke test.
-* The prototype's submission/status body compatibility is intentionally small. The official client or an observed response should determine the final response schema.
+* A standard `.cdsapirc` with accepted S2S terms authenticated successfully. Personal access tokens are sent in the `PRIVATE-TOKEN` header.
+* ECDS submission returned a job ID and status location. Successful status responses exposed `links[rel=results]`; the results endpoint returned the signed download URL at `asset.value.href`.
+* Request `4f5026a6-90f3-4469-9fb4-4cfef9f44dab` retrieved ECMWF control `10_m_u_component_of_wind` for 2026-07-24 at leads 24, 48, and 72 hours. It queued for 12.824 seconds, processed for 4.511 seconds, downloaded in 0.826 seconds, contained three GRIB messages, and occupied 174,786 bytes.
+* Restarting from a seeded 87,393-byte partial file received HTTP 206, appended the remaining bytes, and reproduced the valid 174,786-byte GRIB.
+* Request `1699ae8a-eb95-4f03-afc0-1339a72fcf50` used the official `2m_temperature` payload shape but failed because the backend resolved that name ambiguously. This is an ECDS/MARS mapping issue rather than an authentication or transport failure.
 
 ### Authoritative documentation findings, not file observations
 
@@ -41,7 +43,7 @@ The live ECDS catalogue exposes the exact collection identifier [`s2s-forecasts`
 
 The authoritative [S2S model table](https://confluence.ecmwf.int/display/S2S/Models) records CY48R1 from 2023-06-27 with 100 perturbed members plus one control, daily runs through day 46, TCo319 (~32 km), and a 0.25° archived grid. CY49R1 begins 2024-11-12 with the same headline dimensions but replaces CAPE with MUCAPE, a schema boundary inside the target archive. Live constraints list pressure levels 10, 50, 100, 200, 300, 500, 700, 850, 925, and 1000 hPa and daily pressure-field leads from 0 through 1,104 hours.
 
-Authentication requires an ECMWF account, accepted dataset terms, and a `$HOME/.cdsapirc` token. The official page recommends `cdsapi>=0.7.2`. The incubating [`ecmwf-datastores-client`](https://ecmwf.github.io/ecmwf-datastores-client/) exposes asynchronous submission and status, but production should pin a tested release. Actual member encoding, per-date file inventory, GRIB edition, coordinate orientation, result retention, latency, concurrency, and rate limits remain unobserved.
+Authentication requires an ECMWF account, accepted dataset terms, and a `$HOME/.cdsapirc` token. The official page recommends `cdsapi>=0.7.2`. The incubating [`ecmwf-datastores-client`](https://ecmwf.github.io/ecmwf-datastores-client/) exposes asynchronous submission and status, but production should pin a tested release. Actual member encoding, per-date file inventory, GRIB edition, coordinate orientation, result retention, concurrency, and rate limits remain unobserved.
 
 ## Candidate request and production sharding
 
@@ -52,12 +54,12 @@ A smoke payload should start from this official shape and be generated separatel
   "origin": "ecmwf",
   "forecast_type": "control_forecast",
   "level_type": "single_level",
-  "variable": ["2m_temperature"],
+  "variable": ["10_m_u_component_of_wind"],
   "year": ["2026"],
   "month": ["07"],
   "day": ["24"],
   "leadtime_hour": ["024", "048", "072"],
-  "time": "00:00:00",
+  "time": ["00:00"],
   "data_format": "grib"
 }
 ```
@@ -95,8 +97,7 @@ Relative humidity (`r` / 157) is a fallback if specific humidity is absent; do n
 Run the tool as separate cheap invocations so a scheduler, pod, or replacement process can resume state:
 
 ```bash
-export ECDS_API_ENDPOINT=... # environment secret; never commit it
-export ECDS_API_KEY=...      # environment secret; never commit it
+# Configure url and key in ~/.cdsapirc and accept the S2S terms first.
 uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json submit --payload payload.json
 uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json poll --maximum-polls 1
 uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json download --target data/ecmwf-er/recent-smoke.grib
@@ -104,7 +105,7 @@ uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-sm
 
 State writes use a temporary sibling and atomic rename. Poll failures are recorded with bounded exponential backoff. Downloads use `.partial`, request a byte range on restart, only append after HTTP 206, validate leading `GRIB` and terminal `7777`, count messages, atomically rename, and write a completion marker. A production adapter must additionally parse every GRIB key, validate content length/checksum or stable validator, and compare the exact expected Cartesian inventory before completion.
 
-The machine-readable matrix records seven required cases plus intermediate, second-recent, and simulated-transient cases. Authenticated cases are `blocked_credentials`; restart and state persistence are unit-tested with simulated HTTP responses. Empty observations are deliberate and must not be interpreted as zero latency or 100% reliability.
+The machine-readable matrix records seven required cases plus intermediate, second-recent, and simulated-transient cases. The recent control smoke and real HTTP Range restart are complete; the larger authenticated cases remain pending. State persistence, live result discovery, and both HTTP 206 append and HTTP 200 restart behavior are covered by unit tests.
 
 ## Development Zarr proof
 
@@ -114,17 +115,17 @@ The unit test writes a deterministic 101-member × 46-daily-lead synthetic initi
 
 | Metric | Observation |
 |---|---|
-| authenticated requests | 0 |
-| success rate | not measured |
-| typical/worst queue time | not measured |
-| typical/worst end-to-end latency | not measured |
+| authenticated requests | 3 small control requests: two wind successes and one `2m_temperature` backend failure |
+| success rate | 2/2 for the wind smoke shape; 2/3 across both tested variable names |
+| typical/worst queue time | one instrumented fresh run: 12.824 seconds |
+| typical/worst end-to-end latency | one instrumented fresh run: 17.335 seconds queue plus server processing; download added 0.826 seconds |
 | update-cadence fit | unknown |
-| real restart/retry/idempotency | unknown; simulated state recovery only |
+| real restart/retry/idempotency | HTTP 206 resume succeeded from a 50% partial file; duplicate submission behavior remains untested |
 | incomplete-success behavior | unknown; strict inventory requirement identified |
 
 ## Storage and compute
 
-There were no actual downloaded or generated representative files, so raw GRIB bytes per initialization, staging bytes, production Zarr bytes, compression ratio, peak memory, CPU time, transform wall time, requests per initialization, annual growth, initial archive size, backfill duration, and dollar cost are **not measured**. Supplying numeric values from theoretical dimensions would violate the spike requirement to use actual files.
+The three-message smoke GRIB was 174,786 bytes. It is not representative of a complete initialization, so staging bytes, production Zarr bytes, compression ratio, peak memory, CPU time, transform wall time, requests per initialization, annual growth, initial archive size, backfill duration, and dollar cost remain unmeasured.
 
 After one complete initialization, calculate:
 
@@ -149,8 +150,8 @@ Paid pre-scheduled delivery would replace unpredictable on-demand queueing and i
 
 Top risks:
 
-1. **Unobserved source contract:** authenticated request syntax, archive calendar, schema eras, full manifest, member completeness, and result retention are not established.
-2. **Unobserved operational behavior:** queue latency, throughput, limits, resumability, idempotency, and structurally incomplete successful responses are not measured.
+1. **Incomplete source contract:** authentication and the small control request work, but archive calendar, schema eras, full manifest, member completeness, and result retention are not established; `2m_temperature` currently fails in backend parameter mapping.
+2. **Partially observed operational behavior:** one small request had low latency and resumability worked, but production-size throughput, limits, duplicate submission behavior, and structurally incomplete successful responses are not measured.
 3. **Redistribution and cost:** dataset-specific terms need confirmation, while actual storage/compute and paid-delivery economics have no measured basis.
 
 Recommend GO only after all of these pass unattended:
@@ -163,7 +164,7 @@ Recommend GO only after all of these pass unattended:
 
 ## Proposed `dynamical-org/meta#144` comment
 
-> **ECMWF Extended Range is a conditional go, not yet ready for a fixed-price commitment.** Most GRIB normalization, deaccumulation, Zarr writing, metadata, and validation can be reused from IFS ENS, but ECDS needs a durable asynchronous source adapter and strict whole-initialization completeness checks. I recommend a bounded first product: ECMWF real-time forecasts only, daily lead samples through the available extended horizon, all members, a useful surface set, and temperature/wind/humidity/geopotential at 500/700/850 hPa represented as fixed-level variables; start at the first live-verified stable 101-member date. This spike environment had no ECDS credentials, so it produced no defensible bytes/init, archive-size, compute, queue-latency, or reliability measurements. Remaining source risk is therefore high: live schema/calendar, unattended queue behavior, and dataset-specific redistribution terms. Budget human effort for an authenticated acceptance run plus source-adapter/integration work; do not quote production until three dates, ten shards, one complete real Zarr, restart/retry tests, measured storage, and ECMWF terms confirmation pass.
+> **ECMWF Extended Range is a conditional go, not yet ready for a fixed-price commitment.** Authenticated ECDS submission, durable one-shot polling, nested result discovery, validated GRIB download, and real HTTP Range resume now work. A three-lead wind smoke request queued for 12.8 seconds, processed for 4.5 seconds, and produced a 174,786-byte GRIB with three messages; the official `2m_temperature` name failed in backend parameter mapping. Most GRIB normalization, deaccumulation, Zarr writing, metadata, and validation can be reused from IFS ENS, but the full member/surface/pressure inventory and a complete real Zarr remain untested. Do not quote production until three dates, ten representative shards, one complete real Zarr, duplicate/retry tests, measured storage, and ECMWF terms confirmation pass.
 
 ## Artifacts
 

--- a/docs/plans/ecmwf_extended_range_spike.md
+++ b/docs/plans/ecmwf_extended_range_spike.md
@@ -1,0 +1,173 @@
+# ECMWF IFS Extended Range through ECDS: decision spike
+
+## Executive summary
+
+**Recommendation: CONDITIONAL GO, with no fixed-price production commitment until the authenticated acceptance gate below passes.** The repository has most of the expensive transformation machinery, and a durable asynchronous retrieval prototype demonstrates the required local control flow under simulated responses. This run could not answer the primary source question, however: the environment had no CDS/ECDS credential, so it submitted no live request and downloaded no GRIB. Consequently there are **no measured bytes, queue times, success rate, transformation costs, or end-to-end development Zarr from ECDS**. Documentation is not a substitute for those decision criteria.
+
+The minimum acceptance gate is three real dates (near June 2023, intermediate, and recent), one complete proposed initialization, ten total request shards, interruption/retry exercises, a strict GRIB inventory, and an end-to-end Zarr. A fixed implementation price should wait for that run. If it fails because operational ECDS retrieval is unreliable, seek a quote for scheduled dissemination rather than making the public dataset depend on manual recovery.
+
+Expected remaining human effort is roughly 2–5 engineering days for the credentialed acceptance run, then 3–5 engineering weeks for a production source adapter, strict inventory/decode integration, template and validation work, operational deployment, and a bounded backfill. This is a planning range rather than a fixed estimate; observed queue behavior and file layout are the largest multipliers.
+
+### Proposed bounded production scope
+
+* ECMWF real-time forecasts only; exclude hindcasts/reforecasts.
+* Begin at 2023-06-27, the documented CY48R1 start and first daily 101-member configuration, subject to real-file verification.
+* Publish daily initializations after the mandatory 48-hour access delay, checking actual per-date availability before creating each append region.
+* Daily lead samples through 1,104 hours (46 days), selected from the parameter-dependent 6-hourly, 24-hourly, or daily-average output.
+* Use the documented global 0.25° archived grid. Coordinate orientation and longitude convention remain real-file observations.
+* Start with the surface manifest below and fixed-level root variables at 500, 700, and 850 hPa. Fixed-level names avoid adding materialized multi-group support during the first integration.
+
+## What was inspected and what is reusable
+
+The existing 15-day IFS ENS integration already supplies canonical variable models and metadata, init/lead/member/latitude/longitude coordinates, `valid_time`, regional chunking, rasterio GRIB decoding, scale conversion, lead-time deaccumulation, materialized Zarr writes, Icechunk atomic commits, and forecast-current/recent-NaN validators. Its tests cover source coordinates, availability cutovers, absent step zero, strict metadata and shape checks, scaling, deaccumulation, operational updates, and real-file integration.
+
+ECDS needs a source adapter rather than another transformation stack. The adapter must own authenticated submission, durable request IDs, one-shot polling, result expiry, request sharding, resumable downloads, local GRIB indexing, and strict validation of the expected variable × level × member × step product.
+
+The current integration is specifically coupled to public Open Data or the internal MARS mirror by URL naming, `.index` sidecars, byte-range reads, GCS-to-S3 fallback, one init/lead/member source-coordinate granularity, a `(721, 1440)` grid, 51 members, and fixed 3/6-hour lead coordinates. Its operational deadline assumes directly downloadable objects. None of these are safe ECDS assumptions.
+
+There is also an important completeness gap: failed individual downloads can remain fill values while finalization trims to an initialization with any successful coordinate. Extended Range must withhold the entire initialization unless its pre-write inventory is complete; recent-NaN validation after publication is too late.
+
+## Source findings
+
+### Observed in this run
+
+* Neither `ECDS_API_ENDPOINT` nor `ECDS_API_KEY` was exposed to the process, and no CDS credential file was present. No authenticated request was attempted. This was rechecked after the environment secrets were identified by name.
+* The checked-in prototype defaults to the process endpoint for the live `s2s-forecasts` collection. The retrieve endpoint and response body still require an authenticated smoke test.
+* The prototype's submission/status body compatibility is intentionally small. The official client or an observed response should determine the final response schema.
+
+### Authoritative documentation findings, not file observations
+
+The live ECDS catalogue exposes the exact collection identifier [`s2s-forecasts`](https://ecds.ecmwf.int/api/catalogue/v1/collections/s2s-forecasts). Its current form and constraint resources expose `origin`, `forecast_type`, `level_type`, `variable`, `year`, `month`, `day`, `time`, and `leadtime_hour`; the official [API example](https://ecds.ecmwf.int/how-to-api) uses `cdsapi.Client().retrieve("s2s-forecasts", request, target)`. These are live schema responses, not returned-GRIB observations.
+
+The authoritative [S2S model table](https://confluence.ecmwf.int/display/S2S/Models) records CY48R1 from 2023-06-27 with 100 perturbed members plus one control, daily runs through day 46, TCo319 (~32 km), and a 0.25° archived grid. CY49R1 begins 2024-11-12 with the same headline dimensions but replaces CAPE with MUCAPE, a schema boundary inside the target archive. Live constraints list pressure levels 10, 50, 100, 200, 300, 500, 700, 850, 925, and 1000 hPa and daily pressure-field leads from 0 through 1,104 hours.
+
+Authentication requires an ECMWF account, accepted dataset terms, and a `$HOME/.cdsapirc` token. The official page recommends `cdsapi>=0.7.2`. The incubating [`ecmwf-datastores-client`](https://ecmwf.github.io/ecmwf-datastores-client/) exposes asynchronous submission and status, but production should pin a tested release. Actual member encoding, per-date file inventory, GRIB edition, coordinate orientation, result retention, latency, concurrency, and rate limits remain unobserved.
+
+## Candidate request and production sharding
+
+A smoke payload should start from this official shape and be generated separately for control and perturbed forecast types:
+
+```json
+{
+  "origin": "ecmwf",
+  "forecast_type": "control_forecast",
+  "level_type": "single_level",
+  "variable": ["2m_temperature"],
+  "year": ["2026"],
+  "month": ["07"],
+  "day": ["24"],
+  "leadtime_hour": ["024", "048", "072"],
+  "time": "00:00:00",
+  "data_format": "grib"
+}
+```
+
+Production-size shards should separate surface from pressure levels, control from perturbed members if required by the API, and split variables/steps until observed queue and response sizes are bounded. Shard boundaries must be tuned from measurements, not guessed.
+
+## Candidate variable manifest
+
+Every row is a **candidate to verify in actual S2S GRIB**. Parameter IDs are ECMWF GRIB table identifiers commonly used by the existing integration; availability, units, statistical processing, and equivalence are not asserted until inventory validation passes.
+
+| ECDS/MARS parameter | short name / ID | level | expected source units | Dynamical name | processing | archive status |
+|---|---|---|---|---|---|---|
+| 2 metre temperature | `2t` / 167 | 2 m | K | `temperature_2m` | instantaneous | unverified |
+| 2 metre dewpoint | `2d` / 168 | 2 m | K | `dew_point_temperature_2m` | instantaneous | unverified |
+| 10 metre U wind | `10u` / 165 | 10 m | m s-1 | `wind_u_10m` | instantaneous | unverified |
+| 10 metre V wind | `10v` / 166 | 10 m | m s-1 | `wind_v_10m` | instantaneous | unverified |
+| mean sea-level pressure | `msl` / 151 | surface | Pa | `pressure_reduced_to_mean_sea_level` | instantaneous | unverified |
+| surface pressure | `sp` / 134 | surface | Pa | `pressure_surface` | instantaneous | unverified |
+| total precipitation | `tp` / 228 | surface | m | `precipitation_surface` | deaccumulate and convert to rate | unverified |
+| total cloud cover | `tcc` / 164 | atmosphere | 1 | `total_cloud_cover_atmosphere` | instantaneous | unverified |
+| surface solar radiation downwards | `ssrd` / 169 | surface | J m-2 | `downward_short_wave_radiation_flux_surface` | deaccumulate to W m-2 | unverified |
+| surface thermal radiation downwards | `strd` / 175 | surface | J m-2 | `downward_long_wave_radiation_flux_surface` | deaccumulate to W m-2 | unverified |
+| runoff | `ro` / 205 | surface | m | `runoff_surface` | deaccumulate to rate | unverified |
+| volumetric soil water layer 1 | `swvl1` / 39 | soil layer 1 | m3 m-3 | `soil_moisture_0_7cm` | instantaneous; verify layer | unverified |
+| temperature | `t` / 130 | 500/700/850 hPa | K | `temperature_{level}hpa` | instantaneous | unverified |
+| U wind | `u` / 131 | 500/700/850 hPa | m s-1 | `wind_u_{level}hpa` | instantaneous | unverified |
+| V wind | `v` / 132 | 500/700/850 hPa | m s-1 | `wind_v_{level}hpa` | instantaneous | unverified |
+| specific humidity | `q` / 133 | 500/700/850 hPa | kg kg-1 | `specific_humidity_{level}hpa` | instantaneous | unverified |
+| geopotential | `z` / 129 | 500/700/850 hPa | m2 s-2 | `geopotential_height_{level}hpa` | divide by standard gravity if canonical field is height | unverified |
+
+Relative humidity (`r` / 157) is a fallback if specific humidity is absent; do not publish both without a use case. Wind gust, 100 m winds, categorical precipitation type, and every other existing 15-day field are unsupported for planning purposes until observed. Soil moisture layer bounds and accumulated-field reset semantics require message-level verification.
+
+## Retrieval prototype and request matrix
+
+Run the tool as separate cheap invocations so a scheduler, pod, or replacement process can resume state:
+
+```bash
+export ECDS_API_ENDPOINT=... # environment secret; never commit it
+export ECDS_API_KEY=...      # environment secret; never commit it
+uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json submit --payload payload.json
+uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json poll --maximum-polls 1
+uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json download --target data/ecmwf-er/recent-smoke.grib
+```
+
+State writes use a temporary sibling and atomic rename. Poll failures are recorded with bounded exponential backoff. Downloads use `.partial`, request a byte range on restart, only append after HTTP 206, validate leading `GRIB` and terminal `7777`, count messages, atomically rename, and write a completion marker. A production adapter must additionally parse every GRIB key, validate content length/checksum or stable validator, and compare the exact expected Cartesian inventory before completion.
+
+The machine-readable matrix records seven required cases plus intermediate, second-recent, and simulated-transient cases. Authenticated cases are `blocked_credentials`; restart and state persistence are unit-tested with simulated HTTP responses. Empty observations are deliberate and must not be interpreted as zero latency or 100% reliability.
+
+## Development Zarr proof
+
+The unit test writes a deterministic 101-member × 46-daily-lead synthetic initialization twice, reopens it, checks `valid_time`, and queries an East Africa box. It proves local dimension/order/query/idempotent-write mechanics only. It does **not** prove ECDS retrieval, GRIB decoding, real units, accumulation semantics, missingness, pressure levels, chunk efficiency, or actual complete-initialization transformation. Those remain acceptance-gate work.
+
+## Reliability measurements
+
+| Metric | Observation |
+|---|---|
+| authenticated requests | 0 |
+| success rate | not measured |
+| typical/worst queue time | not measured |
+| typical/worst end-to-end latency | not measured |
+| update-cadence fit | unknown |
+| real restart/retry/idempotency | unknown; simulated state recovery only |
+| incomplete-success behavior | unknown; strict inventory requirement identified |
+
+## Storage and compute
+
+There were no actual downloaded or generated representative files, so raw GRIB bytes per initialization, staging bytes, production Zarr bytes, compression ratio, peak memory, CPU time, transform wall time, requests per initialization, annual growth, initial archive size, backfill duration, and dollar cost are **not measured**. Supplying numeric values from theoretical dimensions would violate the spike requirement to use actual files.
+
+After one complete initialization, calculate:
+
+* initial archive bytes = measured compressed bytes per initialization × observed initialization count from stable-era start;
+* annual growth = measured bytes × observed yearly initialization frequency;
+* monthly storage cost = decimal GB × `$0.015`;
+* staging peak = completed shard bytes + partial shard bytes + transformation workspace;
+* backfill requests = initialization count × observed shards per initialization;
+* backfill wall time from measured queue throughput, download bandwidth, and transform throughput, explicitly reporting the maximum bottleneck.
+
+Sensitivity runs should repeat the same real initialization for 6-hourly versus daily steps, surface-only versus selected pressure levels, selected versus broad pressure profiles, and current-era versus all schema eras. Queue time is expected to be the unique ECDS risk, but calling the backfill queue-limited before measurements would be speculation. The “Storage scenarios” spreadsheet was not present in this repository, so its compute assumptions could not be applied.
+
+## Redistribution and operational terms
+
+The current dataset-specific [S2S licence](https://object-store.os-api.cci2.ecmwf.int:443/cci2-prod-catalogue/licences/s2s-licence/s2s-licence_c6d3b10fff18f2016c2bd4071748c73609d92c0d3cb4938132012457bdf77900.pdf) places ECMWF-origin S2S data under CC BY 4.0. It facially permits sharing and adaptation, including commercially, subject to appropriate attribution, a licence link, an indication of modifications, the requested S2S acknowledgement/citation, no endorsement, and no additional restrictions. The catalogue requests its DOI (10.21957/5ac361bf), Vitart et al. (2017), `Copyright © [year] ECMWF`, ECDS source, licence/disclaimer, and modification notice. A public transformed Zarr therefore appears permissible, but this is not legal advice.
+
+Automated API access is the documented client pattern, and ECMWF-origin forecasts become accessible after a licence-mandated 48-hour delay. No authoritative numeric ECDS S2S concurrency/fair-use limit was found; the catalogue warns that costly requests receive lower priority and recommends smaller requests. Before public redistribution, ask ECMWF to confirm that (1) the exact attribution presentation is sufficient, (2) scheduled unattended access at the measured rate is acceptable, and (3) the transformed service imposes no incompatible downstream restriction.
+
+Paid pre-scheduled delivery would replace unpredictable on-demand queueing and is the fallback if the acceptance gate fails. The internal `meta#135` analysis and “Storage scenarios” spreadsheet were unavailable here, so assigning a dissemination volume band or claiming economic plausibility would be invented. Obtain an ECMWF quote using the measured narrow manifest; do not price broad profiles or 6-hourly output by default.
+
+## Risks and decision gate
+
+Top risks:
+
+1. **Unobserved source contract:** authenticated request syntax, archive calendar, schema eras, full manifest, member completeness, and result retention are not established.
+2. **Unobserved operational behavior:** queue latency, throughput, limits, resumability, idempotency, and structurally incomplete successful responses are not measured.
+3. **Redistribution and cost:** dataset-specific terms need confirmation, while actual storage/compute and paid-delivery economics have no measured basis.
+
+Recommend GO only after all of these pass unattended:
+
+1. Inventory recent, intermediate, and near-start GRIBs; establish edition, grid, members, steps, parameters, levels, statistics, units, and schema cutovers.
+2. Complete ten representative shards including a full initialization, an older full request, a duplicate, a killed download, and an injected transient failure. Record all measurement fields.
+3. Transform one complete real initialization; compare accumulated fields numerically; verify fixed pressure levels, missingness, coordinate orientation, regional query, chunks, and idempotent rerun.
+4. Project storage/cost only from those files and verify latency fits the observed initialization cadence.
+5. Obtain written ECMWF confirmation for public transformed redistribution and intended automation rate if the catalogue terms are ambiguous.
+
+## Proposed `dynamical-org/meta#144` comment
+
+> **ECMWF Extended Range is a conditional go, not yet ready for a fixed-price commitment.** Most GRIB normalization, deaccumulation, Zarr writing, metadata, and validation can be reused from IFS ENS, but ECDS needs a durable asynchronous source adapter and strict whole-initialization completeness checks. I recommend a bounded first product: ECMWF real-time forecasts only, daily lead samples through the available extended horizon, all members, a useful surface set, and temperature/wind/humidity/geopotential at 500/700/850 hPa represented as fixed-level variables; start at the first live-verified stable 101-member date. This spike environment had no ECDS credentials, so it produced no defensible bytes/init, archive-size, compute, queue-latency, or reliability measurements. Remaining source risk is therefore high: live schema/calendar, unattended queue behavior, and dataset-specific redistribution terms. Budget human effort for an authenticated acceptance run plus source-adapter/integration work; do not quote production until three dates, ten shards, one complete real Zarr, restart/retry tests, measured storage, and ECMWF terms confirmation pass.
+
+## Artifacts
+
+* Report: `docs/plans/ecmwf_extended_range_spike.md`
+* Request measurements/matrix: `docs/plans/ecmwf_extended_range_request_measurements.json`
+* Retrieval tool: `src/scripts/ecmwf_extended_range_spike.py`
+* Development-only mechanics proof: `tests/scripts/ecmwf_extended_range_spike_test.py`

--- a/docs/plans/ecmwf_extended_range_spike.md
+++ b/docs/plans/ecmwf_extended_range_spike.md
@@ -2,19 +2,19 @@
 
 ## Executive summary
 
-**Recommendation: CONDITIONAL GO, with no fixed-price production commitment until the full acceptance gate below passes.** Authenticated submission, one-shot polling, persisted result discovery, GRIB download, and HTTP Range resume now work against live ECDS. A three-message control-forecast smoke file was 174,786 bytes; its observed queue time was 12.8 seconds and server processing time was 4.5 seconds. The official `2m_temperature` example failed in the backend because its parameter name was ambiguous, while `10_m_u_component_of_wind` succeeded. The full surface/pressure/member matrix and an end-to-end development Zarr remain untested.
+**Recommendation: CONDITIONAL GO for a revised 1.5° product; NO-GO for the originally assumed 0.25° product through ECDS.** The credentialed acceptance gate passed. Twenty-seven accepted requests downloaded and passed exact inventory validation, including archive-start and intermediate dates, control plus 100 perturbed members, every candidate field, and one full 46-lead initialization. A complete 27-field-level development Zarr reopened and queried successfully.
 
-The minimum acceptance gate is three real dates (near June 2023, intermediate, and recent), one complete proposed initialization, ten total request shards, interruption/retry exercises, a strict GRIB inventory, and an end-to-end Zarr. A fixed implementation price should wait for that run. If it fails because operational ECDS retrieval is unreliable, seek a quote for scheduled dissemination rather than making the public dataset depend on manual recovery.
+The condition is a product decision, not a remaining transport blocker: live ECDS files are global 121 × 240 at 1.5°, not the documented 0.25° archived grid assumed by the original proposal. If 1.5° is useful, proceed to production design and obtain ECMWF confirmation of the intended unattended request rate and attribution presentation. If 0.25° is required, stop this path and seek scheduled dissemination or another source.
 
-Expected remaining human effort is roughly 2–5 engineering days for the credentialed acceptance run, then 3–5 engineering weeks for a production source adapter, strict inventory/decode integration, template and validation work, operational deployment, and a bounded backfill. This is a planning range rather than a fixed estimate; observed queue behavior and file layout are the largest multipliers.
+The acceptance run also established the operational scale. The full initialization contained 125,442 GRIB messages and 6,985,939,316 source bytes. A streaming, ten-member-chunk development transform produced an 8,958,032,476-byte Zarr in 784.1 seconds. Expected implementation effort remains approximately 3–5 engineering weeks for a production adapter, template, validators, deployment, and bounded backfill; this is a planning range, not a fixed quote.
 
 ### Proposed bounded production scope
 
 * ECMWF real-time forecasts only; exclude hindcasts/reforecasts.
-* Begin at 2023-06-27, the documented CY48R1 start and first daily 101-member configuration, subject to real-file verification.
+* Begin at 2023-06-28, the first ECMWF initialization exposed by the live catalogue constraints and verified in this run.
 * Publish daily initializations after the mandatory 48-hour access delay, checking actual per-date availability before creating each append region.
 * Daily lead samples through 1,104 hours (46 days), selected from the parameter-dependent 6-hourly, 24-hourly, or daily-average output.
-* Use the documented global 0.25° archived grid. Coordinate orientation and longitude convention remain real-file observations.
+* Publish the observed global 1.5° grid: 121 descending latitudes from 90° to −90° and 240 longitudes from −180° to 178.5°.
 * Start with the surface manifest below and fixed-level root variables at 500, 700, and 850 hPa. Fixed-level names avoid adding materialized multi-group support during the first integration.
 
 ## What was inspected and what is reusable
@@ -33,17 +33,23 @@ There is also an important completeness gap: failed individual downloads can rem
 
 * A standard `.cdsapirc` with accepted S2S terms authenticated successfully. Personal access tokens are sent in the `PRIVATE-TOKEN` header.
 * ECDS submission returned a job ID and status location. Successful status responses exposed `links[rel=results]`; the results endpoint returned the signed download URL at `asset.value.href`.
-* Request `4f5026a6-90f3-4469-9fb4-4cfef9f44dab` retrieved ECMWF control `10_m_u_component_of_wind` for 2026-07-24 at leads 24, 48, and 72 hours. It queued for 12.824 seconds, processed for 4.511 seconds, downloaded in 0.826 seconds, contained three GRIB messages, and occupied 174,786 bytes.
-* Restarting from a seeded 87,393-byte partial file received HTTP 206, appended the remaining bytes, and reproduced the valid 174,786-byte GRIB.
-* Request `1699ae8a-eb95-4f03-afc0-1339a72fcf50` used the official `2m_temperature` payload shape but failed because the backend resolved that name ambiguously. This is an ECDS/MARS mapping issue rather than an authentication or transport failure.
+* Twenty-seven accepted requests downloaded and passed strict variable × level × member × lead inventory checks. They covered 2023-06-28, 2024-06-27, 2026-07-23, and 2026-07-24.
+* The current selector is `2_m_temperature`. The earlier `2m_temperature` failure used a stale selector and is not evidence of a backend mapping defect.
+* Exact all-member files contained perturbation numbers 1–100; the separate control requests supplied member 0.
+* The full 2026-07-24 candidate initialization used 14 shards and contained exactly 125,442 messages: 12 single-level fields plus five pressure variables at 500, 700, and 850 hPa, across 101 members and 46 daily leads.
+* Every returned file used a 121 × 240 global 1.5° grid. GRIB coordinates decode to descending latitude 90° to −90°, longitude −180° to 178.5°, and an earth radius of 6,367,470 m.
+* A duplicate request returned byte-identical output with SHA-256 `85abedb05adcffcb405879ef136cb8e019dad5d8713f382625ac23900dafaad9`.
+* Restarting from a seeded partial file received HTTP 206 and reproduced the original GRIB. The HTTP 200 fallback correctly restarts rather than appending.
+* One large all-member pressure submission received HTTP 502 before a request ID existed. Resubmission succeeded. No accepted job failed or returned an incomplete inventory.
+* The download-state counter originally found 4,603 `GRIB` byte strings in a structurally valid 4,600-message file. It now follows each GRIB message length and validates every trailer rather than counting embedded payload bytes.
 
 ### Authoritative documentation findings, not file observations
 
 The live ECDS catalogue exposes the exact collection identifier [`s2s-forecasts`](https://ecds.ecmwf.int/api/catalogue/v1/collections/s2s-forecasts). Its current form and constraint resources expose `origin`, `forecast_type`, `level_type`, `variable`, `year`, `month`, `day`, `time`, and `leadtime_hour`; the official [API example](https://ecds.ecmwf.int/how-to-api) uses `cdsapi.Client().retrieve("s2s-forecasts", request, target)`. These are live schema responses, not returned-GRIB observations.
 
-The authoritative [S2S model table](https://confluence.ecmwf.int/display/S2S/Models) records CY48R1 from 2023-06-27 with 100 perturbed members plus one control, daily runs through day 46, TCo319 (~32 km), and a 0.25° archived grid. CY49R1 begins 2024-11-12 with the same headline dimensions but replaces CAPE with MUCAPE, a schema boundary inside the target archive. Live constraints list pressure levels 10, 50, 100, 200, 300, 500, 700, 850, 925, and 1000 hPa and daily pressure-field leads from 0 through 1,104 hours.
+The authoritative [S2S model table](https://confluence.ecmwf.int/display/S2S/Models) records CY48R1 from 2023-06-27 with 100 perturbed members plus one control, daily runs through day 46, TCo319 (~32 km), and a 0.25° archived grid. The live ECMWF catalogue begins on 2023-06-28 and its returned files are 1.5°. CY49R1 begins 2024-11-12 with the same headline dimensions but replaces CAPE with MUCAPE, a schema boundary inside the target archive. Live constraints list pressure levels 10, 50, 100, 200, 300, 500, 700, 850, 925, and 1000 hPa and daily pressure-field leads through 1,104 hours.
 
-Authentication requires an ECMWF account, accepted dataset terms, and a `$HOME/.cdsapirc` token. The official page recommends `cdsapi>=0.7.2`. The incubating [`ecmwf-datastores-client`](https://ecmwf.github.io/ecmwf-datastores-client/) exposes asynchronous submission and status, but production should pin a tested release. Actual member encoding, per-date file inventory, GRIB edition, coordinate orientation, result retention, concurrency, and rate limits remain unobserved.
+Authentication requires an ECMWF account, accepted dataset terms, and a `$HOME/.cdsapirc` token. The official page recommends `cdsapi>=0.7.2`. The incubating [`ecmwf-datastores-client`](https://ecmwf.github.io/ecmwf-datastores-client/) exposes asynchronous submission and status, but production should pin a tested release. Result retention and numeric concurrency/rate limits remain undocumented by this run.
 
 ## Candidate request and production sharding
 
@@ -68,29 +74,29 @@ Production-size shards should separate surface from pressure levels, control fro
 
 ## Candidate variable manifest
 
-Every row is a **candidate to verify in actual S2S GRIB**. Parameter IDs are ECMWF GRIB table identifiers commonly used by the existing integration; availability, units, statistical processing, and equivalence are not asserted until inventory validation passes.
+Every row below passed live inventory validation for control and 100 perturbed members. The full 46-lead transform validated the combined 27 field-level outputs.
 
-| ECDS/MARS parameter | short name / ID | level | expected source units | Dynamical name | processing | archive status |
-|---|---|---|---|---|---|---|
-| 2 metre temperature | `2t` / 167 | 2 m | K | `temperature_2m` | instantaneous | unverified |
-| 2 metre dewpoint | `2d` / 168 | 2 m | K | `dew_point_temperature_2m` | instantaneous | unverified |
-| 10 metre U wind | `10u` / 165 | 10 m | m s-1 | `wind_u_10m` | instantaneous | unverified |
-| 10 metre V wind | `10v` / 166 | 10 m | m s-1 | `wind_v_10m` | instantaneous | unverified |
-| mean sea-level pressure | `msl` / 151 | surface | Pa | `pressure_reduced_to_mean_sea_level` | instantaneous | unverified |
-| surface pressure | `sp` / 134 | surface | Pa | `pressure_surface` | instantaneous | unverified |
-| total precipitation | `tp` / 228 | surface | m | `precipitation_surface` | deaccumulate and convert to rate | unverified |
-| total cloud cover | `tcc` / 164 | atmosphere | 1 | `total_cloud_cover_atmosphere` | instantaneous | unverified |
-| surface solar radiation downwards | `ssrd` / 169 | surface | J m-2 | `downward_short_wave_radiation_flux_surface` | deaccumulate to W m-2 | unverified |
-| surface thermal radiation downwards | `strd` / 175 | surface | J m-2 | `downward_long_wave_radiation_flux_surface` | deaccumulate to W m-2 | unverified |
-| runoff | `ro` / 205 | surface | m | `runoff_surface` | deaccumulate to rate | unverified |
-| volumetric soil water layer 1 | `swvl1` / 39 | soil layer 1 | m3 m-3 | `soil_moisture_0_7cm` | instantaneous; verify layer | unverified |
-| temperature | `t` / 130 | 500/700/850 hPa | K | `temperature_{level}hpa` | instantaneous | unverified |
-| U wind | `u` / 131 | 500/700/850 hPa | m s-1 | `wind_u_{level}hpa` | instantaneous | unverified |
-| V wind | `v` / 132 | 500/700/850 hPa | m s-1 | `wind_v_{level}hpa` | instantaneous | unverified |
-| specific humidity | `q` / 133 | 500/700/850 hPa | kg kg-1 | `specific_humidity_{level}hpa` | instantaneous | unverified |
-| geopotential | `z` / 129 | 500/700/850 hPa | m2 s-2 | `geopotential_height_{level}hpa` | divide by standard gravity if canonical field is height | unverified |
+| ECDS variable | level | observed decoded units | Dynamical name | processing |
+|---|---|---|---|---|
+| `2_m_temperature` | 2 m | °C | `temperature_2m` | daily average |
+| `2_m_dewpoint_temperature` | 2 m | °C | `dew_point_temperature_2m` | daily average |
+| `10_m_u_component_of_wind` | 10 m | m s-1 | `wind_u_10m` | instantaneous |
+| `10_m_v_component_of_wind` | 10 m | m s-1 | `wind_v_10m` | instantaneous |
+| `mean_sea_level_pressure` | mean sea level | Pa | `pressure_reduced_to_mean_sea_level` | instantaneous |
+| `surface_pressure` | surface | Pa | `pressure_surface` | instantaneous |
+| `total_precipitation` | surface | kg m-2 accumulated | `precipitation_surface` | difference to kg m-2 s-1 |
+| `total_cloud_cover` | atmosphere | percent | `total_cloud_cover_atmosphere` | daily average |
+| `surface_solar_radiation_downwards` | surface | J m-2 accumulated | `downward_short_wave_radiation_flux_surface` | difference to W m-2 |
+| `surface_thermal_radiation_downwards` | surface | J m-2 accumulated | `downward_long_wave_radiation_flux_surface` | difference to W m-2 |
+| `surface_runoff` | surface | kg m-2 accumulated | `runoff_surface` | difference to kg m-2 s-1 |
+| `soil_moisture_top_20_cm` | 0–20 cm | kg m-3 | `soil_moisture_0_20cm` | daily average |
+| `temperature` | 500/700/850 hPa | °C | `temperature_{level}hpa` | instantaneous |
+| `u_component_of_wind` | 500/700/850 hPa | m s-1 | `wind_u_{level}hpa` | instantaneous |
+| `v_component_of_wind` | 500/700/850 hPa | m s-1 | `wind_v_{level}hpa` | instantaneous |
+| `specific_humidity` | 500/700/850 hPa | 1 | `specific_humidity_{level}hpa` | instantaneous |
+| `geopotential_height` | 500/700/850 hPa | m | `geopotential_height_{level}hpa` | instantaneous |
 
-Relative humidity (`r` / 157) is a fallback if specific humidity is absent; do not publish both without a use case. Wind gust, 100 m winds, categorical precipitation type, and every other existing 15-day field are unsupported for planning purposes until observed. Soil moisture layer bounds and accumulated-field reset semantics require message-level verification.
+The accumulated fields increase from initialization and are differenced across daily leads. GRIB packing creates small negative precipitation/runoff differences; the development transform clamps rates above the repository's established invalid-negative thresholds to zero. Soil moisture and runoff are land-only and share a 66.18% global missing mask. Soil moisture reaches −6.8×10⁻¹⁰ and cloud cover 100.0012% from packing; production should clamp these to their physical ranges and test the observed clamp fraction.
 
 ## Retrieval prototype and request matrix
 
@@ -105,38 +111,36 @@ uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-sm
 
 State writes use a temporary sibling and atomic rename. Poll failures are recorded with bounded exponential backoff. Downloads use `.partial`, request a byte range on restart, only append after HTTP 206, validate leading `GRIB` and terminal `7777`, count messages, atomically rename, and write a completion marker. A production adapter must additionally parse every GRIB key, validate content length/checksum or stable validator, and compare the exact expected Cartesian inventory before completion.
 
-The machine-readable matrix records seven required cases plus intermediate, second-recent, and simulated-transient cases. The recent control smoke and real HTTP Range restart are complete; the larger authenticated cases remain pending. State persistence, live result discovery, and both HTTP 206 append and HTTP 200 restart behavior are covered by unit tests.
+The machine-readable measurements now record every live case without signed URLs. State persistence, live result discovery, structural GRIB counting, and both HTTP 206 append and HTTP 200 restart behavior are covered by unit tests. Production should continue using short-lived one-shot poll processes; the acceptance run showed no benefit to keeping a worker allocated while ECDS queues a job.
 
 ## Development Zarr proof
 
-The unit test writes a deterministic 101-member × 46-daily-lead synthetic initialization twice, reopens it, checks `valid_time`, and queries an East Africa box. It proves local dimension/order/query/idempotent-write mechanics only. It does **not** prove ECDS retrieval, GRIB decoding, real units, accumulation semantics, missingness, pressure levels, chunk efficiency, or actual complete-initialization transformation. Those remain acceptance-gate work.
+The complete real development Zarr contains dimensions `(init_time=1, lead_time=46, ensemble_member=101, latitude=121, longitude=240)` and 27 data variables. Xarray recognized `valid_time` and `spatial_ref` as coordinates, verified `valid_time = init_time + lead_time`, and selected an East Africa box with shape `(1, 46, 101, 21, 17)`.
+
+The 6,985,939,316 source bytes became 8,958,032,476 Zarr bytes in 784.078 seconds. The writer streams GRIB and groups ten ensemble members per Zarr chunk; the resulting tree has 13,703 files. A one-member-per-chunk attempt was interrupted after its small-file throughput degraded, which is direct evidence against that layout.
+
+All non-land variables had zero missing values. Soil moisture and runoff had the same expected 66.18% land mask. Temperature, wind, pressure, humidity, geopotential height, radiation, precipitation, and cloud-cover ranges were physically plausible after unit conversion and deaccumulation. A 772.101-second repeated build reproduced the same byte count and full-tree SHA-1 `215e037503e6ffc413ce38b87cb545616331753b`.
 
 ## Reliability measurements
 
 | Metric | Observation |
 |---|---|
-| authenticated requests | 3 small control requests: two wind successes and one `2m_temperature` backend failure |
-| success rate | 2/2 for the wind smoke shape; 2/3 across both tested variable names |
-| typical/worst queue time | one instrumented fresh run: 12.824 seconds |
-| typical/worst end-to-end latency | one instrumented fresh run: 17.335 seconds queue plus server processing; download added 0.826 seconds |
-| update-cadence fit | unknown |
-| real restart/retry/idempotency | HTTP 206 resume succeeded from a 50% partial file; duplicate submission behavior remains untested |
-| incomplete-success behavior | unknown; strict inventory requirement identified |
+| authenticated accepted requests | 27 downloaded and inventory-valid |
+| accepted-job success rate | 27/27; one additional submission received HTTP 502 before a job ID and succeeded on resubmission |
+| queue time | min 11.705 s; median 64.286 s; p95 216.431 s; max 299.646 s |
+| server processing | min 2.884 s; median 12.592 s; p95 71.636 s; max 201.415 s |
+| downloads | 7,128,215,624 bytes across all acceptance cases in 410.549 s total; largest download 154.799 s |
+| update-cadence fit | daily operation has ample margin after the mandatory 48-hour delay |
+| restart/retry/idempotency | HTTP 206 resume and HTTP 200 restart passed; duplicate output was byte-identical; deterministic Zarr rerun passed |
+| incomplete-success behavior | no incomplete successful response observed; every completion still requires strict inventory validation |
 
 ## Storage and compute
 
-The three-message smoke GRIB was 174,786 bytes. It is not representative of a complete initialization, so staging bytes, production Zarr bytes, compression ratio, peak memory, CPU time, transform wall time, requests per initialization, annual growth, initial archive size, backfill duration, and dollar cost remain unmeasured.
+The measured candidate initialization requires 6.986 GB of source staging and 8.958 GB of development Zarr storage. The output/source ratio is 1.282. The simple streaming transform took 13.1 minutes on this workstation; production RegionJobs should parallelize the 27 variables and member blocks.
 
-After one complete initialization, calculate:
+Assuming every daily initialization from 2023-06-28 through 2026-07-24 exists gives 1,123 initializations. Linear projection from the measured Zarr is 10.060 decimal TB for that archive and 3.270 TB of annual growth. At the proposal's `$0.015/GB-month`, those are approximately `$150.90/month` for the initial archive and `$49.05/month` of storage added per year. These figures exclude Icechunk metadata, replicas, requests, compute, staging overlap, missing dates, and variable-dependent compression changes across model cycles.
 
-* initial archive bytes = measured compressed bytes per initialization × observed initialization count from stable-era start;
-* annual growth = measured bytes × observed yearly initialization frequency;
-* monthly storage cost = decimal GB × `$0.015`;
-* staging peak = completed shard bytes + partial shard bytes + transformation workspace;
-* backfill requests = initialization count × observed shards per initialization;
-* backfill wall time from measured queue throughput, download bandwidth, and transform throughput, explicitly reporting the maximum bottleneck.
-
-Sensitivity runs should repeat the same real initialization for 6-hourly versus daily steps, surface-only versus selected pressure levels, selected versus broad pressure profiles, and current-era versus all schema eras. Queue time is expected to be the unique ECDS risk, but calling the backfill queue-limited before measurements would be speculation. The “Storage scenarios” spreadsheet was not present in this repository, so its compute assumptions could not be applied.
+The measured request plan uses 14 source shards per initialization, or 15,722 accepted jobs for the 1,123-initialization projection. Do not multiply median queue time by that count as a backfill duration: concurrent submissions overlapped, ECDS appeared to serialize some large jobs, and no authoritative concurrency limit was found. Run a bounded multi-initialization throughput test before pricing backfill wall time.
 
 ## Redistribution and operational terms
 
@@ -150,25 +154,22 @@ Paid pre-scheduled delivery would replace unpredictable on-demand queueing and i
 
 Top risks:
 
-1. **Incomplete source contract:** authentication and the small control request work, but archive calendar, schema eras, full manifest, member completeness, and result retention are not established; `2m_temperature` currently fails in backend parameter mapping.
-2. **Partially observed operational behavior:** one small request had low latency and resumability worked, but production-size throughput, limits, duplicate submission behavior, and structurally incomplete successful responses are not measured.
-3. **Redistribution and cost:** dataset-specific terms need confirmation, while actual storage/compute and paid-delivery economics have no measured basis.
+1. **Resolution mismatch:** ECDS returned 1.5° files, so it cannot deliver the originally assumed 0.25° product.
+2. **Backfill throughput:** one initialization is operationally comfortable, but 15,722 projected backfill jobs need a bounded multi-date concurrency test and an ECMWF automation-rate discussion.
+3. **Static source details:** result retention is still unmeasured, and model-cycle boundaries require date-aware availability tests even though the selected 27-field manifest passed start, intermediate, and recent samples.
+4. **Physical-range cleanup:** production transformations must clamp the measured soil-moisture/cloud-cover packing artifacts and validate the land mask and deaccumulation clamp fractions.
+5. **Redistribution confirmation:** the licence appears compatible with a transformed public Zarr, but attribution presentation and unattended access rate should be confirmed with ECMWF.
 
-Recommend GO only after all of these pass unattended:
-
-1. Inventory recent, intermediate, and near-start GRIBs; establish edition, grid, members, steps, parameters, levels, statistics, units, and schema cutovers.
-2. Complete ten representative shards including a full initialization, an older full request, a duplicate, a killed download, and an injected transient failure. Record all measurement fields.
-3. Transform one complete real initialization; compare accumulated fields numerically; verify fixed pressure levels, missingness, coordinate orientation, regional query, chunks, and idempotent rerun.
-4. Project storage/cost only from those files and verify latency fits the observed initialization cadence.
-5. Obtain written ECMWF confirmation for public transformed redistribution and intended automation rate if the catalogue terms are ambiguous.
+The technical acceptance gate is complete. Proceed only if the product owner accepts 1.5°. The next implementation gate is a production-quality ECDS source adapter plus a small multi-initialization staging backfill; it is not another single-file spike.
 
 ## Proposed `dynamical-org/meta#144` comment
 
-> **ECMWF Extended Range is a conditional go, not yet ready for a fixed-price commitment.** Authenticated ECDS submission, durable one-shot polling, nested result discovery, validated GRIB download, and real HTTP Range resume now work. A three-lead wind smoke request queued for 12.8 seconds, processed for 4.5 seconds, and produced a 174,786-byte GRIB with three messages; the official `2m_temperature` name failed in backend parameter mapping. Most GRIB normalization, deaccumulation, Zarr writing, metadata, and validation can be reused from IFS ENS, but the full member/surface/pressure inventory and a complete real Zarr remain untested. Do not quote production until three dates, ten representative shards, one complete real Zarr, duplicate/retry tests, measured storage, and ECMWF terms confirmation pass.
+> **ECMWF Extended Range passed the technical ECDS acceptance gate, with one product-level catch: live files are global 1.5°, not the assumed 0.25°.** Twenty-seven accepted requests passed strict inventory checks across archive-start, intermediate, and recent dates. The full candidate initialization contained 125,442 messages, 101 members, 46 daily leads, and 27 field-level outputs; 6.986 GB of GRIB became an 8.958 GB Zarr in 13.1 minutes and reopened/query-tested successfully. Queue time was 64.3 s median and 299.6 s worst; one pre-job HTTP 502 succeeded on resubmission, HTTP Range recovery passed, and duplicate output was byte-identical. Recommend GO only if a 1.5° product is useful. If 0.25° is required, seek dissemination or another source. Before pricing production, confirm unattended request rate/attribution with ECMWF and run a bounded multi-initialization throughput test.
 
 ## Artifacts
 
 * Report: `docs/plans/ecmwf_extended_range_spike.md`
 * Request measurements/matrix: `docs/plans/ecmwf_extended_range_request_measurements.json`
 * Retrieval tool: `src/scripts/ecmwf_extended_range_spike.py`
-* Development-only mechanics proof: `tests/scripts/ecmwf_extended_range_spike_test.py`
+* Inventory and development transform: `src/scripts/ecmwf_extended_range_acceptance.py`
+* Tests: `tests/scripts/ecmwf_extended_range_spike_test.py` and `tests/scripts/ecmwf_extended_range_acceptance_test.py`

--- a/src/scripts/ecmwf_extended_range_acceptance.py
+++ b/src/scripts/ecmwf_extended_range_acceptance.py
@@ -1,0 +1,801 @@
+import argparse
+import json
+import time
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta
+from itertools import product
+from pathlib import Path
+from typing import Protocol
+
+import numpy as np
+import rasterio
+import zarr
+from gribberish import parse_grib_message_metadata  # ty: ignore[unresolved-import]
+
+from reformatters.common.deaccumulation import (
+    PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD,
+    RADIATION_INVALID_BELOW_THRESHOLD,
+)
+from reformatters.common.logging import get_logger
+
+log = get_logger(__name__)
+
+ENSEMBLE_CHUNK_SIZE = 10
+
+VARIABLE_GRIB_SELECTORS = {
+    "2_m_dewpoint_temperature": ("DPT", "specific height level above ground"),
+    "2_m_temperature": ("TMP", "specific height level above ground"),
+    "10_m_u_component_of_wind": ("UGRD", "specific height level above ground"),
+    "10_m_v_component_of_wind": ("VGRD", "specific height level above ground"),
+    "geopotential_height": ("HGT", "isobaric surface"),
+    "mean_sea_level_pressure": ("PRES", "mean sea level"),
+    "soil_moisture_top_20_cm": ("SM", "depth below land surface"),
+    "specific_humidity": ("SPFH", "isobaric surface"),
+    "surface_pressure": ("PRES", "ground or water surface"),
+    "surface_runoff": ("missing", "ground or water surface"),
+    "surface_solar_radiation_downwards": ("dswrf", "ground or water surface"),
+    "surface_thermal_radiation_downwards": ("DLWRF", "ground or water surface"),
+    "temperature": ("TMP", "isobaric surface"),
+    "total_cloud_cover": ("TCDC", "ground or water surface"),
+    "total_precipitation": ("TP", "ground or water surface"),
+    "u_component_of_wind": ("UGRD", "isobaric surface"),
+    "v_component_of_wind": ("VGRD", "isobaric surface"),
+}
+
+
+@dataclass(frozen=True)
+class VariableSpec:
+    name: str
+    long_name: str
+    units: str
+    standard_name: str | None = None
+    cumulative_rate: bool = False
+
+
+VARIABLE_SPECS = {
+    "2_m_dewpoint_temperature": VariableSpec(
+        "dew_point_temperature_2m",
+        "2 metre dewpoint temperature",
+        "degree_Celsius",
+        "dew_point_temperature",
+    ),
+    "2_m_temperature": VariableSpec(
+        "temperature_2m",
+        "2 metre temperature",
+        "degree_Celsius",
+        "air_temperature",
+    ),
+    "10_m_u_component_of_wind": VariableSpec(
+        "wind_u_10m", "10 metre U wind component", "m s-1", "eastward_wind"
+    ),
+    "10_m_v_component_of_wind": VariableSpec(
+        "wind_v_10m", "10 metre V wind component", "m s-1", "northward_wind"
+    ),
+    "mean_sea_level_pressure": VariableSpec(
+        "pressure_reduced_to_mean_sea_level",
+        "Pressure reduced to MSL",
+        "Pa",
+        "air_pressure_at_mean_sea_level",
+    ),
+    "soil_moisture_top_20_cm": VariableSpec(
+        "soil_moisture_0_20cm", "Soil moisture top 20 cm", "kg m-3"
+    ),
+    "surface_pressure": VariableSpec(
+        "pressure_surface", "Surface pressure", "Pa", "surface_air_pressure"
+    ),
+    "surface_runoff": VariableSpec(
+        "runoff_surface",
+        "Surface runoff rate",
+        "kg m-2 s-1",
+        cumulative_rate=True,
+    ),
+    "surface_solar_radiation_downwards": VariableSpec(
+        "downward_short_wave_radiation_flux_surface",
+        "Surface downward short-wave radiation flux",
+        "W m-2",
+        "surface_downwelling_shortwave_flux_in_air",
+        cumulative_rate=True,
+    ),
+    "surface_thermal_radiation_downwards": VariableSpec(
+        "downward_long_wave_radiation_flux_surface",
+        "Surface downward long-wave radiation flux",
+        "W m-2",
+        "surface_downwelling_longwave_flux_in_air",
+        cumulative_rate=True,
+    ),
+    "total_cloud_cover": VariableSpec(
+        "total_cloud_cover_atmosphere",
+        "Total cloud cover",
+        "percent",
+        "cloud_area_fraction",
+    ),
+    "total_precipitation": VariableSpec(
+        "precipitation_surface",
+        "Precipitation rate",
+        "kg m-2 s-1",
+        "precipitation_flux",
+        cumulative_rate=True,
+    ),
+}
+
+
+class GribMetadata(Protocol):
+    message_size: int
+    var_abbrev: str
+    level_type: str
+    level_value: float | None
+    perturbation_number: int | None
+    reference_date: datetime
+    forecast_date: datetime
+    forecast_date_end: datetime | None
+    units: str
+    grid_shape: tuple[int, int]
+
+
+@dataclass(frozen=True, order=True)
+class InventoryKey:
+    variable: str
+    level: str | None
+    ensemble_member: int
+    leadtime_hour: str
+
+
+@dataclass(frozen=True)
+class InventoryRecord:
+    offset: int
+    message_size: int
+    variable: str
+    level: str | None
+    ensemble_member: int
+    leadtime_hour: str
+    units: str
+    grib_level_type: str
+    grib_level_value: float | None
+    grid_shape: tuple[int, int]
+
+    @property
+    def key(self) -> InventoryKey:
+        return InventoryKey(
+            self.variable,
+            self.level,
+            self.ensemble_member,
+            self.leadtime_hour,
+        )
+
+
+@dataclass(frozen=True)
+class GribInventory:
+    source: str
+    valid: bool
+    byte_count: int
+    message_count: int
+    grid_shape: list[int]
+    variables: list[str]
+    levels: list[str]
+    members: list[int]
+    leadtimes: list[str]
+    records: list[InventoryRecord]
+
+
+@dataclass(frozen=True)
+class DevelopmentSource:
+    source: Path
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ZarrMeasurement:
+    target: str
+    complete: bool
+    source_bytes: int
+    zarr_bytes: int
+    message_count: int
+    transformation_seconds: float
+    variables: list[str]
+    members: list[int]
+    leadtime_hours: list[int]
+
+
+def inspect_grib(source: Path, payload: Mapping[str, object]) -> GribInventory:
+    requested_variables = _strings(payload.get("variable"))
+    requested_leadtimes = _strings(payload.get("leadtime_hour"))
+    expected = Counter(
+        InventoryKey(variable, level, member, leadtime)
+        for variable, level, member, leadtime in product(
+            requested_variables,
+            _expected_levels(payload),
+            _expected_members(payload),
+            requested_leadtimes,
+        )
+    )
+
+    records: list[InventoryRecord] = []
+    with source.open("rb") as source_file:
+        offset = 0
+        while header := source_file.read(16):
+            assert len(header) == 16
+            assert header[:4] == b"GRIB", f"Expected GRIB message at byte {offset}"
+            message_size = int.from_bytes(header[8:16], byteorder="big")
+            assert message_size >= 20
+            message = header + source_file.read(message_size - len(header))
+            assert len(message) == message_size
+            assert message.endswith(b"7777")
+            metadata: GribMetadata = parse_grib_message_metadata(message, 0)
+            assert metadata.message_size == message_size
+            records.append(
+                _inventory_record(
+                    offset,
+                    metadata,
+                    payload,
+                    requested_variables,
+                    requested_leadtimes,
+                )
+            )
+            offset += message_size
+        assert offset == source.stat().st_size
+
+    actual = Counter(record.key for record in records)
+    missing = sorted((expected - actual).elements())
+    unexpected = sorted((actual - expected).elements())
+    assert not missing, f"Missing inventory: {missing}"
+    assert not unexpected, f"Unexpected inventory: {unexpected}"
+
+    grid_shapes = {record.grid_shape for record in records}
+    assert len(grid_shapes) == 1
+    grid_shape = list(grid_shapes.pop())
+    return GribInventory(
+        source=str(source),
+        valid=True,
+        byte_count=source.stat().st_size,
+        message_count=len(records),
+        grid_shape=grid_shape,
+        variables=sorted({record.variable for record in records}),
+        levels=sorted(
+            {record.level for record in records if record.level is not None},
+            key=_level_sort_key,
+        ),
+        members=sorted({record.ensemble_member for record in records}),
+        leadtimes=sorted(
+            {record.leadtime_hour for record in records}, key=_leadtime_sort_key
+        ),
+        records=records,
+    )
+
+
+def build_development_zarr(
+    sources: Sequence[DevelopmentSource],
+    target: Path,
+    *,
+    require_complete: bool = True,
+) -> ZarrMeasurement:
+    started = time.monotonic()
+    inventories = [inspect_grib(source.source, source.payload) for source in sources]
+    assert inventories
+    records = [record for inventory in inventories for record in inventory.records]
+    members, leadtime_hours, canonical_names, complete = _zarr_axes(
+        records, require_complete
+    )
+
+    init_times = {_init_time(source.payload) for source in sources}
+    assert len(init_times) == 1
+    grid_shapes = {tuple(inventory.grid_shape) for inventory in inventories}
+    assert len(grid_shapes) == 1
+    grid_shape_values = grid_shapes.pop()
+    assert len(grid_shape_values) == 2
+    grid_shape = (grid_shape_values[0], grid_shape_values[1])
+    with rasterio.open(sources[0].source) as first_reader:
+        transform = first_reader.transform
+    root = _initialize_development_zarr(
+        target,
+        init_times.pop(),
+        grid_shape,
+        transform,
+        members,
+        leadtime_hours,
+        canonical_names,
+        records,
+    )
+
+    member_indexes = {member: index for index, member in enumerate(members)}
+    lead_indexes = {lead: index for index, lead in enumerate(leadtime_hours)}
+    for source, inventory in zip(sources, inventories, strict=True):
+        _write_source_to_zarr(
+            root,
+            source,
+            inventory,
+            transform,
+            member_indexes,
+            lead_indexes,
+        )
+
+    for name in canonical_names:
+        source_record = next(
+            record for record in records if _variable_spec(record).name == name
+        )
+        spec = _variable_spec(source_record)
+        if spec.cumulative_rate:
+            _convert_cumulative_to_rate(
+                _zarr_array(root, name),
+                members,
+                leadtime_hours,
+                invalid_below_threshold_rate=(
+                    RADIATION_INVALID_BELOW_THRESHOLD
+                    if spec.units == "W m-2"
+                    else PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD
+                ),
+            )
+
+    zarr.consolidate_metadata(target)
+    return ZarrMeasurement(
+        target=str(target),
+        complete=complete,
+        source_bytes=sum(source.source.stat().st_size for source in sources),
+        zarr_bytes=sum(
+            path.stat().st_size for path in target.rglob("*") if path.is_file()
+        ),
+        message_count=len(records),
+        transformation_seconds=time.monotonic() - started,
+        variables=canonical_names,
+        members=members,
+        leadtime_hours=leadtime_hours,
+    )
+
+
+def _zarr_axes(
+    records: Sequence[InventoryRecord], require_complete: bool
+) -> tuple[list[int], list[int], list[str], bool]:
+    members = sorted({record.ensemble_member for record in records})
+    leadtime_hours = sorted({_leadtime_end(record.leadtime_hour) for record in records})
+    canonical_names = sorted({_variable_spec(record).name for record in records})
+    coverage = {
+        canonical_name: {
+            (record.ensemble_member, _leadtime_end(record.leadtime_hour))
+            for record in records
+            if _variable_spec(record).name == canonical_name
+        }
+        for canonical_name in canonical_names
+    }
+    expected_coverage = set(product(members, leadtime_hours))
+    complete = all(found == expected_coverage for found in coverage.values())
+    if require_complete:
+        incomplete = {
+            name: sorted(expected_coverage - found)
+            for name, found in coverage.items()
+            if found != expected_coverage
+        }
+        assert not incomplete, f"Incomplete Zarr source inventory: {incomplete}"
+    return members, leadtime_hours, canonical_names, complete
+
+
+def _initialize_development_zarr(
+    target: Path,
+    init_time: np.datetime64,
+    grid_shape: tuple[int, int],
+    transform: rasterio.transform.Affine,
+    members: Sequence[int],
+    leadtime_hours: Sequence[int],
+    canonical_names: Sequence[str],
+    records: Sequence[InventoryRecord],
+) -> zarr.Group:
+    latitude_count, longitude_count = grid_shape
+    latitude = transform.f + transform.e * (np.arange(latitude_count) + 0.5)
+    longitude = transform.c + transform.a * (np.arange(longitude_count) + 0.5)
+    root = zarr.open_group(target, mode="w")
+    root.attrs.update(
+        {
+            "title": "ECMWF Extended Range ECDS development dataset",
+            "source": "ECMWF Data Store s2s-forecasts",
+            "spatial_resolution": f"{abs(transform.a):g} degrees",
+        }
+    )
+    _create_coordinate(
+        root,
+        "init_time",
+        np.array([init_time], dtype="datetime64[ns]"),
+        ("init_time",),
+        {"standard_name": "forecast_reference_time"},
+    )
+    _create_coordinate(
+        root,
+        "lead_time",
+        np.array(leadtime_hours, dtype="timedelta64[h]"),
+        ("lead_time",),
+        {"standard_name": "forecast_period"},
+    )
+    _create_coordinate(
+        root,
+        "ensemble_member",
+        np.array(members, dtype=np.int16),
+        ("ensemble_member",),
+        {"standard_name": "realization"},
+    )
+    _create_coordinate(
+        root,
+        "latitude",
+        latitude.astype(np.float64),
+        ("latitude",),
+        {
+            "standard_name": "latitude",
+            "units": "degrees_north",
+            "axis": "Y",
+        },
+    )
+    _create_coordinate(
+        root,
+        "longitude",
+        longitude.astype(np.float64),
+        ("longitude",),
+        {
+            "standard_name": "longitude",
+            "units": "degrees_east",
+            "axis": "X",
+        },
+    )
+    valid_time = (
+        np.array([init_time], dtype="datetime64[ns]")[:, None]
+        + np.array(leadtime_hours, dtype="timedelta64[h]")[None, :]
+    )
+    _create_coordinate(
+        root,
+        "valid_time",
+        valid_time,
+        ("init_time", "lead_time"),
+        {"standard_name": "time"},
+    )
+    _create_coordinate(
+        root,
+        "spatial_ref",
+        np.array(0, dtype=np.int64),
+        (),
+        {
+            "grid_mapping_name": "latitude_longitude",
+            "earth_radius": 6_367_470.0,
+        },
+    )
+
+    shape = (1, len(leadtime_hours), len(members), latitude_count, longitude_count)
+    dimensions = (
+        "init_time",
+        "lead_time",
+        "ensemble_member",
+        "latitude",
+        "longitude",
+    )
+    for name in canonical_names:
+        source_record = next(
+            record for record in records if _variable_spec(record).name == name
+        )
+        spec = _variable_spec(source_record)
+        attributes = {
+            "coordinates": "valid_time spatial_ref",
+            "long_name": spec.long_name,
+            "units": spec.units,
+            "grid_mapping": "spatial_ref",
+        }
+        if spec.standard_name is not None:
+            attributes["standard_name"] = spec.standard_name
+        root.create_array(
+            name,
+            shape=shape,
+            chunks=(
+                1,
+                1,
+                min(ENSEMBLE_CHUNK_SIZE, len(members)),
+                latitude_count,
+                longitude_count,
+            ),
+            dtype=np.float32,
+            fill_value=np.nan,
+            attributes=attributes,  # ty: ignore[invalid-argument-type]
+            dimension_names=dimensions,
+        )
+    return root
+
+
+def _write_source_to_zarr(
+    root: zarr.Group,
+    source: DevelopmentSource,
+    inventory: GribInventory,
+    transform: rasterio.transform.Affine,
+    member_indexes: Mapping[int, int],
+    lead_indexes: Mapping[int, int],
+) -> None:
+    grouped_records: dict[tuple[str, int, int], list[tuple[int, InventoryRecord]]] = {}
+    for band, record in enumerate(inventory.records, start=1):
+        member_index = member_indexes[record.ensemble_member]
+        key = (
+            _variable_spec(record).name,
+            lead_indexes[_leadtime_end(record.leadtime_hour)],
+            member_index // ENSEMBLE_CHUNK_SIZE,
+        )
+        grouped_records.setdefault(key, []).append((band, record))
+
+    with rasterio.open(source.source) as reader:
+        assert reader.count == inventory.message_count
+        assert reader.transform == transform
+        for (name, lead_index, member_chunk), entries in grouped_records.items():
+            member_start = member_chunk * ENSEMBLE_CHUNK_SIZE
+            member_stop = min(member_start + ENSEMBLE_CHUNK_SIZE, len(member_indexes))
+            target = _zarr_array(root, name)
+            data = np.array(
+                target[0, lead_index, member_start:member_stop, :, :], copy=True
+            )
+            bands = [band for band, _record in entries]
+            values = reader.read(bands, out_dtype=np.float32, masked=True)
+            decoded = np.asarray(values.filled(np.nan), dtype=np.float32)
+            for source_index, (_band, record) in enumerate(entries):
+                member_index = member_indexes[record.ensemble_member]
+                data[member_index - member_start, :, :] = decoded[source_index]
+            target[0, lead_index, member_start:member_stop, :, :] = data
+
+
+def _zarr_array(root: zarr.Group, name: str) -> zarr.Array:
+    result = root[name]
+    assert isinstance(result, zarr.Array)
+    return result
+
+
+def _create_coordinate(
+    root: zarr.Group,
+    name: str,
+    data: np.ndarray,
+    dimension_names: tuple[str, ...],
+    attributes: Mapping[str, object],
+) -> None:
+    root.create_array(
+        name,
+        data=data,
+        chunks=data.shape or (),
+        attributes=dict(attributes),  # ty: ignore[invalid-argument-type]
+        dimension_names=dimension_names,
+    )
+
+
+def _convert_cumulative_to_rate(
+    target: zarr.Array,
+    members: Sequence[int],
+    leadtime_hours: Sequence[int],
+    *,
+    invalid_below_threshold_rate: float,
+) -> None:
+    for member_start in range(0, len(members), ENSEMBLE_CHUNK_SIZE):
+        member_stop = min(member_start + ENSEMBLE_CHUNK_SIZE, len(members))
+        previous = np.zeros(
+            (member_stop - member_start, *target.shape[-2:]), dtype=np.float32
+        )
+        previous_hour = 0
+        for lead_index, leadtime_hour in enumerate(leadtime_hours):
+            current = np.array(
+                target[0, lead_index, member_start:member_stop, :, :], copy=True
+            )
+            duration_seconds = (leadtime_hour - previous_hour) * 3_600
+            rate = (current - previous) / duration_seconds
+            assert not np.any(rate < invalid_below_threshold_rate)
+            rate[(rate < 0) & (rate >= invalid_below_threshold_rate)] = 0
+            target[0, lead_index, member_start:member_stop, :, :] = rate
+            previous = current
+            previous_hour = leadtime_hour
+
+
+def _variable_spec(record: InventoryRecord) -> VariableSpec:
+    if record.level is None:
+        return VARIABLE_SPECS[record.variable]
+    level = record.level.replace("_", "")
+    match record.variable:
+        case "geopotential_height":
+            return VariableSpec(
+                f"geopotential_height_{level}",
+                "Geopotential height",
+                "m",
+                "geopotential_height",
+            )
+        case "specific_humidity":
+            return VariableSpec(
+                f"specific_humidity_{level}",
+                "Specific humidity",
+                "1",
+                "specific_humidity",
+            )
+        case "temperature":
+            return VariableSpec(
+                f"temperature_{level}",
+                "Temperature",
+                "degree_Celsius",
+                "air_temperature",
+            )
+        case "u_component_of_wind":
+            return VariableSpec(
+                f"wind_u_{level}", "U wind component", "m s-1", "eastward_wind"
+            )
+        case "v_component_of_wind":
+            return VariableSpec(
+                f"wind_v_{level}", "V wind component", "m s-1", "northward_wind"
+            )
+        case _:
+            raise AssertionError(record)
+
+
+def _leadtime_end(leadtime: str) -> int:
+    return int(leadtime.rsplit("_", maxsplit=1)[-1])
+
+
+def _init_time(payload: Mapping[str, object]) -> np.datetime64:
+    year = _strings(payload.get("year"))
+    month = _strings(payload.get("month"))
+    day = _strings(payload.get("day"))
+    forecast_time = _strings(payload.get("time"))
+    assert len(year) == len(month) == len(day) == len(forecast_time) == 1
+    return np.datetime64(f"{year[0]}-{month[0]}-{day[0]}T{forecast_time[0]}")
+
+
+def _inventory_record(
+    offset: int,
+    metadata: GribMetadata,
+    payload: Mapping[str, object],
+    requested_variables: Sequence[str],
+    requested_leadtimes: Sequence[str],
+) -> InventoryRecord:
+    matching_variables = [
+        variable
+        for variable in requested_variables
+        if VARIABLE_GRIB_SELECTORS.get(variable)
+        == (metadata.var_abbrev, metadata.level_type)
+    ]
+    assert len(matching_variables) == 1, (
+        f"Could not map {metadata.var_abbrev!r} to one requested variable: "
+        f"{matching_variables}"
+    )
+    level = (
+        _pressure_level(metadata.level_value)
+        if payload.get("level_type") == "pressure"
+        else None
+    )
+    return InventoryRecord(
+        offset=offset,
+        message_size=metadata.message_size,
+        variable=matching_variables[0],
+        level=level,
+        ensemble_member=metadata.perturbation_number or 0,
+        leadtime_hour=_requested_leadtime(metadata, requested_leadtimes),
+        units=metadata.units,
+        grib_level_type=metadata.level_type,
+        grib_level_value=metadata.level_value,
+        grid_shape=metadata.grid_shape,
+    )
+
+
+def _requested_leadtime(
+    metadata: GribMetadata, requested_leadtimes: Sequence[str]
+) -> str:
+    start = _hours(metadata.forecast_date - metadata.reference_date)
+    end = _hours(
+        (metadata.forecast_date_end or metadata.forecast_date) - metadata.reference_date
+    )
+    matches = [
+        leadtime
+        for leadtime in requested_leadtimes
+        if _leadtime_matches(leadtime, start, end)
+    ]
+    assert len(matches) == 1, (
+        f"Could not map GRIB interval {start}-{end} to one requested lead time: "
+        f"{matches}"
+    )
+    return matches[0]
+
+
+def _leadtime_matches(leadtime: str, start: int, end: int) -> bool:
+    if "_" not in leadtime:
+        return int(leadtime) == end
+    requested_start, requested_end = (int(value) for value in leadtime.split("_"))
+    return (requested_start, requested_end) == (start, end)
+
+
+def _expected_members(payload: Mapping[str, object]) -> list[int]:
+    if payload.get("forecast_type") == "control_forecast":
+        return [0]
+    members = [int(value) for value in _strings(payload.get("number"))]
+    assert members, "Perturbed requests must specify number for strict inventory"
+    return members
+
+
+def _expected_levels(payload: Mapping[str, object]) -> Sequence[str | None]:
+    if payload.get("level_type") != "pressure":
+        return [None]
+    levels = _strings(payload.get("level_value"))
+    assert levels
+    return levels
+
+
+def _pressure_level(level_value: float | None) -> str:
+    assert level_value is not None
+    level_hpa = level_value / 100 if level_value > 2_000 else level_value
+    assert level_hpa.is_integer()
+    return f"{int(level_hpa)}_hpa"
+
+
+def _hours(duration: timedelta) -> int:
+    total_seconds = duration.total_seconds()
+    hours = total_seconds / 3_600
+    assert hours.is_integer()
+    return int(hours)
+
+
+def _strings(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence):
+        return [str(item) for item in value]
+    return []
+
+
+def _leadtime_sort_key(value: str) -> tuple[int, int]:
+    parts = [int(part) for part in value.split("_")]
+    return (parts[-1], parts[0])
+
+
+def _level_sort_key(value: str) -> int:
+    return int(value.removesuffix("_hpa"))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    inventory = commands.add_parser("inventory")
+    inventory.add_argument("--source", type=Path, required=True)
+    inventory.add_argument("--payload", type=Path, required=True)
+    inventory.add_argument("--output", type=Path, required=True)
+    build_zarr = commands.add_parser("build-zarr")
+    build_zarr.add_argument("--manifest", type=Path, required=True)
+    build_zarr.add_argument("--target", type=Path, required=True)
+    build_zarr.add_argument("--measurement", type=Path, required=True)
+    build_zarr.add_argument("--allow-incomplete", action="store_true")
+    return parser
+
+
+def main() -> None:
+    arguments = _parser().parse_args()
+    match arguments.command:
+        case "inventory":
+            payload = json.loads(arguments.payload.read_text())
+            inventory = inspect_grib(arguments.source, payload)
+            _write_json(arguments.output, inventory)
+            log.info(
+                "Validated %d GRIB messages in %s",
+                inventory.message_count,
+                arguments.source,
+            )
+        case "build-zarr":
+            manifest = json.loads(arguments.manifest.read_text())
+            sources = [
+                DevelopmentSource(
+                    Path(source["source"]),
+                    json.loads(Path(source["payload"]).read_text()),
+                )
+                for source in manifest["sources"]
+            ]
+            measurement = build_development_zarr(
+                sources,
+                arguments.target,
+                require_complete=not arguments.allow_incomplete,
+            )
+            _write_json(arguments.measurement, measurement)
+            log.info(
+                "Wrote %d messages to %s",
+                measurement.message_count,
+                arguments.target,
+            )
+        case _:
+            raise AssertionError(arguments.command)
+
+
+def _write_json(path: Path, value: GribInventory | ZarrMeasurement) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(f"{path.suffix}.tmp")
+    temporary_path.write_text(json.dumps(asdict(value), indent=2, sort_keys=True))
+    temporary_path.replace(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/ecmwf_extended_range_spike.py
+++ b/src/scripts/ecmwf_extended_range_spike.py
@@ -1,0 +1,254 @@
+import argparse
+import json
+import os
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+import requests
+
+from reformatters.common.logging import get_logger
+
+log = get_logger(__name__)
+
+DEFAULT_API_URL = (
+    "https://ecds.ecmwf.int/api/retrieve/v1/processes/s2s-forecasts/execution"
+)
+TERMINAL_FAILURES = {"failed", "dismissed", "cancelled"}
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass
+class RequestMeasurement:
+    request_id: str
+    payload: dict[str, Any]
+    submitted_at: str
+    status_url: str
+    status: str = "submitted"
+    completed_at: str | None = None
+    result_url: str | None = None
+    queue_seconds: float | None = None
+    server_processing_seconds: float | None = None
+    download_seconds: float | None = None
+    downloaded_bytes: int | None = None
+    grib_messages: int | None = None
+    expected_members: list[int] = field(default_factory=list)
+    received_members: list[int] = field(default_factory=list)
+    expected_steps: list[int] = field(default_factory=list)
+    received_steps: list[int] = field(default_factory=list)
+    expected_variables: list[str] = field(default_factory=list)
+    received_variables: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    retry_count: int = 0
+    retry_idempotent: bool | None = None
+    interrupted_download_resumable: bool | None = None
+    completed_result_reusable: bool | None = None
+
+
+class StateStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def read(self) -> RequestMeasurement:
+        return RequestMeasurement(**json.loads(self.path.read_text()))
+
+    def write(self, measurement: RequestMeasurement) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        temporary_path.write_text(
+            json.dumps(asdict(measurement), indent=2, sort_keys=True)
+        )
+        temporary_path.replace(self.path)
+
+
+class EcdsRequest:
+    def __init__(
+        self,
+        state_store: StateStore,
+        api_url: str | None = None,
+        session: requests.Session | None = None,
+    ) -> None:
+        self.state_store = state_store
+        self.api_url = _execution_url(
+            api_url or os.environ.get("ECDS_API_ENDPOINT", DEFAULT_API_URL)
+        )
+        self.session = session or requests.Session()
+        api_key = os.environ.get("ECDS_API_KEY")
+        if api_key and ":" in api_key:
+            self.session.auth = tuple(api_key.split(":", maxsplit=1))
+        elif api_key:
+            self.session.headers["Authorization"] = f"Bearer {api_key}"
+
+    def submit(self, payload: dict[str, Any]) -> RequestMeasurement:
+        assert os.environ.get("ECDS_API_KEY") or self.session.auth, (
+            "Set ECDS_API_KEY before submitting a request"
+        )
+        response = self.session.post(self.api_url, json={"inputs": payload}, timeout=60)
+        response.raise_for_status()
+        response_body = response.json()
+        request_id = str(response_body.get("jobID") or response_body.get("id"))
+        assert request_id != "None", response_body
+        status_url = response.headers.get("Location") or str(
+            response_body.get("location") or f"{self.api_url}/{request_id}"
+        )
+        measurement = RequestMeasurement(
+            request_id=request_id,
+            payload=payload,
+            submitted_at=utc_now(),
+            status_url=status_url,
+            expected_members=[int(value) for value in payload.get("number", [])],
+            expected_steps=[int(value) for value in payload.get("step", [])],
+            expected_variables=_as_strings(payload.get("param", [])),
+        )
+        self.state_store.write(measurement)
+        return measurement
+
+    def poll_once(self) -> tuple[RequestMeasurement, str | None]:
+        measurement = self.state_store.read()
+        response = self.session.get(measurement.status_url, timeout=60)
+        response.raise_for_status()
+        response_body = response.json()
+        measurement.status = str(
+            response_body.get("status") or response_body.get("state")
+        ).lower()
+        if measurement.status in TERMINAL_FAILURES:
+            measurement.errors.append(json.dumps(response_body, sort_keys=True))
+        result_url = _result_url(response_body)
+        if result_url is not None:
+            measurement.completed_at = utc_now()
+            measurement.result_url = result_url
+        self.state_store.write(measurement)
+        return measurement, result_url
+
+    def poll_until_complete(
+        self,
+        poll_seconds: float,
+        maximum_polls: int,
+    ) -> tuple[RequestMeasurement, str]:
+        for poll_index in range(maximum_polls):
+            try:
+                measurement, result_url = self.poll_once()
+            except requests.RequestException as error:
+                measurement = self.state_store.read()
+                measurement.retry_count += 1
+                measurement.errors.append(str(error))
+                self.state_store.write(measurement)
+                time.sleep(poll_seconds * 2 ** min(poll_index, 6))
+                continue
+            if measurement.status in TERMINAL_FAILURES:
+                raise RuntimeError(f"ECDS request ended with {measurement.status}")
+            if result_url is not None:
+                return measurement, result_url
+            time.sleep(poll_seconds)
+        raise TimeoutError(f"Request did not complete after {maximum_polls} polls")
+
+    def download(
+        self, target: Path, result_url: str | None = None
+    ) -> RequestMeasurement:
+        measurement = self.state_store.read()
+        result_url = result_url or measurement.result_url
+        assert result_url is not None, (
+            "Poll the request to completion before downloading"
+        )
+        partial_path = target.with_suffix(f"{target.suffix}.partial")
+        existing_bytes = partial_path.stat().st_size if partial_path.exists() else 0
+        headers = {"Range": f"bytes={existing_bytes}-"} if existing_bytes else {}
+        started = time.monotonic()
+        response = self.session.get(
+            result_url, headers=headers, stream=True, timeout=120
+        )
+        response.raise_for_status()
+        append = existing_bytes > 0 and response.status_code == requests.codes.partial
+        with partial_path.open("ab" if append else "wb") as output:
+            for chunk in response.iter_content(1024 * 1024):
+                output.write(chunk)
+        _validate_grib_container(partial_path)
+        partial_path.replace(target)
+        target.with_suffix(f"{target.suffix}.complete").write_text(utc_now())
+        measurement.download_seconds = time.monotonic() - started
+        measurement.downloaded_bytes = target.stat().st_size
+        measurement.grib_messages = _count_grib_messages(target)
+        measurement.status = "downloaded"
+        measurement.interrupted_download_resumable = append
+        self.state_store.write(measurement)
+        return measurement
+
+
+def _as_strings(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence):
+        return [str(item) for item in value]
+    return []
+
+
+def _execution_url(api_endpoint: str) -> str:
+    if api_endpoint.rstrip("/").endswith("/execution"):
+        return api_endpoint.rstrip("/")
+    return f"{api_endpoint.rstrip('/')}/retrieve/v1/processes/s2s-forecasts/execution"
+
+
+def _result_url(response_body: Mapping[str, Any]) -> str | None:
+    for key in ("href", "location", "result_url"):
+        value = response_body.get(key)
+        if isinstance(value, str):
+            return value
+    result = response_body.get("result")
+    if isinstance(result, Mapping):
+        return _result_url(result)
+    return None
+
+
+def _count_grib_messages(path: Path) -> int:
+    return path.read_bytes().count(b"GRIB")
+
+
+def _validate_grib_container(path: Path) -> None:
+    contents = path.read_bytes()
+    assert contents.startswith(b"GRIB"), "Download does not start with a GRIB message"
+    assert contents.endswith(b"7777"), "Download ends inside a GRIB message"
+    assert _count_grib_messages(path) > 0, "Download contains no GRIB messages"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--state", type=Path, required=True)
+    parser.add_argument("--api-url", default=DEFAULT_API_URL)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    submit = subparsers.add_parser("submit")
+    submit.add_argument("--payload", type=Path, required=True)
+    poll = subparsers.add_parser("poll")
+    poll.add_argument("--poll-seconds", type=float, default=60)
+    poll.add_argument("--maximum-polls", type=int, default=1)
+    download = subparsers.add_parser("download")
+    download.add_argument("--result-url")
+    download.add_argument("--target", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    arguments = _parser().parse_args()
+    request = EcdsRequest(StateStore(arguments.state), api_url=arguments.api_url)
+    command: Literal["submit", "poll", "download"] = arguments.command
+    match command:
+        case "submit":
+            request.submit(json.loads(arguments.payload.read_text()))
+        case "poll":
+            if arguments.maximum_polls == 1:
+                request.poll_once()
+            else:
+                request.poll_until_complete(
+                    arguments.poll_seconds, arguments.maximum_polls
+                )
+        case "download":
+            request.download(arguments.target, arguments.result_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/ecmwf_extended_range_spike.py
+++ b/src/scripts/ecmwf_extended_range_spike.py
@@ -17,7 +17,7 @@ log = get_logger(__name__)
 DEFAULT_API_URL = (
     "https://ecds.ecmwf.int/api/retrieve/v1/processes/s2s-forecasts/execution"
 )
-TERMINAL_FAILURES = {"failed", "dismissed", "cancelled"}
+TERMINAL_FAILURES = {"failed", "rejected", "dismissed", "cancelled"}
 
 
 def utc_now() -> str:
@@ -75,19 +75,32 @@ class EcdsRequest:
         session: requests.Session | None = None,
     ) -> None:
         self.state_store = state_store
+        cdsapi_config = _read_cdsapi_config()
         self.api_url = _execution_url(
-            api_url or os.environ.get("ECDS_API_ENDPOINT", DEFAULT_API_URL)
+            api_url
+            or os.environ.get("ECDS_API_ENDPOINT")
+            or os.environ.get("CDSAPI_URL")
+            or cdsapi_config.get("url")
+            or DEFAULT_API_URL
         )
         self.session = session or requests.Session()
-        api_key = os.environ.get("ECDS_API_KEY")
+        api_key = (
+            os.environ.get("ECDS_API_KEY")
+            or os.environ.get("CDSAPI_KEY")
+            or cdsapi_config.get("key")
+        )
         if api_key and ":" in api_key:
-            self.session.auth = tuple(api_key.split(":", maxsplit=1))
+            username, key = api_key.split(":", maxsplit=1)
+            self.session.auth = (username, key)
         elif api_key:
-            self.session.headers["Authorization"] = f"Bearer {api_key}"
+            self.session.headers["PRIVATE-TOKEN"] = api_key
+        self.credentials_configured = bool(
+            api_key or self.session.auth or self.session.headers.get("PRIVATE-TOKEN")
+        )
 
     def submit(self, payload: dict[str, Any]) -> RequestMeasurement:
-        assert os.environ.get("ECDS_API_KEY") or self.session.auth, (
-            "Set ECDS_API_KEY before submitting a request"
+        assert self.credentials_configured, (
+            "Configure ECDS credentials in .cdsapirc or the environment"
         )
         response = self.session.post(self.api_url, json={"inputs": payload}, timeout=60)
         response.raise_for_status()
@@ -103,8 +116,13 @@ class EcdsRequest:
             submitted_at=utc_now(),
             status_url=status_url,
             expected_members=[int(value) for value in payload.get("number", [])],
-            expected_steps=[int(value) for value in payload.get("step", [])],
-            expected_variables=_as_strings(payload.get("param", [])),
+            expected_steps=[
+                int(value)
+                for value in payload.get("leadtime_hour", payload.get("step", []))
+            ],
+            expected_variables=_as_strings(
+                payload.get("variable", payload.get("param", []))
+            ),
         )
         self.state_store.write(measurement)
         return measurement
@@ -117,11 +135,34 @@ class EcdsRequest:
         measurement.status = str(
             response_body.get("status") or response_body.get("state")
         ).lower()
-        if measurement.status in TERMINAL_FAILURES:
-            measurement.errors.append(json.dumps(response_body, sort_keys=True))
         result_url = _result_url(response_body)
+        results_url = _related_url(response_body, "results")
+        if measurement.status in TERMINAL_FAILURES:
+            error_body = response_body
+            if results_url is not None:
+                error_body = self.session.get(results_url, timeout=60).json()
+            measurement.errors.append(json.dumps(error_body, sort_keys=True))
+        elif (
+            measurement.status == "successful"
+            and result_url is None
+            and results_url is not None
+        ):
+            results_response = self.session.get(results_url, timeout=60)
+            results_response.raise_for_status()
+            result_url = _result_url(results_response.json())
+        measurement.queue_seconds = _duration_seconds(
+            response_body.get("created"), response_body.get("started")
+        )
+        measurement.server_processing_seconds = _duration_seconds(
+            response_body.get("started"), response_body.get("finished")
+        )
         if result_url is not None:
-            measurement.completed_at = utc_now()
+            finished_at = response_body.get("finished")
+            measurement.completed_at = (
+                _utc_datetime(finished_at).isoformat()
+                if isinstance(finished_at, str)
+                else utc_now()
+            )
             measurement.result_url = result_url
         self.state_store.write(measurement)
         return measurement, result_url
@@ -188,6 +229,18 @@ def _as_strings(value: object) -> list[str]:
     return []
 
 
+def _read_cdsapi_config() -> dict[str, str]:
+    config_path = Path(os.environ.get("CDSAPI_RC", Path.home() / ".cdsapirc"))
+    if not config_path.exists():
+        return {}
+    config: dict[str, str] = {}
+    for line in config_path.read_text().splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip() in {"url", "key"}:
+            config[key.strip()] = value.strip()
+    return config
+
+
 def _execution_url(api_endpoint: str) -> str:
     if api_endpoint.rstrip("/").endswith("/execution"):
         return api_endpoint.rstrip("/")
@@ -199,10 +252,38 @@ def _result_url(response_body: Mapping[str, Any]) -> str | None:
         value = response_body.get(key)
         if isinstance(value, str):
             return value
-    result = response_body.get("result")
-    if isinstance(result, Mapping):
-        return _result_url(result)
+    for key in ("result", "asset", "value"):
+        nested = response_body.get(key)
+        if isinstance(nested, Mapping):
+            result_url = _result_url(nested)
+            if result_url is not None:
+                return result_url
     return None
+
+
+def _related_url(response_body: Mapping[str, Any], relation: str) -> str | None:
+    links = response_body.get("links")
+    if not isinstance(links, Sequence):
+        return None
+    for link in links:
+        if isinstance(link, Mapping) and link.get("rel") == relation:
+            href = link.get("href")
+            if isinstance(href, str):
+                return href
+    return None
+
+
+def _duration_seconds(start: object, end: object) -> float | None:
+    if not isinstance(start, str) or not isinstance(end, str):
+        return None
+    return (_utc_datetime(end) - _utc_datetime(start)).total_seconds()
+
+
+def _utc_datetime(value: str) -> datetime:
+    timestamp = datetime.fromisoformat(value)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    return timestamp.astimezone(UTC)
 
 
 def _count_grib_messages(path: Path) -> int:
@@ -219,7 +300,7 @@ def _validate_grib_container(path: Path) -> None:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--state", type=Path, required=True)
-    parser.add_argument("--api-url", default=DEFAULT_API_URL)
+    parser.add_argument("--api-url")
     subparsers = parser.add_subparsers(dest="command", required=True)
     submit = subparsers.add_parser("submit")
     submit.add_argument("--payload", type=Path, required=True)

--- a/src/scripts/ecmwf_extended_range_spike.py
+++ b/src/scripts/ecmwf_extended_range_spike.py
@@ -287,13 +287,25 @@ def _utc_datetime(value: str) -> datetime:
 
 
 def _count_grib_messages(path: Path) -> int:
-    return path.read_bytes().count(b"GRIB")
+    message_count = 0
+    with path.open("rb") as source:
+        while header := source.read(16):
+            assert len(header) == 16
+            assert header[:4] == b"GRIB"
+            message_size = int.from_bytes(header[8:16], byteorder="big")
+            assert message_size >= 20
+            source.seek(message_size - len(header) - 4, 1)
+            assert source.read(4) == b"7777"
+            message_count += 1
+        assert source.tell() == path.stat().st_size
+    return message_count
 
 
 def _validate_grib_container(path: Path) -> None:
-    contents = path.read_bytes()
-    assert contents.startswith(b"GRIB"), "Download does not start with a GRIB message"
-    assert contents.endswith(b"7777"), "Download ends inside a GRIB message"
+    with path.open("rb") as source:
+        assert source.read(4) == b"GRIB", "Download does not start with a GRIB message"
+        source.seek(-4, 2)
+        assert source.read(4) == b"7777", "Download ends inside a GRIB message"
     assert _count_grib_messages(path) > 0, "Download contains no GRIB messages"
 
 

--- a/tests/scripts/ecmwf_extended_range_acceptance_test.py
+++ b/tests/scripts/ecmwf_extended_range_acceptance_test.py
@@ -1,0 +1,303 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Self
+
+import numpy as np
+import pytest
+import xarray as xr
+from affine import Affine
+
+from scripts.ecmwf_extended_range_acceptance import (
+    DevelopmentSource,
+    GribInventory,
+    InventoryRecord,
+    build_development_zarr,
+    inspect_grib,
+)
+
+
+@dataclass
+class FakeMetadata:
+    message_size: int
+    var_abbrev: str
+    level_type: str
+    level_value: float | None
+    perturbation_number: int
+    reference_date: datetime
+    forecast_date: datetime
+    forecast_date_end: datetime | None
+    units: str
+    grid_shape: tuple[int, int] = (121, 240)
+
+
+def metadata(
+    *,
+    variable: str,
+    member: int = 0,
+    lead: int = 24,
+    level: float | None = None,
+    interval_start: int | None = None,
+) -> FakeMetadata:
+    reference = datetime(2026, 7, 24)
+    level_type = (
+        "isobaric surface"
+        if level is not None and level != 2
+        else "specific height level above ground"
+    )
+    return FakeMetadata(
+        message_size=24,
+        var_abbrev=variable,
+        level_type=level_type,
+        level_value=level,
+        perturbation_number=member,
+        reference_date=reference,
+        forecast_date=reference + timedelta(hours=lead)
+        if interval_start is None
+        else reference + timedelta(hours=interval_start),
+        forecast_date_end=reference + timedelta(hours=lead)
+        if interval_start is not None
+        else None,
+        units="K",
+    )
+
+
+def write_messages(path: Path, count: int) -> None:
+    message = b"GRIB\x00\x00\x00\x02" + (24).to_bytes(8) + b"data7777"
+    path.write_bytes(message * count)
+
+
+def test_inspect_grib_validates_exact_surface_product(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "surface.grib"
+    write_messages(source, 4)
+    messages = iter(
+        [
+            metadata(variable="UGRD", member=0, lead=24),
+            metadata(variable="VGRD", member=0, lead=24),
+            metadata(variable="UGRD", member=0, lead=48),
+            metadata(variable="VGRD", member=0, lead=48),
+        ]
+    )
+    monkeypatch.setattr(
+        "scripts.ecmwf_extended_range_acceptance.parse_grib_message_metadata",
+        lambda data, offset: next(messages),
+    )
+
+    inventory = inspect_grib(
+        source,
+        {
+            "forecast_type": "control_forecast",
+            "level_type": "single_level",
+            "variable": [
+                "10_m_u_component_of_wind",
+                "10_m_v_component_of_wind",
+            ],
+            "leadtime_hour": ["24", "48"],
+        },
+    )
+
+    assert inventory.valid
+    assert inventory.message_count == 4
+    assert inventory.members == [0]
+    assert inventory.leadtimes == ["24", "48"]
+    assert inventory.variables == [
+        "10_m_u_component_of_wind",
+        "10_m_v_component_of_wind",
+    ]
+    assert inventory.grid_shape == [121, 240]
+
+
+def test_inspect_grib_validates_pressure_levels_and_members(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "pressure.grib"
+    write_messages(source, 4)
+    messages = iter(
+        [
+            metadata(variable="TMP", member=1, level=500),
+            metadata(variable="TMP", member=1, level=850),
+            metadata(variable="TMP", member=2, level=500),
+            metadata(variable="TMP", member=2, level=850),
+        ]
+    )
+    monkeypatch.setattr(
+        "scripts.ecmwf_extended_range_acceptance.parse_grib_message_metadata",
+        lambda data, offset: next(messages),
+    )
+
+    inventory = inspect_grib(
+        source,
+        {
+            "forecast_type": "perturbed_forecast",
+            "number": ["1", "2"],
+            "level_type": "pressure",
+            "level_value": ["500_hpa", "850_hpa"],
+            "variable": ["temperature"],
+            "leadtime_hour": ["24"],
+        },
+    )
+
+    assert inventory.valid
+    assert inventory.members == [1, 2]
+    assert inventory.levels == ["500_hpa", "850_hpa"]
+
+
+def test_inspect_grib_matches_interval_leadtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "daily.grib"
+    write_messages(source, 1)
+    monkeypatch.setattr(
+        "scripts.ecmwf_extended_range_acceptance.parse_grib_message_metadata",
+        lambda data, offset: metadata(
+            variable="TMP", lead=24, interval_start=0, level=2
+        ),
+    )
+
+    inventory = inspect_grib(
+        source,
+        {
+            "forecast_type": "control_forecast",
+            "level_type": "single_level",
+            "variable": ["2_m_temperature"],
+            "leadtime_hour": ["0_24"],
+        },
+    )
+
+    assert inventory.valid
+    assert inventory.leadtimes == ["0_24"]
+
+
+def test_inspect_grib_rejects_missing_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "incomplete.grib"
+    write_messages(source, 1)
+    monkeypatch.setattr(
+        "scripts.ecmwf_extended_range_acceptance.parse_grib_message_metadata",
+        lambda data, offset: metadata(variable="UGRD"),
+    )
+
+    with pytest.raises(AssertionError, match="Missing inventory"):
+        inspect_grib(
+            source,
+            {
+                "forecast_type": "control_forecast",
+                "level_type": "single_level",
+                "variable": [
+                    "10_m_u_component_of_wind",
+                    "10_m_v_component_of_wind",
+                ],
+                "leadtime_hour": ["24"],
+            },
+        )
+
+
+def test_build_development_zarr_streams_complete_realization_product(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.grib"
+    source.write_bytes(b"source")
+    payload: dict[str, object] = {
+        "year": ["2026"],
+        "month": ["07"],
+        "day": ["24"],
+        "time": ["00:00"],
+        "forecast_type": "perturbed_forecast",
+        "number": ["1", "2"],
+        "level_type": "single_level",
+        "variable": ["total_precipitation"],
+        "leadtime_hour": ["24", "48"],
+    }
+    records = [
+        InventoryRecord(
+            offset=(band - 1) * 24,
+            message_size=24,
+            variable="total_precipitation",
+            level=None,
+            ensemble_member=member,
+            leadtime_hour=lead,
+            units="ms-1",
+            grib_level_type="specific height level above ground",
+            grib_level_value=10,
+            grid_shape=(2, 3),
+        )
+        for band, (lead, member) in enumerate(
+            [("24", 1), ("24", 2), ("48", 1), ("48", 2)], start=1
+        )
+    ]
+    inventory = GribInventory(
+        source=str(source),
+        valid=True,
+        byte_count=96,
+        message_count=4,
+        grid_shape=[2, 3],
+        variables=["total_precipitation"],
+        levels=[],
+        members=[1, 2],
+        leadtimes=["24", "48"],
+        records=records,
+    )
+    monkeypatch.setattr(
+        "scripts.ecmwf_extended_range_acceptance.inspect_grib",
+        lambda source, payload: inventory,
+    )
+
+    class FakeReader:
+        count = 4
+        transform = Affine(1.5, 0, -180.75, 0, -1.5, 90.75)
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(
+            self, bands: list[int], *, out_dtype: object, masked: bool
+        ) -> np.ma.MaskedArray:
+            assert out_dtype is np.float32
+            assert masked
+            return np.ma.array(
+                np.stack(
+                    [np.full((2, 3), band * 86_400, dtype=np.float32) for band in bands]
+                )
+            )
+
+    monkeypatch.setattr(
+        "scripts.ecmwf_extended_range_acceptance.rasterio.open",
+        lambda source: FakeReader(),
+    )
+    target = tmp_path / "development.zarr"
+
+    measurement = build_development_zarr([DevelopmentSource(source, payload)], target)
+    rerun = build_development_zarr([DevelopmentSource(source, payload)], target)
+
+    reopened = xr.open_zarr(target)
+    assert measurement.complete
+    assert rerun.complete
+    assert {"valid_time", "spatial_ref"} <= set(reopened.coords)
+    assert reopened.sizes == {
+        "init_time": 1,
+        "lead_time": 2,
+        "ensemble_member": 2,
+        "latitude": 2,
+        "longitude": 3,
+    }
+    assert (
+        reopened.precipitation_surface.sel(lead_time="24h", ensemble_member=2).values[
+            0, 0, 0
+        ]
+        == 2
+    )
+    assert (
+        reopened.precipitation_surface.sel(lead_time="48h", ensemble_member=1).values[
+            0, 0, 0
+        ]
+        == 2
+    )
+    assert np.array_equal(reopened.valid_time, reopened.init_time + reopened.lead_time)
+    assert reopened.longitude.values.tolist() == [-180.0, -178.5, -177.0]
+    assert reopened.latitude.values.tolist() == [90.0, 88.5]

--- a/tests/scripts/ecmwf_extended_range_spike_test.py
+++ b/tests/scripts/ecmwf_extended_range_spike_test.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from scripts.ecmwf_extended_range_spike import (
+    EcdsRequest,
+    RequestMeasurement,
+    StateStore,
+)
+
+
+def response(body: dict[str, object], status_code: int = 200) -> Mock:
+    result = Mock()
+    result.json.return_value = body
+    result.status_code = status_code
+    result.headers = {}
+    result.raise_for_status.return_value = None
+    return result
+
+
+def test_request_state_can_resume_in_another_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ECDS_API_KEY", "test-key")
+    session = Mock()
+    session.headers = {}
+    session.post.return_value = response({"jobID": "job-1", "location": "status"})
+    state_store = StateStore(tmp_path / "state.json")
+    request = EcdsRequest(state_store, session=session)
+
+    request.submit({"number": [0, 1], "step": [24], "param": ["2t"]})
+
+    resumed_session = Mock()
+    resumed_session.headers = {}
+    resumed_session.get.return_value = response(
+        {"status": "successful", "result": {"href": "result"}}
+    )
+    resumed = EcdsRequest(state_store, session=resumed_session)
+    measurement, result_url = resumed.poll_once()
+    assert measurement.request_id == "job-1"
+    assert measurement.expected_members == [0, 1]
+    assert result_url == "result"
+    assert state_store.read().result_url == "result"
+
+
+def test_configures_endpoint_and_basic_credentials_from_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ECDS_API_ENDPOINT", "https://example.test/api/")
+    monkeypatch.setenv("ECDS_API_KEY", "user:key")
+    request = EcdsRequest(StateStore(tmp_path / "state.json"))
+
+    assert request.api_url == (
+        "https://example.test/api/retrieve/v1/processes/s2s-forecasts/execution"
+    )
+    assert request.session.auth == ("user", "key")
+
+
+def test_state_writes_machine_readable_measurements_atomically(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(RequestMeasurement("id", {"date": "2026-07-24"}, "now", "status"))
+    assert json.loads(state_store.path.read_text())["request_id"] == "id"
+    assert not state_store.path.with_suffix(".json.tmp").exists()
+
+
+def test_download_uses_result_url_saved_by_poll(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(
+        RequestMeasurement(
+            "id", {}, "now", "status", result_url="https://example.test/result"
+        )
+    )
+    download_response = response({})
+    download_response.iter_content.return_value = [b"GRIB", b"contents", b"7777"]
+    session = Mock()
+    session.headers = {}
+    session.auth = ("user", "key")
+    session.get.return_value = download_response
+
+    measurement = EcdsRequest(state_store, session=session).download(
+        tmp_path / "result.grib"
+    )
+
+    assert measurement.downloaded_bytes == len(b"GRIBcontents7777")
+    assert measurement.grib_messages == 1
+    assert (tmp_path / "result.grib.complete").exists()
+
+
+def test_complete_initialization_can_be_written_and_queried(tmp_path: Path) -> None:
+    ensemble_members = np.arange(101)
+    lead_times = np.arange(24, 46 * 24 + 1, 24).astype("timedelta64[h]")
+    latitude = np.array([5.0, 0.0, -5.0])
+    longitude = np.array([35.0, 40.0, 45.0])
+    values = np.zeros((1, 46, 101, 3, 3), dtype=np.float32)
+    dataset = xr.Dataset(
+        {
+            "temperature_2m": (
+                ("init_time", "lead_time", "ensemble_member", "latitude", "longitude"),
+                values,
+            )
+        },
+        coords={
+            "init_time": [np.datetime64("2026-07-24")],
+            "lead_time": lead_times,
+            "ensemble_member": ensemble_members,
+            "latitude": latitude,
+            "longitude": longitude,
+        },
+    ).assign_coords(valid_time=lambda ds: ds.init_time + ds.lead_time)
+    store = tmp_path / "complete_initialization.zarr"
+    dataset.to_zarr(store, mode="w")
+    dataset.to_zarr(store, mode="w")
+
+    reopened = xr.open_zarr(store)
+    east_africa = reopened.sel(latitude=slice(5, -5), longitude=slice(35, 45))
+    assert east_africa.sizes == {
+        "init_time": 1,
+        "lead_time": 46,
+        "ensemble_member": 101,
+        "latitude": 3,
+        "longitude": 3,
+    }
+    assert np.array_equal(reopened.valid_time, reopened.init_time + reopened.lead_time)

--- a/tests/scripts/ecmwf_extended_range_spike_test.py
+++ b/tests/scripts/ecmwf_extended_range_spike_test.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
+import requests
 import xarray as xr
 
 from scripts.ecmwf_extended_range_spike import (
@@ -28,23 +29,46 @@ def test_request_state_can_resume_in_another_process(
     monkeypatch.setenv("ECDS_API_KEY", "test-key")
     session = Mock()
     session.headers = {}
-    session.post.return_value = response({"jobID": "job-1", "location": "status"})
+    submit_response = response({"jobID": "job-1"})
+    submit_response.headers = {"Location": "status"}
+    session.post.return_value = submit_response
     state_store = StateStore(tmp_path / "state.json")
     request = EcdsRequest(state_store, session=session)
 
-    request.submit({"number": [0, 1], "step": [24], "param": ["2t"]})
+    request.submit(
+        {
+            "number": [0, 1],
+            "leadtime_hour": ["024"],
+            "variable": ["10_m_u_component_of_wind"],
+        }
+    )
 
     resumed_session = Mock()
     resumed_session.headers = {}
-    resumed_session.get.return_value = response(
-        {"status": "successful", "result": {"href": "result"}}
-    )
+    resumed_session.get.side_effect = [
+        response(
+            {
+                "status": "successful",
+                "created": "2026-07-28T17:46:07",
+                "started": "2026-07-28T17:47:07",
+                "finished": "2026-07-28T17:48:07",
+                "links": [{"rel": "results", "href": "results"}],
+            }
+        ),
+        response({"asset": {"value": {"href": "result"}}}),
+    ]
     resumed = EcdsRequest(state_store, session=resumed_session)
     measurement, result_url = resumed.poll_once()
     assert measurement.request_id == "job-1"
     assert measurement.expected_members == [0, 1]
+    assert measurement.expected_steps == [24]
+    assert measurement.expected_variables == ["10_m_u_component_of_wind"]
+    assert measurement.queue_seconds == 60
+    assert measurement.server_processing_seconds == 60
+    assert measurement.completed_at == "2026-07-28T17:48:07+00:00"
     assert result_url == "result"
     assert state_store.read().result_url == "result"
+    assert resumed_session.get.call_args_list[1].args == ("results",)
 
 
 def test_configures_endpoint_and_basic_credentials_from_environment(
@@ -60,11 +84,57 @@ def test_configures_endpoint_and_basic_credentials_from_environment(
     assert request.session.auth == ("user", "key")
 
 
+def test_configures_endpoint_and_token_from_cdsapirc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / ".cdsapirc"
+    config_path.write_text(
+        "url: https://example.test/api\nkey: personal-access-token\n"
+    )
+    monkeypatch.setenv("CDSAPI_RC", str(config_path))
+    monkeypatch.delenv("ECDS_API_ENDPOINT", raising=False)
+    monkeypatch.delenv("ECDS_API_KEY", raising=False)
+    request = EcdsRequest(StateStore(tmp_path / "state.json"))
+
+    assert request.api_url == (
+        "https://example.test/api/retrieve/v1/processes/s2s-forecasts/execution"
+    )
+    assert request.session.headers["PRIVATE-TOKEN"] == "personal-access-token"
+    assert "Authorization" not in request.session.headers
+
+
 def test_state_writes_machine_readable_measurements_atomically(tmp_path: Path) -> None:
     state_store = StateStore(tmp_path / "measurement.json")
     state_store.write(RequestMeasurement("id", {"date": "2026-07-24"}, "now", "status"))
     assert json.loads(state_store.path.read_text())["request_id"] == "id"
     assert not state_store.path.with_suffix(".json.tmp").exists()
+
+
+def test_failed_poll_records_results_error(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(RequestMeasurement("id", {}, "now", "status"))
+    failure: dict[str, object] = {
+        "status": 400,
+        "title": "The job has failed",
+        "traceback": "failure detail",
+    }
+    session = Mock()
+    session.headers = {}
+    session.auth = ("user", "key")
+    session.get.side_effect = [
+        response(
+            {
+                "status": "failed",
+                "links": [{"rel": "results", "href": "results"}],
+            }
+        ),
+        response(failure, status_code=400),
+    ]
+
+    measurement, result_url = EcdsRequest(state_store, session=session).poll_once()
+
+    assert result_url is None
+    assert measurement.errors == [json.dumps(failure, sort_keys=True)]
 
 
 def test_download_uses_result_url_saved_by_poll(tmp_path: Path) -> None:
@@ -88,6 +158,48 @@ def test_download_uses_result_url_saved_by_poll(tmp_path: Path) -> None:
     assert measurement.downloaded_bytes == len(b"GRIBcontents7777")
     assert measurement.grib_messages == 1
     assert (tmp_path / "result.grib.complete").exists()
+
+
+def test_download_resumes_partial_file_after_http_206(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(
+        RequestMeasurement("id", {}, "now", "status", result_url="result")
+    )
+    target = tmp_path / "result.grib"
+    target.with_suffix(".grib.partial").write_bytes(b"GRIB")
+    download_response = response({}, status_code=requests.codes.partial)
+    download_response.iter_content.return_value = [b"contents7777"]
+    session = Mock()
+    session.headers = {}
+    session.auth = ("user", "key")
+    session.get.return_value = download_response
+
+    measurement = EcdsRequest(state_store, session=session).download(target)
+
+    assert target.read_bytes() == b"GRIBcontents7777"
+    assert measurement.interrupted_download_resumable
+    assert session.get.call_args.kwargs["headers"] == {"Range": "bytes=4-"}
+
+
+def test_download_restarts_partial_file_after_http_200(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(
+        RequestMeasurement("id", {}, "now", "status", result_url="result")
+    )
+    target = tmp_path / "result.grib"
+    target.with_suffix(".grib.partial").write_bytes(b"incomplete")
+    download_response = response({})
+    download_response.iter_content.return_value = [b"GRIBcontents7777"]
+    session = Mock()
+    session.headers = {}
+    session.auth = ("user", "key")
+    session.get.return_value = download_response
+
+    measurement = EcdsRequest(state_store, session=session).download(target)
+
+    assert target.read_bytes() == b"GRIBcontents7777"
+    assert not measurement.interrupted_download_resumable
+    assert session.get.call_args.kwargs["headers"] == {"Range": "bytes=10-"}
 
 
 def test_complete_initialization_can_be_written_and_queried(tmp_path: Path) -> None:

--- a/tests/scripts/ecmwf_extended_range_spike_test.py
+++ b/tests/scripts/ecmwf_extended_range_spike_test.py
@@ -23,6 +23,17 @@ def response(body: dict[str, object], status_code: int = 200) -> Mock:
     return result
 
 
+def grib_message(payload: bytes = b"contents") -> bytes:
+    message_size = 16 + len(payload) + 4
+    return (
+        b"GRIB"
+         b"\x00\x00\x00\x02"
+        + message_size.to_bytes(8, byteorder="big")
+        + payload
+        + b"7777"
+    )
+
+
 def test_request_state_can_resume_in_another_process(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -145,7 +156,8 @@ def test_download_uses_result_url_saved_by_poll(tmp_path: Path) -> None:
         )
     )
     download_response = response({})
-    download_response.iter_content.return_value = [b"GRIB", b"contents", b"7777"]
+    message = grib_message()
+    download_response.iter_content.return_value = [message]
     session = Mock()
     session.headers = {}
     session.auth = ("user", "key")
@@ -155,7 +167,7 @@ def test_download_uses_result_url_saved_by_poll(tmp_path: Path) -> None:
         tmp_path / "result.grib"
     )
 
-    assert measurement.downloaded_bytes == len(b"GRIBcontents7777")
+    assert measurement.downloaded_bytes == len(message)
     assert measurement.grib_messages == 1
     assert (tmp_path / "result.grib.complete").exists()
 
@@ -166,9 +178,10 @@ def test_download_resumes_partial_file_after_http_206(tmp_path: Path) -> None:
         RequestMeasurement("id", {}, "now", "status", result_url="result")
     )
     target = tmp_path / "result.grib"
-    target.with_suffix(".grib.partial").write_bytes(b"GRIB")
+    message = grib_message()
+    target.with_suffix(".grib.partial").write_bytes(message[:4])
     download_response = response({}, status_code=requests.codes.partial)
-    download_response.iter_content.return_value = [b"contents7777"]
+    download_response.iter_content.return_value = [message[4:]]
     session = Mock()
     session.headers = {}
     session.auth = ("user", "key")
@@ -176,7 +189,7 @@ def test_download_resumes_partial_file_after_http_206(tmp_path: Path) -> None:
 
     measurement = EcdsRequest(state_store, session=session).download(target)
 
-    assert target.read_bytes() == b"GRIBcontents7777"
+    assert target.read_bytes() == message
     assert measurement.interrupted_download_resumable
     assert session.get.call_args.kwargs["headers"] == {"Range": "bytes=4-"}
 
@@ -189,7 +202,8 @@ def test_download_restarts_partial_file_after_http_200(tmp_path: Path) -> None:
     target = tmp_path / "result.grib"
     target.with_suffix(".grib.partial").write_bytes(b"incomplete")
     download_response = response({})
-    download_response.iter_content.return_value = [b"GRIBcontents7777"]
+    message = grib_message()
+    download_response.iter_content.return_value = [message]
     session = Mock()
     session.headers = {}
     session.auth = ("user", "key")
@@ -197,9 +211,31 @@ def test_download_restarts_partial_file_after_http_200(tmp_path: Path) -> None:
 
     measurement = EcdsRequest(state_store, session=session).download(target)
 
-    assert target.read_bytes() == b"GRIBcontents7777"
+    assert target.read_bytes() == message
     assert not measurement.interrupted_download_resumable
     assert session.get.call_args.kwargs["headers"] == {"Range": "bytes=10-"}
+
+
+def test_download_counts_structural_messages_not_embedded_grib_bytes(
+    tmp_path: Path,
+) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(
+        RequestMeasurement("id", {}, "now", "status", result_url="result")
+    )
+    message = grib_message(b"compressed GRIB payload")
+    download_response = response({})
+    download_response.iter_content.return_value = [message]
+    session = Mock()
+    session.headers = {}
+    session.auth = ("user", "key")
+    session.get.return_value = download_response
+
+    measurement = EcdsRequest(state_store, session=session).download(
+        tmp_path / "result.grib"
+    )
+
+    assert measurement.grib_messages == 1
 
 
 def test_complete_initialization_can_be_written_and_queried(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Provide a durable asynchronous prototype source adapter to exercise ECMWF ECDS `s2s-forecasts` retrieval semantics and measure feasibility for extended-range ingestion.  
- Capture spike findings, a candidate variable manifest, a planned measurement matrix, and operational recommendations in repository documentation.  
- Enable an authenticated acceptance run and structured acceptance gate (sharded requests, interruption/retry, strict GRIB inventory, and an end-to-end Zarr proof) while safely handling environments that lack credentials.  

### Description

- Add a decision spike report and a machine-readable request measurement matrix as `docs/plans/ecmwf_extended_range_spike.md` and `docs/plans/ecmwf_extended_range_request_measurements.json`.  
- Implement a prototype retrieval tool `src/scripts/ecmwf_extended_range_spike.py` exposing `EcdsRequest`, `StateStore`, and `RequestMeasurement` and supporting submit/poll/download flows, environment-configured endpoints/credentials, atomic state writes, resumable downloads via `Range` headers, GRIB container validation, and message counting.  
- Wire default API discovery via `ECDS_API_ENDPOINT`/`ECDS_API_KEY` with support for colon-separated basic auth or bearer tokens and normalize execution/result URLs.  
- Add unit tests `tests/scripts/ecmwf_extended_range_spike_test.py` that simulate HTTP responses and exercise resume/poll/download, atomic state writes, endpoint/credential parsing, and a development-only Zarr write/read proof.  

### Testing

- Ran the new unit tests with `pytest tests/scripts/ecmwf_extended_range_spike_test.py`, which simulate responses for submission/poll/download and assert state resumption, atomic writes, GRIB validation, and Zarr read/write semantics, and all tests passed.  
- Tests cover `EcdsRequest` credential handling, `StateStore` atomic writes and resume semantics, download resume and GRIB validation, and a deterministic Zarr write/read idempotency check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68ca0bcce4832d84f376dd8342c69b)