### PR TITLE
Drop unreachable PermissionDeniedError handler from GEFS fallback

### DIFF
--- a/src/reformatters/noaa/gefs/utils.py
+++ b/src/reformatters/noaa/gefs/utils.py
@@ -3,7 +3,6 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pandas as pd
-from obstore.exceptions import PermissionDeniedError
 
 from reformatters.common.download import http_download_to_disk, httpx_download_to_disk
 from reformatters.common.iterating import digest
@@ -54,19 +53,16 @@ def gefs_download_file(
     except FileNotFoundError:
         # if init time is within the last 4 days, try to download from the fallback source (NOMADS)
         if coord.init_time >= pd.Timestamp.now() - pd.Timedelta(days=4):
-            try:
-                return _download_file_from_gefs_source(
-                    dataset_id,
-                    coord,
-                    coord.get_index_url(fallback=True),
-                    coord.get_fallback_url(),
-                    download=functools.partial(
-                        httpx_download_to_disk,
-                        rate_limiter=nomads_rate_limiter,
-                        retry_status_codes=NOMADS_RETRY_STATUS_CODES,
-                    ),
-                )
-            except PermissionDeniedError as e:
-                raise FileNotFoundError(coord.get_url()) from e
+            return _download_file_from_gefs_source(
+                dataset_id,
+                coord,
+                coord.get_index_url(fallback=True),
+                coord.get_fallback_url(),
+                download=functools.partial(
+                    httpx_download_to_disk,
+                    rate_limiter=nomads_rate_limiter,
+                    retry_status_codes=NOMADS_RETRY_STATUS_CODES,
+                ),
+            )
         else:
             raise

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from obstore.exceptions import PermissionDeniedError
 
 from reformatters.common.config_models import DataVarAttrs, Encoding
 from reformatters.common.pydantic import replace
@@ -780,52 +779,6 @@ def test_download_file_no_fallback_for_old_data(
         url = call[0][0]
         # All calls should be to primary source (AWS S3), not fallback (NOMADS)
         assert urlparse(url).netloc == "noaa-gefs-retrospective.s3.amazonaws.com"
-
-
-def test_download_file_fallback_permission_denied_converts_to_file_not_found(
-    template_ds: xr.Dataset,
-    example_data_vars: list[GEFSDataVar],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test that PermissionDeniedError from fallback is converted to FileNotFoundError."""
-    tmp_store = get_local_tmp_store()
-    data_vars = example_data_vars[:1]
-
-    job = GefsAnalysisRegionJob(
-        tmp_store=tmp_store,
-        template_ds=xr.DataTree.from_dict({"/": template_ds}),
-        data_vars=data_vars,
-        append_dim="time",
-        region=slice(0, 1),
-        reformat_job_name="test-job",
-    )
-
-    # Use a recent init_time (within 4 days) to trigger fallback behavior
-    recent_init_time = pd.Timestamp.now() - pd.Timedelta(days=1)
-    coord = GefsAnalysisSourceFileCoord(
-        init_time=recent_init_time,
-        lead_time=pd.Timedelta("6h"),
-        data_vars=data_vars,
-    )
-
-    # Primary source fails with FileNotFoundError
-    monkeypatch.setattr(
-        "reformatters.noaa.gefs.utils.http_download_to_disk",
-        Mock(side_effect=FileNotFoundError("Primary index not found")),
-    )
-    # Fallback source (NOMADS via httpx) fails with PermissionDeniedError
-    monkeypatch.setattr(
-        "reformatters.noaa.gefs.utils.httpx_download_to_disk",
-        Mock(side_effect=PermissionDeniedError("Permission denied")),
-    )
-
-    # Should raise FileNotFoundError (not PermissionDeniedError)
-    with pytest.raises(FileNotFoundError) as exc_info:
-        job.download_file(coord)
-
-    # Verify it's a FileNotFoundError with PermissionDeniedError as cause
-    assert exc_info.value.__cause__ is not None
-    assert isinstance(exc_info.value.__cause__, PermissionDeniedError)
 
 
 def _make_analysis_region_job() -> GefsAnalysisRegionJob:

--- a/tests/noaa/gefs/forecast_35_day/region_job_test.py
+++ b/tests/noaa/gefs/forecast_35_day/region_job_test.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from obstore.exceptions import PermissionDeniedError
 
 from reformatters.common.config_models import DataVarAttrs, Encoding
 from reformatters.common.pydantic import replace
@@ -667,53 +666,6 @@ def test_operational_update_jobs(
             mock_open_zarr.assert_called_once_with(
                 store_factory.primary_store(), decode_timedelta=True, chunks=None
             )
-
-
-def test_download_file_fallback_permission_denied_converts_to_file_not_found(
-    template_ds: xr.Dataset,
-    example_data_vars: list[GEFSDataVar],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test that PermissionDeniedError from fallback is converted to FileNotFoundError."""
-    tmp_store = get_local_tmp_store()
-    data_vars = example_data_vars[:1]
-
-    job = GefsForecast35DayRegionJob(
-        tmp_store=tmp_store,
-        template_ds=xr.DataTree.from_dict({"/": template_ds}),
-        data_vars=data_vars,
-        append_dim="init_time",
-        region=slice(0, 1),
-        reformat_job_name="test-job",
-    )
-
-    # Use a recent init_time (within 4 days) to trigger fallback behavior
-    recent_init_time = pd.Timestamp.now() - pd.Timedelta(days=1)
-    coord = GefsForecast35DaySourceFileCoord(
-        init_time=recent_init_time,
-        lead_time=pd.Timedelta("3h"),
-        ensemble_member=1,
-        data_vars=data_vars,
-    )
-
-    # Primary source fails with FileNotFoundError
-    monkeypatch.setattr(
-        "reformatters.noaa.gefs.utils.http_download_to_disk",
-        Mock(side_effect=FileNotFoundError("Primary index not found")),
-    )
-    # Fallback source (NOMADS via httpx) fails with PermissionDeniedError
-    monkeypatch.setattr(
-        "reformatters.noaa.gefs.utils.httpx_download_to_disk",
-        Mock(side_effect=PermissionDeniedError("Permission denied")),
-    )
-
-    # Should raise FileNotFoundError (not PermissionDeniedError)
-    with pytest.raises(FileNotFoundError) as exc_info:
-        job.download_file(coord)
-
-    # Verify it's a FileNotFoundError with PermissionDeniedError as cause
-    assert exc_info.value.__cause__ is not None
-    assert isinstance(exc_info.value.__cause__, PermissionDeniedError)
 
 
 def _make_forecast_region_job() -> GefsForecast35DayRegionJob:


### PR DESCRIPTION
Stacked on #862 — review that one first. GitHub will retarget this to `main` when #862 merges. Based on #862 because both edit the same statement; on `main` they would conflict.

## What

`gefs_download_file` wraps the NOMADS fallback in `except PermissionDeniedError as e: raise FileNotFoundError(...) from e`. Nothing in that try block can raise it:

- #349 (Jan 2026) added the handler when the fallback downloaded through `http_download_to_disk`, i.e. obstore, which raises `PermissionDeniedError` on a 403.
- #452 (Feb 2026) switched the fallback to `httpx_download_to_disk` for Akamai cookie/redirect handling. httpx raises `httpx.HTTPStatusError`; obstore is no longer in that code path.

The handler's original purpose is also covered from a different direction now: since #847, `download.is_not_found()` treats `PermissionDeniedError` as missing data wherever it is raised, so the download-error classifier no longer needs the exception laundered into `FileNotFoundError` to log it quietly.

Removes the handler, the now-unused import, and the two tests (analysis + forecast_35_day) that pinned the conversion by mocking `httpx_download_to_disk` to raise an obstore exception — a scenario the real code cannot produce.

## Unchanged behavior worth noting

The **primary** source is still obstore, so it can raise `PermissionDeniedError` — and because the outer handler catches only `FileNotFoundError`, that has always skipped the NOMADS fallback and propagated. `is_not_found()` logs it quietly. This PR does not change that. In practice `noaa-gefs-pds` answers a missing key with `404 NoSuchKey`, so the path is theoretical; making a primary 403 fall through to NOMADS would be a behavior change and belongs in its own PR if we ever see one.

## Test plan

- [x] `uv run ruff format && uv run ruff check --fix && uv run ty check` clean
- [x] `uv run pytest -m "not slow"` — 1799 passed (1801 minus the two removed tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)