### PR TITLE
State the keep-alive comment as fact

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -268,7 +268,7 @@ if Config.is_sentry_enabled:
         in_app_include=["reformatters"],
         default_integrations=True,
         enable_logs=True,
-        # Hypothesis: connection idles are causing us to loose events after quiet periods
+        # Connection idles cause us to lose events after quiet periods
         keep_alive=True,
         before_send_log=before_log,
         integrations=[


### PR DESCRIPTION
## Why

The `keep_alive=True` comment added in #888 was written as a hypothesis, because at the time it was one. The soak since has supported it, so the comment should state the reason plainly. Also fixes "loose" → "lose".

```diff
-        # Hypothesis: connection idles are causing us to loose events after quiet periods
+        # Connection idles cause us to lose events after quiet periods
```

## Draft until the soak completes

Opened as a draft deliberately. The bar is 18 hours with no new REFORMATTERS-H3 occurrence: the fix deployed 2026-08-13T20:04Z, the first fire under it was 20:50Z, and the window closes at 15:49Z on 2026-08-14 when the 14:50Z fire's check-in window ends.

As of ~10:40Z the streak is clean — the issue is still at 20 occurrences, last seen 2026-08-13T12:49Z, with every fire since the deploy completing end to end. Mark ready and merge once the window closes clean; close it if a new occurrence fires, since the comment would then be wrong.

One caveat worth carrying: at roughly two failures a day, an 18-hour clean window still leaves about a 1-in-5 chance of being luck rather than the fix.

## Testing

Comment-only change. `ruff format`, `ruff check`, `ty check` clean; `uv run pytest -m "not slow"` — 1888 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRxcPKwiV9xXaJhgr6ZM3h)_