### PR TITLE
AIFS Single virtual: read the transitional experimental/ source path

### DIFF
--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/region_job.py
@@ -19,6 +19,7 @@ from reformatters.ecmwf.ecmwf_grib_index import parse_index_file
 
 from .template_config import (
     AIFS_SINGLE_FORMAT_CHANGE_DATE,
+    AIFS_SINGLE_OPERATIONAL_PATH_DATE,
     PRESSURE_LEVELS,
     EcmwfAifsSingleVirtualDataVar,
 )
@@ -53,16 +54,17 @@ class EcmwfAifsSingleForecastVirtualSourceFileCoord(SourceFileCoord):
     data_vars: Sequence[EcmwfAifsSingleVirtualDataVar]
 
     def _get_base_url(self) -> str:
-        model_dir = (
-            "aifs-single"
-            if self.init_time >= AIFS_SINGLE_FORMAT_CHANGE_DATE
-            else "aifs"
-        )
+        if self.init_time < AIFS_SINGLE_FORMAT_CHANGE_DATE:
+            stream_path = "aifs/0p25/oper"
+        elif self.init_time < AIFS_SINGLE_OPERATIONAL_PATH_DATE:
+            stream_path = "aifs-single/0p25/experimental/oper"
+        else:
+            stream_path = "aifs-single/0p25/oper"
         init_date_str = self.init_time.strftime("%Y%m%d")
         init_hour_str = self.init_time.strftime("%H")
         return (
             f"{SOURCE_LOCATION_PREFIX}{init_date_str}/{init_hour_str}z/"
-            f"{model_dir}/0p25/oper/"
+            f"{stream_path}/"
             f"{init_date_str}{init_hour_str}0000-{whole_hours(self.lead_time)}h-oper-fc"
         )
 

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/template_config.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/template_config.py
@@ -35,9 +35,12 @@ _GRID_NLON = 1440
 # AIFS_2026_UPGRADE_DATE (q never has it).
 PRESSURE_LEVELS = [1000, 925, 850, 700, 600, 500, 400, 300, 250, 200, 150, 100, 50, 10]
 
-# The open-data format change: the source path segment switches aifs/ -> aifs-single/,
+# The open-data format change: the source stream switches from aifs/ to aifs-single/,
 # many variables are added, and tp/cp switch from metres to kg m-2.
-AIFS_SINGLE_FORMAT_CHANGE_DATE = pd.Timestamp("2025-02-26T00:00")
+AIFS_SINGLE_FORMAT_CHANGE_DATE = pd.Timestamp("2025-02-24T06:00")
+# The aifs-single stream spends its first 36 hours under an experimental/ path
+# segment before moving to the operational one.
+AIFS_SINGLE_OPERATIONAL_PATH_DATE = pd.Timestamp("2025-02-25T06:00")
 # Model upgrade adding fscov and the 10 hPa pressure level.
 AIFS_2026_UPGRADE_DATE = pd.Timestamp("2026-05-13T00:00")
 

