### PR TITLE
Never let an operational update retract published data

### DIFF
--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -35,6 +35,12 @@ Readers must always see a consistent view — either the old data or the fully u
 
 Before any writes, worker 0 of an operational update asserts that the update template's structure still matches the already-published store — for every variable present in the store, the variable must still exist and its dims, on-disk dtype, chunks, and shards must be unchanged (`template_utils.assert_no_structural_drift_from_existing_store`). A drifted template (a removed/renamed variable or a changed dtype/dims/chunks/shards) would corrupt the existing archive or break readers, so the update fails fast and leaves the live store untouched. Changing structure requires a backfill.
 
+### Retraction guard (operational updates)
+
+`RegionJob.update_template_with_results` trims the update template to what the run actually processed, and when nothing was processed the default trims to the start of the trailing shard — inside data readers can already see. Before publishing that template, finalization asserts it is no shorter along the append dim than the published store (`template_utils.assert_no_append_dim_retraction`), so a source outage fails the update instead of dropping whole shards from the published extent. Shrinking a store on purpose requires a backfill.
+
+This guards the published extent, not the chunks: workers write their whole region before finalization runs, and a region whose source files were all missing writes fill values over whatever those chunks held (`write_shard_to_zarr` passes `write_empty_chunks=True`, so an all-fill shard is persisted rather than skipped). A dataset's NaN-fraction validator is what catches that.
+
 ### Overwrite guard (backfills into an existing store)
 
 A backfill into an existing store (`--overwrite-chunks` / `--overwrite-metadata`) runs `template_utils.assert_safe_overwrite` — in the `backfill-kubernetes` driver before submitting, and again on worker 0 before any writes (the deployed image's template can differ from the driver's). It rejects structural drift of arrays the store already has, any template shorter than the store along the append dim (trimming an existing store is never supported), new arrays unless `--overwrite-metadata` was passed, and a longer template unless an explicit `--append-dim-end` was given with both overwrite flags. Overwrite metadata writes also exclude coordinate value chunks the template renders entirely null (`template_utils.store_written_coords`, e.g. `ingested_forecast_length`) so job-written coordinate state is never clobbered by the template's empty values.

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -462,7 +462,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         if is_first and overwrite:
             template_utils.assert_safe_overwrite(
                 template_ds,
-                self._open_primary_datatree(),
+                self.store_factory.open_primary_datatree(),
                 self.template_config.append_dim,
                 allow_new_arrays=overwrite_metadata,
                 allow_expansion=overwrite_chunks and overwrite_metadata,
@@ -697,14 +697,6 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     def _get_template(self, append_dim_end: DatetimeLike) -> xr.DataTree:
         return self.template_config.get_template(pd.Timestamp(append_dim_end))
 
-    def _open_primary_datatree(self) -> xr.DataTree:
-        return xr.open_datatree(
-            self.store_factory.primary_store(),  # ty: ignore[invalid-argument-type]
-            engine="zarr",
-            decode_timedelta=True,
-            chunks=None,
-        )
-
     def _open_existing_store(self) -> xr.DataTree | None:
         """The primary store's current contents, or None if no dataset exists there yet.
 
@@ -712,7 +704,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         misclassifying an existing store as absent would route a backfill past the
         overwrite guards."""
         try:
-            return self._open_primary_datatree()
+            return self.store_factory.open_primary_datatree()
         except (
             FileNotFoundError,  # zarr3 store path absent
             zarr.errors.GroupNotFoundError,  # store path exists but holds no dataset
@@ -775,7 +767,9 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
 
     def _assert_no_structural_drift(self, template_ds: xr.DataTree) -> None:
         template_utils.assert_no_structural_drift_from_existing_store(
-            template_ds, self._open_primary_datatree(), self.template_config.append_dim
+            template_ds,
+            self.store_factory.open_primary_datatree(),
+            self.template_config.append_dim,
         )
 
     def _can_run_in_kubernetes(self) -> bool:

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -174,6 +174,11 @@ def finalize(
     if update_template_with_results:
         assert len(all_jobs) > 0
         updated_template = all_jobs[0].update_template_with_results(merged_results)
+        template_utils.assert_no_append_dim_retraction(
+            updated_template,
+            store_factory.open_primary_datatree(),
+            all_jobs[0].append_dim,
+        )
     else:
         updated_template = template_ds
     # Ensure tmp_store has written metadata. Virtual workers (besides worker 0)

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -108,6 +108,15 @@ class StoreFactory(FrozenBaseModel):
             self.icechunk_virtual_config,
         )
 
+    def open_primary_datatree(self) -> xr.DataTree:
+        """The primary store's current published contents."""
+        return xr.open_datatree(
+            self.primary_store(),  # ty: ignore[invalid-argument-type]
+            engine="zarr",
+            decode_timedelta=True,
+            chunks=None,
+        )
+
     def replica_stores(
         self, writable: bool = False, branch: str = "main"
     ) -> list[Store]:

--- a/src/reformatters/common/template_utils.py
+++ b/src/reformatters/common/template_utils.py
@@ -289,26 +289,19 @@ def assert_safe_overwrite(
                 "(pass --overwrite-metadata to add them)"
             )
 
-    existing_sizes = {
-        node.path: node.sizes[append_dim]
-        for node in existing_ds.subtree
-        if append_dim in node.sizes
-    }
-    for node in template_ds.subtree:
-        if append_dim not in node.sizes or node.path not in existing_sizes:
-            continue
-        template_size = node.sizes[append_dim]
-        existing_size = existing_sizes[node.path]
+    for node, template_size, existing_size in _append_dim_size_pairs(
+        template_ds, existing_ds, append_dim
+    ):
+        sizes = (
+            f"{node}: template has {template_size} {append_dim} steps but the "
+            f"store has {existing_size}"
+        )
         if template_size < existing_size:
-            problems.append(
-                f"{node.path}: template has {template_size} {append_dim} steps but the "
-                f"store has {existing_size}; trimming an existing store is never supported"
-            )
+            problems.append(f"{sizes}; trimming an existing store is never supported")
         elif template_size > existing_size and not allow_expansion:
             problems.append(
-                f"{node.path}: template has {template_size} {append_dim} steps but the "
-                f"store has {existing_size}; extending requires an explicit "
-                "--append-dim-end with both --overwrite-metadata and --overwrite-chunks"
+                f"{sizes}; extending requires an explicit --append-dim-end with both "
+                "--overwrite-metadata and --overwrite-chunks"
             )
 
     if problems:
@@ -316,6 +309,50 @@ def assert_safe_overwrite(
             "Template is not safe to write over the existing store:\n"
             + "\n".join(f"- {p}" for p in problems)
         )
+
+
+def assert_no_append_dim_retraction(
+    template_ds: xr.DataTree, existing_ds: xr.DataTree, append_dim: str
+) -> None:
+    """Fail an operational update whose template would un-publish data readers can already see.
+
+    An update's template is trimmed to what the run actually processed
+    (`RegionJob.update_template_with_results`), so a source outage that yields nothing can
+    trim back into already-published data, dropping whole shards of append-dim steps from
+    the store's metadata. Raising here runs before the metadata write, so the published
+    extent is unchanged.
+    """
+    retractions = [
+        f"{node}: template has {template_size} {append_dim} steps but the "
+        f"store has {existing_size}"
+        for node, template_size, existing_size in _append_dim_size_pairs(
+            template_ds, existing_ds, append_dim
+        )
+        if template_size < existing_size
+    ]
+    if retractions:
+        raise ValueError(
+            "Update template would retract already-published data. Operational updates "
+            "only ever extend the published store; run a backfill to shrink it. "
+            "Retractions:\n" + "\n".join(f"- {r}" for r in retractions)
+        )
+
+
+def _append_dim_size_pairs(
+    template_ds: xr.DataTree, existing_ds: xr.DataTree, append_dim: str
+) -> list[tuple[str, int, int]]:
+    """(group path, template size, existing size) for each group both trees carry along
+    `append_dim`."""
+    existing_sizes = {
+        node.path: node.sizes[append_dim]
+        for node in existing_ds.subtree
+        if append_dim in node.sizes
+    }
+    return [
+        (node.path, node.sizes[append_dim], existing_sizes[node.path])
+        for node in template_ds.subtree
+        if append_dim in node.sizes and node.path in existing_sizes
+    ]
 
 
 def store_written_coords(template_ds: xr.DataTree) -> set[str]:
@@ -344,12 +381,7 @@ def refresh_store_metadata(
     backfilled); store-written coordinate values are preserved. Icechunk stores commit
     only when something actually changed.
     """
-    existing = xr.open_datatree(
-        store_factory.primary_store(),  # ty: ignore[invalid-argument-type]
-        engine="zarr",
-        chunks=None,
-        decode_timedelta=True,
-    )
+    existing = store_factory.open_primary_datatree()
     existing_sizes = {
         node.path: node.sizes[append_dim]
         for node in existing.subtree

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -488,6 +488,8 @@ def test_backfill_kubernetes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     )
     monkeypatch.setattr(template_utils, "write_metadata", lambda *args, **kwargs: None)
 
+    monkeypatch.setattr(ExampleDataset, "_open_existing_store", lambda self: None)
+
     dataset = ExampleDataset(
         template_config=ExampleConfig(),
         region_job_class=ExampleRegionJob,

--- a/tests/common/test_parallel_coordination.py
+++ b/tests/common/test_parallel_coordination.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
@@ -31,6 +32,7 @@ class FakeStoreFactory:
         }
         self._primary_store: object = MagicMock(name="primary_zarr3_store")
         self._replica_stores: list[object] = []
+        self.published_tree: xr.DataTree = xr.DataTree.from_dict({"/": xr.Dataset()})
         self.persist_virtual_config_calls = 0
 
     def persist_virtual_config(self) -> None:
@@ -59,6 +61,9 @@ class FakeStoreFactory:
 
     def primary_store(self, writable: bool = False) -> object:  # noqa: ARG002
         return self._primary_store
+
+    def open_primary_datatree(self) -> xr.DataTree:
+        return self.published_tree
 
     def replica_stores(self, writable: bool = False) -> list[object]:  # noqa: ARG002
         return list(self._replica_stores)
@@ -144,6 +149,18 @@ def stub_io(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
 def _template() -> xr.DataTree:
     # An empty dataset is enough — every real use of template_ds is stubbed.
     return xr.DataTree.from_dict({"/": xr.Dataset()})
+
+
+def _time_tree(n_time: int) -> xr.DataTree:
+    times = pd.date_range("2026-04-01", periods=n_time, freq="D")
+    return xr.DataTree.from_dict(
+        {
+            "/": xr.Dataset(
+                {"v": xr.DataArray(np.zeros(n_time), dims=("time",))},
+                coords={"time": times},
+            )
+        }
+    )
 
 
 class TestParallelSetupFirstWorker:
@@ -906,6 +923,35 @@ class TestFinalize:
         assert copy_kwargs["zarr3_only"] is True
         assert copy_kwargs["replica_stores"] == []
         stub_io["write_metadata"].assert_called_once()
+
+    def test_update_refuses_to_publish_template_shorter_than_store(
+        self, tmp_path: Path, stub_io: dict[str, MagicMock]
+    ) -> None:
+        """A source outage trims the update template back into published data; finalize
+        must raise before any metadata write rather than un-publish those steps."""
+        factory = FakeStoreFactory()
+        factory.published_tree = _time_tree(5)
+        job = MagicMock()
+        job.append_dim = "time"
+        job.update_template_with_results.return_value = _time_tree(3)
+
+        with pytest.raises(ValueError, match="would retract already-published data"):
+            pc.finalize(
+                factory,  # ty: ignore[invalid-argument-type]
+                all_jobs=[job],
+                merged_results={},
+                reformat_job_name="job",
+                branch_name="main",
+                template_ds=_time_tree(5),
+                tmp_store=tmp_path,
+                setup_info={},
+                workers_total=1,
+                update_template_with_results=True,
+                consolidated=True,
+            )
+
+        stub_io["write_metadata"].assert_not_called()
+        stub_io["copy_zarr_metadata"].assert_not_called()
 
     def test_clear_coordination_files_only_when_multi_worker(
         self, tmp_path: Path


### PR DESCRIPTION
## What

Assert in `parallel_coordination.finalize` that an operational update's template, after `RegionJob.update_template_with_results` trims it, is no shorter along the append dim than the published store — `template_utils.assert_no_append_dim_retraction`. It runs before any metadata write, so an update can only ever extend the published extent. Equal lengths pass, so reprocessing the same trailing region and the `isel(time=slice(None, -1))` overrides in the GEFS/GFS/HRRR analysis jobs are unaffected. Shrinking a store still goes through a backfill, where `assert_safe_overwrite` already rejected it.

Two supporting cleanups, both to leave one way of doing things:

- Extracted `_append_dim_size_pairs`, the per-group size comparison `assert_safe_overwrite` already ran, so both guards share it. `assert_safe_overwrite`'s two messages are unchanged.
- Added `StoreFactory.open_primary_datatree()`, replacing `DynamicalDataset._open_primary_datatree` and the duplicate `xr.open_datatree` inside `refresh_store_metadata`. Finalization needed the same read, which would have made three copies.

## Testing

`uv run pytest tests/common/` — 961 passed; the full suite passed on the same change set. New test `test_update_refuses_to_publish_template_shorter_than_store` asserts `finalize` raises with no `write_metadata` or `copy_zarr_metadata` call. `ruff format`, `ruff check`, `ty check` clean. `docs/parallel_processing.md` documents the guard.