### PR TITLE
Check HRRR analysis sentinel-NaN vars over the whole grid

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
@@ -73,10 +73,15 @@ class NoaaHrrrAnalysisDataset(
                 validation.check_analysis_recent_nans,
                 exclude_vars=source_fill_value_vars,
             ),
+            # NaN here is the source's no-precipitation / no-cloud-ceiling marker, so
+            # coverage is small and clustered: a sampled quadrant is regularly all
+            # marker, while whole-grid coverage stays well clear of the threshold
+            # (percent frozen precipitation, the sparser of the two, peaks near 0.996
+            # in the driest hours of the year).
             partial(
                 validation.check_analysis_recent_nans,
                 include_vars=source_fill_value_vars,
-                max_nan_fraction=0.9999,
-                spatial_sampling="quarter",
+                max_nan_fraction=0.999,
+                spatial_sampling="all",
             ),
         )

--- a/tests/noaa/hrrr/analysis/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/analysis/dynamical_dataset_test.py
@@ -148,8 +148,8 @@ def test_validators(dataset: NoaaHrrrAnalysisDataset) -> None:
     assert (
         validators[2].keywords["include_vars"] == validators[1].keywords["exclude_vars"]
     )
-    assert validators[2].keywords["max_nan_fraction"] == 0.9999
-    assert validators[2].keywords["spatial_sampling"] == "quarter"
+    assert validators[2].keywords["max_nan_fraction"] == 0.999
+    assert validators[2].keywords["spatial_sampling"] == "all"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Fixes the flaky `noaa-hrrr-analysis` validation alert ([sentry](https://dynamical.sentry.io/issues/7675248833/)):

```
time=2026-08-17T17:00:00: Excessive NaN fraction (> 0.9999):
- percent_frozen_precipitation_surface: 0.999990 NaN fraction
```

## Not a data issue

The archive matches the source exactly. Reading the CPOFP message from the source GRIB the analysis pulls that hour from (`hrrr.20260817/conus/hrrr.t16z.wrfsfcf01.grib2`) and computing the −50 marker fraction per quadrant reproduces the alert's number to all six digits:

| quadrant | −50 fraction |
|---|---|
| south-west | 0.998919 |
| south-east | 0.960639 |
| **north-west** | **0.999990** |
| north-east | 0.997403 |
| whole grid | 0.989241 |

The store's whole-grid NaN fraction at that time is 0.989241 — the same value. So the pipeline masked the source marker correctly, the check just happened to draw the one quadrant where nothing was precipitating.

## Why the threshold could not be tuned in place

`percent_frozen_precipitation_surface` is NaN wherever HRRR reports its −50 "no/undefined precipitation" marker, which is ~98–99.6% of CONUS. What is left is small and clustered in precipitating areas, so a single quadrant is a poor estimator of it:

- **402 consecutive August hours** (the driest stretch of the year): 43 hours (11%) had a quadrant above 0.9999, 195 (49%) above 0.999. Whole grid never exceeded **0.9962** (minimum 7222 valid cells of 1.9M).
- **119 hours sampled across a full year**: quadrants hit **exactly 1.0** in 8 of them, so no threshold below 1.0 survives quadrant sampling, and 1.0 disables the check. Whole grid never exceeded **0.9958**.
- `geopotential_height_cloud_ceiling`, the other marker-valued variable, sits far lower either way: whole-grid max 0.886, quadrant max 0.974.

Whole-grid sampling removes the sampling variance and leaves a threshold with real margin: 0.999 requires ≥1906 valid cells, against a measured floor of 7222.

## Cost

Whole-grid reads are cheap against the published store — the tuned validator runs both variables at both checked times in **14.8s** (quarter sampling was ~13s), well inside the validate cron's 10-minute deadline. Running it against the store as of the alert:

```
NaN fractions: geopotential_height_cloud_ceiling=0.741889, percent_frozen_precipitation_surface=0.989241
passed=True — All 2 recent times have NaN fraction <= 0.999
```

## Not changed here

`noaa-hrrr-forecast-48-hour` holds the same two variables to the same `0.9999` / `quarter` pair. It is much less exposed because its NaN fraction is averaged over 49 lead times, which needs every lead's quadrant to be dry before it trips — but it is the same latent flake, and its whole-grid cost across 49 leads is 4× what I measured here, so I left it alone rather than change it unmeasured. Happy to do it as a follow-up.

## Testing

`ruff format`, `ruff check`, `ty check` clean; `tests/noaa/hrrr/analysis/dynamical_dataset_test.py` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Co2yhrSJ3fmTuJ1jkKRFyc)_