### PR TITLE
Say what NaN means where the quantity does not apply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,9 @@ When one value covers every missing cell in both reads:
 - Materialized either already receives NaN from rasterio or records rasterio's exact non-NaN value in `internal_attrs.source_fill_value` and replaces it with NaN. It writes physical NaN and uses NaN for both metadata fields.
 - Virtual sets `fill_value` and `_FillValue` to gribberish's value, or leaves both NaN when gribberish already returns NaN.
 
-When no single value does, neither product changes any value and the variable's `comment` records what the raw values mean. Never normalize part of a variable's invalid set — masking some invalid values claims the rest are good. Treat an equivalent variable the same way across models where you can, but the single-value test overrides.
+When no single value does, neither product changes any value and the variable's `comment` records what the raw values mean and ends with the range to mask, such as "Mask values < -0.1." Never normalize part of a variable's invalid set — masking some invalid values claims the rest are good. Treat an equivalent variable the same way across models where you can, but the single-value test overrides.
+
+A `comment` states what NaN means when the answer is not "data we do not have": that the quantity does not apply there, such as no cloud ceiling because there is no cloud, or percent frozen where there is no precipitation. Without it a reader takes those cells for an outage and reads the NaN fraction as an availability statistic. A variable whose NaN does mean missing data needs no `comment`. Where the marker is a declared `fill_value`, write the sentence about the NaN rather than the marker — a CF-aware reader only ever sees NaN, and the materialized and virtual products then describe the variable identically — and say nothing about masking, which `fill_value` already handles. Only an undeclared marker, the no-single-value case above, is named by its raw value and paired with the range to mask.
 
 Materialized scaling is applied before values are written. Virtual scaling uses Zarr's `ScaleOffset` filter, which decodes as `encoded / scale + offset`.
 

