### PR TITLE
Migrate pydantic generic to PEP 695 syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,10 +104,7 @@ select = [
 ignore = [
     "S101",    # disallow asserts
     "E501",    # line too long (ruff format will handle)
-    "W293",    # black line contains whitespace
     "UP046",   # non-pep695-generic-class - defer migration to PEP 695 generics
-    "UP047",   # non-pep695-generic-function - defer migration to PEP 695 generics
-    "PLC0414", # import aliases to same name - we use to specifically re-export
     "PLR0913", # too many arguments
     "PLR0917", # too many positional arguments
     "TD003",   # don't require issue link in todos

--- a/src/reformatters/common/pydantic.py
+++ b/src/reformatters/common/pydantic.py
@@ -1,11 +1,9 @@
-from typing import Any, TypeVar
+from typing import Any
 
 import pydantic
 
-B = TypeVar("B", bound=pydantic.BaseModel)
 
-
-def replace(obj: B, **kwargs: Any) -> B:  # noqa: ANN401
+def replace[B: pydantic.BaseModel](obj: B, **kwargs: Any) -> B:  # noqa: ANN401
     """Replace properties of pydantic model instances."""
     # From https://github.com/pydantic/pydantic/discussions/3352#discussioncomment-10531773
     # pydantic's model_copy(update=...) does not validate updates, this function does.


### PR DESCRIPTION
## Summary
Modernize the `replace` function in `src/reformatters/common/pydantic.py` to use PEP 695 generic syntax instead of `TypeVar`, and update linting rules to reflect this migration.

## Changes
- **pydantic.py**: Replaced `TypeVar`-based generic with PEP 695 bracket syntax (`def replace[B: pydantic.BaseModel]`) for cleaner, more modern type hints
- **pyproject.toml**: 
  - Removed `UP047` from ruff ignore list (non-pep695-generic-function) to enforce PEP 695 syntax going forward
  - Removed `W293` (whitespace on blank lines) and `PLC0414` (import aliases) from ignore list as they are no longer needed or relevant

## Implementation Details
The function signature now uses PEP 695's native generic syntax, which is more readable and aligns with Python 3.12+ conventions. The `TypeVar` import is no longer needed. This change maintains full backward compatibility while improving code clarity.

https://claude.ai/code/session_01FVmt9oPofNfuwK2wJMqkvT