### PR TITLE
DWD ICON-EU: widen the aswdir_s deaccumulation thresholds

### DIFF
--- a/src/reformatters/common/deaccumulation.py
+++ b/src/reformatters/common/deaccumulation.py
@@ -14,6 +14,10 @@ VALID_OUTPUT_UNITS_FOR_DEACCUMULATION = ["mm s-1", "m s-1", "kg m-2 s-1", "W m-2
 # mm s-1, ~= 0.25 mm/h or "trace" precipitation
 PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD = -7e-5
 RADIATION_INVALID_BELOW_THRESHOLD = -50.0  # W/m^2 aka J/m^2/s
+# Direct beam short wave running means are non-monotonic enough at domain edges, high latitudes
+# and steep terrain to produce isolated step rates approaching -100 W/m^2. Only a corrupt or
+# mismatched source field, which deaccumulates to thousands of W/m^2, goes beyond this.
+DIRECT_RADIATION_INVALID_BELOW_THRESHOLD = -1000.0
 
 # How the input values along `dim` should be interpreted:
 #   - "accumulated": values are cumulative totals (e.g. J m-2 since forecast start).

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/template_config.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/template_config.py
@@ -18,6 +18,7 @@ from reformatters.common.config_models import (
     StatisticsApproximate,
 )
 from reformatters.common.deaccumulation import (
+    DIRECT_RADIATION_INVALID_BELOW_THRESHOLD,
     RADIATION_INVALID_BELOW_THRESHOLD,
     AccumulationType,
 )
@@ -359,8 +360,9 @@ class DwdIconEuForecast5DayTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                     deaccumulate_to_rate=True,
                     window_reset_frequency=pd.Timedelta.max,
                     deaccumulation_invalid_below_threshold_rate=RADIATION_INVALID_BELOW_THRESHOLD,
-                    # GRIB precision jitter in the running mean drives nighttime clamping to ~20%.
-                    deaccumulation_expected_clamp_fraction=0.25,
+                    # GRIB precision jitter in the running mean clamps every dark grid cell to 0,
+                    # reaching ~28% of an init's values in February and more at midwinter.
+                    deaccumulation_expected_clamp_fraction=0.4,
                     deaccumulation_type="running_mean",
                 ),
             ),
@@ -380,9 +382,10 @@ class DwdIconEuForecast5DayTemplateConfig(TemplateConfig[DwdIconEuDataVar]):
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     deaccumulate_to_rate=True,
                     window_reset_frequency=pd.Timedelta.max,
-                    deaccumulation_invalid_below_threshold_rate=RADIATION_INVALID_BELOW_THRESHOLD,
-                    # GRIB precision jitter in the running mean drives nighttime clamping to ~20%.
-                    deaccumulation_expected_clamp_fraction=0.25,
+                    deaccumulation_invalid_below_threshold_rate=DIRECT_RADIATION_INVALID_BELOW_THRESHOLD,
+                    # GRIB precision jitter in the running mean clamps every dark grid cell to 0,
+                    # reaching ~28% of an init's values in February and more at midwinter.
+                    deaccumulation_expected_clamp_fraction=0.4,
                     deaccumulation_type="running_mean",
                 ),
             ),

--- a/tests/common/test_deaccumulation.py
+++ b/tests/common/test_deaccumulation.py
@@ -7,6 +7,7 @@ import pytest
 import xarray as xr
 
 from reformatters.common.deaccumulation import (
+    DIRECT_RADIATION_INVALID_BELOW_THRESHOLD,
     PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD,
     RADIATION_INVALID_BELOW_THRESHOLD,
     deaccumulate_to_rates_inplace,
@@ -1095,6 +1096,35 @@ def test_deaccumulate_running_mean_invalid_below_threshold_raises() -> None:
             accumulation_type="running_mean",
             invalid_below_threshold_rate=RADIATION_INVALID_BELOW_THRESHOLD,
         )
+
+
+def test_deaccumulate_running_mean_direct_radiation_threshold_clamps_instead_of_raising() -> (
+    None
+):
+    """The direct radiation threshold clamps the same drop the general one rejects."""
+    reset_frequency = pd.Timedelta.max
+    lead_times = pd.to_timedelta(["0h", "1h", "2h"])
+
+    values = np.array([0.0, 1000.0, 400.0], dtype=np.float32)
+    expected = np.array([np.nan, 1000.0, 0.0], dtype=np.float32)
+
+    data_array = xr.DataArray(
+        values,
+        coords={"lead_time": lead_times},
+        dims=["lead_time"],
+        attrs={"units": "W m-2"},
+    )
+
+    result = deaccumulate_to_rates_inplace(
+        data_array,
+        dim="lead_time",
+        reset_frequency=reset_frequency,
+        accumulation_type="running_mean",
+        invalid_below_threshold_rate=DIRECT_RADIATION_INVALID_BELOW_THRESHOLD,
+        expected_clamp_fraction=0.4,
+    )
+
+    np.testing.assert_allclose(result.values, expected, equal_nan=True)
 
 
 def test_deaccumulate_running_mean_preserves_float32_precision_at_long_lead() -> None:


