### PR TITLE
Fix live ECDS spike workflow

### DIFF
--- a/docs/plans/ecmwf_extended_range_request_measurements.json
+++ b/docs/plans/ecmwf_extended_range_request_measurements.json
@@ -1,20 +1,96 @@
 {
-  "generated_at": "2026-07-28T00:00:00Z",
+  "generated_at": "2026-07-28T18:05:00Z",
   "environment": {
-    "authenticated_ecds_access": false,
-    "reason": "Neither ECDS_API_ENDPOINT nor ECDS_API_KEY was exposed to the process, and no CDS/ECDS credential file was available. No request was submitted."
+    "authenticated_ecds_access": true,
+    "accepted_s2s_terms": true,
+    "credential_source": ".cdsapirc"
   },
-  "observations": [],
+  "observations": [
+    {
+      "id": "recent_smoke_2m_temperature",
+      "request_id": "1699ae8a-eb95-4f03-afc0-1339a72fcf50",
+      "status": "failed",
+      "variable": "2m_temperature",
+      "members": 1,
+      "steps": [
+        24,
+        48,
+        72
+      ],
+      "error_category": "ambiguous_backend_parameter_mapping"
+    },
+    {
+      "id": "recent_smoke_wind_u_10m",
+      "request_id": "4f5026a6-90f3-4469-9fb4-4cfef9f44dab",
+      "status": "downloaded",
+      "variable": "10_m_u_component_of_wind",
+      "members": 1,
+      "steps": [
+        24,
+        48,
+        72
+      ],
+      "queue_seconds": 12.824365,
+      "server_processing_seconds": 4.511008,
+      "download_seconds": 0.826459,
+      "downloaded_bytes": 174786,
+      "grib_messages": 3,
+      "http_range_resume": true,
+      "partial_bytes_before_resume": 87393
+    }
+  ],
   "planned_matrix": [
-    {"id": "recent_smoke", "status": "blocked_credentials", "variables": 1, "members": 1, "steps": [24, 48, 72]},
-    {"id": "recent_surface_all_members", "status": "blocked_credentials"},
-    {"id": "recent_pressure_all_members", "status": "blocked_credentials", "levels_hpa": [500, 700, 850]},
-    {"id": "recent_complete_sharded", "status": "blocked_credentials"},
-    {"id": "archive_start_complete_sharded", "status": "blocked_credentials"},
-    {"id": "completed_request_rerun", "status": "blocked_credentials"},
-    {"id": "interrupted_download_resume", "status": "simulated_only"},
-    {"id": "intermediate_smoke", "status": "blocked_credentials"},
-    {"id": "second_recent_smoke", "status": "blocked_credentials"},
-    {"id": "transient_poll_failure", "status": "simulated_only"}
+    {
+      "id": "recent_smoke",
+      "status": "completed",
+      "variables": 1,
+      "members": 1,
+      "steps": [
+        24,
+        48,
+        72
+      ]
+    },
+    {
+      "id": "recent_surface_all_members",
+      "status": "pending"
+    },
+    {
+      "id": "recent_pressure_all_members",
+      "status": "pending",
+      "levels_hpa": [
+        500,
+        700,
+        850
+      ]
+    },
+    {
+      "id": "recent_complete_sharded",
+      "status": "pending"
+    },
+    {
+      "id": "archive_start_complete_sharded",
+      "status": "pending"
+    },
+    {
+      "id": "completed_request_rerun",
+      "status": "pending"
+    },
+    {
+      "id": "interrupted_download_resume",
+      "status": "completed"
+    },
+    {
+      "id": "intermediate_smoke",
+      "status": "pending"
+    },
+    {
+      "id": "second_recent_smoke",
+      "status": "pending"
+    },
+    {
+      "id": "transient_poll_failure",
+      "status": "simulated_only"
+    }
   ]
 }

--- a/docs/plans/ecmwf_extended_range_spike.md
+++ b/docs/plans/ecmwf_extended_range_spike.md
@@ -2,7 +2,7 @@
 
 ## Executive summary
 
