### PR TITLE
Fingerprint validate_dataset's Sentry reports by (dataset_id, check)

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -20,7 +20,6 @@ from reformatters.common.config import Config
 from reformatters.common.dynamical_dataset import DynamicalDataset, register_run_monitor
 from reformatters.common.initialize_new_integration import initialize_new_integration
 from reformatters.common.storage import DatasetFormat, StorageConfig
-from reformatters.common.validation import ZarrValidationError
 from reformatters.contrib.nasa.smap.level3_36km_v9 import NasaSmapLevel336KmV9Dataset
 from reformatters.contrib.noaa.ndvi_cdr.analysis import (
     NoaaNdviCdrAnalysisDataset,
@@ -272,9 +271,6 @@ if Config.is_sentry_enabled:
         integrations=[
             TyperIntegration(),
         ],
-        # validate_dataset already reports failures itself, fingerprinted per dataset;
-        # this avoids a second, differently-grouped report of the same raised exception.
-        ignore_errors=[ZarrValidationError],
     )
     sentry_sdk.set_tag("env", Config.env.value)
     sentry_sdk.set_tag("cron_job_name", cron_job_name)

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -20,6 +20,7 @@ from reformatters.common.config import Config
 from reformatters.common.dynamical_dataset import DynamicalDataset, register_run_monitor
 from reformatters.common.initialize_new_integration import initialize_new_integration
 from reformatters.common.storage import DatasetFormat, StorageConfig
+from reformatters.common.validation import ZarrValidationError
 from reformatters.contrib.nasa.smap.level3_36km_v9 import NasaSmapLevel336KmV9Dataset
 from reformatters.contrib.noaa.ndvi_cdr.analysis import (
     NoaaNdviCdrAnalysisDataset,
@@ -271,6 +272,9 @@ if Config.is_sentry_enabled:
         integrations=[
             TyperIntegration(),
         ],
+        # validate_dataset already reports failures itself, fingerprinted per dataset;
+        # this avoids a second, differently-grouped report of the same raised exception.
+        ignore_errors=[ZarrValidationError],
     )
     sentry_sdk.set_tag("env", Config.env.value)
     sentry_sdk.set_tag("cron_job_name", cron_job_name)

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -594,6 +594,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             validation.validate_dataset(
                 primary_store,
                 validators=primary_store_validators,
+                dataset_id=self.dataset_id,
                 region_job=region_job,
             )
             log.info(f"Done validating {primary_store}")
@@ -620,6 +621,7 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                 validation.validate_dataset(
                     replica_store,
                     validators=replica_store_validators,
+                    dataset_id=self.dataset_id,
                     region_job=region_job,
                 )
                 log.info(f"Done validating {replica_store}")

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -63,13 +63,8 @@ class ValidationResult(pydantic.BaseModel):
     )
 
 
-class ZarrValidationError(ValueError):
-    """Raised by validate_dataset when one or more checks fail.
-
-    Listed in the Sentry SDK's ignore_errors so the default exception-capturing
-    integration, which groups by raise-site stack trace regardless of dataset, doesn't
-    also report this alongside validate_dataset's own per-dataset fingerprinted capture.
-    """
+class OperationalValidationError(ValueError):
+    """Raised by validate_dataset when one or more checks fail."""
 
 
 @runtime_checkable
