### PR TITLE
Check analysis NaN fractions per timestep, by position

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -460,9 +460,8 @@ def _check_nan_fractions(
         for future in as_completed(future_to_var):
             fractions[future_to_var[future]] = future.result()
 
-    # One record rather than one per variable: many log records emitted within the same
-    # second are dropped before reaching Sentry, and the per-variable fractions are what
-    # inspecting a past run needs.
+    # Combine: many info level log records emitted within the same second are dropped
+    # before reaching Sentry.
     summary = ", ".join(f"{var}={fractions[var]:.6f}" for var in sorted(fractions))
     log.info(f"NaN fractions: {summary}")
 

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -325,13 +325,17 @@ def check_analysis_recent_nans(
     """
     Check the NaN fraction of recent timesteps in an analysis dataset.
 
+    The window spans `max_expected_delay` back from the dataset's newest timestamp,
+    not from now, so it always selects data. Whether that newest timestamp is itself
+    recent enough is `check_analysis_current_data`'s question.
+
     Default `spatial_sampling="random_points"` reads 2 random spatial points
     (across all timesteps in the window) — cheap and covers independent
     locations. Use `"quarter"` for structural-NaN datasets and `"all"` only
     when small.
     """
-    now = pd.Timestamp.now()
-    sample_ds = ds.sel(time=slice(now - max_expected_delay, None))
+    latest_time = pd.Timestamp(ds["time"].values[-1])
+    sample_ds = ds.sel(time=slice(latest_time - max_expected_delay, None))
     sample_ds = _apply_spatial_sampling(sample_ds, spatial_sampling)
 
     return _check_nan_fractions(
@@ -454,10 +458,13 @@ def _check_nan_fractions(
             for var_name in var_names
         }
         for future in as_completed(future_to_var):
-            var_name = future_to_var[future]
-            fraction = future.result()
-            fractions[var_name] = fraction
-            log.info(f"NaN fraction for {var_name}: {fraction:.6f}")
+            fractions[future_to_var[future]] = future.result()
+
+    # One record rather than one per variable: many log records emitted within the same
+    # second are dropped before reaching Sentry, and the per-variable fractions are what
+    # inspecting a past run needs.
+    summary = ", ".join(f"{var}={fractions[var]:.6f}" for var in sorted(fractions))
+    log.info(f"NaN fractions: {summary}")
 
     # An empty selection means the check measured nothing. Its NaN fraction is NaN,
     # which is not > any threshold, so without this it reports a pass.

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -315,7 +315,8 @@ def check_forecast_recent_nans(
 def check_analysis_recent_nans(
     ds: xr.Dataset,
     *,
-    max_expected_delay: timedelta = timedelta(hours=12),
+    time_offset: int = -1,
+    num_recent_times: int = 2,
     max_nan_fraction: float = 0.0,
     include_vars: Sequence[str] | Literal["all"] = "all",
     exclude_vars: Sequence[str] = (),
@@ -325,26 +326,60 @@ def check_analysis_recent_nans(
     """
     Check the NaN fraction of recent timesteps in an analysis dataset.
 
-    The window spans `max_expected_delay` back from the dataset's newest timestamp,
-    not from now, so it always selects data. Whether that newest timestamp is itself
-    recent enough is `check_analysis_current_data`'s question.
+    Checks `num_recent_times` timesteps ending at `time_offset` (inclusive), newest
+    first, and fails if any of them exceeds `max_nan_fraction`. Each timestep is
+    checked independently, so a timestep that is entirely NaN cannot be averaged away
+    by healthy neighbours. Selecting by position rather than by clock also means an
+    off-schedule run still checks real data; whether the newest timestep is recent
+    enough is `check_analysis_current_data`'s question.
 
-    Default `spatial_sampling="random_points"` reads 2 random spatial points
-    (across all timesteps in the window) — cheap and covers independent
-    locations. Use `"quarter"` for structural-NaN datasets and `"all"` only
-    when small.
+    `time_offset` selects the newest timestep to check, counted from the end (`-1` =
+    newest, `-2` = the one before). Use `-2` where the newest timestep is structurally
+    incomplete by design, so its expected emptiness does not have to be absorbed into
+    `max_nan_fraction` (e.g. MRMS gauge-collection latency leaves it entirely NaN).
+
+    Default `spatial_sampling="random_points"` reads 2 random spatial points — cheap
+    and covers independent locations. Use `"quarter"` for structural-NaN datasets and
+    `"all"` only when small.
     """
-    latest_time = pd.Timestamp(ds["time"].values[-1])
-    sample_ds = ds.sel(time=slice(latest_time - max_expected_delay, None))
-    sample_ds = _apply_spatial_sampling(sample_ds, spatial_sampling)
+    assert num_recent_times >= 1, "num_recent_times must be >= 1"
 
-    return _check_nan_fractions(
-        sample_ds,
-        max_nan_fraction=max_nan_fraction,
-        include_vars=include_vars,
-        exclude_vars=exclude_vars,
-        additional_skip_lead_time_0_vars=(),
-        max_workers=max_workers or _DEFAULT_MAX_WORKERS[spatial_sampling],
+    newest = time_offset % ds.sizes["time"]  # positive index
+    oldest = max(0, newest - num_recent_times + 1)
+
+    results = [
+        (
+            index,
+            _check_nan_fractions(
+                _apply_spatial_sampling(ds.isel(time=[index]), spatial_sampling),
+                max_nan_fraction=max_nan_fraction,
+                include_vars=include_vars,
+                exclude_vars=exclude_vars,
+                additional_skip_lead_time_0_vars=(),
+                max_workers=max_workers or _DEFAULT_MAX_WORKERS[spatial_sampling],
+            ),
+        )
+        for index in range(newest, oldest - 1, -1)
+    ]
+
+    if len(results) == 1:
+        return results[0][1]
+
+    failures = [
+        f"time={_format_coord_value(ds['time'].values[index])}: {result.message}"
+        for index, result in results
+        if not result.passed
+    ]
+    if failures:
+        return ValidationResult(
+            passed=False,
+            message=f"Excessive NaN fraction in {len(failures)} of {len(results)} "
+            "recent times:\n" + "\n".join(failures),
+        )
+    return ValidationResult(
+        passed=True,
+        message=f"All {len(results)} recent times have NaN fraction "
+        f"<= {max_nan_fraction}",
     )
 
 

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -326,21 +326,17 @@ def check_analysis_recent_nans(
     """
     Check the NaN fraction of recent timesteps in an analysis dataset.
 
-    Checks `num_recent_times` timesteps ending at `time_offset` (inclusive), newest
-    first, and fails if any of them exceeds `max_nan_fraction`. Each timestep is
-    checked independently, so a timestep that is entirely NaN cannot be averaged away
-    by healthy neighbours. Selecting by position rather than by clock also means an
-    off-schedule run still checks real data; whether the newest timestep is recent
-    enough is `check_analysis_current_data`'s question.
+    Checks `num_recent_times` timesteps ending at `time_offset` (`-1` = newest), each
+    independently, failing if any exceeds `max_nan_fraction`. Positional selection
+    means an off-schedule run still checks real data; recency is
+    `check_analysis_current_data`'s question.
 
-    `time_offset` selects the newest timestep to check, counted from the end (`-1` =
-    newest, `-2` = the one before). Use `-2` where the newest timestep is structurally
-    incomplete by design, so its expected emptiness does not have to be absorbed into
-    `max_nan_fraction` (e.g. MRMS gauge-collection latency leaves it entirely NaN).
+    For a variable that fills in over several timesteps, separate calls with different
+    `time_offset` / `num_recent_times` / `max_nan_fraction` check each stage against
+    what is complete by then, instead of one threshold loose enough for all of them.
 
-    Default `spatial_sampling="random_points"` reads 2 random spatial points — cheap
-    and covers independent locations. Use `"quarter"` for structural-NaN datasets and
-    `"all"` only when small.
+    Default `spatial_sampling="random_points"` reads 2 random spatial points. Use
+    `"quarter"` for structural-NaN datasets and `"all"` only when small.
     """
     assert num_recent_times >= 1, "num_recent_times must be >= 1"
 
@@ -495,8 +491,7 @@ def _check_nan_fractions(
         for future in as_completed(future_to_var):
             fractions[future_to_var[future]] = future.result()
 
-    # Combine: many info level log records emitted within the same second are dropped
-    # before reaching Sentry.
+    # Combine: many info records in the same second are dropped before reaching Sentry.
     summary = ", ".join(f"{var}={fractions[var]:.6f}" for var in sorted(fractions))
     log.info(f"NaN fractions: {summary}")
 

--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
@@ -64,7 +64,6 @@ class NasaSmapLevel336KmV9Dataset(
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
                 # Oceans and about half of land (due to swaths) are expected to be NaNs
                 # This value sounds very loose but has been tuned based on real values
                 max_nan_fraction=0.995,

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
@@ -56,7 +56,6 @@ class NoaaNdviCdrAnalysisDataset(
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
                 # Large NaN fraction is expected: oceans and water bodies are always NaN
                 # (~93% baseline, observed up to ~96%). Use full-grid sampling because
                 # structural NaN makes random_points bimodal/unstable.

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -35,7 +35,6 @@ class UarizonaSwannAnalysisDataset(
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
                 # Check the full grid for a stable NaN fraction.
                 max_nan_fraction=MAX_NAN_FRACTION,
                 spatial_sampling="all",

--- a/src/reformatters/nasa/imerg/dynamical_dataset.py
+++ b/src/reformatters/nasa/imerg/dynamical_dataset.py
@@ -66,7 +66,6 @@ class NasaImergAnalysisMaterializedDataset(
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=self.max_expected_delay,
                 # IMERG is globally complete (precip is 0, not NaN, where it is dry);
                 # only sparse polar gaps are NaN. On-disk granules measure <=0.8% NaN
                 # globally (deep archive) and <=0.15% recent; "quarter" sampling can

--- a/src/reformatters/noaa/gfs/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/analysis/dynamical_dataset.py
@@ -63,6 +63,5 @@ class NoaaGfsAnalysisDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
             ),
         )

--- a/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
@@ -71,12 +71,10 @@ class NoaaHrrrAnalysisDataset(
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
                 exclude_vars=source_fill_value_vars,
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
                 include_vars=source_fill_value_vars,
                 max_nan_fraction=0.9999,
                 spatial_sampling="quarter",

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
@@ -52,13 +52,16 @@ class NoaaMrmsConusAnalysisHourlyDataset(
 
     def validators(self) -> Sequence[validation.DataValidator]:
         max_expected_delay = timedelta(hours=3, minutes=30)
-        # Pass 1 and Pass 2 have gauge-collection latency (~60 min); all other vars are always current.
-        gauge_latency_vars = [
+        # Gauge-corrected values arrive an hour late, leaving the newest timestamp
+        # entirely NaN, so these are checked from the second-newest onward. Measured
+        # quarter-sampled NaN there is 18.4% (6.2% over the whole domain), constant
+        # across timestamps. precipitation_surface joins them from -2 back; at -1 it
+        # falls back to radar-only and is checked separately below.
+        gauge_corrected_vars = [
+            "precipitation_surface",
             "precipitation_pass_1_surface",
             "precipitation_pass_2_surface",
         ]
-        radar_only_var = ["precipitation_radar_only_surface"]
-        flash_var = ["flash_qpe_ffg_max_surface"]
         return (
             partial(
                 validation.check_analysis_current_data,
@@ -66,39 +69,44 @@ class NoaaMrmsConusAnalysisHourlyDataset(
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
-                # precipitation_surface worst-case quarter-sampled NaN is ~36% (most recent
-                # timestamp falls back to radar-only with ~34% structural coverage gaps).
-                # categorical (PrecipFlag) is radar-derived with no gauge latency, similar coverage to radar_only.
-                max_nan_fraction=0.40,
+                time_offset=-2,
+                max_nan_fraction=0.25,
                 spatial_sampling="quarter",
-                exclude_vars=gauge_latency_vars + radar_only_var + flash_var,
+                include_vars=gauge_corrected_vars,
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
-                # pass_1 and pass_2 worst-case quarter-sampled NaN is ~45.5% (1 of 3 checked
-                # timestamps is 100% NaN due to gauge-collection latency, rest are ~6%).
-                max_nan_fraction=0.48,
-                spatial_sampling="quarter",
-                include_vars=gauge_latency_vars,
-            ),
-            partial(
-                validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
-                # Radar only is ~34% NaN always. With quarter sampling this can get as
-                # high as 62.2%. It is available at all timestamps.
+                # The newest precipitation_surface is the radar-only field until gauge
+                # data lands, so it carries radar-only's coverage gaps, not the 18.4%
+                # its older timestamps show.
+                num_recent_times=1,
                 max_nan_fraction=0.63,
                 spatial_sampling="quarter",
-                include_vars=radar_only_var,
+                include_vars=["precipitation_surface"],
             ),
             partial(
                 validation.check_analysis_recent_nans,
-                max_expected_delay=max_expected_delay,
-                # FLASH QPE/FFG ratio has ~64% structural NaN (outside radar/FFG coverage).
-                # With quarter sampling this can reach ~86%.
+                # Radar coverage gaps only, identical at every timestamp: 34.1% over
+                # the domain, 52.9% in the worst quarter.
+                max_nan_fraction=0.63,
+                spatial_sampling="quarter",
+                include_vars=["precipitation_radar_only_surface"],
+            ),
+            partial(
+                validation.check_analysis_recent_nans,
+                # PrecipFlag is populated everywhere the grid is, measuring 0% NaN
+                # across the domain at every timestamp.
+                spatial_sampling="quarter",
+                include_vars=["categorical_precipitation_type_surface"],
+            ),
+            partial(
+                validation.check_analysis_recent_nans,
+                # Outside radar/FFG coverage this is NaN: 64.2% over the domain, 77.3%
+                # in the worst quarter. Its newest timestamp lands late like the
+                # gauge-corrected fields.
+                time_offset=-2,
                 max_nan_fraction=0.86,
                 spatial_sampling="quarter",
-                include_vars=flash_var,
+                include_vars=["flash_qpe_ffg_max_surface"],
             ),
         )

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -283,39 +283,50 @@ def test_check_forecast_recent_nans_empty_selection_fails(
     assert "precipitation" in result.message
 
 
-def test_check_analysis_recent_nans_empty_window_fails(
+def test_check_analysis_recent_nans_window_anchors_to_newest_time(
     monkeypatch: pytest.MonkeyPatch, analysis_dataset: xr.Dataset
 ) -> None:
-    """An empty recency window must fail, not vacuously pass.
+    """The window is measured back from the newest timestamp, not from now.
 
-    Running off-schedule, or before a late update publishes, selects no times.
-    Every variable's NaN fraction is then NaN, which passes every threshold.
+    A clock far past the data — an off-schedule run, or one before a late update
+    publishes — still selects the newest timesteps and checks them.
     """
-    now = pd.Timestamp("2024-01-10")
+    now = pd.Timestamp("2024-01-10")  # dataset ends 2024-01-02 23:00
     monkeypatch.setattr("pandas.Timestamp.now", lambda tz=None: now)
 
     result = validation.check_analysis_recent_nans(
         analysis_dataset, max_expected_delay=timedelta(hours=4)
     )
+    assert result.passed
 
+    # Proves the window selected real values rather than passing vacuously.
+    analysis_dataset["temperature"].loc[{"time": slice("2024-01-02 22:00", None)}] = (
+        np.nan
+    )
+    result = validation.check_analysis_recent_nans(
+        analysis_dataset, max_expected_delay=timedelta(hours=4)
+    )
     assert not result.passed
     assert "temperature" in result.message
 
 
-def test_check_analysis_recent_nans_empty_window_fails_with_loose_threshold(
-    monkeypatch: pytest.MonkeyPatch, analysis_dataset: xr.Dataset
+def test_check_nan_fractions_logs_one_record_for_all_variables(
+    caplog: pytest.LogCaptureFixture, analysis_dataset: xr.Dataset
 ) -> None:
-    """An empty window fails even where a high NaN fraction would be tolerated."""
-    now = pd.Timestamp("2024-01-10")
-    monkeypatch.setattr("pandas.Timestamp.now", lambda tz=None: now)
+    """Per-variable fractions arrive in a single log record.
 
-    result = validation.check_analysis_recent_nans(
-        analysis_dataset,
-        max_expected_delay=timedelta(hours=4),
-        max_nan_fraction=0.9999,
-    )
+    Sentry drops log records emitted in bursts within the same second, so a line
+    per variable loses exactly the detail a later inspection needs.
+    """
+    with caplog.at_level(logging.INFO, logger="reformatters.common.validation"):
+        assert validation.check_analysis_recent_nans(analysis_dataset).passed
 
-    assert not result.passed
+    fraction_records = [
+        r.getMessage() for r in caplog.records if "NaN fractions:" in r.getMessage()
+    ]
+    assert len(fraction_records) == 1
+    assert "temperature=0.000000" in fraction_records[0]
+    assert "humidity=0.000000" in fraction_records[0]
 
 
 def test_check_analysis_current_data_passes(

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -283,31 +283,56 @@ def test_check_forecast_recent_nans_empty_selection_fails(
     assert "precipitation" in result.message
 
 
-def test_check_analysis_recent_nans_window_anchors_to_newest_time(
+def test_check_analysis_recent_nans_selects_by_position_not_clock(
     monkeypatch: pytest.MonkeyPatch, analysis_dataset: xr.Dataset
 ) -> None:
-    """The window is measured back from the newest timestamp, not from now.
+    """Timesteps are chosen by position, so a clock far past the data still checks it.
 
-    A clock far past the data — an off-schedule run, or one before a late update
-    publishes — still selects the newest timesteps and checks them.
+    An off-schedule run, or one before a late update publishes, used to select no
+    times at all.
     """
     now = pd.Timestamp("2024-01-10")  # dataset ends 2024-01-02 23:00
     monkeypatch.setattr("pandas.Timestamp.now", lambda tz=None: now)
 
-    result = validation.check_analysis_recent_nans(
-        analysis_dataset, max_expected_delay=timedelta(hours=4)
-    )
-    assert result.passed
+    assert validation.check_analysis_recent_nans(analysis_dataset).passed
 
-    # Proves the window selected real values rather than passing vacuously.
+    # Proves it selected real values rather than passing vacuously.
     analysis_dataset["temperature"].loc[{"time": slice("2024-01-02 22:00", None)}] = (
         np.nan
     )
-    result = validation.check_analysis_recent_nans(
-        analysis_dataset, max_expected_delay=timedelta(hours=4)
-    )
+    result = validation.check_analysis_recent_nans(analysis_dataset)
     assert not result.passed
     assert "temperature" in result.message
+
+
+def test_check_analysis_recent_nans_checks_each_time_independently(
+    analysis_dataset: xr.Dataset,
+) -> None:
+    """One ruined timestep fails even when its neighbours are clean.
+
+    A single fraction over the whole window would average it away, which is what
+    forced structural thresholds to encode expected emptiness.
+    """
+    analysis_dataset["temperature"].loc[{"time": "2024-01-02 23:00"}] = np.nan
+
+    result = validation.check_analysis_recent_nans(
+        analysis_dataset, num_recent_times=2, max_nan_fraction=0.4
+    )
+
+    assert not result.passed
+    assert "1 of 2 recent times" in result.message
+
+
+def test_check_analysis_recent_nans_time_offset_skips_newest(
+    analysis_dataset: xr.Dataset,
+) -> None:
+    """time_offset excludes a newest timestep that is empty by design."""
+    analysis_dataset["temperature"].loc[{"time": "2024-01-02 23:00"}] = np.nan
+
+    assert not validation.check_analysis_recent_nans(analysis_dataset).passed
+    assert validation.check_analysis_recent_nans(
+        analysis_dataset, time_offset=-2, num_recent_times=2
+    ).passed
 
 
 def test_check_nan_fractions_logs_one_record_for_all_variables(
@@ -319,7 +344,9 @@ def test_check_nan_fractions_logs_one_record_for_all_variables(
     per variable loses exactly the detail a later inspection needs.
     """
     with caplog.at_level(logging.INFO, logger="reformatters.common.validation"):
-        assert validation.check_analysis_recent_nans(analysis_dataset).passed
+        assert validation.check_analysis_recent_nans(
+            analysis_dataset, num_recent_times=1
+        ).passed
 
     fraction_records = [
         r.getMessage() for r in caplog.records if "NaN fractions:" in r.getMessage()
@@ -400,7 +427,6 @@ def test_check_analysis_recent_nans_fails(
 
     result = validation.check_analysis_recent_nans(
         analysis_dataset,
-        max_expected_delay=timedelta(hours=12),
         max_nan_fraction=0.05,
     )
 
@@ -422,7 +448,6 @@ def test_check_analysis_recent_nans_custom_parameters(
     # Should fail with 0.05 threshold
     result = validation.check_analysis_recent_nans(
         analysis_dataset,
-        max_expected_delay=timedelta(hours=12),
         max_nan_fraction=0.05,
     )
     assert not result.passed
@@ -430,7 +455,6 @@ def test_check_analysis_recent_nans_custom_parameters(
     # Should pass with 1.0 threshold
     result = validation.check_analysis_recent_nans(
         analysis_dataset,
-        max_expected_delay=timedelta(hours=12),
         max_nan_fraction=1.0,
     )
     assert result.passed
@@ -461,7 +485,6 @@ def test_check_analysis_recent_nans_quarter_sampling_fails(
 
     result = validation.check_analysis_recent_nans(
         analysis_dataset,
-        max_expected_delay=timedelta(hours=12),
         max_nan_fraction=0.05,
         spatial_sampling="quarter",
     )
@@ -503,7 +526,6 @@ def test_check_analysis_recent_nans_quarter_sampling_different_quarters(
 
     result = validation.check_analysis_recent_nans(
         analysis_dataset,
-        max_expected_delay=timedelta(hours=12),
         max_nan_fraction=0.05,
         spatial_sampling="quarter",
     )
@@ -524,7 +546,6 @@ def test_check_analysis_recent_nans_quarter_sampling_different_quarters(
 
     result = validation.check_analysis_recent_nans(
         analysis_dataset,
-        max_expected_delay=timedelta(hours=12),
         max_nan_fraction=0.05,
         spatial_sampling="quarter",
     )
@@ -548,7 +569,6 @@ def test_check_analysis_recent_nans_random_points_sampling(
     analysis_dataset["temperature"].loc[{"time": slice("2024-01-02", None)}] = np.nan
     result = validation.check_analysis_recent_nans(
         analysis_dataset,
-        max_expected_delay=timedelta(hours=12),
         max_nan_fraction=0.05,
         spatial_sampling="random_points",
     )

--- a/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
+++ b/tests/noaa/mrms/conus_analysis_hourly/dynamical_dataset_test.py
@@ -1,3 +1,4 @@
+from functools import partial
 from pathlib import Path
 
 import numpy as np
@@ -227,5 +228,19 @@ def test_operational_kubernetes_resources(
 
 def test_validators(dataset: NoaaMrmsConusAnalysisHourlyDataset) -> None:
     validators = tuple(dataset.validators())
-    assert len(validators) == 5
+    assert len(validators) == 6
     assert all(isinstance(v, validation.DataValidator) for v in validators)
+
+    # The variables whose newest timestamp is empty by design are checked from the
+    # second-newest onward, so their thresholds describe coverage, not late arrival.
+    offsets = {
+        var: v.keywords.get("time_offset", -1)
+        for v in validators
+        if isinstance(v, partial)
+        for var in v.keywords.get("include_vars", ())
+    }
+    assert offsets["precipitation_pass_1_surface"] == -2
+    assert offsets["precipitation_pass_2_surface"] == -2
+    assert offsets["flash_qpe_ffg_max_surface"] == -2
+    assert offsets["precipitation_radar_only_surface"] == -1
+    assert offsets["categorical_precipitation_type_surface"] == -1


### PR DESCRIPTION
## Why

Two problems, both seen in production this morning, with a common root: `check_analysis_recent_nans` selected a *window by wall clock* and reduced it to *one fraction*.

**1. The selection could be empty.** A hand-run validation of `noaa-hrrr-analysis` launched shortly before the next update selected zero timesteps (`time=<empty>` in its log). #895 made that fail loudly instead of vacuously passing, but an empty selection was still the wrong answer — nothing was wrong with the archive. Selecting the last *n* timesteps by position always checks real data. Whether the newest one is recent enough is `check_analysis_current_data`'s question, and it already answers it — that validator is what correctly failed the run.

**2. Averaging a window hides a ruined timestep, and forced thresholds to encode expected emptiness.** MRMS is the clear case. Its own comment said it: `0.48` was arithmetic over "1 of 3 checked timestamps is 100% NaN due to gauge-collection latency, rest are ~6%". So the check could not distinguish "the newest timestamp is empty because gauges are late" from "because ingestion broke", and a genuinely 47%-NaN timestep passed.

Measured against the live store (whole domain, all four quarters, four timesteps):

```
variable                     pos-1     pos-2+ domain   pos-2+ worst quarter
precipitation_surface        0.3388       0.0618            0.1841
precipitation_pass_1         1.0000       0.0618            0.1841
precipitation_pass_2         1.0000       0.0618            0.1841
precipitation_radar_only     0.3388       0.3405            0.5292
categorical_precip_type      0.0000       0.0000            0.0000
flash_qpe_ffg_max            1.0000       0.6424            0.7731
```

Three things that changes:

- **Structural NaN is constant across timesteps** (identical to four decimals at −2, −3, −4). Once the late-arriving timestep is excluded there is no temporal component, so a threshold can describe coverage geometry alone.
- **`categorical_precipitation_type` is dense everywhere** — 0% NaN, not "similar coverage to radar_only" as its comment claimed. It was sharing a 0.40 threshold it never needed.
- **`precipitation_surface` has two regimes.** Its newest timestep *is* the radar-only field until gauge data lands — pos-1 matches `radar_only` exactly (0.5292 worst quarter), pos-2 and older match the gauge-corrected fields (0.1841). One threshold cannot serve both: 0.40 would fail at pos-1 and be far too loose at pos-2.

## What changed

`check_analysis_recent_nans` takes `time_offset` / `num_recent_times` instead of `max_expected_delay`, mirroring `check_forecast_recent_nans`, and checks each timestep independently. `max_expected_delay` remains on `check_analysis_current_data`, which is where lateness belongs.

MRMS thresholds now describe coverage only:

| variables | offset | threshold | was |
|---|---|---|---|
| `precipitation_surface`, `pass_1`, `pass_2` | −2 | 0.25 (measured 0.1841) | 0.40 / 0.48 |
| `precipitation_surface` newest | −1 | 0.63 (measured 0.5292) | 0.40 |
| `radar_only` | −1 | 0.63 (measured 0.5292) | 0.63 |
| `categorical_precipitation_type` | −1 | 0.0 (measured 0.0) | 0.40 |
| `flash_qpe_ffg_max` | −2 | 0.86 (measured 0.7731) | 0.86 |

Other analysis datasets keep their thresholds and take the `num_recent_times=2` default: HRRR analysis, GFS analysis, GEFS analysis, IMERG early/late, and contrib SMAP / NDVI-CDR / SWANN.

This is a net **tightening**: `pass_1`/`pass_2` go from tolerating 48% to 25% on a field that measures 18%, and any wholly-empty timestep now fails at 1.0 instead of being averaged to ~0.37.

**Also:** the per-variable NaN fraction records are combined into one. Bursty `info` records are dropped before reaching Sentry — the `noaa-hrrr-forecast-48-hour` validation at 14:03Z landed 10 of ~54, survivors clustered inside single seconds while sparse records seconds apart all arrived. Pass/fail was never affected (that flows through the exception and pod exit code); the per-variable detail needed to inspect a past run was.

## Tests

Two tests from #895 asserted that a clock past the data yields an empty selection and fails — that state can no longer occur, so they are replaced by ones pinning the new behavior: selection by position, per-timestep independence, and `time_offset` skipping a by-design-empty newest timestep. #895's forecast-variant test still covers the non-finite guard as the backstop for any other route to an empty selection.

- `uv run pytest -m "not slow" tests/` — 1890 passed
- `uv run ruff format`, `uv run ruff check`, `uv run ty check` — clean

## Note

`generate-manual-workflows` wants to rewrite four workflow files with action-SHA pin bumps unrelated to this change; excluded, as in #885.