### PR TITLE
Consolidate not-found exception handling into shared utility

### DIFF
--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -372,14 +372,18 @@ def http_status_code(e: Exception) -> int | None:
 
 
 # obstore raises PermissionDeniedError for a 403 and GenericError for everything it doesn't
-# map to a specific type, including the 416 Range Not Satisfiable returned for a zero size
-# object and AWS's 503 Slow Down.
-NOT_FOUND_EXCEPTIONS = (FileNotFoundError, GenericError, PermissionDeniedError)
+# map to a specific type, including both missing data and retry-exhausted transient errors.
+FALLBACK_EXCEPTIONS = (FileNotFoundError, GenericError, PermissionDeniedError)
+
+# A range request against a zero size object gets a 416 whose body reports the object's real
+# size. A 416 against a non-empty object means we asked for the wrong bytes, which is a bug.
+_EMPTY_OBJECT_RANGE_ERROR = "<ActualObjectSize>0</ActualObjectSize>"
 
 
 def is_not_found(e: Exception) -> bool:
-    """Whether e indicates the source file isn't available, as opposed to an unexpected failure."""
-    return isinstance(e, NOT_FOUND_EXCEPTIONS) or http_status_code(e) in (
-        HTTPStatus.FORBIDDEN,
-        HTTPStatus.NOT_FOUND,
-    )
+    """Whether e indicates the source file has no data, as opposed to an unexpected failure."""
+    if isinstance(e, FileNotFoundError | PermissionDeniedError):
+        return True
+    if isinstance(e, GenericError):
+        return _EMPTY_OBJECT_RANGE_ERROR in str(e)
+    return http_status_code(e) in (HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -7,6 +7,7 @@ import time
 import uuid
 from collections.abc import Sequence
 from datetime import timedelta
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -15,6 +16,7 @@ import httpx
 import numpy as np
 import obstore
 import requests
+from obstore.exceptions import GenericError, PermissionDeniedError
 
 from reformatters.common.logging import get_logger
 
@@ -367,3 +369,17 @@ def http_status_code(e: Exception) -> int | None:
     if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
         return e.response.status_code
     return None
+
+
+# obstore raises PermissionDeniedError for a 403 and GenericError for everything it doesn't
+# map to a specific type, including the 416 Range Not Satisfiable returned for a zero size
+# object and AWS's 503 Slow Down.
+NOT_FOUND_EXCEPTIONS = (FileNotFoundError, GenericError, PermissionDeniedError)
+
+
+def is_not_found(e: Exception) -> bool:
+    """Whether e indicates the source file isn't available, as opposed to an unexpected failure."""
+    return isinstance(e, NOT_FOUND_EXCEPTIONS) or http_status_code(e) in (
+        HTTPStatus.FORBIDDEN,
+        HTTPStatus.NOT_FOUND,
+    )

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import suppress
 from copy import deepcopy
-from http import HTTPStatus
 from multiprocessing.shared_memory import SharedMemory
 from pathlib import Path
 from typing import Any, ClassVar, Generic, cast
@@ -16,7 +15,7 @@ from zarr.abc.store import Store
 
 from reformatters.common import storage, template_utils
 from reformatters.common.binary_rounding import round_float32_inplace
-from reformatters.common.download import http_status_code
+from reformatters.common.download import is_not_found
 from reformatters.common.iterating import split_groups
 from reformatters.common.logging import get_logger
 from reformatters.common.pydantic import replace
@@ -310,11 +309,8 @@ class MaterializedRegionJob(
                 # else, log exception so it is caught by error reporting but doesn't stop processing
                 append_dim_coord = coord.append_dim_coord
                 two_days_ago = pd.Timestamp.now() - pd.Timedelta(hours=48)
-                is_not_found = isinstance(e, FileNotFoundError) or (
-                    http_status_code(e) in (HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)
-                )
                 if (
-                    is_not_found
+                    is_not_found(e)
                     and isinstance(append_dim_coord, np.datetime64 | pd.Timestamp)
                     and append_dim_coord > two_days_ago
                 ):

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
@@ -10,7 +10,7 @@ from rasterio.io import MemoryFile
 from zarr.abc.store import Store
 
 from reformatters.common.deaccumulation import deaccumulate_to_rates_inplace
-from reformatters.common.download import NOT_FOUND_EXCEPTIONS, http_download_to_disk
+from reformatters.common.download import FALLBACK_EXCEPTIONS, http_download_to_disk
 from reformatters.common.iterating import item
 from reformatters.common.logging import get_logger
 from reformatters.common.materialized_region_job import MaterializedRegionJob
@@ -137,7 +137,7 @@ class DwdIconEuForecast5DayRegionJob(
         url = coord.get_url()
         try:
             bz2_file_path = http_download_to_disk(url, self.dataset_id)
-        except NOT_FOUND_EXCEPTIONS as e:
+        except FALLBACK_EXCEPTIONS as e:
             log.debug(f"Failed to download '{url}': {e}")
             fallback_url = coord.get_fallback_url()
             log.debug(f"Attempting to download from {fallback_url=}")

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/region_job.py
@@ -6,12 +6,11 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import xarray as xr
-from obstore.exceptions import GenericError, PermissionDeniedError
 from rasterio.io import MemoryFile
 from zarr.abc.store import Store
 
 from reformatters.common.deaccumulation import deaccumulate_to_rates_inplace
-from reformatters.common.download import http_download_to_disk
+from reformatters.common.download import NOT_FOUND_EXCEPTIONS, http_download_to_disk
 from reformatters.common.iterating import item
 from reformatters.common.logging import get_logger
 from reformatters.common.materialized_region_job import MaterializedRegionJob
@@ -138,7 +137,7 @@ class DwdIconEuForecast5DayRegionJob(
         url = coord.get_url()
         try:
             bz2_file_path = http_download_to_disk(url, self.dataset_id)
-        except (FileNotFoundError, GenericError, PermissionDeniedError) as e:
+        except NOT_FOUND_EXCEPTIONS as e:
             log.debug(f"Failed to download '{url}': {e}")
             fallback_url = coord.get_fallback_url()
             log.debug(f"Attempting to download from {fallback_url=}")

--- a/src/reformatters/ecmwf/ecmwf_utils.py
+++ b/src/reformatters/ecmwf/ecmwf_utils.py
@@ -2,7 +2,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Literal
 
-from reformatters.common.download import NOT_FOUND_EXCEPTIONS
+from reformatters.common.download import FALLBACK_EXCEPTIONS
 from reformatters.common.logging import get_logger
 
 log = get_logger(__name__)
@@ -20,7 +20,7 @@ def ecmwf_download_with_fallback(
     for source in sources:
         try:
             return download_one(source)
-        except NOT_FOUND_EXCEPTIONS as e:
+        except FALLBACK_EXCEPTIONS as e:
             log.warning(f"ECMWF download from {source!r} failed, will fall back: {e}")
             last_exc = e
     assert last_exc is not None

--- a/src/reformatters/ecmwf/ecmwf_utils.py
+++ b/src/reformatters/ecmwf/ecmwf_utils.py
@@ -2,17 +2,12 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Literal
 
-from obstore.exceptions import GenericError, PermissionDeniedError
-
+from reformatters.common.download import NOT_FOUND_EXCEPTIONS
 from reformatters.common.logging import get_logger
 
 log = get_logger(__name__)
 
 type EcmwfOpenDataSource = Literal["s3", "gcs"]
-
-# Triggers fallback to the next source: missing files, AWS 503 Slow Down translated
-# by obstore to GenericError, and AWS 403s which obstore raises as PermissionDeniedError.
-_FALLBACK_EXCEPTIONS = (FileNotFoundError, GenericError, PermissionDeniedError)
 
 
 def ecmwf_download_with_fallback(
@@ -25,7 +20,7 @@ def ecmwf_download_with_fallback(
     for source in sources:
         try:
             return download_one(source)
-        except _FALLBACK_EXCEPTIONS as e:
+        except NOT_FOUND_EXCEPTIONS as e:
             log.warning(f"ECMWF download from {source!r} failed, will fall back: {e}")
             last_exc = e
     assert last_exc is not None

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 import requests
 import xarray as xr
+from obstore.exceptions import GenericError, PermissionDeniedError
 
 from reformatters.common import template_utils, validation
 from reformatters.common.config_models import (
@@ -1284,6 +1285,36 @@ class TestDownloadErrorLogging:
         job = self._make_job(pd.Timestamp.now() - pd.Timedelta(days=5))
         levels = self._download_and_get_log_levels(
             job, _make_requests_http_error(404), monkeypatch, caplog
+        )
+        assert levels == [logging.ERROR]
+
+    def test_obstore_generic_error_recent_logs_info(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(hours=1))
+        levels = self._download_and_get_log_levels(
+            job,
+            GenericError("416 Range Not Satisfiable ... ActualObjectSize: 0"),
+            monkeypatch,
+            caplog,
+        )
+        assert levels == [logging.INFO]
+
+    def test_obstore_permission_denied_recent_logs_info(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(hours=1))
+        levels = self._download_and_get_log_levels(
+            job, PermissionDeniedError("denied"), monkeypatch, caplog
+        )
+        assert levels == [logging.INFO]
+
+    def test_obstore_generic_error_old_logs_exception(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(days=5))
+        levels = self._download_and_get_log_levels(
+            job, GenericError("416 Range Not Satisfiable"), monkeypatch, caplog
         )
         assert levels == [logging.ERROR]
 

--- a/tests/common/region_job_test.py
+++ b/tests/common/region_job_test.py
@@ -1154,6 +1154,14 @@ def _make_requests_http_error(status_code: int) -> requests.exceptions.HTTPError
     )
 
 
+def _make_empty_object_range_error() -> GenericError:
+    return GenericError(
+        "Generic HTTP error: Server returned non-2xx status code:"
+        " 416 Range Not Satisfiable: <Error><Code>InvalidRange</Code>"
+        "<ActualObjectSize>0</ActualObjectSize></Error>"
+    )
+
+
 class TestDownloadErrorLogging:
     """Test that download errors for recent files use quiet logging for expected errors."""
 
@@ -1288,15 +1296,12 @@ class TestDownloadErrorLogging:
         )
         assert levels == [logging.ERROR]
 
-    def test_obstore_generic_error_recent_logs_info(
+    def test_obstore_empty_object_range_recent_logs_info(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
         job = self._make_job(pd.Timestamp.now() - pd.Timedelta(hours=1))
         levels = self._download_and_get_log_levels(
-            job,
-            GenericError("416 Range Not Satisfiable ... ActualObjectSize: 0"),
-            monkeypatch,
-            caplog,
+            job, _make_empty_object_range_error(), monkeypatch, caplog
         )
         assert levels == [logging.INFO]
 
@@ -1309,12 +1314,24 @@ class TestDownloadErrorLogging:
         )
         assert levels == [logging.INFO]
 
-    def test_obstore_generic_error_old_logs_exception(
+    def test_obstore_empty_object_range_old_logs_exception(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
         job = self._make_job(pd.Timestamp.now() - pd.Timedelta(days=5))
         levels = self._download_and_get_log_levels(
-            job, GenericError("416 Range Not Satisfiable"), monkeypatch, caplog
+            job, _make_empty_object_range_error(), monkeypatch, caplog
+        )
+        assert levels == [logging.ERROR]
+
+    def test_obstore_other_generic_error_recent_logs_exception(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        job = self._make_job(pd.Timestamp.now() - pd.Timedelta(hours=1))
+        levels = self._download_and_get_log_levels(
+            job,
+            GenericError("Server returned non-2xx status code: 503 Slow Down"),
+            monkeypatch,
+            caplog,
         )
         assert levels == [logging.ERROR]
 

--- a/tests/common/test_download.py
+++ b/tests/common/test_download.py
@@ -6,6 +6,7 @@ import httpx
 import obstore.store
 import pytest
 import requests
+from obstore.exceptions import GenericError, PermissionDeniedError
 
 from reformatters.common import download as download_module
 from reformatters.common.download import (
@@ -18,6 +19,7 @@ from reformatters.common.download import (
     http_status_code,
     http_store,
     httpx_download_to_disk,
+    is_not_found,
     s3_download_to_disk,
     s3_store,
 )
@@ -53,6 +55,35 @@ def test_http_status_code_requests_without_response() -> None:
 
 def test_http_status_code_other_exception() -> None:
     assert http_status_code(FileNotFoundError("missing")) is None
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        FileNotFoundError("missing"),
+        GenericError("416 Range Not Satisfiable ... ActualObjectSize: 0"),
+        PermissionDeniedError("denied"),
+        _httpx_error(404),
+        _httpx_error(403),
+        _requests_error(404),
+        _requests_error(403),
+    ],
+)
+def test_is_not_found_true(exception: Exception) -> None:
+    assert is_not_found(exception)
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        ValueError("bad value"),
+        _httpx_error(500),
+        _requests_error(500),
+        requests.exceptions.HTTPError("no response"),
+    ],
+)
+def test_is_not_found_false(exception: Exception) -> None:
+    assert not is_not_found(exception)
 
 
 def test_get_local_path_basic() -> None:

--- a/tests/common/test_download.py
+++ b/tests/common/test_download.py
@@ -57,12 +57,24 @@ def test_http_status_code_other_exception() -> None:
     assert http_status_code(FileNotFoundError("missing")) is None
 
 
+def _obstore_invalid_range_error(actual_object_size: int) -> GenericError:
+    return GenericError(
+        "Generic HTTP error: Error performing GET https://example.com/file in 67.980838ms"
+        " - Server returned non-2xx status code: 416 Range Not Satisfiable:"
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<Error><Code>InvalidRange</Code>"
+        "<Message>The requested range is not satisfiable</Message>"
+        "<RangeRequested>bytes=6990081-7165729</RangeRequested>"
+        f"<ActualObjectSize>{actual_object_size}</ActualObjectSize></Error>"
+    )
+
+
 @pytest.mark.parametrize(
     "exception",
     [
         FileNotFoundError("missing"),
-        GenericError("416 Range Not Satisfiable ... ActualObjectSize: 0"),
         PermissionDeniedError("denied"),
+        _obstore_invalid_range_error(actual_object_size=0),
         _httpx_error(404),
         _httpx_error(403),
         _requests_error(404),
@@ -80,6 +92,9 @@ def test_is_not_found_true(exception: Exception) -> None:
         _httpx_error(500),
         _requests_error(500),
         requests.exceptions.HTTPError("no response"),
+        # A byte range past the end of a non-empty object is our bug, not missing data
+        _obstore_invalid_range_error(actual_object_size=7165728),
+        GenericError("Server returned non-2xx status code: 503 Slow Down"),
     ],
 )
 def test_is_not_found_false(exception: Exception) -> None:


### PR DESCRIPTION
## Summary

Fixes #846.

The shared "is this an expected missing file" check in `_call_download_file` only recognized `FileNotFoundError` and status codes surfaced via `http_status_code()` (httpx/requests only). A 416 Range Not Satisfiable against a zero-size GEFS object comes back from obstore as `GenericError`, so `is_not_found` was always `False` for it and every occurrence fell through to `log.exception` and shipped to Sentry, regardless of the source file's age.

Widens the shared classifier rather than adding a GEFS-only workaround, and consolidates the three copies of the obstore exception tuple that had accumulated.

## Key changes

- **`is_not_found()` in `common/download.py`** is now the single source of truth for whether a download failure means the source file has no data:
  - `FileNotFoundError` and `PermissionDeniedError` (obstore's 403) → not found
  - `GenericError` → not found only when the body reports `<ActualObjectSize>0</ActualObjectSize>`
  - httpx/requests 403 and 404 → not found
- **`FALLBACK_EXCEPTIONS`** replaces the identical tuple previously defined in both `ecmwf_utils.py` (as `_FALLBACK_EXCEPTIONS`) and `dwd/icon_eu/forecast_5_day/region_job.py`. It answers a deliberately coarser question than `is_not_found` — which failures are worth retrying against another source — so fallback-on-503 behavior at both sites is unchanged.
- **`materialized_region_job.py`** calls `is_not_found(e)` in place of its inline expression, so the empty-object 416 now logs at info for recent append-dim coords instead of reporting an error.

## Why match the response body rather than accept every `GenericError`

`GenericError` is obstore's catch-all, so treating all of them as not-found would also silence retry-exhausted 503 Slow Down errors, and would silence a 416 against a *non-empty* object — which means the byte range we derived from the GRIB index is wrong, i.e. our bug. Matching `<ActualObjectSize>0</ActualObjectSize>` keeps both of those loud.

No retry behavior changes: obstore's stores retry up to 16 times with a 5 minute timeout, and `_httpx_get_with_retry` retries `{429, 500, 502, 503, 504}`, so retries are already exhausted before `is_not_found` sees the exception. It selects a log level only — the coord is marked `DownloadFailed` either way.

Known gap: the marker is S3's XML. GCS returns a 416 with a different body, so an empty object reached through ECMWF's GCS fallback would still log at error. Left alone rather than guessing at the format.

## Testing

`ruff format`, `ruff check`, and `ty check` are clean; `pytest -m "not slow"` passes (1791 tests). New coverage, built from the real error body:

- `is_not_found` with `ActualObjectSize` of 0 (true) and non-zero (false), a 503 `GenericError` (false), plus the existing `FileNotFoundError` / `PermissionDeniedError` / 403 / 404 / 500 cases
- `TestDownloadErrorLogging` cases asserting log level for the empty-object 416 at recent and old coords, `PermissionDeniedError`, and a non-matching `GenericError`