@@ -132,8 +127,8 @@ def open_flattened_dataset(
 
 def _validator_check_name(validator: DataValidator) -> str:
     """A stable per-check identifier for Sentry fingerprinting, independent of any
-    particular failure's message text (which embeds per-run details like variable
-    names, fractions, or init times)."""
+    particular failure's message text.
+    """
     if isinstance(validator, VirtualDataValidator):
         return type(validator).__name__
     if isinstance(validator, partial):
@@ -144,8 +139,8 @@ def _validator_check_name(validator: DataValidator) -> str:
 def validate_dataset(
     store: zarr.storage.StoreLike,
     validators: Sequence[DataValidator],
-    dataset_id: str,
     *,
+    dataset_id: str,
     region_job: VirtualRegionJob[Any, Any] | None = None,
 ) -> None:
     """
@@ -155,12 +150,12 @@ def validate_dataset(
         store: the zarr/icechunk store to validate.
         validators: the checks to run; XarrayDataValidators receive the opened dataset,
             VirtualDataValidators receive (region_job, store, ds).
-        dataset_id: identifies the dataset in Sentry fingerprints for failures below.
+        dataset_id: identifies the dataset in the Sentry fingerprint of a failure.
         region_job: the operational-window job, required when any validator is a
             VirtualDataValidator (it supplies the source-file coords + manifest probe).
 
     Raises:
-        ZarrValidationError: If any validation checks fail
+        OperationalValidationError: If any validation checks fail
     """
     log.info(f"Validating zarr {store}")
 
@@ -168,6 +163,7 @@ def validate_dataset(
 
     # Run all validators
     failed_validations = []
+    failed_checks = []
     for validator in validators:
         ds = open_flattened_dataset(store, consolidated=consolidated)
 
@@ -182,14 +178,10 @@ def validate_dataset(
             result = validator(ds)
 
         if not result.passed:
-            # An explicit fingerprint keeps repeated failures of the same check on the
-            # same dataset grouped together, instead of Sentry's default message-based
-            # grouping fragmenting on a per-run detail (a NaN fraction, an init_time, ...)
-            # embedded in result.message.
-            with sentry_sdk.new_scope() as scope:
-                scope.fingerprint = [dataset_id, _validator_check_name(validator)]
-                log.error(f"Failed validation: {result.message}")
+            # Warn don't error; the raise below creates a single Sentry issue.
+            log.warning(f"Failed validation: {result.message}")
             failed_validations.append(result.message)
+            failed_checks.append(_validator_check_name(validator))
         else:
             log.info(f"Passed validation: {result.message}")
 
@@ -200,13 +192,8 @@ def validate_dataset(
         message = "Zarr validation failed:\n" + "\n".join(
             f"- {msg}" for msg in failed_validations
         )
-        # Captured explicitly (fingerprinted per dataset) rather than relying on the
-        # default capture of the exception below, which groups by raise-site stack
-        # trace and would otherwise lump every dataset's generic failures together.
-        with sentry_sdk.new_scope() as scope:
-            scope.fingerprint = [dataset_id, "zarr_validation_failed"]
-            sentry_sdk.capture_message(message, level="error")
-        raise ZarrValidationError(message)
+        sentry_sdk.get_isolation_scope().fingerprint = [dataset_id, *failed_checks]
+        raise OperationalValidationError(message)
 
     log.info("Zarr validation passed all checks")
 

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -21,6 +21,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 import pydantic
+import sentry_sdk
 import xarray as xr
 import zarr
 import zarr.core.sync
@@ -60,6 +61,15 @@ class ValidationResult(pydantic.BaseModel):
     checked_count: int | None = (
         None  # items/references checked, when the validator tracks it
     )
+
+
+class ZarrValidationError(ValueError):
+    """Raised by validate_dataset when one or more checks fail.
+
+    Listed in the Sentry SDK's ignore_errors so the default exception-capturing
+    integration, which groups by raise-site stack trace regardless of dataset, doesn't
+    also report this alongside validate_dataset's own per-dataset fingerprinted capture.
+    """
 
 
 @runtime_checkable
@@ -120,9 +130,21 @@ def open_flattened_dataset(
     return iterating.flatten_groups(tree)
 
 
+def _validator_check_name(validator: DataValidator) -> str:
+    """A stable per-check identifier for Sentry fingerprinting, independent of any
+    particular failure's message text (which embeds per-run details like variable
+    names, fractions, or init times)."""
+    if isinstance(validator, VirtualDataValidator):
+        return type(validator).__name__
+    if isinstance(validator, partial):
+        return validator.func.__name__  # ty: ignore[unresolved-attribute]
+    return validator.__name__  # ty: ignore[unresolved-attribute]
+
+
 def validate_dataset(
     store: zarr.storage.StoreLike,
     validators: Sequence[DataValidator],
+    dataset_id: str,
     *,
     region_job: VirtualRegionJob[Any, Any] | None = None,
 ) -> None:
@@ -133,11 +155,12 @@ def validate_dataset(
         store: the zarr/icechunk store to validate.
         validators: the checks to run; XarrayDataValidators receive the opened dataset,
             VirtualDataValidators receive (region_job, store, ds).
+        dataset_id: identifies the dataset in Sentry fingerprints for failures below.
         region_job: the operational-window job, required when any validator is a
             VirtualDataValidator (it supplies the source-file coords + manifest probe).
 
     Raises:
-        ValueError: If any validation checks fail
+        ZarrValidationError: If any validation checks fail
     """
     log.info(f"Validating zarr {store}")
 
@@ -159,7 +182,13 @@ def validate_dataset(
             result = validator(ds)
 
         if not result.passed:
-            log.error(f"Failed validation: {result.message}")
+            # An explicit fingerprint keeps repeated failures of the same check on the
+            # same dataset grouped together, instead of Sentry's default message-based
+            # grouping fragmenting on a per-run detail (a NaN fraction, an init_time, ...)
+            # embedded in result.message.
+            with sentry_sdk.new_scope() as scope:
+                scope.fingerprint = [dataset_id, _validator_check_name(validator)]
+                log.error(f"Failed validation: {result.message}")
             failed_validations.append(result.message)
         else:
             log.info(f"Passed validation: {result.message}")
@@ -168,10 +197,16 @@ def validate_dataset(
         del ds
 
     if failed_validations:
-        raise ValueError(
-            "Zarr validation failed:\n"
-            + "\n".join(f"- {msg}" for msg in failed_validations)
+        message = "Zarr validation failed:\n" + "\n".join(
+            f"- {msg}" for msg in failed_validations
         )
+        # Captured explicitly (fingerprinted per dataset) rather than relying on the
+        # default capture of the exception below, which groups by raise-site stack
+        # trace and would otherwise lump every dataset's generic failures together.
+        with sentry_sdk.new_scope() as scope:
+            scope.fingerprint = [dataset_id, "zarr_validation_failed"]
+            sentry_sdk.capture_message(message, level="error")
+        raise ZarrValidationError(message)
 
     log.info("Zarr validation passed all checks")
 

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 from datetime import timedelta
 from functools import partial
@@ -653,7 +654,7 @@ def test_validate_dataset_raises_on_failed_validator(
     def failing(ds: xr.Dataset) -> validation.ValidationResult:
         return validation.ValidationResult(passed=False, message="bad thing")
 
-    with pytest.raises(validation.ZarrValidationError, match="bad thing"):
+    with pytest.raises(validation.OperationalValidationError, match="bad thing"):
         validation.validate_dataset(
             store, validators=[passing, failing], dataset_id="d"
         )
@@ -663,11 +664,17 @@ def test_validate_dataset_raises_on_failed_validator(
 
 
 def test_validate_dataset_fingerprints_by_dataset_and_check(
-    monkeypatch: pytest.MonkeyPatch, rng: np.random.Generator
+    caplog: pytest.LogCaptureFixture, rng: np.random.Generator
 ) -> None:
-    """Failures fingerprint by (dataset_id, check), not by message text, so repeated
-    failures with different per-run details (a NaN fraction, an init_time, ...) group
-    together instead of each filing a new Sentry issue."""
+    """A failure fingerprints by (dataset_id, failed checks), not by message text, so
+    repeated failures carrying different per-run details (a NaN fraction, an init_time,
+    ...) group into one Sentry issue instead of each filing a new one. The fingerprint
+    goes on the isolation scope, which outlives validate_dataset's frame, so it is still
+    in effect when Sentry captures the raised exception at process exit — that capture
+    would otherwise group by the dataset-agnostic raise site. And no failure is logged at
+    ERROR, which the Sentry logging integration would report as a second, differently
+    grouped issue.
+    """
     times = pd.date_range("2024-01-01", periods=4, freq="1h")
     ds = xr.Dataset(
         {"temperature": (["time", "y", "x"], rng.standard_normal((4, 4, 4)))},
@@ -685,32 +692,25 @@ def test_validate_dataset_fingerprints_by_dataset_and_check(
     def failing(ds: xr.Dataset) -> validation.ValidationResult:
         return validation.ValidationResult(passed=False, message="bad thing")
 
-    per_check_fingerprints = []
-    original_error = validation.log.error
+    def also_failing(ds: xr.Dataset) -> validation.ValidationResult:
+        return validation.ValidationResult(passed=False, message="another bad thing")
 
-    def spy_error(message: str) -> None:
-        per_check_fingerprints.append(sentry_sdk.get_current_scope()._fingerprint)
-        original_error(message)
+    with sentry_sdk.isolation_scope():
+        with pytest.raises(validation.OperationalValidationError):
+            validation.validate_dataset(
+                store,
+                validators=[failing, also_failing],
+                dataset_id="noaa-gfs-forecast",
+            )
 
-    monkeypatch.setattr(validation.log, "error", spy_error)
+        assert sentry_sdk.get_isolation_scope()._fingerprint == [
+            "noaa-gfs-forecast",
+            "failing",
+            "also_failing",
+        ]
 
-    captured_messages = []
-
-    def fake_capture_message(message: str, level: str) -> None:
-        captured_messages.append((message, sentry_sdk.get_current_scope()._fingerprint))
-
-    monkeypatch.setattr(sentry_sdk, "capture_message", fake_capture_message)
-
-    with pytest.raises(validation.ZarrValidationError):
-        validation.validate_dataset(
-            store, validators=[failing], dataset_id="noaa-gfs-forecast"
-        )
-
-    assert per_check_fingerprints == [["noaa-gfs-forecast", "failing"]]
-    assert len(captured_messages) == 1
-    message, fingerprint = captured_messages[0]
-    assert "bad thing" in message
-    assert fingerprint == ["noaa-gfs-forecast", "zarr_validation_failed"]
+    failure_logs = [r for r in caplog.records if "Failed validation" in r.getMessage()]
+    assert [r.levelno for r in failure_logs] == [logging.WARNING, logging.WARNING]
 
 
 def test_validator_check_name() -> None:

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -1,10 +1,12 @@
 import warnings
 from datetime import timedelta
+from functools import partial
 
 import icechunk
 import numpy as np
 import pandas as pd
 import pytest
+import sentry_sdk
 import xarray as xr
 import zarr.core.sync
 import zarr.storage
@@ -651,11 +653,76 @@ def test_validate_dataset_raises_on_failed_validator(
     def failing(ds: xr.Dataset) -> validation.ValidationResult:
         return validation.ValidationResult(passed=False, message="bad thing")
 
-    with pytest.raises(ValueError, match="bad thing"):
-        validation.validate_dataset(store, validators=[passing, failing])
+    with pytest.raises(validation.ZarrValidationError, match="bad thing"):
+        validation.validate_dataset(
+            store, validators=[passing, failing], dataset_id="d"
+        )
 
     # Passing-only validators should not raise.
-    validation.validate_dataset(store, validators=[passing])
+    validation.validate_dataset(store, validators=[passing], dataset_id="d")
+
+
+def test_validate_dataset_fingerprints_by_dataset_and_check(
+    monkeypatch: pytest.MonkeyPatch, rng: np.random.Generator
+) -> None:
+    """Failures fingerprint by (dataset_id, check), not by message text, so repeated
+    failures with different per-run details (a NaN fraction, an init_time, ...) group
+    together instead of each filing a new Sentry issue."""
+    times = pd.date_range("2024-01-01", periods=4, freq="1h")
+    ds = xr.Dataset(
+        {"temperature": (["time", "y", "x"], rng.standard_normal((4, 4, 4)))},
+        coords={"time": times, "y": np.arange(4), "x": np.arange(4)},
+    )
+    store = zarr.storage.MemoryStore()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Consolidated metadata is currently not part in the Zarr format 3 specification",
+            category=UserWarning,
+        )
+        ds.to_zarr(store, mode="w")
+
+    def failing(ds: xr.Dataset) -> validation.ValidationResult:
+        return validation.ValidationResult(passed=False, message="bad thing")
+
+    per_check_fingerprints = []
+    original_error = validation.log.error
+
+    def spy_error(message: str) -> None:
+        per_check_fingerprints.append(sentry_sdk.get_current_scope()._fingerprint)
+        original_error(message)
+
+    monkeypatch.setattr(validation.log, "error", spy_error)
+
+    captured_messages = []
+
+    def fake_capture_message(message: str, level: str) -> None:
+        captured_messages.append((message, sentry_sdk.get_current_scope()._fingerprint))
+
+    monkeypatch.setattr(sentry_sdk, "capture_message", fake_capture_message)
+
+    with pytest.raises(validation.ZarrValidationError):
+        validation.validate_dataset(
+            store, validators=[failing], dataset_id="noaa-gfs-forecast"
+        )
+
+    assert per_check_fingerprints == [["noaa-gfs-forecast", "failing"]]
+    assert len(captured_messages) == 1
+    message, fingerprint = captured_messages[0]
+    assert "bad thing" in message
+    assert fingerprint == ["noaa-gfs-forecast", "zarr_validation_failed"]
+
+
+def test_validator_check_name() -> None:
+    def a_check(ds: xr.Dataset) -> validation.ValidationResult:
+        raise NotImplementedError
+
+    assert validation._validator_check_name(a_check) == "a_check"
+    assert validation._validator_check_name(partial(a_check)) == "a_check"
+    assert (
+        validation._validator_check_name(validation.CheckVirtualManifestCompleteness())
+        == "CheckVirtualManifestCompleteness"
+    )
 
 
 def test_compare_replica_and_primary_coords_divergence(

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -1582,7 +1582,7 @@ def test_validate_dataset_requires_region_job_for_virtual_validator(
     store = _backfilled_store(dataset, _create_template_ds(4), emit=slice(0, 4))
     with pytest.raises(AssertionError, match="needs a region_job"):
         validation.validate_dataset(
-            store, [validation.CheckVirtualManifestCompleteness()]
+            store, [validation.CheckVirtualManifestCompleteness()], dataset_id="test"
         )
 
 


### PR DESCRIPTION
## Summary

Fixes #871.

`common/validation.py`'s failure reporting had no Sentry fingerprint override, producing two opposite grouping problems:

- **Over-fragmentation**: `validate_dataset` logged `log.error(f"Failed validation: {result.message}")` before raising. Sentry's logging integration captures that as a message event and groups by the fully-rendered string, so NaN-fraction messages (which embed per-run variable names/fractions/init_times) created a brand-new issue on every run instead of joining a shared one.
- **Over-merging**: the final `raise ValueError("Zarr validation failed:\n...")` groups by exception type + raise-site stack trace, which is dataset-agnostic — unrelated failures across every dataset landed in one shared bucket, or one per generic check title.

## Changes

- `validate_dataset` now takes a required `dataset_id` and, for each failed check, wraps the `log.error` call in `sentry_sdk.new_scope()` with `fingerprint = [dataset_id, check_name]` (`check_name` derived from the validator function/partial/class via a new `_validator_check_name` helper).
- The final aggregate failure is now raised as a new `ZarrValidationError(ValueError)` and explicitly reported via `sentry_sdk.capture_message(..., level="error")` with `fingerprint = [dataset_id, "zarr_validation_failed"]` before raising.
- `ZarrValidationError` is added to `sentry_sdk.init(ignore_errors=[...])` in `__main__.py` so the default exception-capturing integration doesn't also report it a second time with the old (wrong) grouping.
- Updated the two `DynamicalDataset.validate_dataset` call sites to pass `dataset_id=self.dataset_id`.
- Added tests covering `_validator_check_name` and that both capture points set the expected fingerprint; updated existing tests for the new required `dataset_id` param and `ZarrValidationError` type (a `ValueError` subclass, so existing `pytest.raises(ValueError, ...)`-style callers elsewhere are unaffected).

## Test plan

- [x] `uv run ruff format && uv run ruff check --fix`
- [x] `uv run ty check` (whole repo, no errors)
- [x] `uv run pytest -m "not slow"` (1870 passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EiGHFgZsnAdkVYuyemuX4k)_