--- a/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
@@ -69,6 +69,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "Values near 20,000m mark no cloud ceiling. Interpolation in the source mixes the no data value with real ceiling heights, so unusable values span a range rather than one value and are not converted to NaN. Mask values above 19,000m.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -68,7 +68,7 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "Contains the value -50 when there is no precipitation.",
+    "comment": "Negative values mark no precipitation. Interpolation in the source mixes the no data value with real percentages, so unusable values span a range rather than one value and are not converted to NaN. Mask values < -0.1.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis/templates/latest.zarr/zarr.json
@@ -697,6 +697,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "Values near 20,000m mark no cloud ceiling. Interpolation in the source mixes the no data value with real ceiling heights, so unusable values span a range rather than one value and are not converted to NaN. Mask values above 19,000m.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -1060,7 +1061,7 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "Contains the value -50 when there is no precipitation.",
+          "comment": "Negative values mark no precipitation. Interpolation in the source mixes the no data value with real percentages, so unusable values span a range rather than one value and are not converted to NaN. Mask values < -0.1.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/common_gefs_template_config.py
+++ b/src/reformatters/noaa/gefs/common_gefs_template_config.py
@@ -401,7 +401,7 @@ def get_shared_data_var_configs(
                 short_name="cpofp",
                 long_name="Percent frozen precipitation",
                 units="percent",
-                comment="Contains the value -50 when there is no precipitation.",
+                comment="Negative values mark no precipitation. Interpolation in the source mixes the no data value with real percentages, so unusable values span a range rather than one value and are not converted to NaN. Mask values < -0.1.",
                 step_type="instant",
             ),
             internal_attrs=GEFSInternalAttrs(
@@ -571,6 +571,7 @@ def get_shared_data_var_configs(
                 short_name="gh",
                 long_name="Geopotential height",
                 units="m",
+                comment="Values near 20,000m mark no cloud ceiling. Interpolation in the source mixes the no data value with real ceiling heights, so unusable values span a range rather than one value and are not converted to NaN. Mask values above 19,000m.",
                 step_type="instant",
                 standard_name="geopotential_height",
             ),

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
@@ -41,6 +41,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "Values near 20,000m mark no cloud ceiling. Interpolation in the source mixes the no data value with real ceiling heights, so unusable values span a range rather than one value and are not converted to NaN. Mask values above 19,000m.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -40,7 +40,7 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "Contains the value -50 when there is no precipitation.",
+    "comment": "Negative values mark no precipitation. Interpolation in the source mixes the no data value with real percentages, so unusable values span a range rather than one value and are not converted to NaN. Mask values < -0.1.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_spatial/templates/latest.zarr/zarr.json
@@ -537,6 +537,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "Values near 20,000m mark no cloud ceiling. Interpolation in the source mixes the no data value with real ceiling heights, so unusable values span a range rather than one value and are not converted to NaN. Mask values above 19,000m.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -933,7 +934,7 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "Contains the value -50 when there is no precipitation.",
+          "comment": "Negative values mark no precipitation. Interpolation in the source mixes the no data value with real percentages, so unusable values span a range rather than one value and are not converted to NaN. Mask values < -0.1.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
@@ -75,6 +75,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "Values near 20,000m mark no cloud ceiling. Interpolation in the source mixes the no data value with real ceiling heights, so unusable values span a range rather than one value and are not converted to NaN. Mask values above 19,000m.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "Contains the value -50 when there is no precipitation.",
+    "comment": "Negative values mark no precipitation. Interpolation in the source mixes the no data value with real percentages, so unusable values span a range rather than one value and are not converted to NaN. Mask values < -0.1.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
@@ -867,6 +867,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "Values near 20,000m mark no cloud ceiling. Interpolation in the source mixes the no data value with real ceiling heights, so unusable values span a range rather than one value and are not converted to NaN. Mask values above 19,000m.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1423,7 +1424,7 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "Contains the value -50 when there is no precipitation.",
+          "comment": "Negative values mark no precipitation. Interpolation in the source mixes the no data value with real percentages, so unusable values span a range rather than one value and are not converted to NaN. Mask values < -0.1.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
@@ -69,6 +69,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "NaN where no cloud ceiling was detected.",
     "step_type": "instant",
     "coordinates": "latitude longitude spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -68,7 +68,7 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "The source's -50 no/undefined marker is exposed as NaN.",
+    "comment": "NaN where there is no precipitation.",
     "step_type": "instant",
     "coordinates": "latitude longitude spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
@@ -779,6 +779,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "NaN where no cloud ceiling was detected.",
           "step_type": "instant",
           "coordinates": "latitude longitude spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -978,7 +979,7 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "The source's -50 no/undefined marker is exposed as NaN.",
+          "comment": "NaN where there is no precipitation.",
           "step_type": "instant",
           "coordinates": "latitude longitude spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/echo_top/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/echo_top/zarr.json
@@ -38,7 +38,7 @@
     "long_name": "Echo top",
     "short_name": "retop",
     "units": "m",
-    "comment": "-999 encodes no echo; CF-aware readers mask it to NaN.",
+    "comment": "NaN where no radar echo was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAA4j8A="

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/geopotential_height_cloud_base/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/geopotential_height_cloud_base/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "NaN where no cloud was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "NaN where no cloud ceiling was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/geopotential_height_cloud_top/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/geopotential_height_cloud_top/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height_at_cloud_top",
     "units": "m",
+    "comment": "NaN where no cloud was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -38,7 +38,7 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+    "comment": "NaN where there is no precipitation.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAAScA="

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/pressure_cloud_base/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/pressure_cloud_base/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure_at_cloud_base",
     "units": "Pa",
+    "comment": "NaN where no cloud was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/pressure_cloud_top/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/pressure_cloud_top/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure_at_cloud_top",
     "units": "Pa",
+    "comment": "NaN where no cloud was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/templates/latest.zarr/zarr.json
@@ -1677,7 +1677,7 @@
           "long_name": "Echo top",
           "short_name": "retop",
           "units": "m",
-          "comment": "-999 encodes no echo; CF-aware readers mask it to NaN.",
+          "comment": "NaN where no radar echo was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAA4j8A="
@@ -2333,6 +2333,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "NaN where no cloud was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2388,6 +2389,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "NaN where no cloud ceiling was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2443,6 +2445,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height_at_cloud_top",
           "units": "m",
+          "comment": "NaN where no cloud was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6603,7 +6606,7 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+          "comment": "NaN where there is no precipitation.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAAScA="
@@ -6989,6 +6992,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure_at_cloud_base",
           "units": "Pa",
+          "comment": "NaN where no cloud was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -7044,6 +7048,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure_at_cloud_top",
           "units": "Pa",
+          "comment": "NaN where no cloud was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
@@ -72,6 +72,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "NaN where no cloud ceiling was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -71,7 +71,7 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "The source's -50 no/undefined marker is exposed as NaN.",
+    "comment": "NaN where there is no precipitation.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
@@ -871,6 +871,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "NaN where no cloud ceiling was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1240,7 +1241,7 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "The source's -50 no/undefined marker is exposed as NaN.",
+          "comment": "NaN where there is no precipitation.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/echo_top/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/echo_top/zarr.json
@@ -38,7 +38,7 @@
     "long_name": "Echo top",
     "short_name": "retop",
     "units": "m",
-    "comment": "-999 encodes no echo; CF-aware readers mask it to NaN.",
+    "comment": "NaN where no radar echo was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAA4j8A="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/geopotential_height_cloud_base/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/geopotential_height_cloud_base/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "NaN where no cloud was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/geopotential_height_cloud_ceiling/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
+    "comment": "NaN where no cloud ceiling was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/geopotential_height_cloud_top/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/geopotential_height_cloud_top/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height_at_cloud_top",
     "units": "m",
+    "comment": "NaN where no cloud was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/percent_frozen_precipitation_surface/zarr.json
@@ -38,7 +38,7 @@
     "long_name": "Percent frozen precipitation",
     "short_name": "cpofp",
     "units": "percent",
-    "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+    "comment": "NaN where there is no precipitation.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAAScA="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/pressure_cloud_base/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/pressure_cloud_base/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure_at_cloud_base",
     "units": "Pa",
+    "comment": "NaN where no cloud was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/pressure_cloud_top/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/pressure_cloud_top/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure_at_cloud_top",
     "units": "Pa",
+    "comment": "NaN where no cloud was detected.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/templates/latest.zarr/zarr.json
@@ -1677,7 +1677,7 @@
           "long_name": "Echo top",
           "short_name": "retop",
           "units": "m",
-          "comment": "-999 encodes no echo; CF-aware readers mask it to NaN.",
+          "comment": "NaN where no radar echo was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAA4j8A="
@@ -2333,6 +2333,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "NaN where no cloud was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2388,6 +2389,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
+          "comment": "NaN where no cloud ceiling was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2443,6 +2445,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height_at_cloud_top",
           "units": "m",
+          "comment": "NaN where no cloud was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6603,7 +6606,7 @@
           "long_name": "Percent frozen precipitation",
           "short_name": "cpofp",
           "units": "percent",
-          "comment": "-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+          "comment": "NaN where there is no precipitation.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAAScA="
@@ -6989,6 +6992,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure_at_cloud_base",
           "units": "Pa",
+          "comment": "NaN where no cloud was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -7044,6 +7048,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure_at_cloud_top",
           "units": "Pa",
+          "comment": "NaN where no cloud was detected.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -374,7 +374,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     long_name="Percent frozen precipitation",
                     units="percent",
                     step_type="instant",
-                    comment="The source's -50 no/undefined marker is exposed as NaN.",
+                    comment="NaN where there is no precipitation.",
                 ),
                 internal_attrs=NoaaHrrrInternalAttrs(
                     grib_element="CPOFP",
@@ -522,6 +522,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     long_name="Geopotential height",
                     units="m",
                     step_type="instant",
+                    comment="NaN where no cloud ceiling was detected.",
                 ),
                 internal_attrs=NoaaHrrrInternalAttrs(
                     grib_element="HGT",

--- a/src/reformatters/noaa/hrrr/virtual_template_config.py
+++ b/src/reformatters/noaa/hrrr/virtual_template_config.py
@@ -566,7 +566,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
             short_name="retop",
             long_name="Echo top",
             units="m",
-            comment="-999 encodes no echo; CF-aware readers mask it to NaN.",
+            comment="NaN where no radar echo was detected.",
             fill_value=-999.0,
         ),
         root_var(
@@ -1028,7 +1028,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
             short_name="cpofp",
             long_name="Percent frozen precipitation",
             units="percent",
-            comment="-50 encodes no/undefined frozen precipitation; CF-aware readers mask it to NaN.",
+            comment="NaN where there is no precipitation.",
             fill_value=-50.0,
             hour_0=False,
         ),
