### PR TITLE
Fix HRRR analysis snowfall rate, document VBDSF

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis/template_config.py
+++ b/src/reformatters/noaa/hrrr/analysis/template_config.py
@@ -28,6 +28,10 @@ from reformatters.noaa.hrrr.template_config import NoaaHrrrCommonTemplateConfig
 
 
 class NoaaHrrrAnalysisTemplateConfig(NoaaHrrrCommonTemplateConfig):
+    # Each step reads a 1 hour lead time from its own init, so a source accumulation that
+    # runs from forecast start covers exactly one hour and never carries into the next step.
+    run_total_window_reset_frequency: Timedelta = pd.Timedelta("1h")
+
     dims: Dims = {ROOT: ("time", "y", "x")}
     append_dim: AppendDim = "time"
     # HRRR operational start is 2014-09-30. We start at 2014-10-01 to skip the incomplete first day.

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
@@ -68,6 +68,7 @@
     "long_name": "Visible Beam Downward Solar Flux",
     "short_name": "vbdsf",
     "units": "W m-2",
+    "comment": "Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
     "step_type": "instant",
     "coordinates": "latitude longitude spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
@@ -68,7 +68,7 @@
     "long_name": "Visible Beam Downward Solar Flux",
     "short_name": "vbdsf",
     "units": "W m-2",
-    "comment": "Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
+    "comment": "Direct normal irradiance \u2014 the flux perpendicular to the solar beam, so it exceeds the horizontal downward shortwave flux when the sun is low. Values inflate without bound in a narrow band of grid cells at sunrise, reaching 10000. Mask values > 1361, the solar constant.",
     "step_type": "instant",
     "coordinates": "latitude longitude spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
@@ -2102,7 +2102,7 @@
           "long_name": "Visible Beam Downward Solar Flux",
           "short_name": "vbdsf",
           "units": "W m-2",
-          "comment": "Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
+          "comment": "Direct normal irradiance \u2014 the flux perpendicular to the solar beam, so it exceeds the horizontal downward shortwave flux when the sun is low. Values inflate without bound in a narrow band of grid cells at sunrise, reaching 10000. Mask values > 1361, the solar constant.",
           "step_type": "instant",
           "coordinates": "latitude longitude spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/analysis/templates/latest.zarr/zarr.json
@@ -2102,6 +2102,7 @@
           "long_name": "Visible Beam Downward Solar Flux",
           "short_name": "vbdsf",
           "units": "W m-2",
+          "comment": "Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
           "step_type": "instant",
           "coordinates": "latitude longitude spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
@@ -71,7 +71,7 @@
     "long_name": "Visible Beam Downward Solar Flux",
     "short_name": "vbdsf",
     "units": "W m-2",
-    "comment": "Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
+    "comment": "Direct normal irradiance \u2014 the flux perpendicular to the solar beam, so it exceeds the horizontal downward shortwave flux when the sun is low. Values inflate without bound in a narrow band of grid cells at sunrise, reaching 10000. Mask values > 1361, the solar constant.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/visible_beam_downward_solar_flux_surface/zarr.json
@@ -71,6 +71,7 @@
     "long_name": "Visible Beam Downward Solar Flux",
     "short_name": "vbdsf",
     "units": "W m-2",
+    "comment": "Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
@@ -2414,6 +2414,7 @@
           "long_name": "Visible Beam Downward Solar Flux",
           "short_name": "vbdsf",
           "units": "W m-2",
+          "comment": "Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/templates/latest.zarr/zarr.json
@@ -2414,7 +2414,7 @@
           "long_name": "Visible Beam Downward Solar Flux",
           "short_name": "vbdsf",
           "units": "W m-2",
