### PR TITLE
Rate limit and retry the GEFS NOMADS fallback like GFS and HRRR

### DIFF
--- a/src/reformatters/noaa/gefs/utils.py
+++ b/src/reformatters/noaa/gefs/utils.py
@@ -1,3 +1,4 @@
+import functools
 from collections.abc import Callable
 from pathlib import Path
 
@@ -8,6 +9,10 @@ from reformatters.common.download import http_download_to_disk, httpx_download_t
 from reformatters.common.iterating import digest
 from reformatters.noaa.gefs.gefs_config_models import GefsSourceFileCoord
 from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
+from reformatters.noaa.noaa_utils import (
+    NOMADS_RETRY_STATUS_CODES,
+    nomads_rate_limiter,
+)
 
 type _DownloadFn = Callable[..., Path]
 
@@ -55,7 +60,11 @@ def gefs_download_file(
                     coord,
                     coord.get_index_url(fallback=True),
                     coord.get_fallback_url(),
-                    download=httpx_download_to_disk,
+                    download=functools.partial(
+                        httpx_download_to_disk,
+                        rate_limiter=nomads_rate_limiter,
+                        retry_status_codes=NOMADS_RETRY_STATUS_CODES,
+                    ),
                 )
             except PermissionDeniedError as e:
                 raise FileNotFoundError(coord.get_url()) from e

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -30,6 +30,10 @@ from reformatters.noaa.gefs.gefs_config_models import (
     GEFSDataVar,
     GEFSInternalAttrs,
 )
+from reformatters.noaa.noaa_utils import (
+    NOMADS_RETRY_STATUS_CODES,
+    nomads_rate_limiter,
+)
 
 
 @pytest.fixture
@@ -705,9 +709,10 @@ def test_download_file_fallback(
         "reformatters.noaa.gefs.utils.http_download_to_disk",
         Mock(side_effect=mock_primary_download),
     )
+    mock_fallback = Mock(side_effect=mock_fallback_download)
     monkeypatch.setattr(
         "reformatters.noaa.gefs.utils.httpx_download_to_disk",
-        Mock(side_effect=mock_fallback_download),
+        mock_fallback,
     )
 
     mock_grib_message_byte_ranges_from_index = Mock(
@@ -724,6 +729,11 @@ def test_download_file_fallback(
 
     # Should have called: primary index (failed) + fallback index + fallback data
     assert call_count == 3
+
+    # NOMADS rate limits, and its bot mitigation answers with a retryable 302.
+    for call in mock_fallback.call_args_list:
+        assert call.kwargs["rate_limiter"] is nomads_rate_limiter
+        assert call.kwargs["retry_status_codes"] == NOMADS_RETRY_STATUS_CODES
 
 
 def test_download_file_no_fallback_for_old_data(


### PR DESCRIPTION
## What

`noaa-gefs-forecast-35-day-update` produces ~2800 `log.exception` events per week, all of the same shape:

```
FileNotFoundError: Object at location gefs.20260805/00/atmos/pgrb2bp5/gep25.t00z.pgrb2b.0p50.f450.idx
  not found ... 404 NoSuchKey    (primary: noaa-gefs-pds S3)
  → during handling →
httpx.HTTPStatusError: Redirect response '302 Moved Temporarily' for url
  'https://nomads.ncep.noaa.gov/pub/data/nccf/com/gens/prod/gefs.../....idx'
```

`noaa_utils.py` already names this: `NOMADS_RETRY_STATUS_CODES = {302, 429, 500, 502, 503, 504}`, "Akamai bot mitigation returns 302". GFS (`gfs/region_job.py`) and HRRR (`hrrr/region_job.py`) pass that set plus `nomads_rate_limiter` to `httpx_download_to_disk`. The GEFS fallback in `gefs/utils.py` passed neither, so it was the only NOMADS consumer that hammered the endpoint unthrottled and then treated the resulting bot-mitigation redirect as a hard failure — `is_not_found()` does not classify a 3xx as missing data, so each one went to `log.exception` instead of the quiet recent-gap path.

Fix: use the same `functools.partial(httpx_download_to_disk, rate_limiter=..., retry_status_codes=...)` the other two NOMADS paths use. Throttling should reduce how often Akamai trips at all, and the redirects that still happen get the existing 16-attempt / 300s retry treatment.

This may also clear the occasional `RasterioIOError: ... is a grib file, but no raster dataset was successfully identified` on GEFS b-files, which looks like a bot-mitigation HTML body written to disk as the grib byte-range payload.

## Alternative considered

Classifying any redirect as not-found inside the shared `download.is_not_found()` (what #798 proposed). Rejected: it contradicts the repo's own reading that a NOMADS 302 is transient rather than "file is absent", and it would silence that signal for every dataset rather than the one path that was misconfigured.

## Test plan

- [x] `uv run ruff format && uv run ruff check --fix && uv run ty check` clean
- [x] `test_download_file_fallback` now asserts the fallback download carries the NOMADS rate limiter and retry status codes
- [x] `uv run pytest -m "not slow"` — 1801 passed

Replaces the GEFS half of #798; the IMERG half of that PR was superseded by #811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)