### PR TITLE
Resume NDVI CDR update and validate cron jobs

### DIFF
--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
@@ -20,16 +20,8 @@ class NoaaNdviCdrAnalysisDataset(
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
-        # Suspended: the data disappeared from the source. Neither NOAA access path
-        # (s3://noaa-cdr-ndvi-pds, NCEI's HTTP archive) serves files after 2024-12-31
-        # anymore, so there is nothing to update from. We've asked NOAA's data contact
-        # what happened and are waiting to hear back; resume both cron jobs once the
-        # source serves recent files again.
-        suspend = True
-
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            suspend=suspend,
             schedule="0 20 * * *",
             pod_active_deadline=timedelta(minutes=30),  # runs take <24 min
             image=image_tag,
@@ -42,7 +34,6 @@ class NoaaNdviCdrAnalysisDataset(
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            suspend=suspend,
             schedule="30 20 * * *",  # 30m (pod_active_deadline) after reformat at :00
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,


### PR DESCRIPTION
NOAA repopulated `s3://noaa-cdr-ndvi-pds` on 2026-08-08: 2025 is complete (365 files) and 2026 runs through 2026-08-08, back to the usual ~3 day lag. The source both cron jobs read is serving recent files again, so drop the `suspend` flag added in #854 (`CronJob.suspend` already defaults to `False`).

The store was caught up first, so the resumed update cron starts from current data rather than a 14-month gap. The last update before suspension (2026-08-05) processed shard 22 with no source files available, wrote fill values over it, and — running before #855's retraction guard landed — published a template trimmed to the shard start, leaving the extent ending 2025-06-12. A regular update could not have recovered from that: `filter_start` at the store's end put the job's first region at shard 21, so a single 30-minute update pod would have had to reprocess 730 days of intact data plus the 422-day gap.

A `overwrite-chunks-and-metadata` backfill of shard 22 only (`filter_start=2025-06-13T00:00:00`, `append_dim_end=2026-08-09T00:00:00`) rewrote all three variables over 2025-06-13 → 2026-08-08 and published the extended metadata. It ran in 11.5 minutes, well inside the pod deadline, so the deadline and the 20:30 validate slot are left as they are.

Fixes #859

---
_Generated by [Claude Code](https://claude.ai/code/session_013ePQz1E1FCz4SMXkGQsvzB)_