@@ -1406,6 +1406,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
+            comment="NaN where no cloud ceiling was detected.",
         ),
         root_var(
             "geopotential_height_cloud_base",
@@ -1415,6 +1416,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
+            comment="NaN where no cloud was detected.",
         ),
         root_var(
             "pressure_cloud_base",
@@ -1424,6 +1426,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure_at_cloud_base",
+            comment="NaN where no cloud was detected.",
         ),
         root_var(
             "pressure_cloud_top",
@@ -1433,6 +1436,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure_at_cloud_top",
+            comment="NaN where no cloud was detected.",
         ),
         root_var(
             "geopotential_height_cloud_top",
@@ -1442,6 +1446,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height_at_cloud_top",
+            comment="NaN where no cloud was detected.",
         ),
         root_var(
             "upward_long_wave_radiation_flux_top_of_atmosphere",

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/template_config.py
@@ -327,7 +327,7 @@ class NoaaMrmsConusAnalysisHourlyTemplateConfig(TemplateConfig[NoaaMrmsDataVar])
                     long_name="FLASH QPE-to-FFG percentage maximum",
                     units="percent",
                     step_type="instant",
-                    comment="Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. Available from October 2020 onward.",
+                    comment="Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. NaN outside the area the FLASH system covers. Available from October 2020 onward.",
                 ),
                 internal_attrs=NoaaMrmsInternalAttrs(
                     mrms_product="FLASH_QPE_FFGMAX",

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/flash_qpe_ffg_max_surface/zarr.json
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/flash_qpe_ffg_max_surface/zarr.json
@@ -68,7 +68,7 @@
     "long_name": "FLASH QPE-to-FFG percentage maximum",
     "short_name": "FLASH_QPE_FFGMAX",
     "units": "percent",
-    "comment": "Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. Available from October 2020 onward.",
+    "comment": "Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. NaN outside the area the FLASH system covers. Available from October 2020 onward.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/templates/latest.zarr/zarr.json
@@ -182,7 +182,7 @@
           "long_name": "FLASH QPE-to-FFG percentage maximum",
           "short_name": "FLASH_QPE_FFGMAX",
           "units": "percent",
-          "comment": "Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. Available from October 2020 onward.",
+          "comment": "Maximum percentage of Quantitative Precipitation Estimate (QPE) to Flash Flood Guidance (FFG) from the FLASH system. Percentage where values > 100 indicate QPE exceeds FFG. NaN outside the area the FLASH system covers. Available from October 2020 onward.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="


### PR DESCRIPTION
A correctly set no data value needs no `comment` when its NaN means data we
do not have. It needs one when NaN means the quantity does not apply there —
no cloud ceiling because there is no cloud, percent frozen where there is no
precipitation — because a reader otherwise counts those cells as an outage and
reads the NaN fraction as an availability statistic. Our own validators need
the same distinction to work (`expected_invalid_fraction`,
`source_fill_value_var_names`, `CheckRecentNans(exclude_vars=...)`); external
readers have nothing equivalent.

`AGENTS.md` now states the rule and its two branches: a declared `fill_value`
gets a sentence about the NaN, so materialized and virtual describe a variable
identically and nothing is said about masking; an undeclared marker is named by
its raw value and paired with the range to mask.

## Comments added

| variable | datasets | comment |
|---|---|---|
| `geopotential_height_cloud_ceiling` | hrrr/analysis, hrrr/forecast_48_hour, both hrrr virtual | NaN where no cloud ceiling was detected. |
| `geopotential_height_cloud_base`, `geopotential_height_cloud_top`, `pressure_cloud_base`, `pressure_cloud_top` | both hrrr virtual | NaN where no cloud was detected. |
| `geopotential_height_cloud_ceiling` | gefs/analysis, gefs/forecast_35_day, gefs/forecast_10_day_spatial | Values near 20,000m mark no cloud ceiling… Mask values above 19,000m. |

## Comments changed

`percent_frozen_precipitation_surface`, GEFS — the substantive correction. The
old text, "Contains the value -50 when there is no precipitation", describes
only part of the invalid set: the live stores hold 157,639 cells (15.2%) in
(-50, 0) in the analysis and 171,493 (16.5%) in the 35-day. A reader masking
exactly -50 keeps those. The new text matches GFS and names the range.

`percent_frozen_precipitation_surface`, HRRR materialized — provenance to
meaning: "The source's -50 no/undefined marker is exposed as NaN" becomes "NaN
where there is no precipitation".

`percent_frozen_precipitation_surface` and `echo_top`, HRRR virtual — dropped
"CF-aware readers mask it to NaN" and stopped naming a marker no CF-aware
reader sees, so each now reads the same as its materialized twin.

`flash_qpe_ffg_max_surface`, MRMS — one sentence added: NaN outside the area
the FLASH system covers (its expected invalid fraction is 0.65).

## Verification

Cloud ceiling markers decoded from source GRIB, rasterio and gribberish
agreeing cell-for-cell:

| model / era | marker | cells ≥19,000 below marker | max real value below marker |
|---|---|---|---|
| HRRR sfc conus | 9999.0 exact (`nodata`, NaN in gribberish) | 0 | 9,997.9 |
| GFS 0.25° | 20000.042 | 9,367 | 19,998.8 |
| GEFS current 0.5° | 20000.252 | 3,094 | 19,999.1 |
| GEFS v12 reforecast 2019 | 20000.037 | 8,879 | 19,998.8 |
| GEFS v12 reforecast 2000 | 20000.010 | 8,507 | 19,998.8 |

GEFS holds at ~20,000 across all three of its eras, and the marker is never
bit-exact, which is why the comment gives a threshold rather than a value.
HRRR's marker is exact and bitmapped, so it is masked and needs no threshold.
HRRR's masking is also complete: a live slice is 99.1% NaN for percent frozen
with every remaining value exactly 0 and nothing in (-50, 0), and 71.4% NaN for
cloud ceiling with zero cells at 9999.

Every template diff line is a `"comment"` line; no other metadata moved.
`gefs/forecast_10_day_spatial` is included because it shares the GEFS config.

Adding a `comment` is an allowed addition; the GEFS percent frozen rewrite
corrects a demonstrably incomplete description and changes no values.

After this lands, #901 needs `update-template` re-run — its checked-in virtual
templates were generated from the old comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUSNfkqVJnLAFjVUkDJvnz