### PR TITLE
Add wind gust to NOAA GEFS forecast and analysis

### DIFF
--- a/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/wind_gust_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/wind_gust_surface/zarr.json
@@ -1,0 +1,84 @@
+{
+  "shape": [
+    1,
+    721,
+    1440
+  ],
+  "data_type": "float32",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [
+        2880,
+        384,
+        384
+      ]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "codecs": [
+    {
+      "name": "sharding_indexed",
+      "configuration": {
+        "chunk_shape": [
+          1440,
+          32,
+          32
+        ],
+        "codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "blosc",
+            "configuration": {
+              "typesize": 4,
+              "cname": "zstd",
+              "clevel": 3,
+              "shuffle": "shuffle",
+              "blocksize": 0
+            }
+          }
+        ],
+        "index_codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "crc32c"
+          }
+        ],
+        "index_location": "end"
+      }
+    }
+  ],
+  "attributes": {
+    "long_name": "Wind speed (gust)",
+    "short_name": "gust",
+    "standard_name": "wind_speed_of_gust",
+    "units": "m s-1",
+    "step_type": "instant",
+    "coordinates": "spatial_ref",
+    "_FillValue": "AAAAAAAA+H8="
+  },
+  "dimension_names": [
+    "time",
+    "latitude",
+    "longitude"
+  ],
+  "zarr_format": 3,
+  "node_type": "array",
+  "storage_transformers": []
+}

--- a/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/zarr.json
@@ -1937,6 +1937,90 @@
         "node_type": "array",
         "storage_transformers": []
       },
