### PR TITLE
Detect stale GRIB index byte ranges in GFS/GEFS downloads

### DIFF
--- a/src/reformatters/noaa/gefs/utils.py
+++ b/src/reformatters/noaa/gefs/utils.py
@@ -12,7 +12,10 @@ from reformatters.noaa.gefs.gefs_config_models import (
     GefsSourceFileCoord,
     get_grib_element,
 )
-from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
+from reformatters.noaa.noaa_grib_index import (
+    assert_downloaded_grib_message,
+    grib_message_byte_ranges_from_index,
+)
 from reformatters.noaa.noaa_utils import (
     NOMADS_RETRY_STATUS_CODES,
     nomads_rate_limiter,
@@ -53,12 +56,14 @@ def _download_file_from_gefs_source(
         idx_local_path, _index_data_vars(coord), coord.init_time, coord.lead_time
     )
     vars_suffix = digest(f"{s}-{e}" for s, e in zip(starts, ends, strict=True))
-    return download(
+    local_path = download(
         source_url,
         dataset_id,
         byte_ranges=(starts, ends),
         local_path_suffix=f"-{vars_suffix}",
     )
+    assert_downloaded_grib_message(local_path)
+    return local_path
 
 
 def gefs_download_file(

--- a/src/reformatters/noaa/gfs/region_job.py
+++ b/src/reformatters/noaa/gfs/region_job.py
@@ -34,7 +34,10 @@ from reformatters.common.types import (
     Timestamp,
 )
 from reformatters.noaa.models import NoaaDataVar
-from reformatters.noaa.noaa_grib_index import grib_message_byte_ranges_from_index
+from reformatters.noaa.noaa_grib_index import (
+    assert_downloaded_grib_message,
+    grib_message_byte_ranges_from_index,
+)
 from reformatters.noaa.noaa_utils import (
     NOMADS_RETRY_STATUS_CODES,
     nomads_rate_limiter,
@@ -106,12 +109,14 @@ class NoaaGfsCommonRegionJob(
             idx_local_path, coord.data_vars, coord.init_time, coord.lead_time
         )
         vars_suffix = digest(f"{s}-{e}" for s, e in zip(starts, ends, strict=True))
-        return download(
+        local_path = download(
             coord.get_url(source=source),
             self.dataset_id,
             byte_ranges=(starts, ends),
             local_path_suffix=f"-{vars_suffix}",
         )
+        assert_downloaded_grib_message(local_path)
+        return local_path
 
     def download_file(self, coord: NoaaGfsSourceFileCoord) -> Path:
         try:

--- a/src/reformatters/noaa/noaa_grib_index.py
+++ b/src/reformatters/noaa/noaa_grib_index.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Sequence
 from os import PathLike
+from pathlib import Path
 
 import pandas as pd
 
@@ -12,6 +13,23 @@ from reformatters.noaa.models import NoaaInternalAttrs
 # byte is unknown without the file size. Ranged downloads return bytes up to the
 # end of file; callers needing an exact length must detect ends >= this pad.
 GRIB_INDEX_UNKNOWN_END_PAD = 10 * (2**30)
+
+
+def assert_downloaded_grib_message(path: Path) -> None:
+    """Raise FileNotFoundError if `path` doesn't start with a GRIB message.
+
+    NOAA occasionally reprocesses an archived source file without regenerating
+    its .idx sidecar, leaving the sidecar's byte offsets pointing at the wrong
+    bytes of the reprocessed file. Treating that mismatch like a missing file
+    routes it through the same not-found handling (log softly for old
+    requests, fall back to an alternate source for recent ones) instead of
+    surfacing an opaque decode error from the GRIB reader.
+    """
+    with open(path, "rb") as f:
+        if f.read(4) != b"GRIB":
+            raise FileNotFoundError(
+                f"{path}: GRIB index byte range does not start with a GRIB message"
+            )
 
 
 def _lead_time_str(var: DataVar[NoaaInternalAttrs], lead_hours: int) -> str:

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -373,6 +373,7 @@ def test_download_file(
     template_ds: xr.Dataset,
     example_data_vars: list[GEFSDataVar],
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Test download file method."""
     tmp_store = get_local_tmp_store()
@@ -397,10 +398,13 @@ def test_download_file(
     mock_download = Mock()
     mock_index_path = Mock()
     mock_index_path.read_text.return_value = "ignored"
-    mock_data_path = Mock()
+    mock_data_path = tmp_path / "data.grib2"
+    mock_data_path.write_bytes(b"GRIB" + b"\x00" * 12 + b"7777")
 
     # Configure the mock to return different paths for index and data files
-    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
+    def mock_download_side_effect(
+        url: str, dataset_id: str, **kwargs: object
+    ) -> Path | Mock:
         if url.endswith(".idx"):
             return mock_index_path
         else:
@@ -657,6 +661,7 @@ def test_download_file_fallback(
     template_ds: xr.Dataset,
     example_data_vars: list[GEFSDataVar],
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Test download_file falls back to alternative source when primary fails for recent data."""
     tmp_store = get_local_tmp_store()
@@ -681,7 +686,8 @@ def test_download_file_fallback(
 
     mock_index_path = Mock()
     mock_index_path.read_text.return_value = "ignored"
-    mock_data_path = Mock()
+    mock_data_path = tmp_path / "data.grib2"
+    mock_data_path.write_bytes(b"GRIB" + b"\x00" * 12 + b"7777")
 
     fallback_url = coord.get_fallback_url()
     fallback_index_url = coord.get_index_url(fallback=True)
@@ -695,7 +701,9 @@ def test_download_file_fallback(
         raise FileNotFoundError(f"Primary index not found: {url}")
 
     # Fallback source (httpx_download_to_disk for NOMADS) succeeds
-    def mock_fallback_download(url: str, dataset_id: str, **kwargs: object) -> Mock:
+    def mock_fallback_download(
+        url: str, dataset_id: str, **kwargs: object
+    ) -> Path | Mock:
         nonlocal call_count
         call_count += 1
         if url == fallback_index_url:

--- a/tests/noaa/gefs/forecast_35_day/region_job_test.py
+++ b/tests/noaa/gefs/forecast_35_day/region_job_test.py
@@ -272,6 +272,7 @@ def test_download_file(
     template_ds: xr.Dataset,
     example_data_vars: list[GEFSDataVar],
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Test download_file method."""
     tmp_store = get_local_tmp_store()
@@ -297,10 +298,13 @@ def test_download_file(
     mock_download = Mock()
     mock_index_path = Mock()
     mock_index_path.read_text.return_value = "ignored"
-    mock_data_path = Mock()
+    mock_data_path = tmp_path / "data.grib2"
+    mock_data_path.write_bytes(b"GRIB" + b"\x00" * 12 + b"7777")
 
     # Configure the mock to return different paths for index and data files
-    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
+    def mock_download_side_effect(
+        url: str, dataset_id: str, **kwargs: object
+    ) -> Path | Mock:
         if url.endswith(".idx"):
             return mock_index_path
         else:
@@ -346,6 +350,7 @@ def test_download_file_fallback(
     template_ds: xr.Dataset,
     example_data_vars: list[GEFSDataVar],
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Test download_file falls back to alternative source when primary fails for recent data."""
     tmp_store = get_local_tmp_store()
@@ -371,7 +376,8 @@ def test_download_file_fallback(
 
     mock_index_path = Mock()
     mock_index_path.read_text.return_value = "ignored"
-    mock_data_path = Mock()
+    mock_data_path = tmp_path / "data.grib2"
+    mock_data_path.write_bytes(b"GRIB" + b"\x00" * 12 + b"7777")
 
     fallback_url = coord.get_fallback_url()
     fallback_index_url = coord.get_index_url(fallback=True)
@@ -385,7 +391,9 @@ def test_download_file_fallback(
         raise FileNotFoundError(f"Primary index not found: {url}")
 
     # Fallback source (httpx_download_to_disk for NOMADS) succeeds
-    def mock_fallback_download(url: str, dataset_id: str, **kwargs: object) -> Mock:
+    def mock_fallback_download(
+        url: str, dataset_id: str, **kwargs: object
+    ) -> Path | Mock:
         nonlocal call_count
         call_count += 1
         if url == fallback_index_url:

--- a/tests/noaa/gfs/forecast/region_job_test.py
+++ b/tests/noaa/gfs/forecast/region_job_test.py
@@ -62,7 +62,9 @@ def test_region_job_generete_source_file_coords() -> None:
         assert len(coord.data_vars) == 3
 
 
-def test_region_job_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_region_job_download_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     template_config = NoaaGfsForecastTemplateConfig()
 
     # Create a region job with mock stores
@@ -85,10 +87,13 @@ def test_region_job_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_download = Mock()
     mock_index_path = Mock()
     mock_index_path.read_text.return_value = "ignored"
-    mock_data_path = Mock()
+    mock_data_path = tmp_path / "data.grib2"
+    mock_data_path.write_bytes(b"GRIB" + b"\x00" * 12 + b"7777")
 
     # Configure the mock to return different paths for index and data files
-    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
+    def mock_download_side_effect(
+        url: str, dataset_id: str, **kwargs: object
+    ) -> Path | Mock:
         if url.endswith(".idx"):
             return mock_index_path
         else:

--- a/tests/noaa/gfs/region_job_test.py
+++ b/tests/noaa/gfs/region_job_test.py
@@ -78,7 +78,9 @@ def test_common_region_job_source_groups() -> None:
         assert len(group_has_hour_0) == 1
 
 
-def test_common_region_job_download_file(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_common_region_job_download_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Test download_file method of common region job."""
     template_config = NoaaGfsForecastTemplateConfig()
 
@@ -102,9 +104,12 @@ def test_common_region_job_download_file(monkeypatch: pytest.MonkeyPatch) -> Non
     mock_download = Mock()
     mock_index_path = Mock()
     mock_index_path.read_text.return_value = "ignored"
-    mock_data_path = Mock()
+    mock_data_path = tmp_path / "data.grib2"
+    mock_data_path.write_bytes(b"GRIB" + b"\x00" * 12 + b"7777")
 
-    def mock_download_side_effect(url: str, dataset_id: str, **kwargs: object) -> Mock:
+    def mock_download_side_effect(
+        url: str, dataset_id: str, **kwargs: object
+    ) -> Path | Mock:
         if url.endswith(".idx"):
             return mock_index_path
         else:
@@ -327,7 +332,7 @@ def test_download_file_raises_for_old_init_time(
 
 
 def test_download_file_nomads_fallback_uses_httpx(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """NOMADS fallback uses httpx_download_to_disk (not http_download_to_disk)."""
     template_config = NoaaGfsForecastTemplateConfig()
@@ -343,7 +348,9 @@ def test_download_file_nomads_fallback_uses_httpx(
         "reformatters.noaa.gfs.region_job.http_download_to_disk",
         Mock(side_effect=FileNotFoundError("not on s3")),
     )
-    mock_httpx = Mock(return_value=Mock())
+    grib_path = tmp_path / "nomads.grib2"
+    grib_path.write_bytes(b"GRIB" + b"\x00" * 12 + b"7777")
+    mock_httpx = Mock(return_value=grib_path)
     monkeypatch.setattr(
         "reformatters.noaa.gfs.region_job.httpx_download_to_disk", mock_httpx
     )

--- a/tests/noaa/noaa_grib_index_test.py
+++ b/tests/noaa/noaa_grib_index_test.py
@@ -15,6 +15,7 @@ from reformatters.noaa.hrrr.forecast_48_hour.template_config import (
 )
 from reformatters.noaa.noaa_grib_index import (
     _lead_time_str,
+    assert_downloaded_grib_message,
     grib_message_byte_ranges_from_index,
 )
 
@@ -366,6 +367,19 @@ def test_grib_index_raises_when_no_matches() -> None:
 
     with pytest.raises(ValueError, match="No GRIB index matches found"):
         grib_message_byte_ranges_from_index(idx_path, [bogus_var], init_time, lead_time)
+
+
+class TestAssertDownloadedGribMessage:
+    def test_valid_grib_message_passes(self, tmp_path: Path) -> None:
+        path = tmp_path / "message.grib2"
+        path.write_bytes(b"GRIB" + b"\x00" * 12 + b"7777")
+        assert_downloaded_grib_message(path)
+
+    def test_non_grib_bytes_raises_file_not_found(self, tmp_path: Path) -> None:
+        path = tmp_path / "message.grib2"
+        path.write_bytes(b"\x00" * 16)
+        with pytest.raises(FileNotFoundError, match="does not start with a GRIB"):
+            assert_downloaded_grib_message(path)
 
 
 class TestLeadTimeStr:


### PR DESCRIPTION
## What

[REFORMATTERS-EH](https://dynamical.sentry.io/issues/REFORMATTERS-EH): `RasterioIOError: not recognized as being in a supported file format` when reading downloaded GFS byte ranges, 1183 occurrences since 2026-05-24, recurring for `noaa-gfs-forecast`/`noaa-gfs-analysis` backfills of the 2022-11-29/30 GFS cycles.

## Root cause

Confirmed against the live NOAA S3 archive rather than guessed from code:

- The full `gfs.20221129/12/atmos/gfs.t12z.pgrb2.0p25.f207` object starts with a valid `GRIB` magic number, and its `.idx` sidecar cleanly parses to a single, unambiguous byte range for the `APCP:surface:204-207 hour acc fcst` message we compute via `grib_message_byte_ranges_from_index`.
- Fetching exactly that byte range from the real object returns bytes that are **not** a GRIB message (no `GRIB` header, no `7777` trailer).
- The `.idx` file's `Last-Modified` (2022-11-29 16:25 UTC) is a full day **before** the `.grb2` file's (2022-11-30 16:09 UTC) — NOAA reprocessed the archived GRIB2 file without regenerating its index sidecar, so the sidecar's byte offsets no longer line up with the reprocessed file's message boundaries.

This is an upstream NOAA archive inconsistency for these specific historical cycles, not a bug in our byte-range math — the same `_lead_time_str`/index-parsing logic correctly identifies a single matching entry; the entry's byte offsets are just wrong for the file as it exists today.

## Fix

A byte range built from a stale index can't be repaired without re-scanning the whole (500+MB) file, so this treats it like a missing source file instead: `assert_downloaded_grib_message` (new, in `noaa_grib_index.py`) checks the downloaded range starts with `GRIB` and raises `FileNotFoundError` if not. That routes it through the not-found handling GFS and GEFS already have for genuinely-missing files — soft `log.info` for old backfills, fallback to NOMADS for recent init times — instead of surfacing an opaque `RasterioIOError` deep in the read path. Wired into both `noaa/gfs/region_job.py` and `noaa/gefs/utils.py`, which share the same idx-byte-range-download pattern.

Scoped to GFS/GEFS, where I verified the failure against real source data. HRRR uses the same `grib_message_byte_ranges_from_index` utility but has its own duplicate-element handling I didn't want to touch without separately verifying it hits the same failure mode — a natural follow-up if it ever does.

## Test plan

- [x] New tests in `tests/noaa/noaa_grib_index_test.py::TestAssertDownloadedGribMessage` covering both the valid and invalid-magic-bytes cases
- [x] Updated existing GFS/GEFS `download_file` mocks to return real GRIB-prefixed temp files instead of bare `Mock()`s, since they now flow through the new check
- [x] `uv run ruff format && uv run ruff check --fix && uv run ty check` clean
- [x] `uv run pytest -m "not slow"` — 1997 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01QefBbWWqP75BFjajYF4xX4)_