### PR TITLE
Address ECMWF 46-day blobs by the archive's own manifest

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_region_job.py
@@ -41,7 +41,10 @@ from reformatters.common.types import (
     Timestamp,
 )
 from reformatters.ecmwf.archive_gribs.archive import format_init_time
-from reformatters.ecmwf.archive_gribs.forecast_46_day_archiver import ARCHIVE_BASE_URL
+from reformatters.ecmwf.archive_gribs.forecast_46_day_archiver import (
+    ARCHIVE_BASE_URL,
+    ECDS_VARIABLES,
+)
 from reformatters.ecmwf.archive_gribs.grib_inventory import (
     INDEX_SUFFIX,
     MessageRecord,
@@ -65,14 +68,17 @@ GRID_SHAPE = (121, 240)
 EXPECTED_CLAMP_FRACTION = 0.08
 
 
-def selections_by_variable(
-    data_vars: Sequence[EcmwfIfsEns46DayDataVar],
-) -> dict[tuple[str, str], EcdsSelection]:
-    """The ECDS request each variable is archived in, keyed by (variable, forecast type)."""
-    ecds_variables = sorted({v.internal_attrs.ecds_variable for v in data_vars})
+@lru_cache
+def selections_by_variable() -> Mapping[tuple[str, str], EcdsSelection]:
+    """The ECDS request each variable is archived in, keyed by (variable, forecast type).
+
+    The grouping is over the archive's whole variable manifest. A request's file name
+    identifies the group it was retrieved in, so grouping any subset names blobs that
+    do not exist.
+    """
     return {
         (variable, selection.forecast_type): selection
-        for selection in initialization_selections(ecds_variables)
+        for selection in initialization_selections(ECDS_VARIABLES)
         for variable in selection.variables
     }
 
@@ -126,7 +132,7 @@ class EcmwfIfsEns46DayRegionJob(
         data_vars: Sequence[EcmwfIfsEns46DayDataVar],
     ) -> Sequence[Sequence[EcmwfIfsEns46DayDataVar]]:
         """Group variables by the archived blob they were retrieved in."""
-        selections = selections_by_variable(data_vars)
+        selections = selections_by_variable()
         groups: defaultdict[str, list[EcmwfIfsEns46DayDataVar]] = defaultdict(list)
         for data_var in data_vars:
             selection = selections[
@@ -142,7 +148,7 @@ class EcmwfIfsEns46DayRegionJob(
     ) -> Sequence[EcmwfIfsEns46DaySourceFileCoord]:
         data_var = item(data_var_group)
         ecds_variable = data_var.internal_attrs.ecds_variable
-        selections = selections_by_variable(data_var_group)
+        selections = selections_by_variable()
         levels = _output_levels(processing_region_ds, ecds_variable, data_var)
 
         return [

--- a/tests/ecmwf/archive_gribs/forecast_46_day_archiver_test.py
+++ b/tests/ecmwf/archive_gribs/forecast_46_day_archiver_test.py
@@ -71,10 +71,27 @@ def test_init_times_to_archive_stops_at_the_earliest_initialization() -> None:
 
 
 def test_ecds_variables_shard_into_the_archived_selections() -> None:
-    """One initialization is 12 blobs; the archive's layout is what readers index."""
+    """One initialization is these 12 blobs; the archive's layout is what readers index.
+
+    The names are pinned because a reformatter addresses a blob by name: resharding or
+    changing ECDS_VARIABLES renames files that every reader already indexes by.
+    """
     selections = initialization_selections(ECDS_VARIABLES)
-    assert len(selections) == 12
     assert {v for s in selections for v in s.variables} == set(ECDS_VARIABLES)
+    assert {selection.file_name for selection in selections} == {
+        "pressure-control_forecast-geopotential_height-1526e788.grib2",
+        "pressure-control_forecast-specific_humidity-4cb6cf32.grib2",
+        "pressure-perturbed_forecast-geopotential_height-6b24c498.grib2",
+        "pressure-perturbed_forecast-specific_humidity-4cb6cf32.grib2",
+        "pressure-perturbed_forecast-temperature-f62b6585.grib2",
+        "pressure-perturbed_forecast-u_component_of_wind-09d82879.grib2",
+        "pressure-perturbed_forecast-v_component_of_wind-b41ec9c0.grib2",
+        "pressure-perturbed_forecast-vertical_velocity-6a845ed1.grib2",
+        "single_level-control_forecast-2_m_dewpoint_temperature-52703092.grib2",
+        "single_level-control_forecast-convective_precipitation-c91f8c5b.grib2",
+        "single_level-perturbed_forecast-2_m_dewpoint_temperature-52703092.grib2",
+        "single_level-perturbed_forecast-convective_precipitation-c91f8c5b.grib2",
+    }
 
 
 def test_archiver_is_not_a_dataset_and_defines_no_reformat_crons() -> None:

--- a/tests/ecmwf/ifs_ens/forecast_46_day_region_job_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_46_day_region_job_test.py
@@ -8,7 +8,11 @@ import pytest
 import xarray as xr
 
 from reformatters.common.iterating import item
-from reformatters.ecmwf.archive_gribs.request_shards import DAILY_LEAD_TIMES
+from reformatters.ecmwf.archive_gribs.forecast_46_day_archiver import ECDS_VARIABLES
+from reformatters.ecmwf.archive_gribs.request_shards import (
+    DAILY_LEAD_TIMES,
+    initialization_selections,
+)
 from reformatters.ecmwf.ifs_ens.forecast_46_day_1_5_degree.template_config import (
     EcmwfIfsEnsForecast46Day15DegreeTemplateConfig,
 )
@@ -57,9 +61,7 @@ def source_file_coord(
         ensemble_member=0,
         ecds_variable=ecds_variable,
         levels=levels,
-        selection=selections_by_variable([data_var])[
-            (ecds_variable, "control_forecast")
-        ],
+        selection=selections_by_variable()[(ecds_variable, "control_forecast")],
         downloaded_path=downloaded_path,
     )
 
@@ -252,3 +254,30 @@ def test_a_24_hour_mean_variable_has_no_lead_time_zero_coord() -> None:
     assert not mean_var.has_hour_0_values()
     assert point_var.has_hour_0_values()
     assert DAILY_LEAD_TIMES[0] == "0"
+
+
+def test_every_variable_reads_a_blob_the_archive_writes(tmp_path: Path) -> None:
+    """Every source file URL must name a blob the archiver wrote.
+
+    A blob's file name identifies the request group it was retrieved in, so deriving it
+    from anything narrower than the archive's whole manifest names a file that does not
+    exist, and the variable silently reads as all NaN.
+    """
+    archived_file_names = {
+        selection.file_name for selection in initialization_selections(ECDS_VARIABLES)
+    }
+
+    for data_var in DAILY_CONFIG.data_vars:
+        job = region_job(data_var, tmp_path)
+        processing_region_ds, _ = job._get_region_datasets()
+        coords = job.generate_source_file_coords(
+            processing_region_ds.isel(lead_time=slice(1, 3), ensemble_member=[0, 1]),
+            [data_var],
+        )
+
+        file_names = {coord.get_url().rsplit("/", 1)[-1] for coord in coords}
+        assert file_names <= archived_file_names, (
+            f"{data_var.path} reads {sorted(file_names - archived_file_names)}"
+        )
+        # The control member and the perturbed members are archived separately.
+        assert len(file_names) == 2


### PR DESCRIPTION
Found by the Phase 1 canary backfill in #932: every job "succeeded" and wrote all NaN.

### What broke

A blob's file name carries a digest over the variables of the ECDS request it was retrieved in, so it identifies a *group*, not a variable. `selections_by_variable` regrouped whatever variables the caller handed it, and `max_vars_per_job = 1` makes that a single variable on every job — naming files the archive never wrote:

```
404  single_level-perturbed_forecast-snow_density-112e1b5b.grib2                 <- what the job fetched
200  single_level-perturbed_forecast-2_m_dewpoint_temperature-52703092.grib2     <- where snow_density lives (14 vars)
404  pressure-control_forecast-geopotential_height-6b24c498.grib2                <- what the job fetched
200  pressure-control_forecast-geopotential_height-1526e788.grib2                <- real control group (5 vars)
```

Only the six perturbed pressure-level blobs matched, because each is genuinely its own request at full scale.

### Why it was silent

Downloads 404 → coords land in `DownloadFailed` → `_read_into_data_array` returns only the coords still in `Processing` → the result list comes back empty rather than failed. The region wrote fill values, the worker results file recorded `{"pressure_surface":[]}`, and the pod exited 0. The canary's 35 jobs all reported success while writing 166 KB all-fill shards.

### The fix

Group over `ECDS_VARIABLES`. The archive names the blobs, so the manifest that filled it is the only correct input. The function takes no arguments now and is cached.

### Tests

The read tests built their coords through the same subset call, so nothing ever exercised a URL — which is how this shipped. Added:

- `test_every_variable_reads_a_blob_the_archive_writes` walks every data variable to the file name it would fetch and requires it to be one the archiver writes (verified failing against the old grouping, passing with the fix).
- `test_ecds_variables_shard_into_the_archived_selections` now pins the twelve blob names themselves — resharding or editing `ECDS_VARIABLES` renames files every reader already indexes by. This is the pinning test #922 left as a TODO.

`ruff format`, `ruff check`, `ty check` clean; `pytest -m "not slow"` 2122 passed.

### Noted, not fixed

- Dropping `DownloadFailed` coords from `_read_into_data_array`'s return makes a total download failure indistinguishable from success in both the worker results file and the pod exit code. That's shared `MaterializedRegionJob` behavior affecting every materialized dataset, so it belongs in its own change.
- `forecast_46_day_region_job.py:168` compares against a bare `np.timedelta64(0)`, which NumPy now deprecates (the 15-day region job has the same pattern).