### PR TITLE
Drop redundant SHA-pin check from Code Quality

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -59,6 +59,3 @@ jobs:
 
       - name: Run Pytest
         run: uv run pytest -p no:sugar --verbose
-
-      - name: Ensure SHA pinned actions
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # v5


### PR DESCRIPTION
Removes the `zgosalvez/github-actions-ensure-sha-pinned-actions` step from Code Quality.

GitHub now enforces this natively: the repo has `sha_pinning_required: true` ("Require actions to be pinned to a full-length commit SHA"), which rejects any tag- or branch-pinned `uses:` ref at run startup rather than failing a check step after the fact.

It also removes the last thing needing a hand-maintained entry in the repo Actions allow-list. `zgosalvez` was the only third-party action not covered by "Allow actions by Marketplace verified creators" (`astral-sh`, `aws-actions`, `azure`, `depot` all are), so it was the only one pinned by SHA in `patterns_allowed` — and every dependabot bump of it moved the SHA out of that list, failing Code Quality at startup with an opaque "workflow file issue". That is what has been blocking #756 since 2026-08-04.

Follow-ups once this merges:
1. Clear the repo-level Actions allow-list (Settings → Actions → General); no explicit patterns are needed anymore.
2. Comment `@dependabot recreate` on #756 so the zgosalvez bump drops out of it.

Tradeoff worth noting: with native enforcement, a PR that introduces a tag-pinned action fails as an opaque `startup_failure` instead of a legible red check naming the offending action. Local `./`-style refs are also exempt from the native check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)