### PR TITLE
Enable HRRR analysis virtual operations

### DIFF
--- a/src/reformatters/noaa/hrrr/analysis_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis_virtual/dynamical_dataset.py
@@ -61,8 +61,6 @@ class NoaaHrrrAnalysisVirtualDataset(
             cpu="4",
             memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            # Suspended until the initial backfill completes.
-            suspend=True,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
@@ -75,8 +73,6 @@ class NoaaHrrrAnalysisVirtualDataset(
             cpu="1.5",
             memory="3.7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            # Suspended until the initial backfill completes.
-            suspend=True,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/tests/noaa/hrrr/analysis_virtual/dynamical_dataset_test.py
+++ b/tests/noaa/hrrr/analysis_virtual/dynamical_dataset_test.py
@@ -182,10 +182,10 @@ def test_operational_kubernetes_resources(
     assert update_cron_job.schedule == "50 * * * *"
     assert update_cron_job.pod_active_deadline == timedelta(minutes=30)
     assert update_cron_job.cpu == "4"
-    assert update_cron_job.suspend
+    assert not update_cron_job.suspend
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert validation_cron_job.schedule == "20 * * * *"
-    assert validation_cron_job.suspend
+    assert not validation_cron_job.suspend
     assert len(update_cron_job.secret_names) > 0
 
 


### PR DESCRIPTION
## Summary

- enable the hourly update CronJob for `noaa-hrrr-analysis-virtual` after its successful initial backfill
- enable the corresponding validation CronJob
- update the operational resource test expectations

## Validation

- `uv run pytest tests/noaa/hrrr/analysis_virtual/dynamical_dataset_test.py`
- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`