### PR TITLE
Document fractional categorical flags beyond lead 240h

### DIFF
--- a/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
@@ -14,6 +14,7 @@ from reformatters.common.config_models import (
     Encoding,
     StatisticsApproximate,
 )
+from reformatters.common.pydantic import replace
 from reformatters.common.template_config import SPATIAL_REF_COORDS, TemplateConfig
 from reformatters.common.types import AppendDim, Dim, Dims, Timedelta, Timestamp
 from reformatters.common.zarr import BLOSC_8BYTE_ZSTD_LEVEL3_SHUFFLE
@@ -23,6 +24,12 @@ from reformatters.noaa.gefs.common_gefs_template_config import (
     get_shared_template_dimension_coordinates,
 )
 from reformatters.noaa.gefs.gefs_config_models import GEFSDataVar
+
+_CATEGORICAL_RESAMPLING_COMMENT = (
+    "Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to "
+    "this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 "
+    "occur and give the flagged fraction of the neighborhood."
+)
 
 
 class GefsForecast35DayTemplateConfig(TemplateConfig[GEFSDataVar]):
@@ -286,4 +293,19 @@ class GefsForecast35DayTemplateConfig(TemplateConfig[GEFSDataVar]):
         var_chunks_ordered = tuple(var_chunks[dim] for dim in self.dims[ROOT])
         var_shards_ordered = tuple(var_shards[dim] for dim in self.dims[ROOT])
 
-        return get_shared_data_var_configs(var_chunks_ordered, var_shards_ordered)
+        return [
+            (
+                replace(
+                    var,
+                    attrs=replace(
+                        var.attrs,
+                        comment=f"{var.attrs.comment}. {_CATEGORICAL_RESAMPLING_COMMENT}",
+                    ),
+                )
+                if var.name.startswith("categorical_")
+                else var
+            )
+            for var in get_shared_data_var_configs(
+                var_chunks_ordered, var_shards_ordered
+            )
+        ]

--- a/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
@@ -30,6 +30,12 @@ _CATEGORICAL_RESAMPLING_COMMENT = (
     "this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 "
     "occur and give the flagged fraction of the neighborhood."
 )
+_CATEGORICAL_RESAMPLING_COMMENT_VAR_NAMES = (
+    "categorical_freezing_rain_surface",
+    "categorical_ice_pellets_surface",
+    "categorical_rain_surface",
+    "categorical_snow_surface",
+)
 
 
 class GefsForecast35DayTemplateConfig(TemplateConfig[GEFSDataVar]):
@@ -302,7 +308,7 @@ class GefsForecast35DayTemplateConfig(TemplateConfig[GEFSDataVar]):
                         comment=f"{var.attrs.comment}. {_CATEGORICAL_RESAMPLING_COMMENT}",
                     ),
                 )
