### PR TITLE
Suspend NDVI CDR update and validate cron jobs

### DIFF
--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
@@ -20,8 +20,16 @@ class NoaaNdviCdrAnalysisDataset(
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
+        # Suspended: the data disappeared from the source. Neither NOAA access path
+        # (s3://noaa-cdr-ndvi-pds, NCEI's HTTP archive) serves files after 2024-12-31
+        # anymore, so there is nothing to update from. We've asked NOAA's data contact
+        # what happened and are waiting to hear back; resume both cron jobs once the
+        # source serves recent files again.
+        suspend = True
+
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
+            suspend=suspend,
             schedule="0 20 * * *",
             pod_active_deadline=timedelta(minutes=30),  # runs take <24 min
             image=image_tag,
@@ -34,6 +42,7 @@ class NoaaNdviCdrAnalysisDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
+            suspend=suspend,
             schedule="30 20 * * *",  # 30m (pod_active_deadline) after reformat at :00
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,


### PR DESCRIPTION
## Why

The NDVI CDR data disappeared from the source. Neither NOAA access path serves files after 2024-12-31 anymore:

- `s3://noaa-cdr-ndvi-pds` now holds **only 1981–2024**. `data/2025/` and `data/2026/` list zero keys — confirmed with a prefixed list, a `delimiter=/` prefix list (44 `CommonPrefixes`, 1981…2024), and `start-after=data/2024/zzz`. #849 verified one day earlier that the same bucket had 2025 complete (365 days) and 2026 through 08-01, so this is a change on NOAA's side, not a listing quirk.
- NCEI's HTTP archive is still broken as #849 documented: `access/` index stops at `2024/`, `access/2025/` and `access/2026/` 403, and THREDDS 500s on both years.

With nothing fetchable, `_list_source_files()` returns `[]` for every recent year, so the update has nothing to write and validation has nothing to pass on — both cron jobs only generate alerts (`REFORMATTERS-HC`).

## What

Set `suspend=True` on `noaa-ndvi-cdr-analysis-update` and `noaa-ndvi-cdr-analysis-validate`, with a comment recording that the source data vanished and that we're waiting to hear back from NOAA's data contact. Resume both once the source serves recent files again.

## Testing

`uv run pytest tests/contrib/noaa/ndvi_cdr/ tests/common/deploy_test.py` — 30 passed. `ruff format`, `ruff check`, `ty check` clean.

## Follow-up (not in this PR)

The 2026-08-05 update run also zeroed out `2025-06-13 → 2026-08-05` in the store and then trimmed the metadata back to 2025-06-12 — a separate bug in the update path's "nothing processed" trim. A guard for that is up next in its own PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Mt72de6g854HnueWN9Agw)_