### PR TITLE
Activate HRRR 18-hour virtual operations

### DIFF
--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/dynamical_dataset.py
@@ -58,7 +58,6 @@ class NoaaHrrrForecast18HourVirtualDataset(
             cpu="4",
             memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
@@ -70,7 +69,6 @@ class NoaaHrrrForecast18HourVirtualDataset(
             cpu="1.5",
             memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/tests/noaa/hrrr/forecast_18_hour_virtual/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/forecast_18_hour_virtual/dynamical_dataset_test.py
@@ -186,10 +186,10 @@ def test_operational_kubernetes_resources(
     assert update_cron_job.schedule == "50 * * * *"
     assert update_cron_job.pod_active_deadline == timedelta(minutes=55)
     assert update_cron_job.cpu == "4"
-    assert update_cron_job.suspend
+    assert not update_cron_job.suspend
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert validation_cron_job.schedule == "48 * * * *"
-    assert validation_cron_job.suspend
+    assert not validation_cron_job.suspend
     assert len(update_cron_job.secret_names) > 0
 
 


### PR DESCRIPTION
## Outcome

Activated the staging-only HRRR 18-hour virtual dataset's hourly update and validation CronJobs. Both jobs use the same Sentry cron check-in path as the HRRR 48-hour virtual product.

The STAC declaration remains `staging=True`; this PR did not publish the dataset to production STAC or public status monitoring.

## Plan

- [x] Prove the updater and validator are expected to be active.
- [x] Remove the suspension flags while preserving their schedules and Sentry monitoring.
- [x] Run targeted and repository validation.
- [x] Merge after CI and wait for the operational deployment.
- [x] Backfill the stale interval outside the updater's six-hour re-sweep window.
- [x] Verify update and validation CronJobs run and check in to Sentry.
- [x] Verify staging STAC includes the dataset and production STAC excludes it.

## Validation

- Full GitHub CI passed on amd64 and arm64, including pytest, Ruff, formatting, and `ty`.
- Local focused non-slow dataset tests: 4 passed, 2 deselected.
- Both deployed CronJobs report `suspend=false` with schedules `50 * * * *` and `48 * * * *`.
- First hourly update completed successfully at 2026-07-31 19:16:37Z.
- One-worker overwrite-chunks backfill repaired `[2026-07-28T16:00Z, 2026-07-31T13:00Z)` and completed successfully.
- All 69 formerly missing positions sampled through staging have populated `temperature_2m` at lead 0; latest init is 2026-07-31 18Z.
- Scheduled and post-backfill validations passed freshness, manifest completeness, and decode health across 176 variables. The post-backfill run sent a fresh Sentry result check-in.
- Live catalogs: staging includes the dataset; production excludes it.

## Retro

Checking the updater's six-hour re-sweep window before activation prevented a current tip from masking a historical hole. The rollout needed a bounded catch-up backfill after the first operational writer completed.

The local backfill driver hardcodes `/usr/bin/kubectl`, which is not portable to this Mac. A temporary worktree-only path change was used for submission and immediately restored; that portability issue should be fixed separately.