### PR TITLE
Deploy the ECMWF S2S GRIB archive as its own cron

### DIFF
--- a/.github/workflows/manual-backfill.yml
+++ b/.github/workflows/manual-backfill.yml
@@ -82,25 +82,25 @@ jobs:
     runs-on: ubuntu-24.04
     environment: prod
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Install uv
-      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
       with:
         enable-cache: true
         cache-dependency-glob: uv.lock
     - name: Set up Python
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version-file: .python-version
     - name: Install the project
       run: uv sync --all-extras --dev --locked
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ secrets.AWS_REGION }}
     - name: Install kubectl
-      uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
+      uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b
       with:
         version: latest
     - name: Update kubeconfig

--- a/.github/workflows/manual-create-job-from-cronjob.yml
+++ b/.github/workflows/manual-create-job-from-cronjob.yml
@@ -22,6 +22,7 @@ name: 'Manual: Create Job from CronJob'
         - ecmwf-aifs-single-forecast-virtual-validate
         - ecmwf-ifs-ens-forecast-15-day-0-25-degree-update
         - ecmwf-ifs-ens-forecast-15-day-0-25-degree-validate
+        - ecmwf-s2s-gribs-archive-grib-files
         - nasa-imerg-analysis-early-update
         - nasa-imerg-analysis-early-validate
         - nasa-imerg-analysis-late-update
@@ -64,16 +65,16 @@ jobs:
     runs-on: ubuntu-24.04
     environment: prod
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         sparse-checkout: .
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ secrets.AWS_REGION }}
     - name: Install kubectl
-      uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
+      uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b
       with:
         version: latest
     - name: Update kubeconfig

--- a/.github/workflows/manual-get-jobs.yml
+++ b/.github/workflows/manual-get-jobs.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-24.04
     environment: prod
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         sparse-checkout: .
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ secrets.AWS_REGION }}
     - name: Install kubectl
-      uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
+      uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b
       with:
         version: latest
     - name: Update kubeconfig

--- a/.github/workflows/manual-get-pods.yml
+++ b/.github/workflows/manual-get-pods.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-24.04
     environment: prod
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         sparse-checkout: .
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ secrets.AWS_REGION }}
     - name: Install kubectl
-      uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
+      uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b
       with:
         version: latest
     - name: Update kubeconfig

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,6 @@ repos:
         name: generate manual workflows
         entry: "uv run src/scripts/generate_manual_workflows.py"
         language: system
-        files: ^(src/reformatters/__main__\.py|src/reformatters/.*/dynamical_dataset\.py|src/scripts/generate_manual_workflows\.py)$
+        files: ^(src/reformatters/__main__\.py|src/reformatters/.*/dynamical_dataset\.py|src/reformatters/.*/s2s_archiver\.py|src/scripts/generate_manual_workflows\.py)$
         pass_filenames: false
         require_serial: true

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -18,8 +18,12 @@ from sentry_sdk.types import Hint, Log
 from reformatters.common import deploy as deploy_module
 from reformatters.common import monitoring
 from reformatters.common.config import Config