-          "comment": "Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
+          "comment": "Direct normal irradiance \u2014 the flux perpendicular to the solar beam, so it exceeds the horizontal downward shortwave flux when the sun is low. Values inflate without bound in a narrow band of grid cells at sunrise, reaching 10000. Mask values > 1361, the solar constant.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/hrrr/region_job.py
+++ b/src/reformatters/noaa/hrrr/region_job.py
@@ -186,12 +186,13 @@ class NoaaHrrrRegionJob(
             data_var.internal_attrs.grib_element,
             *data_var.internal_attrs.grib_element_alternatives,
         }
-        # grib element has the accumulation window as a suffix in the grib file attributes, but not in the .idx file
-        # Running-total variables (window_reset_frequency=pd.Timedelta.max, e.g. ASNOW) don't get this suffix
-        if (
-            reset_freq := data_var.internal_attrs.window_reset_frequency
-        ) is not None and reset_freq != pd.Timedelta.max:
-            suffix = f"{whole_hours(reset_freq):02d}"
+        # The grib file attributes suffix the element with its accumulation window, while the
+        # .idx file does not. An f06 file holds both APCP06 (the run total) and APCP01 (that
+        # hour's bucket), so the suffix is what selects between them.
+        if data_var.internal_attrs.include_lead_time_suffix:
+            reset_frequency = data_var.internal_attrs.window_reset_frequency
+            assert reset_frequency is not None
+            suffix = f"{whole_hours(reset_frequency):02d}"
             grib_elements = {f"{e}{suffix}" for e in grib_elements}
 
         with rasterio.open(coord.downloaded_path) as reader:

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -17,6 +17,7 @@ from reformatters.common.template_config import TemplateConfig
 from reformatters.common.types import (
     Array1D,
     Array2D,
+    Timedelta,
 )
 from reformatters.common.zarr import (
     BLOSC_4BYTE_ZSTD_LEVEL3_SHUFFLE,
@@ -29,6 +30,11 @@ from reformatters.noaa.hrrr.hrrr_config_models import (
 
 
 class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
+    # Snowfall accumulates from forecast start and never resets within a forecast. A forecast
+    # dataset reads a growing lead time, so the window never resets; an analysis reads a fixed
+    # lead time from each init, so every step is an independent window.
+    run_total_window_reset_frequency: Timedelta = pd.Timedelta.max
+
     @computed_field
     @property
     def coords(self) -> Sequence[Coordinate]:
@@ -246,6 +252,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     grib_index_level="surface",
                     index_position=84,
                     deaccumulate_to_rate=True,
+                    include_lead_time_suffix=True,
                     window_reset_frequency=default_window_reset_frequency,
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     hrrr_file_type="sfc",
@@ -316,6 +323,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     long_name="Visible Beam Downward Solar Flux",
                     units="W m-2",
                     step_type="instant",
+                    comment="Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
                 ),
                 internal_attrs=NoaaHrrrInternalAttrs(
                     grib_element="VBDSF",
@@ -688,7 +696,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     index_position=65,
                     keep_mantissa_bits=default_keep_mantissa_bits,
                     deaccumulate_to_rate=True,
-                    window_reset_frequency=pd.Timedelta.max,
+                    window_reset_frequency=self.run_total_window_reset_frequency,
                     hrrr_file_type="sfc",
                 ),
             ),

--- a/src/reformatters/noaa/hrrr/template_config.py
+++ b/src/reformatters/noaa/hrrr/template_config.py
@@ -323,7 +323,7 @@ class NoaaHrrrCommonTemplateConfig(TemplateConfig[NoaaHrrrDataVar]):
                     long_name="Visible Beam Downward Solar Flux",
                     units="W m-2",
                     step_type="instant",
