### PR TITLE
Pin the sample the dead-point exclusion test measures

### DIFF
--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -714,7 +714,7 @@ def test_check_recent_nans_logged_worst_excludes_excused_positions(
 
 
 def test_check_recent_nans_excludes_structurally_dead_points(
-    rng: np.random.Generator,
+    rng: np.random.Generator, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A point that is NaN at every position is a structural hole, not a gap.
 
@@ -739,15 +739,26 @@ def test_check_recent_nans_excludes_structurally_dead_points(
     ds["temperature"].loc[{"latitude": 10.0, "longitude": 30.0}] = np.nan
     context = _context(ds, "time")
 
-    # 4 points over a 2x2 grid pairs every index, so the dead cell is always sampled.
-    assert validation.CheckRecentNans(sampled_points=4).check(context).passed
+    # Sample every cell: points are drawn independently, so a 2x2 draw can land wholly
+    # on the dead cell, which is the case below rather than this one.
+    def sample_every_cell(
+        ds: xr.Dataset,
+        sampling_strategy: validation.SpatialSamplingStrategy,
+        num_points: int = 0,
+    ) -> xr.Dataset:
+        return ds.isel(
+            longitude=xr.DataArray([0, 0, 1, 1], dims="point"),
+            latitude=xr.DataArray([0, 1, 0, 1], dims="point"),
+        )
+
+    monkeypatch.setattr(validation, "_apply_spatial_sampling", sample_every_cell)
+
+    assert validation.CheckRecentNans().check(context).passed
 
     # With every sampled point dead there is nothing measurable: fail, don't pass.
     all_dead = ds.copy(deep=True)
     all_dead["temperature"].values[:] = np.nan
-    result = validation.CheckRecentNans(sampled_points=4).check(
-        _context(all_dead, "time")
-    )
+    result = validation.CheckRecentNans().check(_context(all_dead, "time"))
     assert not result.passed
     assert "No values selected" in result.message
 


### PR DESCRIPTION
## Why

`test_check_recent_nans_excludes_structurally_dead_points` (from #909) fails about **1 run in 256**. It took CI down on #901 ([run](https://github.com/dynamical-org/reformatters/actions/runs/32681534952/job/97298958244)) with a bare `AssertionError: assert False`, no S3 or network involved — the check runs against a `MemoryStore`.

`_apply_spatial_sampling` draws the two spatial indices independently:

```python
x_idxs = rng.integers(0, x_size, size=num_points)
y_idxs = rng.integers(0, y_size, size=num_points)
```

so over the test's 2x2 grid each of the 4 points is uniform over 4 cells, and all four land on the single structurally dead cell with probability (1/4)^4. When that happens there is nothing measurable, `_nan_fraction_by_position` returns `None`, and the check fails with `No values selected` — which is what the *second* half of the test asserts, so the first half fails. The failing run's log shows exactly that draw:

```
latitude=[10.0000, 10.0000, 10.0000, 10.0000], longitude=[30.0000, 30.0000, 30.0000, 30.0000]
```

The comment justifying the setup — `4 points over a 2x2 grid pairs every index, so the dead cell is always sampled` — was never true: nothing pairs the indices, and nothing guarantees the dead cell is drawn either.

## Changes

Select all four cells explicitly rather than relying on the draw. What the test is about is how the fraction computation treats a dead point sitting alongside live ones, so which cells the sampler happened to pick was incidental to it. `sampled_points=4` goes away with the randomness.

Both halves stay: the mixed grid must pass, and the all-NaN grid must fail with `No values selected`.

## Verification

- 15/15 consecutive runs pass (was ~1/256 failing).
- Mutation check: forcing `has_signal` to all-True in `_nan_fraction_by_position` makes it fail, so it still covers the exclusion rather than passing trivially.
- Full fast suite 2067 passed; ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)