### PR TITLE
Address HRDPS no-HEAD review findings

### DIFF
--- a/src/reformatters/eccc/README.md
+++ b/src/reformatters/eccc/README.md
@@ -25,16 +25,25 @@ addition to the day's roughly 80,000 file downloads. Reformatter updates add abo
 6,600 requests, for a total near 730,000 requests per day.
 
 The archive enables `--http-no-head`, reducing traversal to roughly one GET per
-directory, or about 1,600 enumeration requests per day. Downloads and reformatter
-updates bring the resulting total to about 88,000 requests per day, so contacting MSC
-is still required.
+directory. It also skips initializations less than six hours old; at the four scheduled
+run times, this leaves 22 date and initialization-hour pairs to examine per day. The
+result is about 1,100 enumeration requests per day. Downloads and reformatter updates
+bring the total to about 88,000 requests per day, so contacting MSC is still required.
 
 Without HEAD requests, rclone does not know source file sizes or modification times
-while listing. `--ignore-existing` still unconditionally skips paths already present at
-the destination, but rclone cannot use an age filter to avoid a source file that has
-become visible while it is still being published. If such a file were copied, later
-archive runs would not repair it automatically. The archive schedule normally starts
-after a complete run is available, but this residual risk remains.
+while listing. New objects therefore have an epoch rclone modification time, while
+objects archived before this change retain the Datamart time. Do not use rclone-visible
+modification times across this transition for age or inventory decisions. A 32 MiB
+streaming upload cutoff buffers each current GRIB before upload so its unknown source
+size does not force an S3 multipart upload.
+
+`--ignore-existing` still unconditionally skips paths already present at the
+destination. Because an unknown source size also prevents rclone's post-transfer size
+comparison, the archiver waits until an initialization is at least six hours old. The
+scheduled cron therefore archives a run at about init+10h, more than six hours after
+the observed init+3h49m p99 publication time. If an exceptionally late file were still
+being published then, later archive runs would not repair it automatically; this
+residual risk remains.
 
 ### Testing locally
 

--- a/src/reformatters/eccc/hrdps/archive_gribs/copy_files_from_eccc.py
+++ b/src/reformatters/eccc/hrdps/archive_gribs/copy_files_from_eccc.py
@@ -18,6 +18,7 @@ from reformatters.common.retry import retry
 log = get_logger(__name__)
 
 MSC_DATAMART_HOST: Final[str] = "https://dd.weather.gc.ca"
