### PR TITLE
Downgrade read-failure logging for old archived source files

### DIFF
--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -361,8 +361,18 @@ class MaterializedRegionJob(
                     updated_coords[index] = replace(
                         coord, status=SourceFileStatus.Succeeded
                     )
-                except Exception:
-                    log.exception(f"Read failed {coord.downloaded_path}")
+                except Exception as e:
+                    append_dim_coord = coord.append_dim_coord
+                    two_days_ago = pd.Timestamp.now() - pd.Timedelta(hours=48)
+                    # Old archived source files are sometimes corrupted or unavailable;
+                    # keep full exception visibility for recent, operationally-relevant reads.
+                    if (
+                        isinstance(append_dim_coord, np.datetime64 | pd.Timestamp)
+                        and append_dim_coord < two_days_ago
+                    ):
+                        log.warning(f"Read failed {coord.downloaded_path}: {e}")
+                    else:
+                        log.exception(f"Read failed {coord.downloaded_path}")
                     updated_coords[index] = replace(
                         coord, status=SourceFileStatus.ReadFailed
                     )


### PR DESCRIPTION
## Summary

Sentry triage flagged `REFORMATTERS-EH` (`RasterioIOError: ... not recognized as being in a supported file format`) with 987 occurrences, all from a `noaa-gfs-forecast` backfill of `gfs.20221129` — a historical (2022) init time. The read failure is already handled: `MaterializedRegionJob._read_and_write_one` catches it, marks the coord `ReadFailed`, and the job continues without crashing. The issue was purely noise volume — every unreadable archived GRIB file (likely truncated/corrupted in NOAA's archive) logged at `log.exception`, generating a Sentry event each time.

`_download_processing_group`'s `_call_download_file` already has a similar age-based severity split for download failures (log `.info` when a *recent* file's absence is expected, since it hasn't been published yet). This mirrors that pattern at the opposite end of the timeline: a read failure on a very old archived file (>48h in the past) is downgraded to `.warning`, since a corrupted/unavailable file from a historical archive is a known characteristic of old GRIB archives rather than an operational problem. A read failure on recent, operationally-relevant data still logs at `.exception` for full visibility.

## Test plan

- [x] `uv run pytest -m "not slow"` — 1885 passed
- [x] `uv run ruff format`, `uv run ruff check --fix` — clean
- [x] `uv run ty check` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)

Related Sentry issue: REFORMATTERS-EH


---
_Generated by [Claude Code](https://claude.ai/code/session_01RHAjeQrykGJ3prEn9Tm8uq)_