### PR TITLE
Opt in to Sentry stdlib log forwarding

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -11,6 +11,7 @@ with contextlib.suppress(RuntimeError):  # skip if already set
 
 import sentry_sdk
 import typer
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.typer import TyperIntegration
 from sentry_sdk.types import Hint, Log
 
@@ -267,11 +268,11 @@ if Config.is_sentry_enabled:
         project_root="src/",
         in_app_include=["reformatters"],
         default_integrations=True,
-        enable_logs=True,
         # Connection idles cause us to lose events after quiet periods
         keep_alive=True,
         before_send_log=before_log,
         integrations=[
+            LoggingIntegration(capture_sentry_logs=True),
             TyperIntegration(),
         ],
     )


### PR DESCRIPTION
No log records have reached Sentry from the `reformatters` project since `2026-08-18T14:35:08`. The last entry is `Operational update complete...` from the 13:50 HRRR 18-hour virtual update — the pod that started before the `sentry-sdk` 2.66.1 → 2.68.0 bump deployed. Every cronjob since has logged nothing, across all datasets.

The jobs themselves were never affected: cron check-ins arrived on schedule with normal durations throughout, and error events still reached Sentry (an `OperationalValidationError` landed at 14:51:32, after the log cutoff). Only the logs category went dark, which is why the loss went unnoticed for a day.

## Cause

From the sentry-sdk 2.68.0 changelog:

> We're making `enable_logs` and `enable_metrics` no-op with this release (#7177), and they'll be dropped in the next major.

> These integrations now get an integration-level `capture_sentry_logs` boolean option to allow for more control over the auto-collection. These options are `False` by default, i.e., nothing is auto-collected without your explicit opt-in.

> If you were auto-collecting logs from either `LoggingIntegration` or `LoguruIntegration`, the auto-collection will be turned off in this release.

That is exactly this setup: `common/logging.py` uses stdlib `logging`, forwarded by the default `LoggingIntegration`, previously gated by `enable_logs=True`. Under 2.68 that option warns and does nothing, and `LoggingIntegration.__init__` now defaults `capture_sentry_logs=False`, so nothing is forwarded. Exception capture is a separate path, so errors kept working.

## Change

Pass `LoggingIntegration(capture_sentry_logs=True)` explicitly and drop the dead `enable_logs` option. `sentry_logs_level` defaults to `INFO`, matching the previous forwarding level, and `before_send_log` is still supported as the filter hook.

## Verification

Confirmed against the installed 2.68.0: `capture_sentry_logs` is present on `LoggingIntegration.__init__` and defaults to `False`, and `client.py` warns that `enable_logs` "has no effect and will be removed in the next major". `ruff format`, `ruff check`, `ty check` and `tests/common/monitoring_test.py` all pass, and the CLI boots.

Worth confirming logs reappear in Sentry after this deploys, since nothing in the test suite exercises the production Sentry init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRxcPKwiV9xXaJhgr6ZM3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRxcPKwiV9xXaJhgr6ZM3h)_