### PR TITLE
Enable ecmwf-aifs-single-forecast-virtual operational updates

### DIFF
--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/dynamical_dataset.py
@@ -70,7 +70,6 @@ class EcmwfAifsSingleForecastVirtualDataset(
             cpu="1.7",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
@@ -82,7 +81,6 @@ class EcmwfAifsSingleForecastVirtualDataset(
             cpu="1.3",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py
+++ b/tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py
@@ -218,10 +218,9 @@ def test_operational_kubernetes_resources(
     assert update_cron_job.workers_total == 1
     assert update_cron_job.parallelism == 1
     assert update_cron_job.pod_active_deadline < timedelta(hours=6)
-    # Cron jobs ship suspended until the store is backfilled.
-    assert update_cron_job.suspend is True
+    assert update_cron_job.suspend is False
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
-    assert validation_cron_job.suspend is True
+    assert validation_cron_job.suspend is False
     assert len(update_cron_job.secret_names) > 0
 
 


### PR DESCRIPTION
Removes `suspend=True` from the `ecmwf-aifs-single-forecast-virtual` update and validate cron jobs, so operational updates start keeping the store current.

Part of the AIFS Single virtual rollout (#831, dataset added in #833). New virtual datasets ship with their crons suspended; per `docs/dataset_development_guide.md` §3 they are enabled once the backfill completes.

**Do not merge until the `create-new-store` backfill finishes** — [run 31190320776](https://github.com/dynamical-org/reformatters/actions/runs/31190320776), 115 workers over 3432 init_times (2024-04-01 → present) into `s3://dynamical-ecmwf-aifs-single/ecmwf-aifs-single-forecast-virtual/v0.1.0.icechunk`.

Once merged, the Validate stage's targeted re-backfills must run between update fires (updates fire at 05:20/11:20/17:20/23:20 UTC), per `docs/backfill.md`.

## Checks
- `ruff check` / `ruff format --check` / `ty check` clean
- `uv run pytest tests/ecmwf/aifs_single/forecast_virtual/` — 32 passed