### PR DESCRIPTION
Fixes [REFORMATTERS-D2](https://dynamical.sentry.io/issues/REFORMATTERS-D2). Supersedes #810, which addressed the same Sentry issue by allowing a nonzero `expected_invalid_fraction` (i.e. occasional NaNs). Measuring the real data shows a wider clamp threshold works instead, so consumers get `0` rather than NaN and we keep alerting on genuinely broken data.

## What the data shows

I downloaded the real `aswdir_s` GRIBs and ran the production deaccumulation over 18 init times spanning the whole archive (Feb 10 – Jul 26, ~1.5e9 values), including the inits Sentry flagged. Init `2026-07-26T06` reproduces the reported failure exactly: 5 cells below −50.

Cell counts per init below each rate threshold:

| init | neg % | worst | <−10 | <−25 | <−50 | <−100 | <−1000 |
|---|---|---|---|---|---|---|---|
| 2026-02-10T12 | 27.7% | −29.4 | 40 | 3 | 0 | 0 | 0 |
| 2026-02-25T12 | 25.5% | −54.4 | 76 | 5 | 1 | 0 | 0 |
| 2026-03-13T06 | 23.0% | −42.7 | 192 | 5 | 0 | 0 | 0 |
| 2026-04-10T00 | 18.9% | −43.5 | 153 | 11 | 0 | 0 | 0 |
| 2026-06-15T12 | 13.0% | −35.0 | 318 | 27 | 0 | 0 | 0 |
| 2026-07-03T06 | 13.6% | −70.8 | 617 | 84 | 1 | 0 | 0 |
| 2026-07-23T12 | 15.3% | −50.1 | 340 | 78 | 1 | 0 | 0 |
| 2026-07-26T06 | 15.3% | **−77.2** | 164 | 19 | 5 | 0 | 0 |

Ten further inits had zero cells below −50. **The most negative rate anywhere in 1.5e9 values is −77.2 W/m². Nothing reaches −100.**

Three things this settles:

- **It is not GRIB quantization.** The packing quantum is exactly 1/64 W/m². With the running-mean amplification factor (`s_{t-1}/dt`, 4–155) quantization can only produce negatives down to about −1.2 W/m². The ~15% of tiny negatives are quantization; everything past ~−2 W/m² is real non-monotonicity in DWD's running mean, which the existing −50 threshold has been silently clamping by the hundreds per init already.
- **It is structural, not random corruption.** The worst cells sit at the domain edges (lon −23.5 / 62.5), high latitudes, and the Caucasus — the same places every init. The diffuse variable `aswdifd_s`, with identical config, bottoms out at −10.2 W/m²; only the direct beam is affected.
- **Corruption looks nothing like this.** A zeroed or mismatched source step deaccumulates to −A·(s/dt), i.e. thousands to tens of thousands of W/m². Legitimate positive rates in this field peak around 1000–1300 W/m².

So there is a clean gap between the artifact tail (≤ 77) and anything genuinely broken (≥ ~1000), with no need to expect a nonzero invalid fraction.

## Changes

- New `DIRECT_RADIATION_INVALID_BELOW_THRESHOLD = -1000.0` beside the other thresholds in `common/deaccumulation.py`, used by `aswdir_s`. 13× headroom over the worst observed artifact, still well below the corruption scale. `expected_invalid_fraction` stays at its `0.0` default.
- Raised `deaccumulation_expected_clamp_fraction` from 0.25 to 0.4 for both radiation variables. Not part of the original Sentry issue, but the same measurement shows negatives run 13% (June) to 27.7% (Feb 10) of an init's values — four of the five February inits sampled already exceed 0.25, and Feb 10 is the darkest data the archive holds, so midwinter will be worse. Also refreshed the stale "~20%" comment.
- A test pinning that the direct-radiation threshold clamps the same drop the general radiation threshold rejects.

No template regeneration needed — these are internal attrs and do not appear in the zarr metadata.

## Scope

ICON-EU `aswdir_s` is the only direct-beam short wave variable in the repo, and ICON-EU is the only dataset using `running_mean` deaccumulation. Every other radiation variable is total downwelling short wave from a true cumulative accumulation, where there is no amplification factor and −50 remains ample. The new constant lives in `common/deaccumulation.py` so any future direct-beam variable picks it up.

## Test plan

- [x] `uv run ruff format && uv run ruff check --fix && uv run ty check` clean
- [x] `uv run pytest tests/common/test_deaccumulation.py tests/dwd/icon_eu/ tests/common/common_template_config_subclasses_test.py tests/common/datasets_cf_compliance_test.py` — 375 passed
- [x] Replayed the new thresholds over all 18 downloaded init times: zero invalid values, max clamp fraction 27.7% (under 0.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pqxi2TSN4YeehfjZ6pwf4J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pqxi2TSN4YeehfjZ6pwf4J)_