-                if var.name.startswith("categorical_")
+                if var.name in _CATEGORICAL_RESAMPLING_COMMENT_VAR_NAMES
                 else var
             )
             for var in get_shared_data_var_configs(

--- a/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/template_config.py
@@ -299,19 +299,21 @@ class GefsForecast35DayTemplateConfig(TemplateConfig[GEFSDataVar]):
         var_chunks_ordered = tuple(var_chunks[dim] for dim in self.dims[ROOT])
         var_shards_ordered = tuple(var_shards[dim] for dim in self.dims[ROOT])
 
+        def append_resampling_comment(var: GEFSDataVar) -> GEFSDataVar:
+            return replace(
+                var,
+                attrs=replace(
+                    var.attrs,
+                    comment=f"{var.attrs.comment}. {_CATEGORICAL_RESAMPLING_COMMENT}",
+                ),
+            )
+
+        var_configs = get_shared_data_var_configs(
+            var_chunks_ordered, var_shards_ordered
+        )
         return [
-            (
-                replace(
-                    var,
-                    attrs=replace(
-                        var.attrs,
-                        comment=f"{var.attrs.comment}. {_CATEGORICAL_RESAMPLING_COMMENT}",
-                    ),
-                )
-                if var.name in _CATEGORICAL_RESAMPLING_COMMENT_VAR_NAMES
-                else var
-            )
-            for var in get_shared_data_var_configs(
-                var_chunks_ordered, var_shards_ordered
-            )
+            append_resampling_comment(var)
+            if var.name in _CATEGORICAL_RESAMPLING_COMMENT_VAR_NAMES
+            else var
+            for var in var_configs
         ]

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/categorical_freezing_rain_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/categorical_freezing_rain_surface/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "Categorical freezing rain",
     "short_name": "cfrzr",
     "units": "1",
-    "comment": "0=no; 1=yes",
+    "comment": "0=no; 1=yes. Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 occur and give the flagged fraction of the neighborhood.",
     "step_type": "avg",
     "flag_values": [
       0,

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/categorical_ice_pellets_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/categorical_ice_pellets_surface/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "Categorical ice pellets",
     "short_name": "cicep",
     "units": "1",
-    "comment": "0=no; 1=yes",
+    "comment": "0=no; 1=yes. Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 occur and give the flagged fraction of the neighborhood.",
     "step_type": "avg",
     "flag_values": [
       0,

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/categorical_rain_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/categorical_rain_surface/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "Categorical rain",
     "short_name": "crain",
     "units": "1",
-    "comment": "0=no; 1=yes",
+    "comment": "0=no; 1=yes. Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 occur and give the flagged fraction of the neighborhood.",
     "step_type": "avg",
     "flag_values": [
       0,

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/categorical_snow_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/categorical_snow_surface/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "Categorical snow",
     "short_name": "csnow",
     "units": "1",
-    "comment": "0=no; 1=yes",
+    "comment": "0=no; 1=yes. Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 occur and give the flagged fraction of the neighborhood.",
     "step_type": "avg",
     "flag_values": [
       0,

--- a/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day/templates/latest.zarr/zarr.json
@@ -94,7 +94,7 @@
           "long_name": "Categorical freezing rain",
           "short_name": "cfrzr",
           "units": "1",
-          "comment": "0=no; 1=yes",
+          "comment": "0=no; 1=yes. Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 occur and give the flagged fraction of the neighborhood.",
           "step_type": "avg",
           "flag_values": [
             0,
@@ -191,7 +191,7 @@
           "long_name": "Categorical ice pellets",
           "short_name": "cicep",
           "units": "1",
-          "comment": "0=no; 1=yes",
+          "comment": "0=no; 1=yes. Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 occur and give the flagged fraction of the neighborhood.",
           "step_type": "avg",
           "flag_values": [
             0,
@@ -288,7 +288,7 @@
           "long_name": "Categorical rain",
           "short_name": "crain",
           "units": "1",
-          "comment": "0=no; 1=yes",
+          "comment": "0=no; 1=yes. Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 occur and give the flagged fraction of the neighborhood.",
           "step_type": "avg",
           "flag_values": [
             0,
@@ -385,7 +385,7 @@
           "long_name": "Categorical snow",
           "short_name": "csnow",
           "units": "1",
-          "comment": "0=no; 1=yes",
+          "comment": "0=no; 1=yes. Beyond lead time 240 hours the source is 0.5 degree and bilinear resampling to this 0.25 degree grid mixes neighboring 0 and 1 values, so values between 0 and 1 occur and give the flagged fraction of the neighborhood.",
           "step_type": "avg",
           "flag_values": [
             0,


### PR DESCRIPTION
Found while validating `noaa-gefs-forecast-35-day` v0.2.0.

Beyond lead time 240 hours this dataset reads its 0.5° source files, which are bilinearly resampled onto the 0.25° output grid. For the categorical precipitation flags that mixes neighboring 0 and 1 values, so the stored values are not flags there:

| lead | distinct values | cells strictly between 0 and 1 |
|---|---|---|
| 222 h | `{0, 1}` | 0.0% |
| 246 h | `{0, 0.25, 0.5, 0.75, 1}` | 8.7% |
| 600 h | `{0, 0.25, 0.5, 0.75, 1}` | 8.7% |

(init 2026-08-10, member 12, `categorical_rain_surface`.)

The variables' `comment` previously read only `0=no; 1=yes`, so this adds a sentence describing the resampled values. This is an intrinsic, always-true property of the variable, so it belongs in `comment` rather than the validation report's review notes.

The comment is applied to exactly these four variables, named explicitly rather than matched by a `categorical_` prefix so that a future flag variable whose source is not resampled at these leads cannot pick it up silently:

- `categorical_freezing_rain_surface`
- `categorical_ice_pellets_surface`
- `categorical_rain_surface`
- `categorical_snow_surface`

`get_shared_data_var_configs` is shared with the GEFS analysis and 10 day spatial datasets, neither of which reads a coarser source at these lead times, so the note is applied in the 35 day forecast's own template config — following the same `replace`-over-shared-configs pattern `forecast_10_day_spatial` already uses for its attr overrides. The template diff is exactly the four variables plus the root consolidated metadata.

The updated attributes ride out with the next operational update; no metadata backfill is needed.

Note for reviewers: these variables also declare `flag_values: [0, 1]` / `flag_meanings: "no yes"`, which the fractional values do not satisfy. Changing those attrs would be a breaking change, so this PR leaves them alone.

Checks: `ruff format`, `ruff check`, `ty check`, `tests/common/common_template_config_subclasses_test.py`, `tests/common/datasets_cf_compliance_test.py`, `tests/noaa/gefs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNv6ccwRpyP3PwLjBZt5WV