### PR TITLE
Log SIGTERM at warning level instead of error

### DIFF
--- a/src/reformatters/common/monitoring.py
+++ b/src/reformatters/common/monitoring.py
@@ -20,7 +20,7 @@ def install_sigterm_logger() -> None:
     """Log and flush telemetry when the process is signalled to stop, then exit."""
 
     def handle_sigterm(signal_number: int, _frame: FrameType | None) -> NoReturn:
-        log.error("Received SIGTERM, exiting")
+        log.warning("Received SIGTERM, exiting")
         sentry_sdk.flush()
         raise SystemExit(128 + signal_number)
 

--- a/tests/common/monitoring_test.py
+++ b/tests/common/monitoring_test.py
@@ -69,7 +69,7 @@ def test_install_sigterm_logger(
         monkeypatch.setattr(sentry_sdk, "flush", mock_flush)
 
         with (
-            caplog.at_level(logging.ERROR),
+            caplog.at_level(logging.WARNING),
             pytest.raises(SystemExit) as exit_info,
         ):
             signal.raise_signal(signal.SIGTERM)


### PR DESCRIPTION
Kubernetes-initiated shutdowns are expected, so the SIGTERM handler now logs at warning rather than error. Test updated to capture at the new level.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ta8pryqkyc8x1W1hTbYKPj)_