-from reformatters.common.dynamical_dataset import DynamicalDataset, register_run_monitor
+from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.initialize_new_integration import initialize_new_integration
+from reformatters.common.operational import (
+    OperationalResources,
+    register_run_monitor,
+)
 from reformatters.common.storage import DatasetFormat, StorageConfig
 from reformatters.contrib.nasa.smap.level3_36km_v9 import NasaSmapLevel336KmV9Dataset
 from reformatters.contrib.noaa.ndvi_cdr.analysis import (
@@ -37,6 +41,7 @@ from reformatters.ecmwf.aifs_single.forecast import (
 from reformatters.ecmwf.aifs_single.forecast_virtual import (
     EcmwfAifsSingleForecastVirtualDataset,
 )
+from reformatters.ecmwf.archive_gribs.s2s_archiver import EcmwfS2sGribArchiver
 from reformatters.ecmwf.ifs_ens.forecast_15_day_0_25_degree.dynamical_dataset import (
     EcmwfIfsEnsForecast15Day025DegreeDataset,
 )
@@ -284,10 +289,17 @@ app = typer.Typer(pretty_exceptions_show_locals=False)
 app.command()(initialize_new_integration)
 
 
+# Source archives that feed a dataset but have no store of their own. They deploy
+# their own cronjobs and are not datasets, so they carry no update/validate/backfill.
+OPERATIONAL_ARCHIVERS: Sequence[OperationalResources] = [EcmwfS2sGribArchiver()]
+
 for dataset in DYNAMICAL_DATASETS:
     app.add_typer(dataset.get_cli(), name=dataset.dataset_id)
 
-deploy_module.register_commands(app, DYNAMICAL_DATASETS)
+for archiver in OPERATIONAL_ARCHIVERS:
+    app.add_typer(archiver.get_cli(), name=archiver.dataset_id)
+
+deploy_module.register_commands(app, DYNAMICAL_DATASETS, OPERATIONAL_ARCHIVERS)
 
 
 if not __debug__:

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -289,8 +289,8 @@ app = typer.Typer(pretty_exceptions_show_locals=False)
 app.command()(initialize_new_integration)
 
 
-# Source archives that feed a dataset but have no store of their own. They deploy
-# their own cronjobs and are not datasets, so they carry no update/validate/backfill.
+# Source archives feed datasets but have no store, so they deploy their own cronjobs
+# without a dataset's update/validate/backfill surface.
 OPERATIONAL_ARCHIVERS: Sequence[OperationalResources] = [EcmwfS2sGribArchiver()]
 
 for dataset in DYNAMICAL_DATASETS:

--- a/src/reformatters/common/deploy.py
+++ b/src/reformatters/common/deploy.py
@@ -8,12 +8,13 @@ import typer
 from reformatters.common import docker, kubernetes, staging
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.logging import get_logger
+from reformatters.common.operational import OperationalResources
 
 log = get_logger(__name__)
 
 
 def deploy_operational_resources(
-    datasets: Iterable[DynamicalDataset[Any, Any]],
+    resources: Iterable[OperationalResources],
     docker_image: str | None = None,
     dataset_id_filter: str | None = None,
     cronjob_transform: Callable[[kubernetes.CronJob], kubernetes.CronJob] | None = None,
@@ -22,15 +23,17 @@ def deploy_operational_resources(
 
     reformat_jobs: list[kubernetes.Job] = []
 
-    for dataset in datasets:
-        if dataset_id_filter is not None and dataset.dataset_id != dataset_id_filter:
+    for resource in resources:
+        if dataset_id_filter is not None and resource.dataset_id != dataset_id_filter:
             continue
 
         try:
-            dataset_cronjobs = list(dataset.operational_kubernetes_resources(image_tag))
+            dataset_cronjobs = list(
+                resource.operational_kubernetes_resources(image_tag)
+            )
         except NotImplementedError:
             log.info(
-                f"Skipping deploy for {dataset.__class__.__name__}, "
+                f"Skipping deploy for {resource.__class__.__name__}, "
                 "`operational_kubernetes_resources` not implemented."
             )
             continue
@@ -65,7 +68,9 @@ def deploy_operational_resources(
 
 
 def register_commands(
-    app: typer.Typer, datasets: Sequence[DynamicalDataset[Any, Any]]
+    app: typer.Typer,
+    datasets: Sequence[DynamicalDataset[Any, Any]],
+    archivers: Sequence[OperationalResources] = (),
 ) -> None:
     @app.command()
     def deploy(
@@ -73,7 +78,7 @@ def register_commands(
         dataset_id: str | None = None,
     ) -> None:
         deploy_operational_resources(
-            datasets, docker_image, dataset_id_filter=dataset_id
+            [*datasets, *archivers], docker_image, dataset_id_filter=dataset_id
         )
 
     @app.command()

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -1,11 +1,10 @@
 import inspect
 import json
 import subprocess
-from collections.abc import Iterator, Sequence
-from contextlib import AbstractContextManager, ExitStack, contextmanager
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Any, Generic, Literal, Protocol, Self, TypeVar
+from typing import Annotated, Any, Generic, Literal, Self, TypeVar
 
 import icechunk
 import numpy as np
@@ -32,7 +31,7 @@ from reformatters.common.kubernetes import (
     get_deployed_cronjob_image,
 )
 from reformatters.common.logging import get_logger
-from reformatters.common.pydantic import FrozenBaseModel
+from reformatters.common.operational import OperationalResources
 from reformatters.common.region_job import (
     RegionJob,
     SourceFileCoord,
@@ -55,7 +54,7 @@ SOURCE_FILE_COORD = TypeVar("SOURCE_FILE_COORD", bound=SourceFileCoord)
 log = get_logger(__name__)
 
 
-class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
+class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     """Top level class managing a dataset configuration and processing."""
 
     template_config: TemplateConfig[DATA_VAR]
@@ -807,49 +806,6 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
             - poll_deadline_grace
         )
 
-    def _operational_cron_job(
-        self, cron_type: type[CronJob], cron_job_name: str | None = None
-    ) -> CronJob:
-        """The single cron job of `cron_type` (and name, when given) this dataset defines."""
-        return item(
-            cron_job
-            for cron_job in self.operational_kubernetes_resources(
-                "placeholder-image-tag"
-            )
-            if isinstance(cron_job, cron_type)
-            and (cron_job_name is None or cron_job.name == cron_job_name)
-        )
-
-    @contextmanager
-    def _monitor(
-        self,
-        cron_type: type[CronJob],
-        reformat_job_name: str,
-        cron_job_name: str | None = None,
-        *,
-        send_in_progress: bool = True,
-        send_result: bool = True,
-    ) -> Iterator[None]:
-        # No registered monitors -> nothing to report to, and no need to require
-        # operational_kubernetes_resources to be defined.
-        if not _RUN_MONITORS:
-            yield
-            return
-
-        cron_job = self._operational_cron_job(cron_type, cron_job_name)
-
-        with ExitStack() as stack:
-            for monitor in _RUN_MONITORS:
-                stack.enter_context(
-                    monitor(
-                        cron_job,
-                        reformat_job_name,
-                        send_in_progress=send_in_progress,
-                        send_result=send_result,
-                    )
-                )
-            yield
-
     @model_validator(mode="after")
     def _validate_virtual_storage(self) -> Self:
         # A virtual region job emits chunk refs into icechunk and needs the source
@@ -902,31 +858,3 @@ class DynamicalDataset(FrozenBaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
                     f"virtual data var {var.name} must declare compressors=()"
                 )
         return self
-
-
-class RunMonitor(Protocol):
-    """Wraps a single operational cron run to report it to a monitoring service.
-
-    The application registers monitors (see `register_run_monitor`); `DynamicalDataset._monitor`
-    enters every registered one around each update/validate run. This keeps
-    DynamicalDataset agnostic of any specific monitoring service — a different
-    deployment registers whatever it uses, or nothing.
-    """
-
-    def __call__(
-        self,
-        cron_job: CronJob,
-        reformat_job_name: str,
-        *,
-        send_in_progress: bool,
-        send_result: bool,
-    ) -> AbstractContextManager[None]: ...
-
-
-_RUN_MONITORS: list[RunMonitor] = []
-
-
-def register_run_monitor(monitor: RunMonitor) -> None:
-    """Register a monitor to wrap every operational cron run. With none registered,
-    monitoring is a no-op."""
-    _RUN_MONITORS.append(monitor)

--- a/src/reformatters/common/operational.py
+++ b/src/reformatters/common/operational.py
@@ -1,0 +1,102 @@
+from collections.abc import Iterator, Sequence
+from contextlib import AbstractContextManager, ExitStack, contextmanager
+from typing import Protocol
+
+import typer
+
+from reformatters.common.iterating import item
+from reformatters.common.kubernetes import CronJob
+from reformatters.common.pydantic import FrozenBaseModel
+
+
+class OperationalResources(FrozenBaseModel):
+    """A unit of work that runs on a schedule in kubernetes and reports each run.
+
+    Subclassed by `DynamicalDataset` and by the source archivers that feed a dataset
+    but have no store of their own. `dataset_id` is the CLI path segment a cron pod
+    invokes, so a subclass's typer app must be registered under it.
+    """
+
+    @property
+    def dataset_id(self) -> str:
+        raise NotImplementedError("Subclasses must implement dataset_id")
+
+    def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+        raise NotImplementedError(
+            "Subclasses must implement operational_kubernetes_resources"
+        )
+
+    def get_cli(self) -> typer.Typer:
+        """The typer app registered under `dataset_id`, holding this unit's commands."""
+        raise NotImplementedError("Subclasses must implement get_cli")
+
+    def _operational_cron_job(
+        self, cron_type: type[CronJob], cron_job_name: str | None = None
+    ) -> CronJob:
+        """The single cron job of `cron_type` (and name, when given) this unit defines."""
+        return item(
+            cron_job
+            for cron_job in self.operational_kubernetes_resources(
+                "placeholder-image-tag"
+            )
+            if isinstance(cron_job, cron_type)
+            and (cron_job_name is None or cron_job.name == cron_job_name)
+        )
+
+    @contextmanager
+    def _monitor(
+        self,
+        cron_type: type[CronJob],
+        reformat_job_name: str,
+        cron_job_name: str | None = None,
+        *,
+        send_in_progress: bool = True,
+        send_result: bool = True,
+    ) -> Iterator[None]:
+        # No registered monitors -> nothing to report to, and no need to require
+        # operational_kubernetes_resources to be defined.
+        if not _RUN_MONITORS:
+            yield
+            return
+
+        cron_job = self._operational_cron_job(cron_type, cron_job_name)
+
+        with ExitStack() as stack:
+            for monitor in _RUN_MONITORS:
+                stack.enter_context(
+                    monitor(
+                        cron_job,
+                        reformat_job_name,
+                        send_in_progress=send_in_progress,
+                        send_result=send_result,
+                    )
+                )
+            yield
+
+
+class RunMonitor(Protocol):
+    """Wraps a single operational cron run to report it to a monitoring service.
+
+    The application registers monitors (see `register_run_monitor`);
+    `OperationalResources._monitor` enters every registered one around each run. This
+    keeps the operational classes agnostic of any specific monitoring service — a
+    different deployment registers whatever it uses, or nothing.
+    """
+
+    def __call__(
+        self,
+        cron_job: CronJob,
+        reformat_job_name: str,
+        *,
+        send_in_progress: bool,
+        send_result: bool,
+    ) -> AbstractContextManager[None]: ...
+
+
+_RUN_MONITORS: list[RunMonitor] = []
+
+
+def register_run_monitor(monitor: RunMonitor) -> None:
+    """Register a monitor to wrap every operational cron run. With none registered,
+    monitoring is a no-op."""
+    _RUN_MONITORS.append(monitor)

--- a/src/reformatters/ecmwf/archive_gribs/s2s_archiver.py
+++ b/src/reformatters/ecmwf/archive_gribs/s2s_archiver.py
@@ -1,0 +1,190 @@
+"""The operational surface of the ECMWF S2S GRIB archive.
+
+The archive is upstream of every dataset built from it: it has its own bucket, its own
+retrieval schedule and no store, so it deploys as its own cron rather than as part of a
+dataset's operational resources. `ECDS_VARIABLES` is the archive's contract with those
+datasets — what a reformatter reading this bucket can expect to find.
+"""
+
+import os
+from collections.abc import Sequence
+from datetime import timedelta
+from typing import Annotated, Any, Final
+
+import pandas as pd
+import typer
+
+from reformatters.common import kubernetes
+from reformatters.common.kubernetes import CronJob
+from reformatters.common.logging import get_logger
+from reformatters.common.operational import OperationalResources
+from reformatters.ecmwf.archive_gribs.archive import (
+    DEFAULT_CONCURRENT_REQUESTS,
+    archive_initialization,
+)
+from reformatters.ecmwf.archive_gribs.request_shards import initialization_selections
+
+log = get_logger(__name__)
+
+ARCHIVE_PREFIX: Final = "dynamical/ecmwf-ifs-grib/ecmwf-ifs-ens-forecast-46-day"
+ARCHIVE_RCLONE_ROOT: Final = f":s3:us-west-2.opendata.source.coop/{ARCHIVE_PREFIX}/"
+ARCHIVE_BASE_URL: Final = f"https://s3-us-west-2.amazonaws.com/us-west-2.opendata.source.coop/{ARCHIVE_PREFIX}"
+
+# ECMWF's licence sets a 48 hour minimum delay, but ECDS publishes an initialization
+# about 51.6 hours after its 00 UTC reference time (measured 51.4-52.1 h daily,
+# 2026-06-26 to 2026-08-11). With the archive cron at 06 UTC, the initialization this
+# selects is one published a couple of hours earlier.
+PUBLICATION_DELAY: Final = pd.Timedelta("53h")
+# ECMWF S2S initializes at 00 UTC only.
+INIT_FREQUENCY: Final = pd.Timedelta("1D")
+EARLIEST_INIT_TIME: Final = pd.Timestamp("2023-06-28")
+
+SOURCE_COOP_SECRET_NAME: Final = "source-coop-storage-options-key"  # noqa: S105
+ECDS_API_KEY_SECRET_NAME: Final = "ecmwf-ecds-api-key"  # noqa: S105
+
+# The ECDS variables archived for every initialization. A dataset reading this archive
+# maps its data variables onto these names; adding one here is what makes it available
+# to be mapped.
+ECDS_VARIABLES: Final[Sequence[str]] = (
+    "2_m_dewpoint_temperature",
+    "2_m_temperature",
+    "convective_precipitation",
+    "eastward_turbulent_surface_stress",
+    "geopotential_height",
+    "mean_sea_level_pressure",
+    "northward_turbulent_surface_stress",
+    "sea_ice_area_fraction",
+    "sea_surface_temperature",
+    "skin_temperature",
+    "snow_albedo",
+    "snow_density",
+    "snow_depth_water_equivalent",
+    "snow_fall_water_equivalent",
+    "soil_moisture_top_100_cm",
+    "soil_moisture_top_20_cm",
+    "soil_temperature_top_100_cm",
+    "soil_temperature_top_20_cm",
+    "specific_humidity",
+    "surface_latent_heat_flux",
+    "surface_net_solar_radiation",
+    "surface_net_thermal_radiation",
+    "surface_pressure",
+    "surface_runoff",
+    "surface_sensible_heat_flux",
+    "surface_solar_radiation_downwards",
+    "surface_thermal_radiation_downwards",
+    "temperature",
+    "top_net_thermal_radiation",
+    "total_cloud_cover",
+    "total_column_water",
+    "u_component_of_wind",
+    "v_component_of_wind",
+    "vertical_velocity",
+    "water_runoff_and_drainage",
+)
+
+
+class EcmwfS2sGribArchiver(OperationalResources):
+    """Retrieves ECMWF S2S initializations from ECDS into dynamical's GRIB archive."""
+
+    @property
+    def dataset_id(self) -> str:
+        return "ecmwf-s2s-gribs"
+
+    def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+        return [
+            CronJob(
+                command=["archive-grib-files"],
+                workers_total=1,
+                parallelism=1,
+                name=f"{self.dataset_id}-archive-grib-files",
+                schedule="0 6 * * *",
+                pod_active_deadline=timedelta(hours=6),
+                image=image_tag,
+                dataset_id=self.dataset_id,
+                cpu="1.5",
+                memory="8G",
+                ephemeral_storage="60G",
+                secret_names=[SOURCE_COOP_SECRET_NAME, ECDS_API_KEY_SECRET_NAME],
+            )
+        ]
+
+    def archive_grib_files(
+        self,
+        reformat_job_name: Annotated[str, typer.Argument(envvar="JOB_NAME")],
+        # Typer does not handle PurePosixPath, so the rclone destination stays a str.
+        dst_root_path: str = ARCHIVE_RCLONE_ROOT,
+        init_times_back: int = 3,
+        checkers: int = 32,
+        concurrent_requests: int = DEFAULT_CONCURRENT_REQUESTS,
+    ) -> None:
+        """Retrieve `ECDS_VARIABLES` for recent initializations into the archive.
+
+        Initializations are archived newest first, so an interrupted run leaves the most
+        recent data archived.
+
+        Args:
+            dst_root_path: The destination root in the form rclone expects,
+                e.g. ':s3:bucket/foo/bar'.
+            init_times_back: How many initializations back from the newest available
+                one to check. Already archived requests are skipped, so re-checking
+                recent initializations is how an interrupted transfer resumes.
+            checkers: Passed to `rclone --checkers` when listing the destination.
+            concurrent_requests: How many ECDS requests to retrieve at once.
+        """
+        with self._monitor(
+            CronJob,
+            reformat_job_name,
+            cron_job_name=f"{self.dataset_id}-archive-grib-files",
+        ):
+            _set_ecds_api_key_from_secret()
+            selections = initialization_selections(ECDS_VARIABLES)
+            for init_time in self.init_times_to_archive(init_times_back):
+                log.info("Archiving %s", init_time)
+                archive_initialization(
+                    init_time,
+                    selections,
+                    dst_root_path,
+                    checkers=checkers,
+                    concurrent_requests=concurrent_requests,
+                    env_vars=_source_coop_rclone_env_vars(),
+                )
+
+    def init_times_to_archive(
+        self, init_times_back: int, now: pd.Timestamp | None = None
+    ) -> Sequence[pd.Timestamp]:
+        """The initializations one run checks, newest first."""
+        now = now if now is not None else pd.Timestamp.now("UTC")
+        newest_init_time = (now - PUBLICATION_DELAY).normalize().tz_localize(None)
+        init_times = pd.date_range(
+            end=newest_init_time, periods=init_times_back, freq=INIT_FREQUENCY
+        )
+        return [t for t in reversed(init_times) if t >= EARLIEST_INIT_TIME]
+
+    def get_cli(self) -> typer.Typer:
+        app = typer.Typer()
+        app.command()(self.archive_grib_files)
+        return app
+
+
+def _set_ecds_api_key_from_secret() -> None:
+    """Put the mounted ECDS key where `EcdsRequest` looks for it.
+
+    Outside prod no secret is mounted and the client falls back to `~/.cdsapirc`.
+    """
+    secret = kubernetes.load_secret(ECDS_API_KEY_SECRET_NAME)
+    if secret:
+        os.environ["ECDS_API_KEY"] = secret["key"]
+
+
+def _source_coop_rclone_env_vars() -> dict[str, Any] | None:
+    secret = kubernetes.load_secret(SOURCE_COOP_SECRET_NAME)
+    if not secret:
+        return None
+    return {
+        "RCLONE_S3_PROVIDER": "AWS",
+        "RCLONE_S3_ACCESS_KEY_ID": secret["key"],
+        "RCLONE_S3_SECRET_ACCESS_KEY": secret["secret"],
+        "RCLONE_S3_REGION": "us-west-2",
+        "RCLONE_S3_FORCE_PATH_STYLE": "false",
+    }

--- a/src/scripts/generate_manual_workflows.py
+++ b/src/scripts/generate_manual_workflows.py
@@ -39,9 +39,9 @@ def get_all_cronjob_names() -> list[str]:
     """Extract all CronJob names from every unit that deploys them."""
     cronjob_names: list[str] = []
 
-    for dataset in [*DYNAMICAL_DATASETS, *OPERATIONAL_ARCHIVERS]:
+    for deployable in [*DYNAMICAL_DATASETS, *OPERATIONAL_ARCHIVERS]:
         try:
-            resources = dataset.operational_kubernetes_resources(
+            resources = deployable.operational_kubernetes_resources(
                 "placeholder-image-tag"
             )
             cronjob_names.extend(

--- a/src/scripts/generate_manual_workflows.py
+++ b/src/scripts/generate_manual_workflows.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import yaml
 
-from reformatters.__main__ import DYNAMICAL_DATASETS
+from reformatters.__main__ import DYNAMICAL_DATASETS, OPERATIONAL_ARCHIVERS
 from reformatters.common.kubernetes import CronJob, ReformatCronJob
 from reformatters.common.logging import get_logger
 
@@ -36,10 +36,10 @@ MANUAL_K8S_GITHUB_ENVIRONMENT = "prod"
 
 
 def get_all_cronjob_names() -> list[str]:
-    """Extract all CronJob names from DYNAMICAL_DATASETS."""
+    """Extract all CronJob names from every unit that deploys them."""
     cronjob_names: list[str] = []
 
-    for dataset in DYNAMICAL_DATASETS:
+    for dataset in [*DYNAMICAL_DATASETS, *OPERATIONAL_ARCHIVERS]:
         try:
             resources = dataset.operational_kubernetes_resources(
                 "placeholder-image-tag"

--- a/tests/common/dynamical_dataset_test.py
+++ b/tests/common/dynamical_dataset_test.py
@@ -14,7 +14,13 @@ import pytest
 import xarray as xr
 from pydantic import Field, ValidationError, computed_field
 
-from reformatters.common import dynamical_dataset, storage, template_utils, validation
+from reformatters.common import (
+    dynamical_dataset,
+    operational,
+    storage,
+    template_utils,
+    validation,
+)
 from reformatters.common.config import Config, Env
 from reformatters.common.config_models import (
     BaseInternalAttrs,
@@ -749,7 +755,7 @@ class ExampleDatasetWithThreeCronJobs(
 
 def _recording_monitor(
     events: list[tuple[str, str]],
-) -> dynamical_dataset.RunMonitor:
+) -> operational.RunMonitor:
     @contextmanager
     def monitor(
         cron_job: CronJob,
@@ -789,8 +795,8 @@ def test_monitor_noop_without_registered_monitors(
 
 def test_monitor_resolves_cron_job_and_enters_all_monitors() -> None:
     events: list[tuple[str, str]] = []
-    dynamical_dataset.register_run_monitor(_recording_monitor(events))
-    dynamical_dataset.register_run_monitor(_recording_monitor(events))
+    operational.register_run_monitor(_recording_monitor(events))
+    operational.register_run_monitor(_recording_monitor(events))
 
     dataset = ExampleDatasetWithThreeCronJobs()
     # cron_job_name disambiguates among the three crons; the resolved cron reaches monitors.
@@ -804,7 +810,7 @@ def test_monitor_resolves_cron_job_and_enters_all_monitors() -> None:
 
 
 def test_monitor_requires_exactly_one_matching_cron() -> None:
-    dynamical_dataset.register_run_monitor(_recording_monitor([]))
+    operational.register_run_monitor(_recording_monitor([]))
     dataset = ExampleDatasetWithThreeCronJobs()
     # Base CronJob with no name matches all three -> ambiguous.
     with (
@@ -816,7 +822,7 @@ def test_monitor_requires_exactly_one_matching_cron() -> None:
 
 def test_monitor_propagates_errors_to_monitors() -> None:
     events: list[tuple[str, str]] = []
-    dynamical_dataset.register_run_monitor(_recording_monitor(events))
+    operational.register_run_monitor(_recording_monitor(events))
 
     dataset = ExampleDataset(
         template_config=ExampleConfig(), region_job_class=ExampleRegionJob

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 os.environ["DYNAMICAL_ENV"] = "test"
 
 
-from reformatters.common import dynamical_dataset, storage  # noqa: E402
+from reformatters.common import operational, storage  # noqa: E402
 
 
 def pytest_xdist_auto_num_workers(config: pytest.Config) -> int | None:
@@ -68,9 +68,9 @@ def set_local_zarr_store_base_path(
 def reset_run_monitors() -> Iterator[None]:
     """Keep the module-level monitor registry empty by default so importing
     __main__ (which registers prod monitors) in one test doesn't leak into others."""
-    dynamical_dataset._RUN_MONITORS.clear()
+    operational._RUN_MONITORS.clear()
     yield
-    dynamical_dataset._RUN_MONITORS.clear()
+    operational._RUN_MONITORS.clear()
 
 
 @pytest.fixture

--- a/tests/ecmwf/archive_gribs/s2s_archiver_test.py
+++ b/tests/ecmwf/archive_gribs/s2s_archiver_test.py
@@ -1,0 +1,83 @@
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
+from reformatters.ecmwf.archive_gribs.request_shards import initialization_selections
+from reformatters.ecmwf.archive_gribs.s2s_archiver import (
+    EARLIEST_INIT_TIME,
+    ECDS_VARIABLES,
+    EcmwfS2sGribArchiver,
+)
+
+runner = CliRunner()
+
+
+def test_operational_kubernetes_resources_is_one_unsuspended_archive_cron() -> None:
+    archiver = EcmwfS2sGribArchiver()
+    (cron_job,) = archiver.operational_kubernetes_resources("test-image")
+
+    assert cron_job.name == "ecmwf-s2s-gribs-archive-grib-files"
+    assert cron_job.command == ["archive-grib-files"]
+    assert cron_job.dataset_id == archiver.dataset_id
+    assert not cron_job.suspend
+
+
+def test_cron_command_matches_a_registered_cli_command() -> None:
+    archiver = EcmwfS2sGribArchiver()
+    command_names = {
+        (command.name or command.callback.__name__).replace("_", "-")  # ty: ignore[unresolved-attribute]
+        for command in archiver.get_cli().registered_commands
+    }
+    for cron_job in archiver.operational_kubernetes_resources("test-image"):
+        assert cron_job.command[0] in command_names
+
+
+def test_cli_archive_grib_files_help_works() -> None:
+    result = runner.invoke(EcmwfS2sGribArchiver().get_cli(), ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "archive-grib-files" in result.output
+
+
+@pytest.mark.parametrize(
+    ("now", "expected"),
+    [
+        # The 06 UTC fire selects the initialization published a couple of hours
+        # earlier, then walks back.
+        (
+            "2026-08-20T06:00:00Z",
+            ["2026-08-18", "2026-08-17", "2026-08-16"],
+        ),
+        # Just before publication, the same run is still on the previous day.
+        (
+            "2026-08-20T04:00:00Z",
+            ["2026-08-17", "2026-08-16", "2026-08-15"],
+        ),
+    ],
+)
+def test_init_times_to_archive_is_newest_first(now: str, expected: list[str]) -> None:
+    init_times = EcmwfS2sGribArchiver().init_times_to_archive(3, now=pd.Timestamp(now))
+    assert [t.strftime("%Y-%m-%d") for t in init_times] == expected
+
+
+def test_init_times_to_archive_stops_at_the_earliest_initialization() -> None:
+    now = EARLIEST_INIT_TIME.tz_localize("UTC") + pd.Timedelta("53h")
+    assert EcmwfS2sGribArchiver().init_times_to_archive(3, now=now) == [
+        EARLIEST_INIT_TIME
+    ]
+
+
+def test_ecds_variables_shard_into_the_archived_selections() -> None:
+    """One initialization is 12 blobs; the archive's layout is what readers index."""
+    selections = initialization_selections(ECDS_VARIABLES)
+    assert len(selections) == 12
+    assert {v for s in selections for v in s.variables} == set(ECDS_VARIABLES)
+
+
+def test_archiver_is_not_a_dataset_and_defines_no_reformat_crons() -> None:
+    """The archive has no store, so it must not deploy update or validate crons."""
+    cron_jobs = EcmwfS2sGribArchiver().operational_kubernetes_resources("test-image")
+    assert all(
+        not isinstance(c, ReformatCronJob | ValidationCronJob) for c in cron_jobs
+    )
+    assert all(isinstance(c, CronJob) for c in cron_jobs)


### PR DESCRIPTION
Ships the live GRIB archiver ahead of #904, so realtime retrieval stops depending on a hand-started EC2 process while the 46 day dataset is still in review.

## Why now

#906 merged the ECDS archiver with no caller: `archive_initialization`'s only reference on `main` is its own definition. The cron that would call it is defined in #904's `forecast_46_day_1_5_degree/dynamical_dataset.py`, so no archive cron has ever existed in the cluster — confirmed against prod, where `archive-grib-files` crons exist for `dwd-icon-eu-forecast-5-day` and `eccc-hrdps-forecast` and none for the 46 day model.

Every staged GRIB so far came from the EC2 stager, which stopped: the bucket holds 2026-06-13 through 2026-08-16 complete at 12 selections + 12 indexes each, last upload 2026-08-18T17:25Z, nothing newer.

## What deploys

One unsuspended cron, `ecmwf-s2s-gribs-archive-grib-files`, at 06 UTC:

```
python src/reformatters/__main__.py ecmwf-s2s-gribs archive-grib-files
```

with `source-coop-storage-options-key` and `ecmwf-ecds-api-key` mounted. `init_times_back=3` means the first 06 UTC run checks 2026-08-18, 08-17 and 08-16, so it closes the current gap without a separate operation.

## Why not just merge #904

The archive cron only reaches the cluster if `deploy.py` sees it, and that loop iterates `DYNAMICAL_DATASETS`. Registering the dataset to get the cron would drag ~1,700 lines, including the 877-line `template_config.py` that holds all 35 variables' CF metadata — the bulk of what is under review — because `archive_grib_files` derived its variable list from `template_config.data_vars`.

So the variable list moves to where the retrieval happens. `ECDS_VARIABLES` is the archive's contract with the datasets that read it, not a property of any one of them — the same bucket feeds the daily and the deferred 6-hourly dataset. The archive now needs no template, no region job and no store to run, and this PR ships zero lines of zarr metadata.

## Shape

`_monitor` and `_operational_cron_job` only ever needed `operational_kubernetes_resources`, so they move with the run-monitor registry into `common/operational.py` as `OperationalResources`. `DynamicalDataset` inherits it and loses its copies; `deploy` collects cronjobs over the base, so one code path deploys datasets and archivers alike. `deploy-staging` and `cleanup-staging` stay dataset-only — an archive has no version to stage.

## Follow-up in #904

- Drop `ecds_variables()`, `archive_grib_files`, `SOURCE_COOP_SECRET_NAME`, `ECDS_API_KEY_SECRET_NAME` and the archive cron; `s2s_dynamical_dataset.py` largely goes away.
- Import `ARCHIVE_BASE_URL` from `s2s_archiver` instead of defining a second copy of the prefix in `s2s_region_job.py`.
- Add a test pinning `{v.internal_attrs.ecds_variable for v in data_vars}` to `ECDS_VARIABLES` so the dataset and the archive cannot drift.

## Known issue, not addressed here

A partially published initialization is a hard failure rather than a skip. `check_available` returns `False` only when ECDS holds none of the selections; when it holds some, `_assert_available` raises `AssertionError`, which is outside `retryable_exceptions`, and the loop over init times has no handler. Newest-first ordering then makes the newest initialization a single point of failure for the whole run, including the older gap-filling ones. With `PUBLICATION_DELAY = 53h` against a measured 51.6 h the margin is about 2.4 h, so this is worth deciding on separately.

## Notes for review

- Regenerating the manual workflows also refreshes the action pins, which had drifted from the generator's hardcoded SHAs on `main`. That is the 14-line diff in `.github/` unrelated to the new dropdown entry.
- The prek hook that regenerates those workflows now also watches `s2s_archiver.py`, so changing the cron there cannot leave the dropdowns stale.

## Verification

- `uv run ruff format`, `ruff check`, `ty check` clean.
- `uv run pytest -m "not slow"`: 2003 passed.
- Rendered the cronjob object and confirmed the name, schedule, unsuspended state, container command and both mounted secrets, and that the archiver id collides with no dataset id.