### PR TITLE
Retry icechunk reads through a throttling source bucket

### DIFF
--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from functools import cache
 from pathlib import Path
-from typing import Any, Literal, assert_never
+from typing import Any, Literal, Self, assert_never
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -15,7 +15,7 @@ import zarr
 import zarr.abc.store
 import zarr.storage
 from icechunk.store import IcechunkStore
-from pydantic import Field, InstanceOf, computed_field
+from pydantic import Field, InstanceOf, computed_field, model_validator
 from zarr.abc.store import Store
 
 from reformatters.common import kubernetes
@@ -564,6 +564,17 @@ class IcechunkVirtualConfig(FrozenBaseModel):
     # Per-array manifest splitting policy (see manifest_append_dim_split).
     manifest_split: InstanceOf[icechunk.ManifestSplittingConfig]
 
+    @model_validator(mode="after")
+    def _validate_distinct_container_prefixes(self) -> Self:
+        # icechunk keys containers by url_prefix, so a repeat would silently drop the
+        # earlier container's store config rather than register both.
+        prefixes = [container.url_prefix for container in self.containers]
+        if len(set(prefixes)) != len(prefixes):
+            raise ValueError(
+                f"Virtual chunk containers must have distinct url_prefixes, got {prefixes}"
+            )
+        return self
+
 
 def _repository_config_and_credentials(
     virtual_config: IcechunkVirtualConfig | None,
@@ -575,11 +586,18 @@ def _repository_config_and_credentials(
         splitting=virtual_config.manifest_split if virtual_config is not None else None,
         max_concurrent_manifest_fetches_during_commit=16,
     )
+    config.storage = icechunk.StorageSettings(
+        # These retries impact virtual and materialized reads in validators
+        retries=icechunk.StorageRetriesSettings(
+            max_tries=16, initial_backoff_ms=1_000, max_backoff_ms=16_000
+        )
+    )
     if virtual_config is None:
         return config, None
 
     for container in virtual_config.containers:
         config.set_virtual_chunk_container(container)
+
     # Cap the chunk-ref cache: streaming commits each rewrite the active manifest split
     # and never read old versions, so icechunk's default 5M-entry cache fills with dead
     # manifest versions (multi-GB OOM). A virtual ref is ~180 B, so 1M refs ≈ 200 MB.

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -444,6 +444,37 @@ class TestIcechunkVirtualConfig:
         assert caching is not None
         assert caching.num_chunk_refs == 1_000_000
 
+    def test_rejects_duplicate_container_prefixes(self) -> None:
+        # icechunk keys containers by url_prefix, so a repeat silently drops the earlier
+        # container's store config instead of registering both.
+        container = icechunk.VirtualChunkContainer(
+            "s3://noaa-gfs-bdp-pds/", icechunk.s3_store(region="us-east-1")
+        )
+        with pytest.raises(ValidationError, match="distinct url_prefixes"):
+            IcechunkVirtualConfig(
+                containers=(container, container),
+                manifest_split=manifest_append_dim_split(split_size=1, dim="init_time"),
+            )
+
+    @pytest.mark.parametrize("virtual", [True, False])
+    def test_reads_retry_a_throttling_source(self, virtual: bool) -> None:
+        # These settings reach the virtual chunk fetchers, so they are what survives a
+        # 503 SlowDown from a source bucket; icechunk's 10-try default gives up too soon.
+        factory = StoreFactory(
+            primary_storage_config=StorageConfig(
+                base_path="s3://bucket/data", format=DatasetFormat.ICECHUNK
+            ),
+            dataset_id="test-dataset",
+            template_config_version="v1.0",
+            icechunk_virtual_config=_example_virtual_config() if virtual else None,
+        )
+        repo = factory.icechunk_repos(sort="primary-first")[0][1]
+        storage = repo.config.storage
+        assert storage is not None
+        assert storage.retries is not None
+        assert storage.retries.max_tries == 16
+        assert storage.retries.max_backoff_ms == 16_000
+
     def test_unsupported_container_rejected(self) -> None:
         gcs_container = icechunk.VirtualChunkContainer(
             "gs://bucket/", icechunk.gcs_store()


### PR DESCRIPTION
## Why

CI hit a transient failure on #833 ([run](https://github.com/dynamical-org/reformatters/actions/runs/31045423176/job/92442273545)) — not in our download code, but in icechunk fetching a virtual reference:

```
icechunk.StorageError: error fetching virtual reference: service error:
unhandled error (SlowDown): Please reduce your request rate.
```

Auditing test load against `s3://ecmwf-forecasts` showed the failing suite is the *lightest* of the four ECMWF suites, so volume wasn't the problem — retry coverage was. Measured request counts per suite:

| suite | requests | peak concurrency |
|---|---|---|
| `ifs_ens` | 277 | 16 |
| `aifs_ens` | 98 | 16 |
| `aifs_single/forecast` (materialized) | 72 | 16 |
| `aifs_single/forecast_virtual` | ~37 | 6 |

Two paths with very different hardening:

- **Our downloads** (`common/download.py:s3_store`) — `max_retries=16`, 1s→16s backoff. Absorbs `SlowDown` silently.
- **icechunk reads** — `RepositoryConfig.default()`, never setting `.storage`, so icechunk's default 10 tries applied.

The timing confirms retries ran out early rather than never running: the test failed 13.7s after starting (vs ~11s for a clean run), where a full default ladder would burn ~100s.

## What

**1. Set `RepositoryConfig.storage` retries**, matching `s3_store`'s policy, for every icechunk dataset — virtual and materialized.

icechunk builds `storage_settings` from `config.storage` and hands the same object to `VirtualChunkResolver::new`, so this covers both the repo's own reads and virtual source-file fetches. It **merges** with backend defaults rather than replacing them, so concurrency and timeout defaults are untouched.

**2. Reject duplicate `url_prefix`es in `IcechunkVirtualConfig`.** `set_virtual_chunk_container` is a map insert keyed by prefix, so two containers sharing one prefix silently kept only the last container's store config. Verified against the installed build: three distinct prefixes all register; a repeated prefix overwrites. Every current dataset has exactly one container, so this is a guard, not a fix.

## Notes

Unrelated to this PR but found while measuring, if someone wants to pick it up: `VirtualRegionJob.download_concurrency = 64` is unoverridden, so one backfill worker opens ~61 concurrent index GETs (1 init × 61 leads) and virtual backfills run up to 10 workers — against a bucket `docs/backfill.md` says supports at most 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)