### PR TITLE
Fix HRRR semantic-NaN validation sampling

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
@@ -78,6 +78,7 @@ class NoaaHrrrAnalysisDataset(
                 validation.check_analysis_recent_nans,
                 max_expected_delay=max_expected_delay,
                 include_vars=source_fill_value_vars,
-                max_nan_fraction=0.999,
+                max_nan_fraction=0.9999,
+                spatial_sampling="quarter",
             ),
         )

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
@@ -83,6 +83,7 @@ class NoaaHrrrForecast48HourDataset(
                 validation.check_forecast_recent_nans,
                 additional_skip_lead_time_0_vars=HRRR_EXPECTED_HOUR_0_NAN_VARS,
                 include_vars=source_fill_value_vars,
-                max_nan_fraction=0.999,
+                max_nan_fraction=0.9999,
+                spatial_sampling="quarter",
             ),
         )

--- a/tests/noaa/hrrr/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/analysis/dynamical_dataset_test.py
@@ -148,7 +148,8 @@ def test_validators(dataset: NoaaHrrrAnalysisDataset) -> None:
     assert (
         validators[2].keywords["include_vars"] == validators[1].keywords["exclude_vars"]
     )
-    assert validators[2].keywords["max_nan_fraction"] == 0.999
+    assert validators[2].keywords["max_nan_fraction"] == 0.9999
+    assert validators[2].keywords["spatial_sampling"] == "quarter"
 
 
 @pytest.mark.slow

--- a/tests/noaa/hrrr/forecast_48_hour/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/forecast_48_hour/dynamical_dataset_test.py
@@ -191,4 +191,5 @@ def test_validators(dataset: NoaaHrrrForecast48HourDataset) -> None:
     assert (
         validators[3].keywords["include_vars"] == validators[2].keywords["exclude_vars"]
     )
-    assert validators[3].keywords["max_nan_fraction"] == 0.999
+    assert validators[3].keywords["max_nan_fraction"] == 0.9999
+    assert validators[3].keywords["spatial_sampling"] == "quarter"


### PR DESCRIPTION
## What changed

- Sample a quarter of the HRRR spatial domain for the loose recent-NaN checks covering cloud ceiling and percent frozen precipitation.
- Require at least 0.01% finite coverage (`max_nan_fraction=0.9999`).
- Apply the same policy to HRRR analysis and HRRR 48-hour forecast.

## Why

The HRRR analysis operational validation sampled only two random spatial columns over the latest two hours. Both landed in clear/dry locations, so the two variables legitimately decoded entirely to NaN and produced a false alert.

A production check over those same timestamps found finite data for both variables. Every quarter of the domain also contained finite data; the sparsest quarter still had about 0.35% finite percent-frozen coverage.

This uses the existing validation strategy and changes no common validation code.

## Checks

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check --output-format concise`
- `uv run pytest -q tests/noaa/hrrr/analysis/dynamical_dataset_test.py tests/noaa/hrrr/forecast_48_hour/dynamical_dataset_test.py`