-**Recommendation: CONDITIONAL GO, with no fixed-price production commitment until the authenticated acceptance gate below passes.** The repository has most of the expensive transformation machinery, and a durable asynchronous retrieval prototype demonstrates the required local control flow under simulated responses. This run could not answer the primary source question, however: the environment had no CDS/ECDS credential, so it submitted no live request and downloaded no GRIB. Consequently there are **no measured bytes, queue times, success rate, transformation costs, or end-to-end development Zarr from ECDS**. Documentation is not a substitute for those decision criteria.
+**Recommendation: CONDITIONAL GO, with no fixed-price production commitment until the full acceptance gate below passes.** Authenticated submission, one-shot polling, persisted result discovery, GRIB download, and HTTP Range resume now work against live ECDS. A three-message control-forecast smoke file was 174,786 bytes; its observed queue time was 12.8 seconds and server processing time was 4.5 seconds. The official `2m_temperature` example failed in the backend because its parameter name was ambiguous, while `10_m_u_component_of_wind` succeeded. The full surface/pressure/member matrix and an end-to-end development Zarr remain untested.
 
 The minimum acceptance gate is three real dates (near June 2023, intermediate, and recent), one complete proposed initialization, ten total request shards, interruption/retry exercises, a strict GRIB inventory, and an end-to-end Zarr. A fixed implementation price should wait for that run. If it fails because operational ECDS retrieval is unreliable, seek a quote for scheduled dissemination rather than making the public dataset depend on manual recovery.
 
@@ -31,9 +31,11 @@ There is also an important completeness gap: failed individual downloads can rem
 
 ### Observed in this run
 
-* Neither `ECDS_API_ENDPOINT` nor `ECDS_API_KEY` was exposed to the process, and no CDS credential file was present. No authenticated request was attempted. This was rechecked after the environment secrets were identified by name.
-* The checked-in prototype defaults to the process endpoint for the live `s2s-forecasts` collection. The retrieve endpoint and response body still require an authenticated smoke test.
-* The prototype's submission/status body compatibility is intentionally small. The official client or an observed response should determine the final response schema.
+* A standard `.cdsapirc` with accepted S2S terms authenticated successfully. Personal access tokens are sent in the `PRIVATE-TOKEN` header.
+* ECDS submission returned a job ID and status location. Successful status responses exposed `links[rel=results]`; the results endpoint returned the signed download URL at `asset.value.href`.
+* Request `4f5026a6-90f3-4469-9fb4-4cfef9f44dab` retrieved ECMWF control `10_m_u_component_of_wind` for 2026-07-24 at leads 24, 48, and 72 hours. It queued for 12.824 seconds, processed for 4.511 seconds, downloaded in 0.826 seconds, contained three GRIB messages, and occupied 174,786 bytes.
+* Restarting from a seeded 87,393-byte partial file received HTTP 206, appended the remaining bytes, and reproduced the valid 174,786-byte GRIB.
+* Request `1699ae8a-eb95-4f03-afc0-1339a72fcf50` used the official `2m_temperature` payload shape but failed because the backend resolved that name ambiguously. This is an ECDS/MARS mapping issue rather than an authentication or transport failure.
 
 ### Authoritative documentation findings, not file observations
 
