### PR TITLE
Log each retried failure in retry()

### DIFF
--- a/src/reformatters/common/retry.py
+++ b/src/reformatters/common/retry.py
@@ -3,6 +3,10 @@ from collections.abc import Callable
 
 import numpy as np
 
+from reformatters.common.logging import get_logger
+
+log = get_logger(__name__)
+
 
 def retry[T](
     func: Callable[[], T],
@@ -17,6 +21,10 @@ def retry[T](
         except retryable_exceptions as e:
             last_exception = e
             if attempt < max_attempts - 1:  # sleep unless we're out of attempts
+                log.warning(
+                    f"Attempt {attempt + 1}/{max_attempts} failed, retrying: "
+                    f"{type(e).__name__}: {str(e)[:1000]}"
+                )
                 rng = np.random.default_rng()
                 time.sleep(attempt * rng.uniform(0.8, 1.2) + 0.1)
 

--- a/tests/common/test_retry.py
+++ b/tests/common/test_retry.py
@@ -35,3 +35,36 @@ def test_retryable_exceptions_propagates_non_matching() -> None:
     with pytest.raises(TypeError, match="not retryable"):
         retry(mock_func, max_attempts=3, retryable_exceptions=(ValueError,))
     assert mock_func.call_count == 1
+
+
+def test_logs_each_retried_failure_at_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_func = Mock(side_effect=[ValueError("first"), ValueError("second"), "ok"])
+    with caplog.at_level("WARNING"):
+        retry(mock_func, max_attempts=4)
+
+    assert [r.levelname for r in caplog.records] == ["WARNING", "WARNING"]
+    assert "Attempt 1/4 failed, retrying: ValueError: first" in caplog.text
+    assert "Attempt 2/4 failed, retrying: ValueError: second" in caplog.text
+
+
+def test_final_failure_is_not_logged(caplog: pytest.LogCaptureFixture) -> None:
+    # The last attempt raises to the caller, so logging it too would double report.
+    mock_func = Mock(side_effect=ValueError("persistent"))
+    with caplog.at_level("WARNING"), pytest.raises(ValueError, match="persistent"):
+        retry(mock_func, max_attempts=2)
+
+    assert len(caplog.records) == 1
+    assert "Attempt 1/2" in caplog.text
+
+
+def test_logged_exception_message_is_truncated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_func = Mock(side_effect=[ValueError("x" * 5000), "ok"])
+    with caplog.at_level("WARNING"):
+        retry(mock_func, max_attempts=2)
+
+    assert "x" * 1000 in caplog.text
+    assert "x" * 1001 not in caplog.text


### PR DESCRIPTION
## Why

`retry()` swallowed every failure but the last, so a caller retrying a persistently failing operation looked exactly like one blocked inside a single call — no log line either way. That ambiguity is the reason the `noaa-hrrr-forecast-18-hour-virtual-update` timeouts (REFORMATTERS-H3) have been hard to place: after #883 the store timeouts may well be firing, with `commit_if_icechunk`'s `retry(max_attempts=10)` absorbing each one silently.

The evidence pointing there: across seven timeout occurrences, six stop at the same place — the tick that ingests a cycle's last file, after a long idle wait for it.

| occurrence | run | gap before the fatal tick |
|---|---|---|
| Aug 7 17:49 | 16:50 | 8m25s |
| Aug 10 21:49 | 20:50 | 9m13s |
| Aug 10 23:50 | 23:50 | *no gap — stopped mid-run with 33 files pending* |
| Aug 11 03:49 | 02:50 | 6m31s |
| Aug 12 15:49 | 14:50 | 6m03s |
| Aug 12 17:49 | 16:50 | 8m57s |
| Aug 12 20:49 | 19:50 | 7m22s |

Runs that finish cleanly have final gaps of 25–38s. Every failing gap lands in a 6–9 minute band, past the 350s AWS idle timeout — the signature of a pooled connection reaped while idle and then reused. The Aug 10 23:50 outlier predates the SIGTERM handler and fits a hard kill instead.

If that reading is right, this log line settles it within about five minutes of the next occurrence: warnings appear and the store timeouts are working but being retried into the pod's deadline; no warnings and nothing is raising at all, so the block is inside a single native call and needs a watchdog thread to observe.

## What changed

One warning line per retried attempt, carrying the exception class and its message truncated to 1000 characters. Warning rather than error so it does not open a Sentry issue on its own. The final attempt raises to the caller and is not logged, to avoid double reporting.

The exception message is left to identify the operation — icechunk's errors carry their own context (`icechunk::refs::fetch_branch` and similar), and the surrounding log lines place the call — rather than threading a label through every `retry()` call site.

## Not included

Reducing `commit_if_icechunk`'s outer `retry(max_attempts=10)`. Stacked on icechunk's own 10 tries at a 30s operation timeout, the worst case is ~50 minutes inside a 59-minute pod, which is worth cutting — but it changes production retry behaviour (including for legitimate rebase conflicts) and deserves its own decision rather than riding along with a logging change.

## Testing

- `uv run pytest -m "not slow"` — 1880 passed
- `ruff format`, `ruff check`, `ty check` — clean
- New tests cover the per-retry warning, that the final failure is not logged, and the 1000-character truncation

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRxcPKwiV9xXaJhgr6ZM3h)_