### PR TITLE
Make Icechunk's always technically the "primary"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ Base class: `src/reformatters/common/dynamical_dataset.py`, commented example su
 
 **Brings together** a `TemplateConfig` and `RegionJob` class, plus storage and operational configuration. Key responsibilities:
 - Declare `template_config` and `region_job_class`
-- Configure `primary_storage_config` and optional `replica_storage_configs`
+- Configure `primary_storage_config` and optional `replica_storage_configs`. Every new store is icechunk; zarr v3 is deprecated and the remaining zarr v3 stores are only ever replicas of an icechunk primary.
 - Implement `operational_kubernetes_resources()` - define update/validate cron jobs
 - Implement `validators()` - return validation functions for the dataset
 

--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -126,3 +126,5 @@ Because any operational update that publishes during an overwrite backfill makes
 ## Replica ordering
 
 Replicas are always updated before the primary store. This ensures that if a failure occurs between updating replicas and primary, the primary (which drives what work needs to be done) still reflects the pre-update state, causing a retry to redo all the work including re-updating replicas.
+
+Finalization publishes in two passes by format — zarr v3 stores, then icechunk stores. Zarr v3 is deprecated: no new zarr v3 store is created and the remaining ones are only ever replicas of an icechunk primary (a registry test in `tests/datasets_test.py` enforces this), so publishing that format first keeps the primary the last store to advance.

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -164,31 +164,31 @@ class UpstreamGriddedZarrsDatasetStorageConfig(StorageConfig):
 DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
     # NOAA
     NoaaGfsForecastDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[NoaaGfsIcechunkAwsOpenDataDatasetStorageConfig()],
+        primary_storage_config=NoaaGfsIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     NoaaGfsAnalysisDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[NoaaGfsIcechunkAwsOpenDataDatasetStorageConfig()],
+        primary_storage_config=NoaaGfsIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     GefsAnalysisDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[NoaaGefsIcechunkAwsOpenDataDatasetStorageConfig()],
+        primary_storage_config=NoaaGefsIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     GefsForecast35DayDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[NoaaGefsIcechunkAwsOpenDataDatasetStorageConfig()],
+        primary_storage_config=NoaaGefsIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     GefsForecast10DaySpatialDataset(
         primary_storage_config=NoaaGefsIcechunkAwsOpenDataDatasetStorageConfig(),
     ),
     NoaaHrrrForecast48HourDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[NoaaHrrrIcechunkAwsOpenDataDatasetStorageConfig()],
+        primary_storage_config=NoaaHrrrIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     NoaaHrrrAnalysisDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[NoaaHrrrIcechunkAwsOpenDataDatasetStorageConfig()],
+        primary_storage_config=NoaaHrrrIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     NoaaHrrrForecast48HourVirtualDataset(
         primary_storage_config=NoaaHrrrIcechunkAwsOpenDataDatasetStorageConfig(),
@@ -197,19 +197,17 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
         primary_storage_config=NoaaHrrrIcechunkAwsOpenDataDatasetStorageConfig(),
     ),
     NoaaMrmsConusAnalysisHourlyDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[NoaaMrmsIcechunkAwsOpenDataDatasetStorageConfig()],
+        primary_storage_config=NoaaMrmsIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     # ECMWF
     EcmwfIfsEnsForecast15Day025DegreeDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[EcmwfIfsEnsIcechunkAwsOpenDataDatasetStorageConfig()],
