### PR TITLE
Refetch an ECDS result whole when a resume returns 416

### DIFF
--- a/src/reformatters/ecmwf/archive_gribs/ecds_client.py
+++ b/src/reformatters/ecmwf/archive_gribs/ecds_client.py
@@ -276,6 +276,13 @@ class EcdsRequest:
         response = self.session.get(
             result_url, headers=headers, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS
         )
+        if response.status_code == requests.codes.requested_range_not_satisfiable:
+            # The partial file is longer than the result or otherwise unresumable,
+            # so ask for the whole body and overwrite it.
+            response.close()
+            response = self.session.get(
+                result_url, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS
+            )
         response.raise_for_status()
         # A server that ignores the Range header replies 200 with the whole body,
         # which must overwrite rather than extend the partial file.

--- a/tests/ecmwf/archive_gribs/ecds_client_test.py
+++ b/tests/ecmwf/archive_gribs/ecds_client_test.py
@@ -300,6 +300,33 @@ def test_download_restarts_a_partial_file_after_http_200(tmp_path: Path) -> None
     assert session.get.call_args.kwargs["headers"] == {"Range": "bytes=11-"}
 
 
+def test_download_refetches_the_whole_blob_after_http_416(tmp_path: Path) -> None:
+    """A partial file longer than the result makes the ranged request unsatisfiable."""
+    state_store = StateStore(tmp_path / "state.json")
+    state_store.write(RequestState("id", {}, "now", "status", result_url="result"))
+    target = tmp_path / "blob.grib2"
+    message = grib_message()
+    target.with_suffix(".grib2.partial").write_bytes(b"stale bytes")
+    range_response = response(
+        {}, status_code=requests.codes.requested_range_not_satisfiable
+    )
+    range_response.raise_for_status.side_effect = requests.HTTPError(
+        "416 Client Error: Requested Range Not Satisfiable"
+    )
+    full_response = response({})
+    full_response.iter_content.return_value = [message]
+    session = session_mock()
+    session.get.side_effect = [range_response, full_response]
+
+    EcdsRequest(state_store, session=session).download(target)
+
+    assert target.read_bytes() == message
+    range_call, full_call = session.get.call_args_list
+    assert range_call.kwargs["headers"] == {"Range": "bytes=11-"}
+    assert "headers" not in full_call.kwargs
+    range_response.close.assert_called_once_with()
+
+
 def test_download_rejects_a_truncated_blob(tmp_path: Path) -> None:
     state_store = StateStore(tmp_path / "state.json")
     state_store.write(RequestState("id", {}, "now", "status", result_url="result"))


### PR DESCRIPTION
## Failure

The ECMWF 46-day (S2S) backfill died in `EcdsRequest.download()`:

```
HTTPError: 416 Client Error: Requested Range Not Satisfiable
```

`download()` resumes an interrupted transfer by sending `Range: bytes=<partial size>-`. When the leftover `.partial` file is malformed or larger than the result the server is now offering, that range falls outside the result and ECDS answers 416. `raise_for_status()` turned that into a hard failure, so the job could never get past its own stale partial file.

## Recovery

On 416, close the ranged response and retry the request once without a `Range` header. The existing append check (`append` only when the status is 206) then opens the partial file `"wb"`, so the full body overwrites the unusable bytes. GRIB validation and the publish-by-rename are unchanged, and every other HTTP status still raises.

## Test

`test_download_refetches_the_whole_blob_after_http_416` writes a stale partial file, returns 416 for the ranged request and a valid GRIB for the full one, and asserts the target ends up with the GRIB, that the first call carried `Range: bytes=11-`, that the second omitted `headers`, and that the 416 response was closed. It fails on `main` with the same `HTTPError`.

`uv run ruff format`, `uv run ruff check --fix`, `uv run ty check` clean; `uv run pytest tests/ecmwf/archive_gribs` 73 passed.