@@ -41,7 +43,7 @@ The live ECDS catalogue exposes the exact collection identifier [`s2s-forecasts`
 
 The authoritative [S2S model table](https://confluence.ecmwf.int/display/S2S/Models) records CY48R1 from 2023-06-27 with 100 perturbed members plus one control, daily runs through day 46, TCo319 (~32 km), and a 0.25° archived grid. CY49R1 begins 2024-11-12 with the same headline dimensions but replaces CAPE with MUCAPE, a schema boundary inside the target archive. Live constraints list pressure levels 10, 50, 100, 200, 300, 500, 700, 850, 925, and 1000 hPa and daily pressure-field leads from 0 through 1,104 hours.
 
-Authentication requires an ECMWF account, accepted dataset terms, and a `$HOME/.cdsapirc` token. The official page recommends `cdsapi>=0.7.2`. The incubating [`ecmwf-datastores-client`](https://ecmwf.github.io/ecmwf-datastores-client/) exposes asynchronous submission and status, but production should pin a tested release. Actual member encoding, per-date file inventory, GRIB edition, coordinate orientation, result retention, latency, concurrency, and rate limits remain unobserved.
+Authentication requires an ECMWF account, accepted dataset terms, and a `$HOME/.cdsapirc` token. The official page recommends `cdsapi>=0.7.2`. The incubating [`ecmwf-datastores-client`](https://ecmwf.github.io/ecmwf-datastores-client/) exposes asynchronous submission and status, but production should pin a tested release. Actual member encoding, per-date file inventory, GRIB edition, coordinate orientation, result retention, concurrency, and rate limits remain unobserved.
 
 ## Candidate request and production sharding
 
@@ -52,12 +54,12 @@ A smoke payload should start from this official shape and be generated separatel
   "origin": "ecmwf",
   "forecast_type": "control_forecast",
   "level_type": "single_level",
-  "variable": ["2m_temperature"],
+  "variable": ["10_m_u_component_of_wind"],
   "year": ["2026"],
   "month": ["07"],
   "day": ["24"],
   "leadtime_hour": ["024", "048", "072"],
-  "time": "00:00:00",
+  "time": ["00:00"],
   "data_format": "grib"
 }
 ```
@@ -95,8 +97,7 @@ Relative humidity (`r` / 157) is a fallback if specific humidity is absent; do n
 Run the tool as separate cheap invocations so a scheduler, pod, or replacement process can resume state:
 
 ```bash
-export ECDS_API_ENDPOINT=... # environment secret; never commit it
-export ECDS_API_KEY=...      # environment secret; never commit it
+# Configure url and key in ~/.cdsapirc and accept the S2S terms first.
 uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json submit --payload payload.json
 uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json poll --maximum-polls 1
 uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-smoke.json download --target data/ecmwf-er/recent-smoke.grib
@@ -104,7 +105,7 @@ uv run src/scripts/ecmwf_extended_range_spike.py --state data/ecmwf-er/recent-sm
 
 State writes use a temporary sibling and atomic rename. Poll failures are recorded with bounded exponential backoff. Downloads use `.partial`, request a byte range on restart, only append after HTTP 206, validate leading `GRIB` and terminal `7777`, count messages, atomically rename, and write a completion marker. A production adapter must additionally parse every GRIB key, validate content length/checksum or stable validator, and compare the exact expected Cartesian inventory before completion.
 
-The machine-readable matrix records seven required cases plus intermediate, second-recent, and simulated-transient cases. Authenticated cases are `blocked_credentials`; restart and state persistence are unit-tested with simulated HTTP responses. Empty observations are deliberate and must not be interpreted as zero latency or 100% reliability.
+The machine-readable matrix records seven required cases plus intermediate, second-recent, and simulated-transient cases. The recent control smoke and real HTTP Range restart are complete; the larger authenticated cases remain pending. State persistence, live result discovery, and both HTTP 206 append and HTTP 200 restart behavior are covered by unit tests.
 
 ## Development Zarr proof
 
@@ -114,17 +115,17 @@ The unit test writes a deterministic 101-member × 46-daily-lead synthetic initi
 
 | Metric | Observation |
 |---|---|
-| authenticated requests | 0 |
-| success rate | not measured |
-| typical/worst queue time | not measured |
-| typical/worst end-to-end latency | not measured |
+| authenticated requests | 3 small control requests: two wind successes and one `2m_temperature` backend failure |
+| success rate | 2/2 for the wind smoke shape; 2/3 across both tested variable names |
+| typical/worst queue time | one instrumented fresh run: 12.824 seconds |
+| typical/worst end-to-end latency | one instrumented fresh run: 17.335 seconds queue plus server processing; download added 0.826 seconds |
 | update-cadence fit | unknown |
-| real restart/retry/idempotency | unknown; simulated state recovery only |
+| real restart/retry/idempotency | HTTP 206 resume succeeded from a 50% partial file; duplicate submission behavior remains untested |
 | incomplete-success behavior | unknown; strict inventory requirement identified |
 
 ## Storage and compute
 
-There were no actual downloaded or generated representative files, so raw GRIB bytes per initialization, staging bytes, production Zarr bytes, compression ratio, peak memory, CPU time, transform wall time, requests per initialization, annual growth, initial archive size, backfill duration, and dollar cost are **not measured**. Supplying numeric values from theoretical dimensions would violate the spike requirement to use actual files.
+The three-message smoke GRIB was 174,786 bytes. It is not representative of a complete initialization, so staging bytes, production Zarr bytes, compression ratio, peak memory, CPU time, transform wall time, requests per initialization, annual growth, initial archive size, backfill duration, and dollar cost remain unmeasured.
 
 After one complete initialization, calculate:
 
@@ -149,8 +150,8 @@ Paid pre-scheduled delivery would replace unpredictable on-demand queueing and i
 
 Top risks:
 
-1. **Unobserved source contract:** authenticated request syntax, archive calendar, schema eras, full manifest, member completeness, and result retention are not established.
-2. **Unobserved operational behavior:** queue latency, throughput, limits, resumability, idempotency, and structurally incomplete successful responses are not measured.
+1. **Incomplete source contract:** authentication and the small control request work, but archive calendar, schema eras, full manifest, member completeness, and result retention are not established; `2m_temperature` currently fails in backend parameter mapping.
+2. **Partially observed operational behavior:** one small request had low latency and resumability worked, but production-size throughput, limits, duplicate submission behavior, and structurally incomplete successful responses are not measured.
 3. **Redistribution and cost:** dataset-specific terms need confirmation, while actual storage/compute and paid-delivery economics have no measured basis.
 
 Recommend GO only after all of these pass unattended:
@@ -163,7 +164,7 @@ Recommend GO only after all of these pass unattended:
 
 ## Proposed `dynamical-org/meta#144` comment
 
-> **ECMWF Extended Range is a conditional go, not yet ready for a fixed-price commitment.** Most GRIB normalization, deaccumulation, Zarr writing, metadata, and validation can be reused from IFS ENS, but ECDS needs a durable asynchronous source adapter and strict whole-initialization completeness checks. I recommend a bounded first product: ECMWF real-time forecasts only, daily lead samples through the available extended horizon, all members, a useful surface set, and temperature/wind/humidity/geopotential at 500/700/850 hPa represented as fixed-level variables; start at the first live-verified stable 101-member date. This spike environment had no ECDS credentials, so it produced no defensible bytes/init, archive-size, compute, queue-latency, or reliability measurements. Remaining source risk is therefore high: live schema/calendar, unattended queue behavior, and dataset-specific redistribution terms. Budget human effort for an authenticated acceptance run plus source-adapter/integration work; do not quote production until three dates, ten shards, one complete real Zarr, restart/retry tests, measured storage, and ECMWF terms confirmation pass.
+> **ECMWF Extended Range is a conditional go, not yet ready for a fixed-price commitment.** Authenticated ECDS submission, durable one-shot polling, nested result discovery, validated GRIB download, and real HTTP Range resume now work. A three-lead wind smoke request queued for 12.8 seconds, processed for 4.5 seconds, and produced a 174,786-byte GRIB with three messages; the official `2m_temperature` name failed in backend parameter mapping. Most GRIB normalization, deaccumulation, Zarr writing, metadata, and validation can be reused from IFS ENS, but the full member/surface/pressure inventory and a complete real Zarr remain untested. Do not quote production until three dates, ten representative shards, one complete real Zarr, duplicate/retry tests, measured storage, and ECMWF terms confirmation pass.
 
 ## Artifacts
 

--- a/src/scripts/ecmwf_extended_range_spike.py
+++ b/src/scripts/ecmwf_extended_range_spike.py
@@ -17,7 +17,7 @@ log = get_logger(__name__)
 DEFAULT_API_URL = (
     "https://ecds.ecmwf.int/api/retrieve/v1/processes/s2s-forecasts/execution"
 )
-TERMINAL_FAILURES = {"failed", "dismissed", "cancelled"}
+TERMINAL_FAILURES = {"failed", "rejected", "dismissed", "cancelled"}
 
 
 def utc_now() -> str:
@@ -75,19 +75,32 @@ class EcdsRequest:
         session: requests.Session | None = None,
     ) -> None:
         self.state_store = state_store
+        cdsapi_config = _read_cdsapi_config()
         self.api_url = _execution_url(
-            api_url or os.environ.get("ECDS_API_ENDPOINT", DEFAULT_API_URL)
+            api_url
+            or os.environ.get("ECDS_API_ENDPOINT")
+            or os.environ.get("CDSAPI_URL")
+            or cdsapi_config.get("url")
+            or DEFAULT_API_URL
         )
         self.session = session or requests.Session()
-        api_key = os.environ.get("ECDS_API_KEY")
+        api_key = (
+            os.environ.get("ECDS_API_KEY")
+            or os.environ.get("CDSAPI_KEY")
+            or cdsapi_config.get("key")
+        )
         if api_key and ":" in api_key:
-            self.session.auth = tuple(api_key.split(":", maxsplit=1))
+            username, key = api_key.split(":", maxsplit=1)
+            self.session.auth = (username, key)
         elif api_key:
-            self.session.headers["Authorization"] = f"Bearer {api_key}"
+            self.session.headers["PRIVATE-TOKEN"] = api_key
+        self.credentials_configured = bool(
+            api_key or self.session.auth or self.session.headers.get("PRIVATE-TOKEN")
+        )
 
     def submit(self, payload: dict[str, Any]) -> RequestMeasurement:
-        assert os.environ.get("ECDS_API_KEY") or self.session.auth, (
-            "Set ECDS_API_KEY before submitting a request"
+        assert self.credentials_configured, (
+            "Configure ECDS credentials in .cdsapirc or the environment"
         )
         response = self.session.post(self.api_url, json={"inputs": payload}, timeout=60)
         response.raise_for_status()
@@ -103,8 +116,13 @@ class EcdsRequest:
             submitted_at=utc_now(),
             status_url=status_url,
             expected_members=[int(value) for value in payload.get("number", [])],
-            expected_steps=[int(value) for value in payload.get("step", [])],
-            expected_variables=_as_strings(payload.get("param", [])),
+            expected_steps=[
+                int(value)
+                for value in payload.get("leadtime_hour", payload.get("step", []))
+            ],
+            expected_variables=_as_strings(
+                payload.get("variable", payload.get("param", []))
+            ),
         )
         self.state_store.write(measurement)
         return measurement
@@ -117,11 +135,34 @@ class EcdsRequest:
         measurement.status = str(
             response_body.get("status") or response_body.get("state")
         ).lower()
-        if measurement.status in TERMINAL_FAILURES:
-            measurement.errors.append(json.dumps(response_body, sort_keys=True))
         result_url = _result_url(response_body)
+        results_url = _related_url(response_body, "results")
+        if measurement.status in TERMINAL_FAILURES:
+            error_body = response_body
+            if results_url is not None:
+                error_body = self.session.get(results_url, timeout=60).json()
+            measurement.errors.append(json.dumps(error_body, sort_keys=True))
+        elif (
+            measurement.status == "successful"
+            and result_url is None
+            and results_url is not None
+        ):
+            results_response = self.session.get(results_url, timeout=60)
+            results_response.raise_for_status()
+            result_url = _result_url(results_response.json())
+        measurement.queue_seconds = _duration_seconds(
+            response_body.get("created"), response_body.get("started")
+        )
+        measurement.server_processing_seconds = _duration_seconds(
+            response_body.get("started"), response_body.get("finished")
+        )
         if result_url is not None:
-            measurement.completed_at = utc_now()
+            finished_at = response_body.get("finished")
+            measurement.completed_at = (
+                _utc_datetime(finished_at).isoformat()
+                if isinstance(finished_at, str)
+                else utc_now()
+            )
             measurement.result_url = result_url
         self.state_store.write(measurement)
         return measurement, result_url
@@ -188,6 +229,18 @@ def _as_strings(value: object) -> list[str]:
     return []
 
 
+def _read_cdsapi_config() -> dict[str, str]:
+    config_path = Path(os.environ.get("CDSAPI_RC", Path.home() / ".cdsapirc"))
+    if not config_path.exists():
+        return {}
+    config: dict[str, str] = {}
+    for line in config_path.read_text().splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip() in {"url", "key"}:
+            config[key.strip()] = value.strip()
+    return config
+
+
 def _execution_url(api_endpoint: str) -> str:
     if api_endpoint.rstrip("/").endswith("/execution"):
         return api_endpoint.rstrip("/")
@@ -199,10 +252,38 @@ def _result_url(response_body: Mapping[str, Any]) -> str | None:
         value = response_body.get(key)
         if isinstance(value, str):
             return value
-    result = response_body.get("result")
-    if isinstance(result, Mapping):
-        return _result_url(result)
+    for key in ("result", "asset", "value"):
+        nested = response_body.get(key)
+        if isinstance(nested, Mapping):
+            result_url = _result_url(nested)
+            if result_url is not None:
+                return result_url
     return None
+
+
+def _related_url(response_body: Mapping[str, Any], relation: str) -> str | None:
+    links = response_body.get("links")
+    if not isinstance(links, Sequence):
+        return None
+    for link in links:
+        if isinstance(link, Mapping) and link.get("rel") == relation:
+            href = link.get("href")
+            if isinstance(href, str):
+                return href
+    return None
+
+
+def _duration_seconds(start: object, end: object) -> float | None:
+    if not isinstance(start, str) or not isinstance(end, str):
+        return None
+    return (_utc_datetime(end) - _utc_datetime(start)).total_seconds()
+
+
+def _utc_datetime(value: str) -> datetime:
+    timestamp = datetime.fromisoformat(value)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    return timestamp.astimezone(UTC)
 
 
 def _count_grib_messages(path: Path) -> int:
@@ -219,7 +300,7 @@ def _validate_grib_container(path: Path) -> None:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--state", type=Path, required=True)
-    parser.add_argument("--api-url", default=DEFAULT_API_URL)
+    parser.add_argument("--api-url")
     subparsers = parser.add_subparsers(dest="command", required=True)
     submit = subparsers.add_parser("submit")
     submit.add_argument("--payload", type=Path, required=True)

--- a/tests/scripts/ecmwf_extended_range_spike_test.py
+++ b/tests/scripts/ecmwf_extended_range_spike_test.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
+import requests
 import xarray as xr
 
 from scripts.ecmwf_extended_range_spike import (
@@ -28,23 +29,46 @@ def test_request_state_can_resume_in_another_process(
     monkeypatch.setenv("ECDS_API_KEY", "test-key")
     session = Mock()
     session.headers = {}
-    session.post.return_value = response({"jobID": "job-1", "location": "status"})
+    submit_response = response({"jobID": "job-1"})
+    submit_response.headers = {"Location": "status"}
+    session.post.return_value = submit_response
     state_store = StateStore(tmp_path / "state.json")
     request = EcdsRequest(state_store, session=session)
 
-    request.submit({"number": [0, 1], "step": [24], "param": ["2t"]})
+    request.submit(
+        {
+            "number": [0, 1],
+            "leadtime_hour": ["024"],
+            "variable": ["10_m_u_component_of_wind"],
+        }
+    )
 
     resumed_session = Mock()
     resumed_session.headers = {}
-    resumed_session.get.return_value = response(
-        {"status": "successful", "result": {"href": "result"}}
-    )
+    resumed_session.get.side_effect = [
+        response(
+            {
+                "status": "successful",
+                "created": "2026-07-28T17:46:07",
+                "started": "2026-07-28T17:47:07",
+                "finished": "2026-07-28T17:48:07",
+                "links": [{"rel": "results", "href": "results"}],
+            }
+        ),
+        response({"asset": {"value": {"href": "result"}}}),
+    ]
     resumed = EcdsRequest(state_store, session=resumed_session)
     measurement, result_url = resumed.poll_once()
     assert measurement.request_id == "job-1"
     assert measurement.expected_members == [0, 1]
+    assert measurement.expected_steps == [24]
+    assert measurement.expected_variables == ["10_m_u_component_of_wind"]
+    assert measurement.queue_seconds == 60
+    assert measurement.server_processing_seconds == 60
+    assert measurement.completed_at == "2026-07-28T17:48:07+00:00"
     assert result_url == "result"
     assert state_store.read().result_url == "result"
+    assert resumed_session.get.call_args_list[1].args == ("results",)
 
 
 def test_configures_endpoint_and_basic_credentials_from_environment(
@@ -60,11 +84,57 @@ def test_configures_endpoint_and_basic_credentials_from_environment(
     assert request.session.auth == ("user", "key")
 
 
+def test_configures_endpoint_and_token_from_cdsapirc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / ".cdsapirc"
+    config_path.write_text(
+        "url: https://example.test/api\nkey: personal-access-token\n"
+    )
+    monkeypatch.setenv("CDSAPI_RC", str(config_path))
+    monkeypatch.delenv("ECDS_API_ENDPOINT", raising=False)
+    monkeypatch.delenv("ECDS_API_KEY", raising=False)
+    request = EcdsRequest(StateStore(tmp_path / "state.json"))
+
+    assert request.api_url == (
+        "https://example.test/api/retrieve/v1/processes/s2s-forecasts/execution"
+    )
+    assert request.session.headers["PRIVATE-TOKEN"] == "personal-access-token"
+    assert "Authorization" not in request.session.headers
+
+
 def test_state_writes_machine_readable_measurements_atomically(tmp_path: Path) -> None:
     state_store = StateStore(tmp_path / "measurement.json")
     state_store.write(RequestMeasurement("id", {"date": "2026-07-24"}, "now", "status"))
     assert json.loads(state_store.path.read_text())["request_id"] == "id"
     assert not state_store.path.with_suffix(".json.tmp").exists()
+
+
+def test_failed_poll_records_results_error(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(RequestMeasurement("id", {}, "now", "status"))
+    failure: dict[str, object] = {
+        "status": 400,
+        "title": "The job has failed",
+        "traceback": "failure detail",
+    }
+    session = Mock()
+    session.headers = {}
+    session.auth = ("user", "key")
+    session.get.side_effect = [
+        response(
+            {
+                "status": "failed",
+                "links": [{"rel": "results", "href": "results"}],
+            }
+        ),
+        response(failure, status_code=400),
+    ]
+
+    measurement, result_url = EcdsRequest(state_store, session=session).poll_once()
+
+    assert result_url is None
+    assert measurement.errors == [json.dumps(failure, sort_keys=True)]
 
 
 def test_download_uses_result_url_saved_by_poll(tmp_path: Path) -> None:
@@ -88,6 +158,48 @@ def test_download_uses_result_url_saved_by_poll(tmp_path: Path) -> None:
     assert measurement.downloaded_bytes == len(b"GRIBcontents7777")
     assert measurement.grib_messages == 1
     assert (tmp_path / "result.grib.complete").exists()
+
+
+def test_download_resumes_partial_file_after_http_206(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(
+        RequestMeasurement("id", {}, "now", "status", result_url="result")
+    )
+    target = tmp_path / "result.grib"
+    target.with_suffix(".grib.partial").write_bytes(b"GRIB")
+    download_response = response({}, status_code=requests.codes.partial)
+    download_response.iter_content.return_value = [b"contents7777"]
+    session = Mock()
+    session.headers = {}
+    session.auth = ("user", "key")
+    session.get.return_value = download_response
+
+    measurement = EcdsRequest(state_store, session=session).download(target)
+
+    assert target.read_bytes() == b"GRIBcontents7777"
+    assert measurement.interrupted_download_resumable
+    assert session.get.call_args.kwargs["headers"] == {"Range": "bytes=4-"}
+
+
+def test_download_restarts_partial_file_after_http_200(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "measurement.json")
+    state_store.write(
+        RequestMeasurement("id", {}, "now", "status", result_url="result")
+    )
+    target = tmp_path / "result.grib"
+    target.with_suffix(".grib.partial").write_bytes(b"incomplete")
+    download_response = response({})
+    download_response.iter_content.return_value = [b"GRIBcontents7777"]
+    session = Mock()
+    session.headers = {}
+    session.auth = ("user", "key")
+    session.get.return_value = download_response
+
+    measurement = EcdsRequest(state_store, session=session).download(target)
+
+    assert target.read_bytes() == b"GRIBcontents7777"
+    assert not measurement.interrupted_download_resumable
+    assert session.get.call_args.kwargs["headers"] == {"Range": "bytes=10-"}
 
 
 def test_complete_initialization_can_be_written_and_queried(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- read standard `.cdsapirc` credentials while preserving environment overrides
- use ECDS `PRIVATE-TOKEN` authentication for personal access tokens and retain legacy basic authentication
- follow the live ECDS status → results → signed asset response schema
- persist result URLs, UTC-aware completion timestamps, queue time, server processing time, and real failure details
- derive expected request inventory from the ECDS payload field names
- cover result persistence, `.cdsapirc`, failed-job detail, HTTP 206 resume, and HTTP 200 restart behavior
- record the authenticated smoke-test observations in the spike report and measurement artifact

## Why

The original spike client was based on an assumed transport contract. Live ECDS requests showed that personal access tokens use `PRIVATE-TOKEN`, successful jobs expose a `results` relation whose nested asset contains the download URL, and failed-job details are returned by that results endpoint. Without these changes, submission or completed-result discovery failed even with valid credentials.

## Acceptance plan

- [ ] Define catalogue-valid surface and pressure payloads without storing credentials or signed URLs.
- [ ] Complete at least ten representative request shards across recent, intermediate, and archive-start dates.
- [ ] Exercise all-member retrieval, one-shot polling, terminal failures, and interrupted download recovery.
- [ ] Validate each downloaded GRIB against its exact expected variable, member, level, and lead-time inventory.
- [ ] Transform at least one real complete initialization into a development Zarr and validate coordinates, metadata, and sample values.
- [ ] Record queue time, processing time, bytes, message counts, transformation time, and unresolved source limitations.
- [ ] Run focused tests, Ruff, ty, and the full test suite.
- [ ] Update this description with the measured verdict and a brief retro.

Execution will reuse the repository's ECMWF GRIB and materialized Zarr patterns, expand from small representative shards only after their contracts pass, persist one-shot request state under ignored `data/ecmwf-er/`, and commit only redacted measurements.

## Validation so far

- live `s2s-forecasts` control request for `10_m_u_component_of_wind`: 174,786-byte GRIB, 3 messages
- live HTTP Range recovery from an 87,393-byte partial file completed successfully
- `uv run pytest tests/scripts/ecmwf_extended_range_spike_test.py`: 9 passed
- `uv run ruff format --check`: passed
- `uv run ruff check`: passed
- `uv run ty check --output-format concise`: passed
- `uv run pytest`: 1,925 passed, 10 skipped, with the same five pre-existing failures as the base branch (three HRRR GeoTransform precision assertions and two NASA SMAP template metadata assertions)

The official `2m_temperature` request shape reached ECDS but failed in backend parameter mapping because the name resolved ambiguously; the failed request ID and redacted classification are recorded in the spike artifacts.