+      "wind_gust_surface": {
+        "shape": [
+          1,
+          721,
+          1440
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              2880,
+              384,
+              384
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": 0.0,
+        "codecs": [
+          {
+            "name": "sharding_indexed",
+            "configuration": {
+              "chunk_shape": [
+                1440,
+                32,
+                32
+              ],
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "blosc",
+                  "configuration": {
+                    "typesize": 4,
+                    "cname": "zstd",
+                    "clevel": 3,
+                    "shuffle": "shuffle",
+                    "blocksize": 0
+                  }
+                }
+              ],
+              "index_codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "crc32c"
+                }
+              ],
+              "index_location": "end"
+            }
+          }
+        ],
+        "attributes": {
+          "long_name": "Wind speed (gust)",
+          "short_name": "gust",
+          "standard_name": "wind_speed_of_gust",
+          "units": "m s-1",
+          "step_type": "instant",
+          "coordinates": "spatial_ref",
+          "_FillValue": "AAAAAAAA+H8="
+        },
+        "dimension_names": [
+          "time",
+          "latitude",
+          "longitude"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
       "wind_u_100m": {
         "shape": [
           1,

--- a/src/reformatters/noaa/gefs/common_gefs_template_config.py
+++ b/src/reformatters/noaa/gefs/common_gefs_template_config.py
@@ -125,6 +125,25 @@ def get_shared_data_var_configs(
 
     return (
         GEFSDataVar(
+            name="wind_gust_surface",
+            encoding=encoding_float32,
+            attrs=DataVarAttrs(
+                short_name="gust",
+                long_name="Wind speed (gust)",
+                units="m s-1",
+                step_type="instant",
+                standard_name="wind_speed_of_gust",
+            ),
+            internal_attrs=GEFSInternalAttrs(
+                grib_element="GUST",
+                grib_description='0[-] SFC="Ground or water surface"',
+                grib_index_level="surface",
+                gefs_file_type="s+b",
+                index_position=2,
+                keep_mantissa_bits=6,
+            ),
+        ),
+        GEFSDataVar(
             name="pressure_surface",
             encoding=encoding_float32,
             attrs=DataVarAttrs(

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/wind_gust_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/wind_gust_surface/zarr.json
@@ -1,0 +1,58 @@
+{
+  "shape": [
+    1,
+    31,
+    81,
+    721,
+    1440
+  ],
+  "data_type": "float64",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [
+        1,
+        1,
+        1,
+        721,
+        1440
+      ]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": "NaN",
+  "codecs": [
+    {
+      "name": "gribberish",
+      "configuration": {
+        "var": "GUST",
+        "adjust_longitude_range": true,
+        "north_up": true
+      }
+    }
+  ],
+  "attributes": {
+    "long_name": "Wind speed (gust)",
+    "short_name": "gust",
+    "standard_name": "wind_speed_of_gust",
+    "units": "m s-1",
+    "step_type": "instant",
+    "coordinates": "expected_forecast_length spatial_ref valid_time",
+    "_FillValue": "AAAAAAAA+H8="
+  },
+  "dimension_names": [
+    "init_time",
+    "ensemble_member",
+    "lead_time",
+    "latitude",
+    "longitude"
+  ],
+  "zarr_format": 3,
+  "node_type": "array",
+  "storage_transformers": []
+}

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/zarr.json
@@ -1464,6 +1464,64 @@
         "node_type": "array",
         "storage_transformers": []
       },
+      "wind_gust_surface": {
+        "shape": [
+          1,
+          31,
+          81,
+          721,
+          1440
+        ],
+        "data_type": "float64",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              1,
+              1,
+              1,
+              721,
+              1440
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+            "name": "gribberish",
+            "configuration": {
+              "var": "GUST",
+              "adjust_longitude_range": true,
+              "north_up": true
+            }
+          }
+        ],
+        "attributes": {
+          "long_name": "Wind speed (gust)",
+          "short_name": "gust",
+          "standard_name": "wind_speed_of_gust",
+          "units": "m s-1",
+          "step_type": "instant",
+          "coordinates": "expected_forecast_length spatial_ref valid_time",
+          "_FillValue": "AAAAAAAA+H8="
+        },
+        "dimension_names": [
+          "init_time",
+          "ensemble_member",
+          "lead_time",
+          "latitude",
+          "longitude"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
       "wind_u_10m": {
         "shape": [
           1,

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/wind_gust_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/wind_gust_surface/zarr.json
@@ -1,0 +1,92 @@
+{
+  "shape": [
+    1,
+    31,
+    181,
+    721,
+    1440
+  ],
+  "data_type": "float32",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [
+        1,
+        31,
+        192,
+        374,
+        368
+      ]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "codecs": [
+    {
+      "name": "sharding_indexed",
+      "configuration": {
+        "chunk_shape": [
+          1,
+          31,
+          64,
+          17,
+          16
+        ],
+        "codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "blosc",
+            "configuration": {
+              "typesize": 4,
+              "cname": "zstd",
+              "clevel": 3,
+              "shuffle": "shuffle",
+              "blocksize": 0
+            }
+          }
+        ],
+        "index_codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          },
+          {
+            "name": "crc32c"
+          }
+        ],
+        "index_location": "end"
+      }
+    }
+  ],
+  "attributes": {
+    "long_name": "Wind speed (gust)",
+    "short_name": "gust",
+    "standard_name": "wind_speed_of_gust",
+    "units": "m s-1",
+    "step_type": "instant",
+    "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
+    "_FillValue": "AAAAAAAA+H8="
+  },
+  "dimension_names": [
+    "init_time",
+    "ensemble_member",
+    "lead_time",
+    "latitude",
+    "longitude"
+  ],
+  "zarr_format": 3,
+  "node_type": "array",
+  "storage_transformers": []
+}

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
@@ -2376,6 +2376,98 @@
         "node_type": "array",
         "storage_transformers": []
       },
+      "wind_gust_surface": {
+        "shape": [
+          1,
+          31,
+          181,
+          721,
+          1440
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              1,
+              31,
+              192,
+              374,
+              368
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": 0.0,
+        "codecs": [
+          {
+            "name": "sharding_indexed",
+            "configuration": {
+              "chunk_shape": [
+                1,
+                31,
+                64,
+                17,
+                16
+              ],
+              "codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "blosc",
+                  "configuration": {
+                    "typesize": 4,
+                    "cname": "zstd",
+                    "clevel": 3,
+                    "shuffle": "shuffle",
+                    "blocksize": 0
+                  }
+                }
+              ],
+              "index_codecs": [
+                {
+                  "name": "bytes",
+                  "configuration": {
+                    "endian": "little"
+                  }
+                },
+                {
+                  "name": "crc32c"
+                }
+              ],
+              "index_location": "end"
+            }
+          }
+        ],
+        "attributes": {
+          "long_name": "Wind speed (gust)",
+          "short_name": "gust",
+          "standard_name": "wind_speed_of_gust",
+          "units": "m s-1",
+          "step_type": "instant",
+          "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
+          "_FillValue": "AAAAAAAA+H8="
+        },
+        "dimension_names": [
+          "init_time",
+          "ensemble_member",
+          "lead_time",
+          "latitude",
+          "longitude"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
       "wind_u_100m": {
         "shape": [
           1,

--- a/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/region_job_test.py
@@ -420,7 +420,7 @@ def test_real_source_all_vars_resolve_and_decode(template_ds: xr.DataTree) -> No
     key = coord.get_url().removeprefix("s3://noaa-gefs-pds/")
     refs = job.file_refs(coord, file_size)
 
-    assert len(refs) == 19
+    assert len(refs) == 20
     for ref in refs:
         assert 0 <= ref.offset < file_size
         assert 0 < ref.length

--- a/tests/noaa/gefs/forecast_10_day_spatial/template_config_test.py
+++ b/tests/noaa/gefs/forecast_10_day_spatial/template_config_test.py
@@ -98,13 +98,21 @@ def test_dimension_coordinates_native_quarter_degree_grid() -> None:
 
 def test_data_vars_are_s_file_vars_with_virtual_encoding() -> None:
     data_vars = TEMPLATE_CONFIG.data_vars
-    # The 35-day forecast's vars minus the three only available in the 0.5
-    # degree a/b files (geopotential_height_500hpa, wind_u_100m, wind_v_100m).
-    assert len(data_vars) == 19
+    # Every shared GEFS variable except those only available in the 0.5 degree
+    # a/b files, which can't share this dataset's 0.25 degree grid.
+    assert len(data_vars) == 20
     var_names = {v.name for v in data_vars}
     assert "temperature_2m" in var_names
     assert var_names.isdisjoint(
-        {"geopotential_height_500hpa", "wind_u_100m", "wind_v_100m"}
+        {
+            "geopotential_height_500hpa",
+            "pressure_80m",
+            "temperature_80m",
+            "wind_u_100m",
+            "wind_u_80m",
+            "wind_v_100m",
+            "wind_v_80m",
+        }
     )
 
     for var in data_vars:


### PR DESCRIPTION
Customer request: dynamical-org/feedback-at-dynamical.org#29 (needs surface variables from GEFS and IFS ENS out to 7–10 days).

Adds `wind_gust_surface` to `noaa-gefs-forecast-35-day` and `noaa-gefs-analysis`.

## Source data

GUST is a **surface**-level GRIB message (`GRIB_SHORT_NAME=0-SFC`, `GRIB_UNIT=[m/s]`), so this matches the existing HRRR `wind_gust_surface` name and attrs exactly, not the 10 m ECMWF `wind_gust_10m` (a different parameter: `10fg`, `step_type="max"`).

`gefs_file_type="s+b"`, verified against real index files and GRIB messages in every era:

| Era | File | Verified |
| --- | --- | --- |
| Current archive, lead ≤ 240 h | `s` 0.25° | present at every init sampled back to 2020-10-01, including `f000` (`anl`) — **no b22 transition**, so `s+b` not `s+b-b22` |
| Current archive, lead > 240 h | `b` 0.5° | present at f246, f384, f840 |
| Pre-v12 (2020-01-01 → 2020-09-23) | `b` | present at `f00`/`anl` and `f06` |
| v12 reforecast (2000 → 2019) | `gust_sfc_*.grib2` | present for 2000 and 2017, both `Days:1-10` and `Days:10-16` |

All eras share `grib_description = '0[-] SFC="Ground or water surface"'` and `GRIB_ELEMENT=GUST`, so no `grib_element_alternatives` or `available_from` gate is needed. `index_position=2` (its position in the `s` file). `keep_mantissa_bits=6` per the wind convention in AGENTS.md, matching HRRR.

## Verification

Per `docs/add_new_variable.md` step 1d, the variable was temporarily added to both `test_backfill_local_and_operational_update` tests and to a throwaway script covering the read paths those tests don't reach. All temporary changes have been reverted.

| Path | Result |
| --- | --- |
| 35-day test, current-era `s`, lead 0 + 3 h | 0.018–38.0 m/s, mean 8.60, 0 nulls |
| Analysis test, reforecast era (2000-01-01) | 0.124–10.4 m/s, mean 3.56, 0 nulls (tropical subset) |
| Current-era `b`, f246 / f840 | 0.0–49.4 / 0.094–45.3 m/s, 0 NaN |
| Pre-v12 `b`, `anl` / f06 | 0.10–37.3 / 0.10–35.7 m/s, 0 NaN |

The `b`-file cases exercise the 0.5° → 0.25° bilinear reprojection, including the non-prod assert that source values are retained exactly at aligned pixels.

`ruff format`, `ruff check`, `ty check` clean. Full suite: 1771 passed. Two failures in `tests/scripts/validation/` are a pre-existing local Qt/matplotlib SIGABRT — confirmed identical on clean `main`.

## Scope

`get_shared_data_var_configs` is shared by all three GEFS datasets, and `s+b` passes the 10-day-spatial file-type filter, so `noaa-gefs-forecast-10-day-spatial-dev` gains gust too. That's intentional: it's a dev dataset slated for removal and not in the prod STAC, so excluding it would only add a stale-prone name filter. Its virtual encoding resolves correctly — one chunk per GRIB message, `gribberish` serializer with `var: GUST`, and no raw-value attrs override needed since gust isn't transformed by the materialized pipeline. `test_real_source_all_vars_resolve_and_decode` confirms the ref resolves against a real 2024 index.

Backfill scope is still just the two prod datasets.

Two hardcoded variable counts in the 10-day-spatial tests needed updating (19 -> 20). One of them listed the a/b-file variables absent from that dataset and named three of the seven — that list went stale when #749 added the 80m variables, so this corrects it.

No `dataset_version` bump — consistent with #749 and #490, which also added variables without one.

## Next

Template metadata only. Once merged, per `docs/dataset_development_guide.md`:

1. `overwrite-chunks-and-metadata` backfill filtered to `wind_gust_surface` for `noaa-gefs-forecast-35-day` and `noaa-gefs-analysis` (see `docs/backfill.md`)
2. Validate and publish
3. Reply to the customer on the feedback issue

The analysis backfill spans 2000 → present at 3-hourly and is the larger of the two.