+MINIMUM_INIT_AGE: Final[pd.Timedelta] = pd.Timedelta(hours=6)
 
 
 def copy_files_from_eccc_https(
@@ -50,6 +51,10 @@ def copy_files_from_eccc_https(
     for day_offset in range(days_back + 1):
         date_str = (now - pd.Timedelta(days=day_offset)).strftime("%Y%m%d")
         for nwp_init_hour in nwp_init_hours:
+            init_time = pd.Timestamp(f"{date_str}T{nwp_init_hour:02d}:00Z")
+            if now - init_time < MINIMUM_INIT_AGE:
+                continue
+
             src_path = (
                 f"/{date_str}/WXO-DD/model_hrdps/continental/2.5km/{nwp_init_hour:02d}"
             )
@@ -82,6 +87,7 @@ def _copy_one_init_hour(
         dst_path,
         f"--http-url={MSC_DATAMART_HOST}",
         "--http-no-head",
+        "--streaming-upload-cutoff=32Mi",
         "--ignore-existing",
         "--filter=+ *.grib2",
         "--filter=- *",

--- a/tests/eccc/hrdps/archive_gribs/copy_files_from_eccc_test.py
+++ b/tests/eccc/hrdps/archive_gribs/copy_files_from_eccc_test.py
@@ -32,6 +32,7 @@ def test_copy_one_init_hour_builds_expected_command(mock_run_cmd: MagicMock) -> 
     assert cmd[3] == ":s3:bucket/eccc-hrdps-grib/20260704/00"
     assert "--http-url=https://dd.weather.gc.ca" in cmd
     assert "--http-no-head" in cmd
+    assert "--streaming-upload-cutoff=32Mi" in cmd
     assert "--ignore-existing" in cmd
     assert not any(arg.startswith("--min-age") for arg in cmd)
     assert "--filter=+ *.grib2" in cmd
@@ -75,32 +76,33 @@ def test_copy_one_init_hour_raises_on_other_errors(mock_run_cmd: MagicMock) -> N
 
 
 @patch("reformatters.eccc.hrdps.archive_gribs.copy_files_from_eccc._copy_one_init_hour")
-def test_copy_files_from_eccc_https_iterates_days_and_hours(
+def test_copy_files_from_eccc_https_skips_recent_init_hours(
     mock_copy_one: MagicMock,
 ) -> None:
     with patch("pandas.Timestamp.now", return_value=pd.Timestamp("2026-07-09T12:00Z")):
         copy_files_from_eccc_https(
             dst_root_path=":s3:bucket/eccc-hrdps-grib",
-            nwp_init_hours=[0, 12],
+            nwp_init_hours=[0, 6, 12],
             days_back=1,
             transfer_parallelism=8,
             checkers=4,
             stats_logging_freq="1m",
         )
 
-    # 2 days (today + 1 day back) x 2 init hours = 4 calls
-    assert mock_copy_one.call_count == 4
+    assert mock_copy_one.call_count == 5
     src_paths = {call.kwargs["src_path"] for call in mock_copy_one.call_args_list}
     dst_paths = {call.kwargs["dst_path"] for call in mock_copy_one.call_args_list}
     assert src_paths == {
         "/20260709/WXO-DD/model_hrdps/continental/2.5km/00",
-        "/20260709/WXO-DD/model_hrdps/continental/2.5km/12",
+        "/20260709/WXO-DD/model_hrdps/continental/2.5km/06",
         "/20260708/WXO-DD/model_hrdps/continental/2.5km/00",
+        "/20260708/WXO-DD/model_hrdps/continental/2.5km/06",
         "/20260708/WXO-DD/model_hrdps/continental/2.5km/12",
     }
     assert dst_paths == {
         ":s3:bucket/eccc-hrdps-grib/20260709/00",
-        ":s3:bucket/eccc-hrdps-grib/20260709/12",
+        ":s3:bucket/eccc-hrdps-grib/20260709/06",
         ":s3:bucket/eccc-hrdps-grib/20260708/00",
+        ":s3:bucket/eccc-hrdps-grib/20260708/06",
         ":s3:bucket/eccc-hrdps-grib/20260708/12",
     }


### PR DESCRIPTION
## Summary

Follow up on Claude's review of #940, which merged while the background review was running:

- wait until an HRDPS initialization is six hours old before archiving it;
- keep unknown-sized GRIB uploads on the single-PUT path with a 32 MiB streaming cutoff;
- document that no-HEAD copies use an epoch rclone modification time and cannot perform a post-transfer source-size comparison.

## Instrumented request reduction

The #940 baseline probe measured 417 source requests to list one 414-file lead-hour directory. Extrapolated across a 49-lead, 20,021-file initialization, the old traversal cost about 20,100 requests per initialization whether or not files needed copying.

The no-HEAD dry run used the fully published 2026-08-23 00Z initialization:

```sh
/usr/bin/rclone copy ':http:/20260823/WXO-DD/model_hrdps/continental/2.5km/00/' /tmp/hrdps-no-head-probe --http-url=https://dd.weather.gc.ca --http-no-head --ignore-existing '--filter=+ *.grib2' '--filter=- *' --fast-list --dry-run --transfers=1 --checkers=1 --dump=requests --log-level=DEBUG --log-file=/tmp/hrdps-no-head-probe.log
```

| Request/result | Count |
|---|---:|
| Directory GETs | 50 |
| HEAD requests | 0 |
| GRIB GETs | 0 |
| Files inventoried | 20,021 |

That is 20,050 fewer enumeration requests per initialization: a 99.75% reduction, or roughly 402x. The six-hour gate leaves 22 date/initialization pairs across the four daily cron runs, so measured traversal projects to:

| Daily ECCC traffic | Before #940 | After this PR |
|---|---:|---:|
| Archive enumeration | ~643,200 | ~1,100 |
| Archive downloads | ~80,000 | ~80,000 |
| Reformatter updates | 6,624 | 6,624 |
| **Total** | **~730,000** | **~88,000** |

The archive therefore removes about 642,000 ECCC requests per day—approximately 88% of total traffic. The remaining traffic is dominated by the files intentionally downloaded and remains slightly above MSC's contact threshold.

## Review resolution

- A full public archived initialization contained 20,021 objects and had a maximum object size of 7,562,831 bytes. The 32 MiB cutoff is above every measured GRIB, keeping current unknown-sized uploads as single PUTs instead of multipart uploads.
- At the current init+4h cron schedule, the six-hour gate skips the newest run and archives it on the next cron at about init+10h. That is more than six hours after the observed init+3h49m p99 publication time.
- A live ECCC no-HEAD copy still produced an epoch destination mtime with `--no-update-modtime`, so this PR documents the real mtime behavior instead of adding an ineffective flag.
- Unknown source sizes still prevent rclone's post-transfer size check. The age gate reduces the partial-publication risk, and the remaining exceptionally-late-publication risk is explicit in the operational documentation.

## Plan

- [x] Reproduce and assess each #940 review finding without allowing the reviewer to edit files.
- [x] Add the streaming cutoff and six-hour initialization gate.
- [x] Add command-contract and age-boundary coverage.
- [x] Document the mtime transition, size-check limitation, and residual risk.
- [x] Run focused tests, the full suite, ruff, and ty.
- [x] Reply to each #940 review thread with the resolution.

No public Python or CLI interfaces change.

## Validation

- `uv run pytest tests/eccc/hrdps/archive_gribs/copy_files_from_eccc_test.py`: 4 passed
- `MPLBACKEND=Agg uv run pytest`: 2,300 passed, 10 skipped
- `uv run ruff format`: clean
- `uv run ruff check --fix`: clean
- `uv run ty check --output-format concise`: clean

## 2026-08-25 — Review follow-up retro

The no-HEAD optimization makes source size and modification time unavailable during traversal, so both properties needed explicit operational treatment. Real transfer and archive measurements separated useful mitigations—the age gate and single-PUT cutoff—from the suggested mtime flag, which did not change observed behavior.