--- a/tests/ecmwf/aifs_single/forecast_virtual/region_job_test.py
+++ b/tests/ecmwf/aifs_single/forecast_virtual/region_job_test.py
@@ -128,6 +128,28 @@ def test_source_file_coord_url_era2_uses_aifs_single_path() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("init_time", "expected_stream_path"),
+    [
+        ("2025-02-24T00:00", "aifs/0p25/oper"),
+        ("2025-02-24T06:00", "aifs-single/0p25/experimental/oper"),
+        ("2025-02-25T00:00", "aifs-single/0p25/experimental/oper"),
+        ("2025-02-25T06:00", "aifs-single/0p25/oper"),
+    ],
+)
+def test_source_file_coord_url_spans_the_three_source_stream_paths(
+    init_time: str, expected_stream_path: str
+) -> None:
+    """The aifs-single stream is served from an experimental/ path for its first 36 hours."""
+    coord = _coord([get_var("temperature_2m")], init_time=pd.Timestamp(init_time))
+    stamp = pd.Timestamp(init_time)
+    assert coord.get_url() == (
+        f"s3://ecmwf-forecasts/{stamp.strftime('%Y%m%d')}/{stamp.strftime('%H')}z/"
+        f"{expected_stream_path}/"
+        f"{stamp.strftime('%Y%m%d%H')}0000-6h-oper-fc.grib2"
+    )
+
+
 def test_out_loc_with_root_vars_excludes_level() -> None:
     coord = _coord([get_var("temperature_2m"), get_var("pressure_level/temperature")])
     assert dict(coord.out_loc()) == {


### PR DESCRIPTION
Extracted from the closed #868 — this is **only** the `_get_base_url` change; the validation-timeseries pinning from that PR is not included.

Part of the Validate stage for `ecmwf-aifs-single-forecast-virtual` (#831, dataset added in #833).

## The problem

The post-backfill manifest scan flagged **7 init positions with 0 of 61 source files present**: `2025-02-24T06` through `2025-02-25T18`. The files exist upstream — at a path the URL builder never constructed.

The cutover is three-phase, not two:

| path | inits | `expver` |
|---|---|---|
| `aifs/0p25/oper/` | through 2025-02-24T00 | 0001 operational |
| `aifs-single/0p25/experimental/oper/` | 2025-02-24T06 → 2025-02-25T00 | **0102 experimental** |
| `aifs-single/0p25/oper/` | 2025-02-25T06 onward | 0001 operational |

`_get_base_url` now selects between all three. `AIFS_SINGLE_FORMAT_CHANGE_DATE` moves to `2025-02-24T06` (the first init with no `aifs/` file) and a new `AIFS_SINGLE_OPERATIONAL_PATH_DATE = 2025-02-25T06` marks the move off the experimental path.

**Strictly additive:** 2025-02-24T00 and earlier keep reading `aifs/0p25/oper/`, so only the 7 currently-empty positions change and no already-ingested data is affected.

## Please note before merging: the experimental four are `expver` 0102

The four inits served from `experimental/` carry `expver=0102`, not the operational `0001` of the eras either side. They are a different model version that happened to be published to open data during the transition — so ingesting them is an editorial call about whether this archive mixes `expver`, not purely a bug fix.

The three later inits (2025-02-25T06/12/18) are `expver=0001` and are unambiguously ours to have missed.

If mixing `expver` is not wanted, the fix is to set `AIFS_SINGLE_FORMAT_CHANGE_DATE = 2025-02-25T06:00` and drop the middle branch, recovering 3 of the 7 inits.

## Verification

The format change travels with the stream, so the added variables and the tp/cp unit switch start at the same date as the path change:

- **Param set** — `experimental/` already matches post-cutover `oper` (31 params incl. all the added `100u`/`100v`/`tcc`/`lcc`/`mcc`/`hcc`/`rowe`/`sf`/`sot`/`ssrd`/`strd`/`vsw`); pre-cutover `aifs/` has 17.
- **tp units** — already `kg m-2` in the experimental era, so no unit discontinuity is introduced. Decoded `tp` at lead 24h:

  | init | path | max | mean |
  |---|---|---|---|
  | 2025-02-23T00 | `aifs/oper` | 0.239 (metres) | 0.0024 |
  | 2025-02-24T06 | `experimental/oper` | 228.7 | 2.380 |
  | 2025-02-25T06 | `aifs-single/oper` | 234.8 | 2.448 |
  | 2025-02-26T00 | `aifs-single/oper` | 231.1 | 2.486 |

- **Files are real, not placeholders** — all 7 inits have exactly 61 `.grib2` + 61 `.index`, no zero-byte objects, ~73 MB each; index metadata carries each init's own `date`/`time`; decoded `sp` is a 721×1440 `pa` field with the correct `reference_date`.
- **URLs built by this code resolve** for every init across the transition (2025-02-23T18 → 2025-02-26T00), each returning a real object of expected size.

## Scope

- No template change — `date_available` is runtime-only; `update-template` produces no diff.
- **This does not backfill the data.** The 7 positions stay empty until an `overwrite-chunks` backfill filtered to those timestamps runs.

## Checks
- `ruff format --check` / `ruff check` / `ty check` clean
- `uv run pytest tests/ecmwf/aifs_single/ -m "not slow"` — 67 passed