### PR TITLE
Fail recent-NaN validation when nothing was measured

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -459,18 +459,35 @@ def _check_nan_fractions(
             fractions[var_name] = fraction
             log.info(f"NaN fraction for {var_name}: {fraction:.6f}")
 
+    # An empty selection means the check measured nothing. Its NaN fraction is NaN,
+    # which is not > any threshold, so without this it reports a pass.
+    unmeasured_vars = sorted(
+        var_name
+        for var_name, fraction in fractions.items()
+        if not np.isfinite(fraction)
+    )
     problem_vars = {
         var_name: fraction
         for var_name, fraction in fractions.items()
-        if fraction > max_nan_fraction
+        if np.isfinite(fraction) and fraction > max_nan_fraction
     }
 
-    if problem_vars:
-        message = f"Excessive NaN fraction (> {max_nan_fraction}):\n" + "\n".join(
-            f"- {var}: {fraction:.6f} NaN fraction"
-            for var, fraction in sorted(problem_vars.items())
+    messages = []
+    if unmeasured_vars:
+        messages.append(
+            "No values selected to compute a NaN fraction for: "
+            + ", ".join(unmeasured_vars)
         )
-        return ValidationResult(passed=False, message=message)
+    if problem_vars:
+        messages.append(
+            f"Excessive NaN fraction (> {max_nan_fraction}):\n"
+            + "\n".join(
+                f"- {var}: {fraction:.6f} NaN fraction"
+                for var, fraction in sorted(problem_vars.items())
+            )
+        )
+    if messages:
+        return ValidationResult(passed=False, message="\n".join(messages))
 
     return ValidationResult(
         passed=True,

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -250,6 +250,74 @@ def test_check_forecast_recent_nans_window_all_clean_passes(
     assert "All 3 recent init_times" in result.message
 
 
+def test_check_forecast_recent_nans_empty_selection_fails(
+    rng: np.random.Generator,
+) -> None:
+    """A variable left with no values to check must fail, not vacuously pass.
+
+    A non-instant variable's lead_time=0 slice is dropped, so a single-lead
+    dataset leaves it empty. An empty selection yields a NaN fraction of NaN,
+    which no threshold comparison can catch.
+    """
+    lats = np.linspace(-90, 90, 10)
+    lons = np.linspace(-180, 180, 20)
+    ds = xr.Dataset(
+        {
+            "precipitation": (
+                ["init_time", "lead_time", "latitude", "longitude"],
+                rng.standard_normal((2, 1, len(lats), len(lons))),
+                {"step_type": "accum"},
+            ),
+        },
+        coords={
+            "init_time": pd.date_range("2024-01-01", periods=2, freq="6h"),
+            "lead_time": pd.timedelta_range(start="0h", periods=1, freq="6h"),
+            "latitude": lats,
+            "longitude": lons,
+        },
+    )
+
+    result = validation.check_forecast_recent_nans(ds)
+
+    assert not result.passed
+    assert "precipitation" in result.message
+
+
+def test_check_analysis_recent_nans_empty_window_fails(
+    monkeypatch: pytest.MonkeyPatch, analysis_dataset: xr.Dataset
+) -> None:
+    """An empty recency window must fail, not vacuously pass.
+
+    Running off-schedule, or before a late update publishes, selects no times.
+    Every variable's NaN fraction is then NaN, which passes every threshold.
+    """
+    now = pd.Timestamp("2024-01-10")
+    monkeypatch.setattr("pandas.Timestamp.now", lambda tz=None: now)
+
+    result = validation.check_analysis_recent_nans(
+        analysis_dataset, max_expected_delay=timedelta(hours=4)
+    )
+
+    assert not result.passed
+    assert "temperature" in result.message
+
+
+def test_check_analysis_recent_nans_empty_window_fails_with_loose_threshold(
+    monkeypatch: pytest.MonkeyPatch, analysis_dataset: xr.Dataset
+) -> None:
+    """An empty window fails even where a high NaN fraction would be tolerated."""
+    now = pd.Timestamp("2024-01-10")
+    monkeypatch.setattr("pandas.Timestamp.now", lambda tz=None: now)
+
+    result = validation.check_analysis_recent_nans(
+        analysis_dataset,
+        max_expected_delay=timedelta(hours=4),
+        max_nan_fraction=0.9999,
+    )
+
+    assert not result.passed
+
+
 def test_check_analysis_current_data_passes(
     monkeypatch: pytest.MonkeyPatch, analysis_dataset: xr.Dataset
 ) -> None:


### PR DESCRIPTION
## Why

A HRRR analysis validation run this morning logged this:

```
Computing NaN fraction for 25 variables: [...] over coordinates: time=<empty>, ...
NaN fraction for temperature_2m: nan
...
Passed validation: All 25 variables have NaN fraction <= 0.0
```

Every variable's NaN fraction was `nan` and the validator reported a pass. `nan > max_nan_fraction` is `False`, so an empty selection produces no problem vars and `_check_nan_fractions` returns `passed=True` with a message asserting a bound it never checked.

That run did fail overall, because `check_analysis_current_data` is a separate validator that independently caught the empty window. This error case is really the job of `check_analysis_current_data` which is working, but we might as well make the NaN check clearer in this case. For this off cycle run, the NaN check contributed nothing.

The two are coupled only by configuration: `noaa-hrrr-analysis` happens to pass the same `max_expected_delay` to its recency check and both of its NaN checks, so an empty NaN window currently implies a recency failure. Nothing in the code enforces that. A dataset that gives the recency check a longer delay, or omits it, gets a silently green NaN validator.

The empty selection has two causes in practice, one per variant:

- **Analysis** — `check_analysis_recent_nans` slices `time` by wall clock (`now - max_expected_delay`). Running off-schedule, or before a late update publishes, selects no times.
- **Forecast** — `check_forecast_recent_nans` is positional, but `_compute_var_nan_fraction` drops the `lead_time=0` slice for non-instant variables, so a single-lead dataset leaves such a variable empty.

## What changed

`_check_nan_fractions` now treats a non-finite fraction as a failure, reported separately from an exceeded threshold so the message says which problem occurred:

```
No values selected to compute a NaN fraction for: precipitation, temperature
```

Three tests cover it — one per variant, plus one confirming an empty window still fails under a loose threshold (`0.9999`), the regime the HRRR semantic-NaN checks run in.

## Validation

- `uv run pytest tests/common/validation_test.py` — 42 passed (3 new, all failing before this change)
- `uv run pytest -m "not slow" tests/common tests/noaa/hrrr tests/noaa/gefs` — 1107 passed
- `uv run ruff format`, `uv run ruff check`, `uv run ty check` — clean

## Not included

Two follow-ups this surfaced, both deliberately out of scope:

- Switching `check_analysis_recent_nans` from a wall-clock window to last-n-positions, matching `check_forecast_recent_nans`, so an off-schedule run is not empty by construction. That removes the cause; this PR makes the symptom loud either way.
- A manual validate job checks in to the scheduled Sentry cron monitor (slug is the CronJob name), so a hand-run failure registers against the scheduled monitor.