### PR TITLE
Reduce HRDPS Datamart enumeration requests

### DIFF
--- a/src/reformatters/eccc/README.md
+++ b/src/reformatters/eccc/README.md
@@ -11,6 +11,31 @@ window of GRIB2 files. `hrdps/archive_gribs/copy_files_from_eccc.py` copies file
 the Datamart to a public Source Co-Op bucket using [`rclone`](https://rclone.org),
 preserving the Datamart's own `{date}/{init_hour}` directory structure.
 
+### MSC Datamart request volume
+
+ECCC's [MSC Open Data usage policy](https://eccc-msc.github.io/open-data/usage-policy/readme_en/)
+asks users making at least 86,400 requests per day to contact them and directs systematic
+retrieval away from directory listings.
+
+The HRDPS archive contains about 20,000 files per run. Without `--http-no-head`,
+rclone's HTTP backend sends one HEAD request per entry while traversing the Datamart's
+directory listings. The archive cron examines eight date and initialization-hour pairs
+per invocation and runs four times per day, producing about 640,000 HEAD requests in
+addition to the day's roughly 80,000 file downloads. Reformatter updates add about
+6,600 requests, for a total near 730,000 requests per day.
+
+The archive enables `--http-no-head`, reducing traversal to roughly one GET per
+directory, or about 1,600 enumeration requests per day. Downloads and reformatter
+updates bring the resulting total to about 88,000 requests per day, so contacting MSC
+is still required.
+
+Without HEAD requests, rclone does not know source file sizes or modification times
+while listing. `--ignore-existing` still unconditionally skips paths already present at
+the destination, but rclone cannot use an age filter to avoid a source file that has
+become visible while it is still being published. If such a file were copied, later
+archive runs would not repair it automatically. The archive schedule normally starts
+after a complete run is available, but this residual risk remains.
+
 ### Testing locally
 
 `rclone` must be on `PATH` at `/usr/bin/rclone`. Test with:

--- a/src/reformatters/eccc/hrdps/archive_gribs/copy_files_from_eccc.py
+++ b/src/reformatters/eccc/hrdps/archive_gribs/copy_files_from_eccc.py
@@ -78,11 +78,11 @@ def _copy_one_init_hour(
     cmd = (
         "/usr/bin/rclone",
         "copy",
-        f":http:{src_path}",
+        f":http:{src_path}/",
         dst_path,
         f"--http-url={MSC_DATAMART_HOST}",
+        "--http-no-head",
         "--ignore-existing",
-        "--min-age=1m",  # Ignore files that are so young they might still be mid-upload.
         "--filter=+ *.grib2",
         "--filter=- *",
         "--s3-no-check-bucket",  # Workaround for reformatters issue #428

--- a/tests/eccc/hrdps/archive_gribs/copy_files_from_eccc_test.py
+++ b/tests/eccc/hrdps/archive_gribs/copy_files_from_eccc_test.py
@@ -28,10 +28,12 @@ def test_copy_one_init_hour_builds_expected_command(mock_run_cmd: MagicMock) -> 
     cmd = mock_run_cmd.call_args[0][0]
     assert cmd[0] == "/usr/bin/rclone"
     assert cmd[1] == "copy"
-    assert cmd[2] == ":http:/20260704/WXO-DD/model_hrdps/continental/2.5km/00"
+    assert cmd[2] == ":http:/20260704/WXO-DD/model_hrdps/continental/2.5km/00/"
     assert cmd[3] == ":s3:bucket/eccc-hrdps-grib/20260704/00"
     assert "--http-url=https://dd.weather.gc.ca" in cmd
+    assert "--http-no-head" in cmd
     assert "--ignore-existing" in cmd
+    assert not any(arg.startswith("--min-age") for arg in cmd)
     assert "--filter=+ *.grib2" in cmd
     assert "--transfers=8" in cmd
     assert "--checkers=4" in cmd


### PR DESCRIPTION
## Summary

Reduce the HRDPS archiver's ECCC MSC Datamart traffic from about 730,000 to about 88,000 requests per day by disabling rclone's per-file HEAD requests. This implements the immediate mitigation from dynamical-org/meta#189 independently of #938.

## Instrumented request reduction

The pre-change probe measured 417 source requests to list one 414-file lead-hour directory. Extrapolated across a 49-lead, 20,021-file initialization, the old traversal costs about 20,100 requests per initialization whether or not any files need copying.

This PR was tested against the fully published 2026-08-23 00Z initialization with rclone request tracing enabled:

```sh
/usr/bin/rclone copy ':http:/20260823/WXO-DD/model_hrdps/continental/2.5km/00/' /tmp/hrdps-no-head-probe --http-url=https://dd.weather.gc.ca --http-no-head --ignore-existing '--filter=+ *.grib2' '--filter=- *' --fast-list --dry-run --transfers=1 --checkers=1 --dump=requests --log-level=DEBUG --log-file=/tmp/hrdps-no-head-probe.log
```

The dry run traversed the complete 20,021-file initialization and emitted:

| Request/result | Count |
|---|---:|
| Directory GETs | 50 |
| HEAD requests | 0 |
| GRIB GETs | 0 |
| Files inventoried | 20,021 |

A separate one-file copy made two directory GETs plus one GRIB GET, produced a 3,613,289-byte GRIB matching ECCC's `Content-Length`, and opened as the expected 2540 x 1290 grid. Repeating that copy made the same two directory GETs but no GRIB GET, confirming `--ignore-existing` still skips existing destinations.

This reduces enumeration from about 20,100 to exactly 50 requests per initialization: about 20,050 fewer requests, a 99.75% reduction (roughly 402x). Production examines 32 date/initialization pairs per day, so measured traversal behavior projects to:

| Daily ECCC traffic | Before | After |
|---|---:|---:|
| Archive enumeration | ~643,200 | 1,600 |
| Archive downloads | ~80,000 | ~80,000 |
| Reformatter updates | 6,624 | 6,624 |
| **Total** | **~730,000** | **~88,000** |

The change therefore removes about 642,000 ECCC requests per day—approximately 88% of total traffic—while preserving the full-fidelity archive and retry window. The remaining traffic is dominated by the files we intentionally download, and remains slightly above MSC's contact threshold.

## Plan

- [x] Add a failing command-contract test for no-HEAD directory traversal and removal of the ineffective age filter.
- [x] Add `--http-no-head`, terminate the source directory path with `/`, and remove `--min-age=1m`.
- [x] Document the corrected request estimate and residual partial-source risk.
- [x] Verify a filtered live copy, an idempotent repeat, and a no-HEAD dry run.
- [x] Run focused tests, the full suite, ruff, and ty.
- [x] Notify PR #938 and report results on meta issue #189.

## Decisions

- Branch from `origin/main`; do not stack on PR #938.
- Keep the schedule, `days_back`, initialization hours, field coverage, and public CLI unchanged.
- Accept the residual partial-source risk rather than adding a completeness gate or AMQP redesign in this change.

No public Python or CLI interfaces change.

Without HEAD requests, rclone cannot apply the old `--min-age=1m` guard because source modification times are unavailable. If ECCC exposes a file before it has finished publishing, `--ignore-existing` would prevent a later run from repairing that object automatically. The archive normally starts after a complete run is available, but this residual risk remains.

## Validation

- `uv run pytest tests/eccc/hrdps/archive_gribs/copy_files_from_eccc_test.py`: 4 passed
- `MPLBACKEND=Agg uv run pytest`: 2,300 passed, 10 skipped
- `uv run ruff format`: clean
- `uv run ruff check --fix`: clean
- `uv run ty check --output-format concise`: clean

The first full suite run selected the Qt backend and aborted because this headless host lacks the xcb plugin. The affected plotting tests and full suite passed with `MPLBACKEND=Agg`; this is an environment issue unrelated to the change.

## 2026-08-25 — Retro

The implementation stayed at the rclone command boundary. The important addition to the issue's suggested flag was the trailing source slash; without it, rclone treats the path as a file in no-HEAD mode. Removing `--min-age` also avoids presenting an age guard that cannot operate without source modification times.