### PR TITLE
Skip the truncated 2016-08-05 HRRR native files

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
+++ b/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
@@ -28,6 +28,22 @@ class NoaaHrrrAnalysisVirtualRegionJob(
 ):
     operational_update_window: ClassVar[Timedelta] = pd.Timedelta("12h")
 
+    def representative_var(
+        self, coord: NoaaHrrrAnalysisVirtualSourceFileCoord
+    ) -> NoaaHrrrDataVar:
+        if coord.file_type == "nat":
+            cloud_mixing_ratio = next(
+                (
+                    var
+                    for var in coord.data_vars
+                    if var.path == "model_level/cloud_mixing_ratio"
+                ),
+                None,
+            )
+            if cloud_mixing_ratio is not None:
+                return cloud_mixing_ratio
+        return super().representative_var(coord)
+
     def generate_source_file_coords(
         self,
         processing_region_ds: xr.Dataset,

--- a/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
+++ b/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
@@ -32,6 +32,9 @@ class NoaaHrrrAnalysisVirtualRegionJob(
         self, coord: NoaaHrrrAnalysisVirtualSourceFileCoord
     ) -> NoaaHrrrDataVar:
         if coord.file_type == "nat":
+            # Some truncated historical wrfnat files contain CLMR but not the default
+            # TMP probe. Prefer CLMR when this job writes it; filtered jobs must probe
+            # one of their own vars.
             cloud_mixing_ratio = next(
                 (
                     var

--- a/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
+++ b/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
@@ -28,25 +28,6 @@ class NoaaHrrrAnalysisVirtualRegionJob(
 ):
     operational_update_window: ClassVar[Timedelta] = pd.Timedelta("12h")
 
-    def representative_var(
-        self, coord: NoaaHrrrAnalysisVirtualSourceFileCoord
-    ) -> NoaaHrrrDataVar:
-        if coord.file_type == "nat":
-            # Some truncated historical wrfnat files contain CLMR but not the default
-            # TMP probe. Prefer CLMR when this job writes it; filtered jobs must probe
-            # one of their own vars.
-            cloud_mixing_ratio = next(
-                (
-                    var
-                    for var in coord.data_vars
-                    if var.path == "model_level/cloud_mixing_ratio"
-                ),
-                None,
-            )
-            if cloud_mixing_ratio is not None:
-                return cloud_mixing_ratio
-        return super().representative_var(coord)
-
     def generate_source_file_coords(
         self,
         processing_region_ds: xr.Dataset,

--- a/src/reformatters/noaa/hrrr/virtual_region_job.py
+++ b/src/reformatters/noaa/hrrr/virtual_region_job.py
@@ -25,6 +25,15 @@ S3_LOCATION_PREFIX = "s3://noaa-hrrr-bdp-pds/"
 S3_BUCKET_REGION = "us-east-1"
 _S3_HTTPS_PREFIX = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/"
 
+# These uploads ended mid-file: the data file and its .idx stop after a handful of
+# messages. Treated as never published, like the hours the archive is missing entirely.
+_TRUNCATED_SOURCE_FILES = frozenset(
+    {
+        S3_LOCATION_PREFIX + "hrrr.20160805/conus/hrrr.t10z.wrfnatf00.grib2",
+        S3_LOCATION_PREFIX + "hrrr.20160805/conus/hrrr.t12z.wrfnatf00.grib2",
+    }
+)
+
 
 def hrrr_virtual_chunk_containers() -> tuple[icechunk.VirtualChunkContainer, ...]:
     """Fresh container objects per call; icechunk containers can't be shared
@@ -63,12 +72,17 @@ class NoaaHrrrVirtualRegionJob(
     def discover_available(
         self, pending: list[HRRR_VIRTUAL_COORD]
     ) -> list[tuple[HRRR_VIRTUAL_COORD, int]]:
-        return discover_available_by_obstore_listing(
+        available = discover_available_by_obstore_listing(
             pending,
             store=s3_store(S3_LOCATION_PREFIX, region=S3_BUCKET_REGION),
             location_prefix=S3_LOCATION_PREFIX,
             require_index=True,
         )
+        return [
+            (coord, size)
+            for coord, size in available
+            if coord.get_url() not in _TRUNCATED_SOURCE_FILES
+        ]
 
     def file_refs(self, coord: HRRR_VIRTUAL_COORD, file_size: int) -> list[VirtualRef]:
         index_path = s3_download_to_disk(

--- a/src/reformatters/noaa/hrrr/virtual_region_job.py
+++ b/src/reformatters/noaa/hrrr/virtual_region_job.py
@@ -27,11 +27,9 @@ _S3_HTTPS_PREFIX = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/"
 
 # These uploads ended mid-file: the data file and its .idx stop after a handful of
 # messages. Treated as never published, like the hours the archive is missing entirely.
-_TRUNCATED_SOURCE_FILES = frozenset(
-    {
-        S3_LOCATION_PREFIX + "hrrr.20160805/conus/hrrr.t10z.wrfnatf00.grib2",
-        S3_LOCATION_PREFIX + "hrrr.20160805/conus/hrrr.t12z.wrfnatf00.grib2",
-    }
+_TRUNCATED_SOURCE_FILES = (
+    S3_LOCATION_PREFIX + "hrrr.20160805/conus/hrrr.t10z.wrfnatf00.grib2",
+    S3_LOCATION_PREFIX + "hrrr.20160805/conus/hrrr.t12z.wrfnatf00.grib2",
 )
 
 

--- a/src/reformatters/noaa/hrrr/virtual_template_config.py
+++ b/src/reformatters/noaa/hrrr/virtual_template_config.py
@@ -1889,6 +1889,7 @@ def _pressure_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
         pressure_var(
             "cloud_ice_mixing_ratio",
             element="CIMIXR",
+            element_alternatives=("CICE",),
             short_name="cdcimr",
             long_name="Cloud ice mixing ratio",
             units="kg kg-1",
@@ -2075,6 +2076,7 @@ def _model_data_vars(chunks: tuple[int, ...]) -> list[NoaaHrrrDataVar]:
         model_var(
             "cloud_ice_mixing_ratio",
             element="CIMIXR",
+            element_alternatives=("CICE",),
             short_name="cdcimr",
             long_name="Cloud ice mixing ratio",
             units="kg kg-1",

--- a/tests/noaa/hrrr/analysis_virtual/region_job_test.py
+++ b/tests/noaa/hrrr/analysis_virtual/region_job_test.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from reformatters.common.types import DatetimeLike
 from reformatters.noaa.hrrr import virtual_region_job as region_job_module
 from reformatters.noaa.hrrr.analysis_virtual.region_job import (
     NoaaHrrrAnalysisVirtualRegionJob,
@@ -25,22 +24,9 @@ def get_var(path: str) -> NoaaHrrrDataVar:
     return next(v for v in TEMPLATE_CONFIG.data_vars if v.path == path)
 
 
-def build_template(end_time: DatetimeLike) -> xr.DataTree:
-    coords = TEMPLATE_CONFIG.dimension_coordinates()
-    coords["time"] = TEMPLATE_CONFIG.append_dim_coordinates(end_time)
-    return xr.DataTree.from_dict(
-        {
-            TEMPLATE_CONFIG._group_node_path(
-                group
-            ): TEMPLATE_CONFIG._build_node_dataset(group, coords)
-            for group in TEMPLATE_CONFIG.groups
-        }
-    )
-
-
 @pytest.fixture(scope="module")
 def template_ds() -> xr.DataTree:
-    return build_template(pd.Timestamp("2014-10-01T03:00"))
+    return TEMPLATE_CONFIG.get_template(pd.Timestamp("2014-10-01T03:00"))
 
 
 def make_job(
@@ -101,72 +87,31 @@ def test_group_file_probe_loc_carries_first_level(template_ds: xr.DataTree) -> N
     }
 
 
-def test_native_probe_prefers_cloud_mixing_ratio_when_selected(
-    template_ds: xr.DataTree,
+def test_truncated_source_files_are_never_available(
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    temperature = get_var("model_level/temperature")
-    cloud_mixing_ratio = get_var("model_level/cloud_mixing_ratio")
-    coord = NoaaHrrrAnalysisVirtualSourceFileCoord(
-        init_time=pd.Timestamp("2016-08-05T10:00"),
-        lead_time=pd.Timedelta(0),
-        domain="conus",
-        file_type="nat",
-        data_vars=[temperature, cloud_mixing_ratio],
-    )
-    job = make_job(template_ds, data_vars=list(coord.data_vars))
-
-    assert job.representative_var(coord) == cloud_mixing_ratio
-
-
-def test_native_probe_stays_within_filtered_variables(template_ds: xr.DataTree) -> None:
-    cloud_ice = get_var("model_level/cloud_ice_mixing_ratio")
-    coord = NoaaHrrrAnalysisVirtualSourceFileCoord(
-        init_time=pd.Timestamp("2016-08-05T10:00"),
-        lead_time=pd.Timedelta(0),
-        domain="conus",
-        file_type="nat",
-        data_vars=[cloud_ice],
-    )
-    job = make_job(template_ds, data_vars=list(coord.data_vars))
-
-    assert job.representative_var(coord) == cloud_ice
-
-
-def test_partial_historical_native_file_covers_its_probe(
-    template_ds: xr.DataTree,
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    fake_index(
-        monkeypatch,
-        tmp_path,
-        "1:0:d=2016080510:CLMR:1 hybrid level:anl:\n"
-        "2:16613:d=2016080510:CICE:1 hybrid level:anl:\n"
-        "3:222925:d=2016080510:SNMR:1 hybrid level:anl:\n",
-    )
-    data_vars = [
-        get_var("model_level/temperature"),
-        get_var("model_level/cloud_mixing_ratio"),
-        get_var("model_level/cloud_ice_mixing_ratio"),
-        get_var("model_level/snow_mixing_ratio"),
+    """The 2016-08-05 native uploads that end mid-file never reach the write loop."""
+    data_vars = [get_var("model_level/temperature")]
+    coords = [
+        NoaaHrrrAnalysisVirtualSourceFileCoord(
+            init_time=pd.Timestamp(f"2016-08-05T{hour:02d}:00"),
+            lead_time=pd.Timedelta(0),
+            domain="conus",
+            file_type="nat",
+            data_vars=data_vars,
+        )
+        for hour in (9, 10, 12)
     ]
-    coord = NoaaHrrrAnalysisVirtualSourceFileCoord(
-        init_time=pd.Timestamp("2016-08-05T10:00"),
-        lead_time=pd.Timedelta(0),
-        domain="conus",
-        file_type="nat",
-        data_vars=data_vars,
+    monkeypatch.setattr(
+        region_job_module,
+        "discover_available_by_obstore_listing",
+        lambda pending, **kwargs: [(coord, 100) for coord in pending],
     )
     job = make_job(template_ds, data_vars=data_vars)
 
-    refs = job.file_refs(coord, file_size=300_000)
-
-    assert {ref.data_var.path for ref in refs} == {
-        "model_level/cloud_mixing_ratio",
-        "model_level/cloud_ice_mixing_ratio",
-        "model_level/snow_mixing_ratio",
-    }
-    job._assert_probe_chunk_covered(coord, refs)
+    assert [coord.get_url() for coord, _ in job.discover_available(coords)] == [
+        "s3://noaa-hrrr-bdp-pds/hrrr.20160805/conus/hrrr.t09z.wrfnatf00.grib2"
+    ]
 
 
 @pytest.mark.parametrize(
@@ -269,7 +214,7 @@ def test_operational_update_jobs_single_polling_job(
     jobs, template_ds = NoaaHrrrAnalysisVirtualRegionJob.operational_update_jobs(
         primary_store=Mock(),
         tmp_store=Path("unused-tmp.zarr"),
-        get_template_fn=build_template,
+        get_template_fn=TEMPLATE_CONFIG.get_template,
         append_dim="time",
         all_data_vars=TEMPLATE_CONFIG.data_vars,
         reformat_job_name="test",

--- a/tests/noaa/hrrr/analysis_virtual/region_job_test.py
+++ b/tests/noaa/hrrr/analysis_virtual/region_job_test.py
@@ -6,6 +6,8 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from reformatters.common.types import DatetimeLike
+from reformatters.noaa.hrrr import virtual_region_job as region_job_module
 from reformatters.noaa.hrrr.analysis_virtual.region_job import (
     NoaaHrrrAnalysisVirtualRegionJob,
     NoaaHrrrAnalysisVirtualSourceFileCoord,
@@ -23,9 +25,22 @@ def get_var(path: str) -> NoaaHrrrDataVar:
     return next(v for v in TEMPLATE_CONFIG.data_vars if v.path == path)
 
 
+def build_template(end_time: DatetimeLike) -> xr.DataTree:
+    coords = TEMPLATE_CONFIG.dimension_coordinates()
+    coords["time"] = TEMPLATE_CONFIG.append_dim_coordinates(end_time)
+    return xr.DataTree.from_dict(
+        {
+            TEMPLATE_CONFIG._group_node_path(
+                group
+            ): TEMPLATE_CONFIG._build_node_dataset(group, coords)
+            for group in TEMPLATE_CONFIG.groups
+        }
+    )
+
+
 @pytest.fixture(scope="module")
 def template_ds() -> xr.DataTree:
-    return TEMPLATE_CONFIG.get_template(pd.Timestamp("2014-10-01T03:00"))
+    return build_template(pd.Timestamp("2014-10-01T03:00"))
 
 
 def make_job(
@@ -41,6 +56,15 @@ def make_job(
         region=region,
         reformat_job_name="test",
     )
+
+
+def fake_index(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, content: str) -> None:
+    def fake_download(url: str, dataset_id: str, *, region: str) -> Path:
+        path = tmp_path / url.rsplit("/", 1)[-1]
+        path.write_text(content)
+        return path
+
+    monkeypatch.setattr(region_job_module, "s3_download_to_disk", fake_download)
 
 
 def test_source_file_coord_url_and_out_loc() -> None:
@@ -75,6 +99,114 @@ def test_group_file_probe_loc_carries_first_level(template_ds: xr.DataTree) -> N
         "time": pd.Timestamp("2014-10-01T01:00"),
         "pressure_level": 1000,
     }
+
+
+def test_native_probe_prefers_cloud_mixing_ratio_when_selected(
+    template_ds: xr.DataTree,
+) -> None:
+    temperature = get_var("model_level/temperature")
+    cloud_mixing_ratio = get_var("model_level/cloud_mixing_ratio")
+    coord = NoaaHrrrAnalysisVirtualSourceFileCoord(
+        init_time=pd.Timestamp("2016-08-05T10:00"),
+        lead_time=pd.Timedelta(0),
+        domain="conus",
+        file_type="nat",
+        data_vars=[temperature, cloud_mixing_ratio],
+    )
+    job = make_job(template_ds, data_vars=list(coord.data_vars))
+
+    assert job.representative_var(coord) == cloud_mixing_ratio
+
+
+def test_native_probe_stays_within_filtered_variables(template_ds: xr.DataTree) -> None:
+    cloud_ice = get_var("model_level/cloud_ice_mixing_ratio")
+    coord = NoaaHrrrAnalysisVirtualSourceFileCoord(
+        init_time=pd.Timestamp("2016-08-05T10:00"),
+        lead_time=pd.Timedelta(0),
+        domain="conus",
+        file_type="nat",
+        data_vars=[cloud_ice],
+    )
+    job = make_job(template_ds, data_vars=list(coord.data_vars))
+
+    assert job.representative_var(coord) == cloud_ice
+
+
+def test_partial_historical_native_file_covers_its_probe(
+    template_ds: xr.DataTree,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_index(
+        monkeypatch,
+        tmp_path,
+        "1:0:d=2016080510:CLMR:1 hybrid level:anl:\n"
+        "2:16613:d=2016080510:CICE:1 hybrid level:anl:\n"
+        "3:222925:d=2016080510:SNMR:1 hybrid level:anl:\n",
+    )
+    data_vars = [
+        get_var("model_level/temperature"),
+        get_var("model_level/cloud_mixing_ratio"),
+        get_var("model_level/cloud_ice_mixing_ratio"),
+        get_var("model_level/snow_mixing_ratio"),
+    ]
+    coord = NoaaHrrrAnalysisVirtualSourceFileCoord(
+        init_time=pd.Timestamp("2016-08-05T10:00"),
+        lead_time=pd.Timedelta(0),
+        domain="conus",
+        file_type="nat",
+        data_vars=data_vars,
+    )
+    job = make_job(template_ds, data_vars=data_vars)
+
+    refs = job.file_refs(coord, file_size=300_000)
+
+    assert {ref.data_var.path for ref in refs} == {
+        "model_level/cloud_mixing_ratio",
+        "model_level/cloud_ice_mixing_ratio",
+        "model_level/snow_mixing_ratio",
+    }
+    job._assert_probe_chunk_covered(coord, refs)
+
+
+@pytest.mark.parametrize(
+    ("path", "element", "level"),
+    [
+        ("pressure_level/cloud_ice_mixing_ratio", "CICE", "1000 mb"),
+        ("pressure_level/cloud_ice_mixing_ratio", "CIMIXR", "1000 mb"),
+        ("model_level/cloud_ice_mixing_ratio", "CICE", "1 hybrid level"),
+        ("model_level/cloud_ice_mixing_ratio", "CIMIXR", "1 hybrid level"),
+    ],
+)
+def test_cloud_ice_index_spellings_emit_refs(
+    template_ds: xr.DataTree,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    path: str,
+    element: str,
+    level: str,
+) -> None:
+    fake_index(
+        monkeypatch,
+        tmp_path,
+        f"1:0:d=2024060100:{element}:{level}:anl:\n",
+    )
+    var = get_var(path)
+    file_type = "prs" if var.group == "pressure_level" else "nat"
+    coord = NoaaHrrrAnalysisVirtualSourceFileCoord(
+        init_time=pd.Timestamp("2024-06-01T00:00"),
+        lead_time=pd.Timedelta(0),
+        domain="conus",
+        file_type=file_type,
+        data_vars=[var],
+    )
+    job = make_job(template_ds, data_vars=[var])
+
+    refs = job.file_refs(coord, file_size=1000)
+
+    assert [(ref.data_var.path, ref.offset, ref.length) for ref in refs] == [
+        (path, 0, 1000)
+    ]
 
 
 def test_generate_source_file_coords_shortest_available_lead(
@@ -137,7 +269,7 @@ def test_operational_update_jobs_single_polling_job(
     jobs, template_ds = NoaaHrrrAnalysisVirtualRegionJob.operational_update_jobs(
         primary_store=Mock(),
         tmp_store=Path("unused-tmp.zarr"),
-        get_template_fn=TEMPLATE_CONFIG.get_template,
+        get_template_fn=build_template,
         append_dim="time",
         all_data_vars=TEMPLATE_CONFIG.data_vars,
         reformat_job_name="test",


### PR DESCRIPTION
## Summary

- skip the two 2016-08-05 `wrfnat` uploads that end mid-file, treating them as never published
- recognize the historical `CICE` index spelling as an alternative to the current `CIMIXR` for pressure- and model-level cloud ice

## Backfill failure

Worker index 32 repeatedly failed `_assert_probe_chunk_covered` for `hrrr.20160805/conus/hrrr.t10z.wrfnatf00.grib2`. Its index holds three messages:

```
CLMR:1 hybrid level
CICE:1 hybrid level
SNMR:1 hybrid level
```

The file is a truncated upload — it is not a prefix of a normal file (it lacks `PRES`, which is message 1) and its data file stops at 223 KB against a ~57 MB norm. It carries no message for any representative variable the write loop could reasonably probe.

Rather than steer the native product's probe variable around one corrupt file, `discover_available` now drops both truncated files by URL. A source file the archive never published is already an in-band case — roughly 6% of hours in the v1/v2 era have no `wrfnat` file at all — so a backfill logs `N source files not present, skipping` and exits, and no new concept is introduced. `representative_var` keeps its default and `_assert_probe_chunk_covered` stays a real invariant.

## Why both files

`hrrr.t12z.wrfnatf00.grib2` (14 messages) satisfies the assert today, but its data file ends mid-message: the ref it emits for `model_level/turbulent_kinetic_energy` has no `7777` terminator and decodes, without error, to all zeros across 1.9M points. Ingesting it would write a chunk that reads as valid zero data. It is skipped for that reason, not for tidiness.

## Archive survey

Every `wrfnatf00`, `wrfprsf00`, `wrfsfcf00` and `wrfsfcf01` index from 2014-10-01 to 2026-08-20 (411,000 files) was listed and every anomalous file replayed through `file_refs` and `_assert_probe_chunk_covered` against its live index and data size:

| file | index | outcome |
| --- | --- | --- |
| 2016-08-05 10z nat f00 | 3 msgs | assert fails |
| 2016-08-05 12z nat f00 | 14 msgs | ingests, final ref is an incomplete message |
| 2016-08-05 11z / 14z sfc f00, 13z sfc f01 | 0 bytes | already skipped as an unparseable index |
| 2016-08-05 12z sfc f00 / f01 | 29 / 23 msgs | 7 complete refs / no refs |
| 2014-10-11 (12 hours), 2015-03-08 02z, 2016-03-13 02z, 2017-03-12 02z sfc f00 | 48-57 msgs | early-era cycles with fewer fields, all refs complete |
| every `wrfprsf00` | - | no anomalies |

No file outside 2016-08-05 needs handling.

## Cloud ice spelling

The archive writes cloud ice mixing ratio as `CICE` through the 2016-08 cycles and `CIMIXR` from HRRR v2/v3 onward, one spelling per era and never both, across all 50 model levels and 40 pressure levels. Decoded hybrid level 25 messages agree in magnitude across the boundary (2014-10-01 and 2016-08-05 `CICE`: max 7.4e-4 and 2.0e-3, mean ~1e-7; 2018-08-01 and 2024-06-01 `CIMIXR`: max 4.1e-4 and 1.6e-3, mean ~1e-7), confirming the same quantity in kg kg-1. gribberish reports no parameter name for the older code but decodes the array, and `GribberishCodec` does not consult its `var` configuration when decoding, so reads are unaffected.

No template files changed: GRIB element alternatives are internal source-matching configuration, not serialized Zarr metadata.

## Verification

- `uv run ruff format`, `uv run ruff check`, `uv run ty check`
- `uv run pytest -m "not slow" tests/noaa/hrrr/` (131 passed)
- `uv run pytest tests/noaa/hrrr/analysis_virtual/` including the two real-source backfill tests (27 passed)
- `test_truncated_source_files_are_never_available` confirmed to fail without the skip
