### PR TITLE
Fix ECMWF 46-day archiver CronJob name

### DIFF
--- a/.github/workflows/manual-create-job-from-cronjob.yml
+++ b/.github/workflows/manual-create-job-from-cronjob.yml
@@ -19,11 +19,11 @@ name: 'Manual: Create Job from CronJob'
         - ecmwf-aifs-single-forecast-validate
         - ecmwf-aifs-single-forecast-virtual-update
         - ecmwf-aifs-single-forecast-virtual-validate
+        - ecmwf-ifs-ens-46-day-gribs-archive-grib-files
         - ecmwf-ifs-ens-forecast-15-day-0-25-degree-update
         - ecmwf-ifs-ens-forecast-15-day-0-25-degree-validate
         - ecmwf-ifs-ens-forecast-46-day-1-5-degree-update
         - ecmwf-ifs-ens-forecast-46-day-1-5-degree-validate
-        - ecmwf-ifs-ens-forecast-46-day-gribs-archive-grib-files
         - nasa-imerg-analysis-early-update
         - nasa-imerg-analysis-early-validate
         - nasa-imerg-analysis-late-update

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -227,7 +227,7 @@ class Job(pydantic.BaseModel):
 
 
 class CronJob(Job):
-    name: Annotated[str, pydantic.Field(min_length=1)]
+    name: Annotated[str, pydantic.Field(min_length=1, max_length=52)]
     schedule: Annotated[str, pydantic.Field(min_length=1)]
     ttl: timedelta = timedelta(hours=12)
     suspend: bool = False

--- a/src/reformatters/ecmwf/archive_gribs/forecast_46_day_archiver.py
+++ b/src/reformatters/ecmwf/archive_gribs/forecast_46_day_archiver.py
@@ -89,7 +89,7 @@ class EcmwfIfsEns46DayGribArchiver(OperationalResources):
 
     @property
     def dataset_id(self) -> str:
-        return "ecmwf-ifs-ens-forecast-46-day-gribs"
+        return "ecmwf-ifs-ens-46-day-gribs"
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         return [

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 from reformatters.common.config import Config, Env
 from reformatters.common.kubernetes import (
@@ -172,6 +173,26 @@ def test_as_kubernetes_object_comprehensive() -> None:
     }
 
     assert k8s_obj["spec"] == expected_spec
+
+
+def _cron_job_with_name(name: str) -> CronJob:
+    return CronJob(
+        name=name,
+        schedule="0 * * * *",
+        command=["archive-grib-files"],
+        image="img:v1",
+        dataset_id="archive",
+        cpu="1",
+        memory="1Gi",
+        workers_total=1,
+        parallelism=1,
+    )
+
+
+def test_cron_job_name_respects_kubernetes_length_limit() -> None:
+    _cron_job_with_name("a" * 52)
+    with pytest.raises(ValidationError, match="at most 52 characters"):
+        _cron_job_with_name("a" * 53)
 
 
 def test_do_not_disrupt_annotation_only_on_reformat_jobs() -> None:

--- a/tests/ecmwf/archive_gribs/forecast_46_day_archiver_test.py
+++ b/tests/ecmwf/archive_gribs/forecast_46_day_archiver_test.py
@@ -17,7 +17,8 @@ def test_operational_kubernetes_resources_is_one_unsuspended_archive_cron() -> N
     archiver = EcmwfIfsEns46DayGribArchiver()
     (cron_job,) = archiver.operational_kubernetes_resources("test-image")
 
-    assert cron_job.name == "ecmwf-ifs-ens-forecast-46-day-gribs-archive-grib-files"
+    assert cron_job.name == "ecmwf-ifs-ens-46-day-gribs-archive-grib-files"
+    assert len(cron_job.name) <= 52
     assert cron_job.command == ["archive-grib-files"]
     assert cron_job.dataset_id == archiver.dataset_id
     assert not cron_job.suspend


### PR DESCRIPTION
Fixes the operational deploy failure after #904:

> The CronJob "ecmwf-ifs-ens-forecast-46-day-gribs-archive-grib-files" is invalid: metadata.name must be no more than 52 characters.

## Changes

- Shorten the standalone archiver operational ID to `ecmwf-ifs-ens-46-day-gribs`, producing the 45-character CronJob name `ecmwf-ifs-ens-46-day-gribs-archive-grib-files`.
- Enforce Kubernetes’ 52-character CronJob name limit in the shared `CronJob` model so future violations fail during configuration construction.
- Add common and archiver-specific regression coverage and regenerate the manual CronJob workflow choices.

## Verification

- `uv run ruff format src tests`
- `uv run ruff check --fix src tests`
- `uv run ty check --output-format concise src tests`
- `MPLBACKEND=Agg uv run pytest`: 2,223 passed, 10 skipped.