-                    comment="Grid cells where the sun is just rising can carry physically impossible values, up to about 10000 W m-2, present in the source data. Mask values > 1361, the solar constant.",
+                    comment="Direct normal irradiance — the flux perpendicular to the solar beam, so it exceeds the horizontal downward shortwave flux when the sun is low. Values inflate without bound in a narrow band of grid cells at sunrise, reaching 10000. Mask values > 1361, the solar constant.",
                 ),
                 internal_attrs=NoaaHrrrInternalAttrs(
                     grib_element="VBDSF",

--- a/tests/noaa/hrrr/region_job_test.py
+++ b/tests/noaa/hrrr/region_job_test.py
@@ -7,6 +7,10 @@ import pytest
 import xarray as xr
 
 from reformatters.common.pydantic import replace
+from reformatters.noaa.hrrr.analysis.region_job import NoaaHrrrAnalysisRegionJob
+from reformatters.noaa.hrrr.analysis.template_config import (
+    NoaaHrrrAnalysisTemplateConfig,
+)
 from reformatters.noaa.hrrr.forecast_48_hour.region_job import (
     NoaaHrrrForecast48HourRegionJob,
     NoaaHrrrForecast48HourSourceFileCoord,
@@ -402,6 +406,77 @@ def test_apply_data_transformations_deaccumulation(
     call_args = mock_deaccumulate.call_args
     assert call_args.kwargs["dim"] == "time"
     assert call_args.kwargs["reset_frequency"] == pd.Timedelta(hours=1)
+
+
+def test_analysis_snowfall_deaccumulates_each_step_independently() -> None:
+    """Each analysis step reads a fresh 0-1 hour accumulation, so its rate is value / 3600."""
+    template_config = NoaaHrrrAnalysisTemplateConfig()
+    snowfall = next(
+        v for v in template_config.data_vars if v.name == "snowfall_surface"
+    )
+    region_job = NoaaHrrrAnalysisRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=Mock(),
+        data_vars=[snowfall],
+        append_dim=template_config.append_dim,
+        region=slice(0, 4),
+        reformat_job_name="test",
+    )
+    # Real ASNOW values from hrrr.t{07,08,09,10}z.wrfsfcf01 on 2024-01-13, where the hourly
+    # accumulation rises and then falls; differencing them would zero out the final step.
+    accumulations = np.array([0.000302, 0.00507, 0.02098, 0.008972], dtype=np.float32)
+    data_array = xr.DataArray(
+        accumulations.copy(),
+        dims=["time"],
+        coords={"time": pd.date_range("2024-01-13T08", periods=4, freq="1h")},
+        attrs={"units": snowfall.attrs.units},
+    )
+
+    region_job.apply_data_transformations(data_array, snowfall)
+
+    # First step has no preceding value to deaccumulate from.
+    assert np.isnan(data_array.values[0])
+    np.testing.assert_allclose(
+        data_array.values[1:],
+        accumulations[1:] / 3600,
+        rtol=5e-3,  # keep_mantissa_bits rounding is applied after deaccumulation
+    )
+
+
+def test_read_data_selects_the_hourly_accumulation_band(
+    template_config: NoaaHrrrCommonTemplateConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An f06 file holds both APCP06 and APCP01; precipitation must read the hourly bucket."""
+    data_vars = {v.name: v for v in template_config.data_vars}
+    region_job = NoaaHrrrRegionJob.model_construct(
+        tmp_store=Mock(),
+        template_ds=Mock(),
+        data_vars=list(data_vars.values()),
+        append_dim=template_config.append_dim,
+        region=slice(0, 1),
+        reformat_job_name="test",
+    )
+    coord = Mock(downloaded_path=Path("unused.grib2"))
+
+    def read_with_bands(data_var_name: str, elements: list[str]) -> float:
+        data_var = data_vars[data_var_name]
+        description = data_var.internal_attrs.grib_description
+        reader = Mock(count=len(elements), descriptions=[description] * len(elements))
+        reader.tags.side_effect = lambda i: {"GRIB_ELEMENT": elements[i - 1]}
+        reader.read.side_effect = lambda i, out_dtype: np.full(
+            (1, 1), float(i), dtype=out_dtype
+        )
+        monkeypatch.setattr(
+            "reformatters.noaa.hrrr.region_job.rasterio.open",
+            Mock(
+                return_value=Mock(__enter__=Mock(return_value=reader), __exit__=Mock())
+            ),
+        )
+        return float(region_job.read_data(coord, data_var)[0, 0])
+
+    assert read_with_bands("precipitation_surface", ["APCP06", "APCP01"]) == 2
+    assert read_with_bands("snowfall_surface", ["ASNOW"]) == 1
 
 
 def test_update_append_dim_end() -> None:


### PR DESCRIPTION
Found while validating `noaa-hrrr-analysis`.

## `snowfall_surface` was a difference, not a rate

The analysis wrote the hour-over-hour *change* in the source's 1-hour snowfall accumulation, clamped at zero, instead of the hourly rate. Verified against source at the Denver point on 2024-01-13, where `ASNOW` ("0-1 hour acc fcst") is 0.00507 / 0.02098 / 0.008972 m at 09/10/11 UTC:

| valid time | correct rate (m s-1) | archive held |
|---|---|---|
| 09:00 | 1.41e-6 | 1.326e-6 |
| 10:00 | 5.83e-6 | 4.411e-6 |
| 11:00 | 2.49e-6 | **0** |

Exactly the consecutive differences over 3600, with the negative step clamped to 0. The error is one-sided: it understates snowfall and zeroes any hour in which snowfall eased off from the hour before.

`ASNOW` accumulates from forecast start, so a forecast reading a growing lead time never sees the window reset, while an analysis reading a fixed 1 hour lead from each init gets an independent window every step. `window_reset_frequency` for it is now a property of the template config (`run_total_window_reset_frequency`) rather than a constant shared by both dataset shapes. `precipitation_surface` was already correct.

## Untangling the grib element suffix

The suffix that selects `APCP01` (the hourly bucket) over `APCP06` (the run total) was derived from `window_reset_frequency`, which coupled the element lookup to the deaccumulation window and blocked the fix above. It now keys off `include_lead_time_suffix`, the flag `NoaaInternalAttrs` already carries for GEFS, so HRRR no longer maintains a parallel implicit convention.

Why the suffix exists at all, from the source files:

| lead | ASNOW | APCP |
|---|---|---|
| f01 | `ASNOW` (0-1 h) | `APCP01` (0-1 h) |
| f06 | `ASNOW` (0-6 h) | `APCP06` (0-6 h) **and** `APCP01` (5-6 h) |

## VBDSF comment

`visible_beam_downward_solar_flux_surface` is direct normal irradiance, not a flux on a horizontal surface — projecting it with cos(zenith) and adding the visible diffuse component accounts for total downward shortwave to within 1-4% at every solar elevation. Without that stated, a reader comparing it to `downward_short_wave_radiation_flux_surface` sees it exceed the total and reasonably concludes the data is broken.

The same variable inflates without bound in a narrow band of cells at sunrise, reaching ~10,000 W m-2, in the source data itself (the source file for 2023-05-06T12:00 holds 6,353 W m-2 at Denver, just after sunrise there). The comment gives 1361 as the mask threshold: direct normal irradiance cannot exceed the solar constant, and genuine low winter sun reaches ~1,100 W m-2, so nothing lower would be safe.

## Verification

- Live `read_data` against real source files resolves all four variable/dataset combinations, including selecting `APCP01` from an f06 file that also contains `APCP06`.
- Deaccumulation output now matches source/3600, including the step that previously came out 0.
- Two regression tests added: one pins the analysis rate against the real values that used to zero out, one pins the band selection.
- Template diffs are additive (the new `comment` only).

## Follow-up

`noaa-hrrr-analysis` `snowfall_surface` needs a re-backfill to pick this up; the published archive carries the old values until then.

Validation report: https://dataset-validation-reports.dynamical.org/noaa-hrrr-analysis/drafts/v0.2.0_2026-08-19T13-32/validation_report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HH3LyPY1SMG6mSXeAXN4Br

---
_Generated by [Claude Code](https://claude.ai/code/session_01HH3LyPY1SMG6mSXeAXN4Br)_