+        primary_storage_config=EcmwfIfsEnsIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     EcmwfAifsSingleForecastDataset(
-        primary_storage_config=SourceCoopZarrDatasetStorageConfig(),
-        replica_storage_configs=[
-            EcmwfAifsSingleIcechunkAwsOpenDataDatasetStorageConfig()
-        ],
+        primary_storage_config=EcmwfAifsSingleIcechunkAwsOpenDataDatasetStorageConfig(),
+        replica_storage_configs=[SourceCoopZarrDatasetStorageConfig()],
     ),
     EcmwfAifsSingleForecastVirtualDataset(
         primary_storage_config=EcmwfAifsSingleIcechunkAwsOpenDataDatasetStorageConfig(),

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -190,6 +190,25 @@ def finalize(
     now = pd.Timestamp.now(tz="UTC")
     commit_message = f"Update at {now.strftime('%Y-%m-%dT%H:%M:%SZ')}"
 
+    # Zarr v3: copy metadata now (makes data visible to readers). Updates defer the
+    # metadata write to here; overwrite backfills publish here so a metadata change
+    # (new variable, extension) appears only after all chunk data is written. Fresh-store
+    # backfills wrote metadata before workers started and skip this.
+    # A zarr v3 store is only ever a replica, so publishing this format before the
+    # icechunk stores below keeps the primary the last store to advance.
+    if publish_zarr3_metadata:
+        primary_store = store_factory.primary_store(writable=True)
+        replica_stores = store_factory.replica_stores(writable=True)
+        copy_zarr_metadata(
+            updated_template,
+            tmp_store,
+            primary_store,
+            replica_stores=replica_stores,
+            zarr3_only=True,
+            skip_unchanged=not update_template_with_results,
+            exclude_coord_value_chunks=exclude_coord_value_chunks,
+        )
+
     # Icechunk: write final (possibly trimmed) metadata on temp branch, commit, reset main.
     # Uses copy_zarr_metadata (not write_metadata) because the zarr arrays already exist
     # on the temp branch from parallel_setup — we only need to update the metadata files.
@@ -241,23 +260,6 @@ def finalize(
         for _role, repo in replicas_first:
             if branch_name in repo.list_branches():
                 repo.delete_branch(branch_name)
-
-    # Zarr v3: copy metadata now (makes data visible to readers). Updates defer the
-    # metadata write to here; overwrite backfills publish here so a metadata change
-    # (new variable, extension) appears only after all chunk data is written. Fresh-store
-    # backfills wrote metadata before workers started and skip this.
-    if publish_zarr3_metadata:
-        zarr3_primary = store_factory.primary_store(writable=True)
-        zarr3_replicas = store_factory.replica_stores(writable=True)
-        copy_zarr_metadata(
-            updated_template,
-            tmp_store,
-            zarr3_primary,
-            replica_stores=zarr3_replicas,
-            zarr3_only=True,
-            skip_unchanged=not update_template_with_results,
-            exclude_coord_value_chunks=exclude_coord_value_chunks,
-        )
 
     if workers_total > 1:
         store_factory.clear_coordination_files(reformat_job_name)

--- a/tests/common/test_parallel_writes.py
+++ b/tests/common/test_parallel_writes.py
@@ -1052,11 +1052,11 @@ class TestReplicaOrdering:
     commit_if_icechunk. commit_if_icechunk is separately verified to commit
     replicas first in tests/common/test_storage.py.
 
-    Finalize ordering: _finalize iterates icechunk_repos(sort="primary-last")
-    and does the per-repo commit + reset in that order. The test below
-    observes the reset_branch calls end-to-end. Ordering under a partial
-    failure between replica and primary resets is additionally verified by
-    TestLastWorkerRetryAfterPartialFinalize."""
+    Finalize ordering: _finalize publishes zarr v3 stores (only ever replicas)
+    before icechunk ones, and iterates icechunk_repos(sort="primary-last") for
+    the per-repo commit + reset. The tests below observe both end-to-end.
+    Ordering under a partial failure between replica and primary resets is
+    additionally verified by TestLastWorkerRetryAfterPartialFinalize."""
 
     def test_icechunk_repos_sort_order(self, tmp_path: Path) -> None:
         """icechunk_repos returns the primary first or last per the sort kwarg."""
@@ -1146,6 +1146,70 @@ class TestReplicaOrdering:
         _run_workers(dataset, all_jobs, template_ds, workers_total=2)
 
         assert reset_order == ["replica-0", "replica-1", "primary"]
+
+    def test_finalize_publishes_zarr3_replica_before_icechunk_primary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Zarr v3 stores are published in a separate pass from icechunk stores,
+        and that pass runs first: a zarr v3 replica of an icechunk primary is
+        published before the primary's main branch advances."""
+        monkeypatch.setattr(
+            storage_module,
+            "_get_store_path",
+            lambda dataset_id, version, config: (
+                f"{config.base_path}/{dataset_id}/v{version}"
+                f".{'icechunk' if config.format == DatasetFormat.ICECHUNK else 'zarr'}"
+            ),
+        )
+        dataset = ParallelDataset(
+            primary_storage_config=StorageConfig(
+                base_path=str(tmp_path / "primary"), format=DatasetFormat.ICECHUNK
+            ),
+            replica_storage_configs=[
+                StorageConfig(
+                    base_path=str(tmp_path / "replica"), format=DatasetFormat.ZARR3
+                ),
+            ],
+        )
+        template_ds = _create_template_ds(num_time=2)
+        template_utils.write_metadata(template_ds, dataset.store_factory)
+
+        publish_order: list[str] = []
+        original_reset = icechunk.Repository.reset_branch
+
+        def recording_reset(
+            self: icechunk.Repository, *args: object, **kwargs: object
+        ) -> object:
+            publish_order.append("icechunk-primary")
+            return original_reset(self, *args, **kwargs)  # ty: ignore[invalid-argument-type]
+
+        monkeypatch.setattr(icechunk.Repository, "reset_branch", recording_reset)
+
+        original_copy = pc_module.copy_zarr_metadata
+
+        def recording_copy(*args: object, **kwargs: object) -> None:
+            if kwargs.get("zarr3_only"):
+                publish_order.append("zarr3-replica")
+            return original_copy(*args, **kwargs)  # ty: ignore[invalid-argument-type]
+
+        monkeypatch.setattr(pc_module, "copy_zarr_metadata", recording_copy)
+
+        all_jobs = ParallelRegionJob.get_jobs(
+            tmp_store=dataset._tmp_store(),
+            template_ds=template_ds,
+            append_dim="time",
+            all_data_vars=ParallelTemplateConfig().data_vars,
+            reformat_job_name="test",
+        )
+        _run_workers(
+            dataset,
+            all_jobs,
+            template_ds,
+            workers_total=1,
+            update_template_with_results=True,
+        )
+
+        assert publish_order == ["zarr3-replica", "icechunk-primary"]
 
 
 class TestConcurrentJobs:

--- a/tests/datasets_test.py
+++ b/tests/datasets_test.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 from reformatters.__main__ import DYNAMICAL_DATASETS, app
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import ReformatCronJob, ValidationCronJob
+from reformatters.common.storage import DatasetFormat
 from tests.dataset_helpers import IMPLEMENTED_DATASETS
 
 runner = CliRunner()
@@ -287,3 +288,29 @@ def test_store_factory_k8s_secret_names_not_empty_for_datasets_with_replicas(
         assert len(secret_names) >= 1, (
             f"{dataset.dataset_id}: has replicas but no k8s secret names"
         )
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    DYNAMICAL_DATASETS,
+    ids=DATASET_IDS,
+)
+def test_no_zarr3_primary_with_icechunk_replica(
+    dataset: DynamicalDataset[Any, Any],
+) -> None:
+    """Zarr v3 is deprecated: an existing zarr v3 store may only be a replica of an
+    icechunk primary. Finalize publishes zarr v3 stores before icechunk ones, so a
+    zarr v3 primary would advance before its icechunk replica."""
+    if dataset.primary_storage_config.format != DatasetFormat.ZARR3:
+        return
+
+    icechunk_replicas = [
+        config.base_path
+        for config in dataset.replica_storage_configs
+        if config.format == DatasetFormat.ICECHUNK
+    ]
+    assert not icechunk_replicas, (
+        f"{dataset.dataset_id}: zarr v3 primary with icechunk replica(s) "
+        f"{icechunk_replicas}; make the icechunk store the primary and the zarr v3 "
+        "store its replica"
+    )


### PR DESCRIPTION
The primary and replicas are validated to be identical. This is primarily an understanding change so the code reflects how we think about them and sets us up to stop updating the replicas after they are deprecated (https://dynamical.org/migration-2026/).

## Summary
Reorders finalization to publish zarr v3 stores (which are only ever replicas) before icechunk stores. This ensures the primary store is always the last to advance, maintaining consistency guarantees even when a zarr v3 replica exists alongside an icechunk primary.

## Key Changes

- **Finalization ordering**: Moved zarr v3 metadata publishing to occur before icechunk commit/reset operations in `parallel_coordination.py`. This two-pass approach (zarr v3 first, then icechunk) ensures replicas are visible before the primary advances.

- **Dataset configuration**: Swapped primary/replica storage configs in `__main__.py` for NOAA and ECMWF datasets to make icechunk the primary and zarr v3 the replica. This aligns with the deprecation of zarr v3 as a primary format.

- **Validation**: Added `test_no_zarr3_primary_with_icechunk_replica()` in `datasets_test.py` to enforce that zarr v3 can only be a replica, never a primary with icechunk replicas.

- **Test coverage**: Added `test_finalize_publishes_zarr3_replica_before_icechunk_primary()` in `test_parallel_writes.py` to verify the publish ordering end-to-end.

- **Documentation**: Updated docstrings and `parallel_processing.md` to reflect the two-pass finalization strategy.

## Implementation Details

The finalization now operates in two phases:
1. **Zarr v3 phase**: Publishes zarr v3 metadata (replicas only) with `zarr3_only=True`
2. **Icechunk phase**: Commits and resets icechunk repos with `sort="primary-last"` to ensure the primary is last

This ordering guarantees that if a failure occurs between the two phases, readers see either both stores updated or neither, preventing inconsistency where a zarr v3 replica is newer than its icechunk primary.

https://claude.ai/code/session_01TqTHLwbiLUagm9kCdqPqER