### PR TITLE
Bound icechunk object store requests with explicit timeouts

### DIFF
--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -571,9 +571,6 @@ def _repository_config_and_credentials(
     """Build the icechunk `RepositoryConfig` override for a dataset, plus the anonymous
     authorize map for a virtual one (`None` for a materialized one)."""
     config = icechunk.RepositoryConfig.default()
-    # icechunk puts no deadline on an object store request, so a stalled one blocks
-    # its caller indefinitely and silently. These bound one request to
-    # max_tries x operation_timeout_ms, after which it raises.
     config.storage = icechunk.StorageSettings(
         timeouts=icechunk.StorageTimeoutSettings(
             connect_timeout_ms=3_000,
@@ -581,10 +578,6 @@ def _repository_config_and_credentials(
             operation_attempt_timeout_ms=15_000,
             operation_timeout_ms=30_000,
         ),
-        # Tries stay generous -- icechunk gives these settings to virtual chunk
-        # fetchers too, and a throttled source bucket needs every one -- but the
-        # backoff ceiling comes down from icechunk's 3 minutes, longer than an
-        # operational update's whole tick.
         retries=icechunk.StorageRetriesSettings(max_tries=10, max_backoff_ms=5_000),
     )
     config.manifest = icechunk.ManifestConfig(

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -571,6 +571,22 @@ def _repository_config_and_credentials(
     """Build the icechunk `RepositoryConfig` override for a dataset, plus the anonymous
     authorize map for a virtual one (`None` for a materialized one)."""
     config = icechunk.RepositoryConfig.default()
+    # icechunk puts no deadline on an object store request, so a stalled one blocks
+    # its caller indefinitely and silently. These bound one request to
+    # max_tries x operation_timeout_ms, after which it raises.
+    config.storage = icechunk.StorageSettings(
+        timeouts=icechunk.StorageTimeoutSettings(
+            connect_timeout_ms=3_000,
+            read_timeout_ms=15_000,
+            operation_attempt_timeout_ms=15_000,
+            operation_timeout_ms=30_000,
+        ),
+        # Tries stay generous -- icechunk gives these settings to virtual chunk
+        # fetchers too, and a throttled source bucket needs every one -- but the
+        # backoff ceiling comes down from icechunk's 3 minutes, longer than an
+        # operational update's whole tick.
+        retries=icechunk.StorageRetriesSettings(max_tries=10, max_backoff_ms=5_000),
+    )
     config.manifest = icechunk.ManifestConfig(
         splitting=virtual_config.manifest_split if virtual_config is not None else None,
         max_concurrent_manifest_fetches_during_commit=16,

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -18,6 +18,7 @@ from reformatters.common.storage import (
     StoreFactory,
     _get_store_path,
     _icechunk_to_s3fs_storage_options,
+    _repository_config_and_credentials,
     commit_if_icechunk,
     manifest_append_dim_split,
 )
@@ -386,6 +387,29 @@ class TestIcechunkRepos:
         assert len(repos) == 2
         assert repos[0][0] == "primary"
         assert repos[1][0] == "replica-0"
+
+
+class TestRepositoryConfigStorageSettings:
+    @pytest.mark.parametrize("virtual_config", [None, _example_virtual_config()])
+    def test_every_object_store_request_is_bounded(
+        self, virtual_config: IcechunkVirtualConfig | None
+    ) -> None:
+        config, _ = _repository_config_and_credentials(virtual_config)
+        assert config.storage is not None
+        timeouts = config.storage.timeouts
+        retries = config.storage.retries
+        assert timeouts is not None
+        assert retries is not None
+        assert timeouts.connect_timeout_ms is not None
+        assert timeouts.read_timeout_ms is not None
+        assert timeouts.operation_attempt_timeout_ms is not None
+        assert timeouts.operation_timeout_ms is not None
+        assert retries.max_tries is not None
+        # A stalled request must raise well inside an operational update's hour so the
+        # caller can retry, rather than blocking until the pod's deadline kills it.
+        assert timeouts.operation_timeout_ms * retries.max_tries <= 600_000
+        assert retries.max_backoff_ms is not None
+        assert retries.max_backoff_ms <= 10_000
 
 
 class TestIcechunkVirtualConfig:

--- a/tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py
+++ b/tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py
@@ -11,10 +11,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from reformatters.common import storage, validation
+from reformatters.common import validation
 from reformatters.common.storage import (
     DatasetFormat,
-    IcechunkVirtualConfig,
     StorageConfig,
 )
 from reformatters.ecmwf.aifs_single.forecast_virtual.dynamical_dataset import (
@@ -71,30 +70,6 @@ def test_backfill_local_and_operational_update(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     dataset = make_dataset(tmp_path)
-
-    # Give virtual reads icechunk's default retry policy. icechunk hands a repo's own
-    # storage settings to its virtual chunk fetchers, and the local filesystem backend
-    # this test writes to defaults to max_tries=1 with no backoff — so a 503 SlowDown
-    # from s3://ecmwf-forecasts fails the read outright here, where the production
-    # S3-backed store would retry it 10 times.
-    orig_repository_config = storage._repository_config_and_credentials
-
-    def repository_config_with_retries(
-        virtual_config: IcechunkVirtualConfig | None,
-    ) -> tuple[icechunk.RepositoryConfig, dict[str, Any] | None]:
-        config, credentials = orig_repository_config(virtual_config)
-        config.storage = icechunk.StorageSettings(
-            # Keep max_backoff well under icechunk's 3 minute default: a source bucket
-            # throttling every attempt should fail the test, not stall it.
-            retries=icechunk.StorageRetriesSettings(
-                max_tries=10, initial_backoff_ms=100, max_backoff_ms=5_000
-            )
-        )
-        return config, credentials
-
-    monkeypatch.setattr(
-        storage, "_repository_config_and_credentials", repository_config_with_retries
-    )
 
     # Trim to leads 0h and 6h to limit work (virtual backfill downloads only .index
     # sidecars; decode happens when the snapshot cells are read).


### PR DESCRIPTION
## Why

`noaa-hrrr-forecast-18-hour-virtual-update` timed out again today (REFORMATTERS-H3, the 14:50 UTC fire). The run was not evicted and did not crash:

- 15:33:21 — last log, `Ingesting 1 files, 0 still pending`. The whole window was worked through.
- 15:33:23.57 — the final commit **landed**: snapshot `1F5SDJSKAQ5XEHFDV62G`, the same snapshot the 15:50 run opened. No data was lost, and the next run found no leftovers.
- Then 16 minutes of silence: no `Committed N refs` line (which follows the commit call within milliseconds), no completion log, no terminal check-in, no SIGTERM line.
- The process was alive, not dead — `backoffLimitPerIndex: 5` means a crash or OOM would have started a replacement pod within seconds, and a replacement always logs an icechunk store open. Nothing logged until the :49 validate cron.
- At 15:49 the pod hit `activeDeadlineSeconds` (59m). The SIGTERM handler added in #877 produced no line because the main thread was blocked in native code, where Python defers signal handlers.

So `session.commit()` persisted its snapshot and never returned. The gap it exposes: repos are built from `icechunk.RepositoryConfig.default()`, whose `.storage` is `None` — every `StorageTimeoutSettings` field unset, meaning **no deadline on any object store request** — while `StorageRetriesSettings` defaults to a 3 minute backoff ceiling. A single stalled request can consume the rest of a pod's hour with nothing in the logs.

## What changed

Set explicit timeouts and a tighter backoff ceiling on the repository config, so it applies to every icechunk repo, materialized and virtual:

```python
config.storage = icechunk.StorageSettings(
    timeouts=icechunk.StorageTimeoutSettings(
        connect_timeout_ms=3_000,
        read_timeout_ms=15_000,
        operation_attempt_timeout_ms=15_000,
        operation_timeout_ms=30_000,
    ),
    retries=icechunk.StorageRetriesSettings(max_tries=10, max_backoff_ms=5_000),
)
```

Worst case for one request is now `max_tries × operation_timeout_ms` ≈ 5 minutes, after which it raises — against unbounded before. Commits normally run 2–3s, so the normal path has ~100× headroom.

Two judgment calls:

- **Tries stay at 10.** icechunk hands a repo's storage settings to its virtual chunk fetchers, so cutting the try count would also cut retries on throttled reads from source buckets — for our validators and for anyone reading the archive. Pinned explicitly rather than left implicit, since the bound above is only meaningful if the multiplier is known.
- **`commit_if_icechunk` still wraps commits in its own 10-attempt retry**, so a persistently stalled commit can retry for a while. The difference is that it now fails loudly at each layer instead of sitting silent.

This also makes the AIFS Single virtual test's retry monkeypatch redundant — it existed only to give local-filesystem virtual reads a retry policy, and the production config now carries the same settings it was injecting. Dropped, so the test exercises the real configuration.

## Testing

- `uv run pytest -m "not slow"` — 1877 passed
- `tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py::test_backfill_local_and_operational_update` (slow, hits real S3) — passes without the monkeypatch
- `ruff format`, `ruff check`, `ty check` — clean
- New test pins the contract: every timeout set, and `operation_timeout_ms × max_tries` bounded well inside an update's hour.

## Not included

The per-tick stall watchdog. Timeouts stop the unbounded wait inside icechunk; a daemon thread remains the only thing that could report a hang elsewhere in native code, since a signal handler provably cannot.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRxcPKwiV9xXaJhgr6ZM3h)_