### PR TITLE
Cut over HRRR percent-frozen fill values to NaN

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -21,7 +21,7 @@
       "separator": "/"
     }
   },
-  "fill_value": -50.0,
+  "fill_value": "NaN",
   "codecs": [
     {
       "name": "sharding_indexed",
@@ -68,10 +68,10 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+    "comment": "The source's -50 no/undefined marker is exposed as NaN.",
     "step_type": "instant",
     "coordinates": "latitude longitude spatial_ref",
-    "_FillValue": "AAAAAAAAScA="
+    "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [
     "time",

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
@@ -931,7 +931,7 @@
             "separator": "/"
           }
         },
-        "fill_value": -50.0,
+        "fill_value": "NaN",
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -978,10 +978,10 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+          "comment": "The source's -50 no/undefined marker is exposed as NaN.",
           "step_type": "instant",
           "coordinates": "latitude longitude spatial_ref",
-          "_FillValue": "AAAAAAAAScA="
+          "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
           "time",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -23,7 +23,7 @@
       "separator": "/"
     }
   },
-  "fill_value": -50.0,
+  "fill_value": "NaN",
   "codecs": [
     {
       "name": "sharding_indexed",
@@ -71,10 +71,10 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+    "comment": "The source's -50 no/undefined marker is exposed as NaN.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
-    "_FillValue": "AAAAAAAAScA="
+    "_FillValue": "AAAAAAAA+H8="
   },
   "dimension_names": [
     "init_time",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
@@ -1192,7 +1192,7 @@
             "separator": "/"
           }
         },
-        "fill_value": -50.0,
+        "fill_value": "NaN",
         "codecs": [
           {
             "name": "sharding_indexed",
@@ -1240,10 +1240,10 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+          "comment": "The source's -50 no/undefined marker is exposed as NaN.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
-          "_FillValue": "AAAAAAAAScA="
+          "_FillValue": "AAAAAAAA+H8="
         },
         "dimension_names": [
           "init_time",

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -13,7 +13,6 @@ from reformatters.common.config_models import (
     Encoding,
     StatisticsApproximate,
 )
-from reformatters.common.pydantic import replace
 from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import (
     Array1D,
@@ -369,13 +368,13 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
             ),
             NoaaHrrrDataVar(
                 name="percent_frozen_precipitation_surface",
-                encoding=replace(encoding, fill_value=-50.0),
+                encoding=encoding,
                 attrs=DataVarAttrs(
                     short_name="cpofp",
                     long_name="Percent frozen precipitation",
                     units="percent",
                     step_type="instant",
-                    comment="-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+                    comment="The source's -50 no/undefined marker is exposed as NaN.",
                 ),
                 internal_attrs=NoaaHrrrInternalAttrs(
                     grib_element="CPOFP",

--- a/tests/noaa/fill_value_migration_lock_test.py
+++ b/tests/noaa/fill_value_migration_lock_test.py
@@ -23,32 +23,18 @@ type MaterializedNoaaTemplateConfig = (
 )
 
 
-def _same_fill(actual: float, expected: float) -> bool:
-    return bool((np.isnan(actual) and np.isnan(expected)) or actual == expected)
-
-
 @pytest.mark.parametrize(
-    ("template_config", "default_fill", "fill_overrides"),
+    "template_config",
     [
-        (NoaaGfsForecastTemplateConfig(), np.nan, {}),
-        (GefsAnalysisTemplateConfig(), np.nan, {}),
-        (GefsForecast35DayTemplateConfig(), np.nan, {}),
-        (
-            NoaaHrrrForecast48HourTemplateConfig(),
-            np.nan,
-            {"percent_frozen_precipitation_surface": -50.0},
-        ),
-        (
-            NoaaHrrrAnalysisTemplateConfig(),
-            np.nan,
-            {"percent_frozen_precipitation_surface": -50.0},
-        ),
+        NoaaGfsForecastTemplateConfig(),
+        GefsAnalysisTemplateConfig(),
+        GefsForecast35DayTemplateConfig(),
+        NoaaHrrrForecast48HourTemplateConfig(),
+        NoaaHrrrAnalysisTemplateConfig(),
     ],
 )
 def test_materialized_fill_value_migration_lock(
     template_config: MaterializedNoaaTemplateConfig,
-    default_fill: float,
-    fill_overrides: dict[str, float],
 ) -> None:
     float_vars = [
         var
@@ -60,15 +46,9 @@ def test_materialized_fill_value_migration_lock(
     )
 
     for var in float_vars:
-        expected = fill_overrides.get(var.name, default_fill)
-        assert _same_fill(var.encoding.fill_value, expected), var.name
-        assert _same_fill(raw_template[var.name].encoding["fill_value"], expected), (
-            var.name
-        )
-        expected_cf_fill = -50.0 if expected == -50.0 else np.nan
-        assert _same_fill(
-            raw_template[var.name].attrs["_FillValue"], expected_cf_fill
-        ), var.name
+        assert np.isnan(var.encoding.fill_value), var.name
+        assert np.isnan(raw_template[var.name].encoding["fill_value"]), var.name
+        assert np.isnan(raw_template[var.name].attrs["_FillValue"]), var.name
         assert "missing_value" not in raw_template[var.name].attrs
 
     raw_template.close()


### PR DESCRIPTION
## Summary

- Set materialized HRRR `percent_frozen_precipitation_surface` Zarr `fill_value` and CF `_FillValue` to NaN.
- Retain the exact source `-50` marker in `internal_attrs.source_fill_value`, so materialized writes replace it with physical NaN.
- Regenerate only the HRRR analysis and HRRR 48-hour materialized templates.
- Lock every in-scope materialized NOAA float variable to NaN fill metadata.

Virtual HRRR remains unchanged at `fill_value=_FillValue=-50`; CF-aware materialized and virtual reads continue to expose NaN at the same cells.

## Why

This completes #789's approved convention. CF-aware readers already mask the published materialized `-50` marker, so decoded values do not change. The historical rewrite changes the stored representation from `-50` to physical NaN.

## Required rollout sequence

**Do not merge without coordinating the backfills.** Once this template deploys, an operational update could publish NaN metadata while historical chunks still contain physical `-50`.

1. Merge immediately after successful HRRR analysis and HRRR 48-hour operational updates.
2. Wait for the merged image to deploy.
3. Run a single full-history overwrite-chunks backfill of `percent_frozen_precipitation_surface` for HRRR analysis.
4. Run the equivalent full-history HRRR 48-hour backfill before its next operational update.
5. Verify pre/post stored values, both stores, Sentry results, and the following operational validations.

The representative HRRR 48-hour cloud-ceiling rehearsal completed in 49m36s at two jobs per pod and parallelism 50→100. The planned percent-frozen run uses about 20 jobs per pod and parallelism 200 while retaining margin under the 10-minute pod deadline.

## Validation

- 408 focused template, CF, masking, migration-lock, and HRRR tests pass.
- `ruff format`, `ruff check --fix`, and `ty check` pass.
- The preceding ordinary cutover was verified directly against every data variable in all affected production Zarr and Icechunk stores.