### PR TITLE
AIFS Single: read the transitional experimental/ source path

### DIFF
--- a/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/region_job.py
@@ -28,6 +28,7 @@ from reformatters.common.types import (
     Timedelta,
     Timestamp,
 )
+from reformatters.ecmwf.aifs_single.template_config import aifs_single_stream_path
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, vars_available
 from reformatters.ecmwf.ecmwf_grib_index import grib_message_byte_ranges_from_index
 from reformatters.ecmwf.ecmwf_utils import (
@@ -36,9 +37,6 @@ from reformatters.ecmwf.ecmwf_utils import (
 )
 
 log = get_logger(__name__)
-
-# Path changed from aifs/ to aifs-single/ on this date
-AIFS_SINGLE_PATH_CHANGE_DATE = pd.Timestamp("2025-02-26T00:00")
 
 # GRIB master table version changes caused metadata differences for precipitation.
 # Early data (table v27): generic product template codes.
@@ -70,12 +68,8 @@ class EcmwfAifsSingleForecastSourceFileCoord(SourceFileCoord):
         init_hour_str = self.init_time.strftime("%H")
         lead_time_hour_str = whole_hours(self.lead_time)
 
-        if self.init_time >= AIFS_SINGLE_PATH_CHANGE_DATE:
-            model_dir = "aifs-single"
-        else:
-            model_dir = "aifs"
-
-        directory_path = f"{init_time_str}/{init_hour_str}z/{model_dir}/0p25/oper"
+        stream_path = aifs_single_stream_path(self.init_time)
+        directory_path = f"{init_time_str}/{init_hour_str}z/{stream_path}"
         filename = f"{init_time_str}{init_hour_str}0000-{lead_time_hour_str}h-oper-fc"
         return f"{root_url}/{directory_path}/{filename}"
 

--- a/src/reformatters/ecmwf/aifs_single/forecast/template_config.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/template_config.py
@@ -25,6 +25,7 @@ from reformatters.common.zarr import (
     BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE,
 )
 from reformatters.ecmwf.aifs_single.template_config import (
+    AIFS_SINGLE_FORMAT_CHANGE_DATE,
     EcmwfAifsSingleCommonTemplateConfig,
 )
 from reformatters.ecmwf.ecmwf_config_models import (
@@ -126,9 +127,9 @@ class EcmwfAifsSingleForecastTemplateConfig(
 
         default_keep_mantissa_bits = 7
 
-        # Variables available only from 2025-02-26 are marked with date_available.
+        # Variables added at the format change are marked with date_available.
         # All variables listed here are available from 2024-04-01 (append_dim_start) unless noted.
-        expanded_vars_date = pd.Timestamp("2025-02-26T00:00")
+        expanded_vars_date = AIFS_SINGLE_FORMAT_CHANGE_DATE
 
         # Standard acceleration of gravity for geopotential → geopotential height conversion.
         g = 9.80665

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/region_job.py
@@ -15,11 +15,12 @@ from reformatters.common.virtual_region_job import VirtualRef, VirtualRegionJob
 from reformatters.common.virtual_source_listing import (
     discover_available_by_obstore_listing,
 )
+from reformatters.ecmwf.aifs_single.template_config import (
+    aifs_single_stream_path,
+)
 from reformatters.ecmwf.ecmwf_grib_index import parse_index_file
 
 from .template_config import (
-    AIFS_SINGLE_FORMAT_CHANGE_DATE,
-    AIFS_SINGLE_OPERATIONAL_PATH_DATE,
     PRESSURE_LEVELS,
     EcmwfAifsSingleVirtualDataVar,
 )
@@ -54,12 +55,7 @@ class EcmwfAifsSingleForecastVirtualSourceFileCoord(SourceFileCoord):
     data_vars: Sequence[EcmwfAifsSingleVirtualDataVar]
 
     def _get_base_url(self) -> str:
-        if self.init_time < AIFS_SINGLE_FORMAT_CHANGE_DATE:
-            stream_path = "aifs/0p25/oper"
-        elif self.init_time < AIFS_SINGLE_OPERATIONAL_PATH_DATE:
-            stream_path = "aifs-single/0p25/experimental/oper"
-        else:
-            stream_path = "aifs-single/0p25/oper"
+        stream_path = aifs_single_stream_path(self.init_time)
         init_date_str = self.init_time.strftime("%Y%m%d")
         init_hour_str = self.init_time.strftime("%H")
         return (

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/template_config.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/template_config.py
@@ -24,6 +24,7 @@ from reformatters.common.types import (
 )
 from reformatters.common.zarr import BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE
 from reformatters.ecmwf.aifs_single.template_config import (
+    AIFS_SINGLE_FORMAT_CHANGE_DATE,
     EcmwfAifsSingleCommonTemplateConfig,
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar, EcmwfInternalAttrs
@@ -35,12 +36,6 @@ _GRID_NLON = 1440
 # AIFS_2026_UPGRADE_DATE (q never has it).
 PRESSURE_LEVELS = [1000, 925, 850, 700, 600, 500, 400, 300, 250, 200, 150, 100, 50, 10]
 
-# The open-data format change: the source stream switches from aifs/ to aifs-single/,
-# many variables are added, and tp/cp switch from metres to kg m-2.
-AIFS_SINGLE_FORMAT_CHANGE_DATE = pd.Timestamp("2025-02-24T06:00")
-# The aifs-single stream spends its first 36 hours under an experimental/ path
-# segment before moving to the operational one.
-AIFS_SINGLE_OPERATIONAL_PATH_DATE = pd.Timestamp("2025-02-25T06:00")
 # Model upgrade adding fscov and the 10 hPa pressure level.
 AIFS_2026_UPGRADE_DATE = pd.Timestamp("2026-05-13T00:00")
 

--- a/src/reformatters/ecmwf/aifs_single/template_config.py
+++ b/src/reformatters/ecmwf/aifs_single/template_config.py
@@ -20,6 +20,23 @@ from reformatters.common.types import AppendDim, Timedelta, Timestamp
 from reformatters.common.zarr import BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar
 
+# ECMWF's open data cutover from the aifs/ stream to aifs-single/. At this init the
+# source path changes, the added variables start, and tp/cp switch from metres to
+# kg m-2 -- one boundary, so both variants key all three off this constant.
+AIFS_SINGLE_FORMAT_CHANGE_DATE = pd.Timestamp("2025-02-24T06:00")
+# The aifs-single stream spends its first 36 hours under an experimental/ path segment
+# before moving to the operational one.
+AIFS_SINGLE_OPERATIONAL_PATH_DATE = pd.Timestamp("2025-02-25T06:00")
+
+
+def aifs_single_stream_path(init_time: Timestamp) -> str:
+    """The source path segment between the init hour directory and the file name."""
+    if init_time < AIFS_SINGLE_FORMAT_CHANGE_DATE:
+        return "aifs/0p25/oper"
+    if init_time < AIFS_SINGLE_OPERATIONAL_PATH_DATE:
+        return "aifs-single/0p25/experimental/oper"
+    return "aifs-single/0p25/oper"
+
 
 class EcmwfAifsSingleCommonTemplateConfig[DATA_VAR: EcmwfDataVar](
     TemplateConfig[DATA_VAR]

--- a/tests/ecmwf/aifs_single/forecast/region_job_test.py
+++ b/tests/ecmwf/aifs_single/forecast/region_job_test.py
@@ -14,12 +14,14 @@ from reformatters.common.pydantic import replace
 from reformatters.common.storage import DatasetFormat, StorageConfig, StoreFactory
 from reformatters.common.types import ArrayFloat32
 from reformatters.ecmwf.aifs_single.forecast.region_job import (
-    AIFS_SINGLE_PATH_CHANGE_DATE,
     EcmwfAifsSingleForecastRegionJob,
     EcmwfAifsSingleForecastSourceFileCoord,
 )
 from reformatters.ecmwf.aifs_single.forecast.template_config import (
     EcmwfAifsSingleForecastTemplateConfig,
+)
+from reformatters.ecmwf.aifs_single.template_config import (
+    AIFS_SINGLE_FORMAT_CHANGE_DATE,
 )
 from reformatters.ecmwf.ecmwf_config_models import EcmwfDataVar
 
@@ -41,29 +43,37 @@ def test_source_file_coord_url_before_path_change() -> None:
     )
 
 
-def test_source_file_coord_url_after_path_change() -> None:
+@pytest.mark.parametrize(
+    ("init_time", "expected_stream_path"),
+    [
+        ("2025-02-24T00:00", "aifs/0p25/oper"),
+        ("2025-02-24T06:00", "aifs-single/0p25/experimental/oper"),
+        ("2025-02-25T00:00", "aifs-single/0p25/experimental/oper"),
+        ("2025-02-25T06:00", "aifs-single/0p25/oper"),
+        ("2025-02-26T00:00", "aifs-single/0p25/oper"),
+    ],
+)
+def test_source_file_coord_url_spans_the_three_source_stream_paths(
+    init_time: str, expected_stream_path: str
+) -> None:
+    """The aifs-single stream is served from an experimental/ path for its first 36 hours."""
     config = EcmwfAifsSingleForecastTemplateConfig()
+    stamp = pd.Timestamp(init_time)
     coord = EcmwfAifsSingleForecastSourceFileCoord(
-        init_time=AIFS_SINGLE_PATH_CHANGE_DATE,
+        init_time=stamp,
         lead_time=pd.Timedelta("12h"),
         data_var_group=list(config.data_vars[:1]),
     )
-    assert coord.get_url() == (
-        "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
-        "/20250226/00z/aifs-single/0p25/oper/20250226000000-12h-oper-fc.grib2"
+    path = (
+        f"/{stamp.strftime('%Y%m%d')}/{stamp.strftime('%H')}z/{expected_stream_path}"
+        f"/{stamp.strftime('%Y%m%d%H')}0000-12h-oper-fc"
     )
-    assert coord.get_index_url() == (
-        "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
-        "/20250226/00z/aifs-single/0p25/oper/20250226000000-12h-oper-fc.index"
-    )
-    assert coord.get_url("gcs") == (
-        "https://storage.googleapis.com/ecmwf-open-data"
-        "/20250226/00z/aifs-single/0p25/oper/20250226000000-12h-oper-fc.grib2"
-    )
-    assert coord.get_index_url("gcs") == (
-        "https://storage.googleapis.com/ecmwf-open-data"
-        "/20250226/00z/aifs-single/0p25/oper/20250226000000-12h-oper-fc.index"
-    )
+    s3_root = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
+    gcs_root = "https://storage.googleapis.com/ecmwf-open-data"
+    assert coord.get_url() == f"{s3_root}{path}.grib2"
+    assert coord.get_index_url() == f"{s3_root}{path}.index"
+    assert coord.get_url("gcs") == f"{gcs_root}{path}.grib2"
+    assert coord.get_index_url("gcs") == f"{gcs_root}{path}.index"
 
 
 def test_source_file_coord_url_00z_init() -> None:
@@ -79,17 +89,17 @@ def test_source_file_coord_url_00z_init() -> None:
     )
 
 
-def test_source_file_coord_url_day_before_path_change() -> None:
-    """The day before the path change should still use 'aifs'."""
+def test_source_file_coord_url_last_init_before_format_change() -> None:
+    """The last init before the format change still uses 'aifs'."""
     config = EcmwfAifsSingleForecastTemplateConfig()
     coord = EcmwfAifsSingleForecastSourceFileCoord(
-        init_time=AIFS_SINGLE_PATH_CHANGE_DATE - pd.Timedelta("12h"),
+        init_time=AIFS_SINGLE_FORMAT_CHANGE_DATE - pd.Timedelta("6h"),
         lead_time=pd.Timedelta("6h"),
         data_var_group=list(config.data_vars[:1]),
     )
     assert coord.get_url() == (
         "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com"
-        "/20250225/12z/aifs/0p25/oper/20250225120000-6h-oper-fc.grib2"
+        "/20250224/00z/aifs/0p25/oper/20250224000000-6h-oper-fc.grib2"
     )
 
 
@@ -413,7 +423,7 @@ def test_read_data_alt_precip_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     precip_var = item(v for v in config.data_vars if v.name == "precipitation_surface")
     coord = EcmwfAifsSingleForecastSourceFileCoord(
         # v34+ alt metadata is the current "aifs-single" format, so use a current-era init.
-        init_time=AIFS_SINGLE_PATH_CHANGE_DATE,
+        init_time=AIFS_SINGLE_FORMAT_CHANGE_DATE,
         lead_time=pd.Timedelta("6h"),
         data_var_group=[precip_var],
         downloaded_path=Path("fake/path.grib2"),
@@ -482,14 +492,14 @@ def _precip_read_data_mock(
 def test_read_data_legacy_precip_scaled(monkeypatch: pytest.MonkeyPatch) -> None:
     """Legacy 'aifs' precip is stored in metres and scaled x1000 to mm (kg m-2)."""
     result = _precip_read_data_mock(
-        monkeypatch, AIFS_SINGLE_PATH_CHANGE_DATE - pd.Timedelta("6h")
+        monkeypatch, AIFS_SINGLE_FORMAT_CHANGE_DATE - pd.Timedelta("6h")
     )
     np.testing.assert_array_equal(result, 1.0)  # 0.001 m * 1000
 
 
 def test_read_data_current_precip_not_scaled(monkeypatch: pytest.MonkeyPatch) -> None:
     """Current 'aifs-single' precip is already in mm (kg m-2) and is not rescaled."""
-    result = _precip_read_data_mock(monkeypatch, AIFS_SINGLE_PATH_CHANGE_DATE)
+    result = _precip_read_data_mock(monkeypatch, AIFS_SINGLE_FORMAT_CHANGE_DATE)
     np.testing.assert_allclose(result, 0.001, rtol=1e-6)
 
 

--- a/tests/ecmwf/aifs_single/forecast/template_config_test.py
+++ b/tests/ecmwf/aifs_single/forecast/template_config_test.py
@@ -12,6 +12,9 @@ from reformatters.common.template_config import SPATIAL_REF_COORDS
 from reformatters.ecmwf.aifs_single.forecast.template_config import (
     EcmwfAifsSingleForecastTemplateConfig,
 )
+from reformatters.ecmwf.aifs_single.template_config import (
+    AIFS_SINGLE_FORMAT_CHANGE_DATE,
+)
 
 
 def test_template_config_attrs() -> None:
@@ -92,7 +95,7 @@ def test_dimension_coordinates_shapes_and_values() -> None:
 
 def test_data_vars_date_available() -> None:
     config = EcmwfAifsSingleForecastTemplateConfig()
-    expanded_date = pd.Timestamp("2025-02-26T00:00")
+    expanded_date = AIFS_SINGLE_FORMAT_CHANGE_DATE
 
     vars_with_date = [
         v for v in config.data_vars if v.internal_attrs.date_available is not None


### PR DESCRIPTION
@aldenks fixed this gap in virtual -- up to you if you want to resolve it historically in materialized. just a few inits


---

The materialized `ecmwf-aifs-single-forecast` carries the same two-phase source path assumption that #869 fixed in the virtual dataset, so **2025-02-24T06 through 2025-02-25T18 are all-NaN in the published store** — seven consecutive forecast cycles.

Verified against the live store before this change:

```
2025-02-24T00:00  data mean 4.2      2025-02-25T06:00  all-nan
2025-02-24T06:00  all-nan            2025-02-25T12:00  all-nan
2025-02-24T12:00  all-nan            2025-02-25T18:00  all-nan
2025-02-24T18:00  all-nan            2025-02-26T00:00  data mean 4.3
2025-02-25T00:00  all-nan
```

The published validation report currently tells users this data **"cannot be recovered"** from the source. That is false — all seven cycles are in ECMWF's archive under a path we never constructed. Correcting the report is follow-up work, tracked separately from this code fix.

## The change

`AIFS_SINGLE_PATH_CHANGE_DATE = 2025-02-26T00:00` resolved these inits to `aifs/0p25/oper/`, which holds no forecast GRIBs then. The real layout is three-phase:

| path | inits |
|---|---|
| `aifs/0p25/oper/` | through 2025-02-24T00 |
| `aifs-single/0p25/experimental/oper/` | 2025-02-24T06 → 2025-02-25T00 |
| `aifs-single/0p25/oper/` | 2025-02-25T06 onward |

Both variants now resolve the stream through one `aifs_single_stream_path()` helper, and the two boundary constants live in the shared `ecmwf/aifs_single/template_config.py`. The virtual dataset previously defined its own copies; a value this subtle should not be duplicated across two datasets that read the same source.

**The boundary also moves `expanded_vars_date`**, which drives two things in the materialized dataset besides `date_available`: most importantly the `InitTimeScaleFactor(scale_factor=1000, end=expanded_vars_date)` that converts metres-era precipitation. That has to move in lockstep — the recovered inits are already in kg m-2 (verified by decode: `tp` at lead 24h jumps from max 0.239 to 228.7 exactly at 2025-02-24T06), so leaving the scale boundary at 2025-02-26 would multiply them by 1000.

## Verification

Every init across the transition resolves with the corrected URLs, on both mirrors:

```
init                 s3   gcs  path
2025-02-23 18:00    206   404  aifs/0p25/oper
2025-02-24 00:00    206   404  aifs/0p25/oper
2025-02-24 06:00    206   206  aifs-single/0p25/experimental/oper
2025-02-25 00:00    206   206  aifs-single/0p25/experimental/oper
2025-02-25 06:00    206   404  aifs-single/0p25/oper
2025-02-26 00:00    206   404  aifs-single/0p25/oper
```

The GCS 404s are not a regression — the mirror has a genuine hole here (it lacks `aifs/` entirely in this window and only resumes `oper/` at 2025-02-27T06), and `ecmwf_download_with_fallback(("gcs", "s3"), ...)` already falls back to S3 on missing files. The pre-existing `aifs/` era relies on that same fallback today.

- `update-template` produces **no diff** for either dataset — `date_available` and `init_time_scale_factors` are internal attrs, so no metadata change and no re-backfill of existing positions is implied.
- `ruff format` / `ruff check` / `ty check` clean
- `uv run pytest tests/ecmwf/aifs_single/` — 71 passed
- `common_template_config_subclasses_test.py` + `datasets_cf_compliance_test.py` — 325 passed

The old test asserting `2025-02-25T12` uses `aifs/` encoded the bug; it is replaced by a parametrized test covering all three phases on both S3 and GCS.

## After merge

This only changes where we look. Recovering the data needs an `overwrite-chunks` backfill filtered to the seven timestamps, then the published validation report's "cannot be recovered" note should be corrected.