### PR TITLE
Install SIGTERM handler at CLI startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude-newer = "5 days"
 
 
 [project.scripts]
-main = "reformatters.__main__:app"
+main = "reformatters.__main__:main"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude-newer = "5 days"
 
 
 [project.scripts]
-main = "reformatters.__main__:main"
+main = "reformatters.__main__:app"
 
 [dependency-groups]
 dev = [

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -265,7 +265,6 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
 ]
 
 register_run_monitor(monitoring.monitor_cron)
-monitoring.install_sigterm_logger()
 
 if Config.is_sentry_enabled:
     cron_job_name = os.getenv("CRON_JOB_NAME")
@@ -318,10 +317,15 @@ for archiver in OPERATIONAL_ARCHIVERS:
 deploy_module.register_commands(app, DYNAMICAL_DATASETS, OPERATIONAL_ARCHIVERS)
 
 
+def main() -> None:
+    monitoring.install_sigterm_logger()
+    app()
+
+
 if not __debug__:
     raise RuntimeError(
         "This project relies on assert statements. Do not run with python -O."
     )
 
 if __name__ == "__main__":
-    app()
+    main()

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -301,6 +301,13 @@ if Config.is_sentry_enabled:
 
 
 app = typer.Typer(pretty_exceptions_show_locals=False)
+
+
+@app.callback()
+def startup() -> None:
+    monitoring.install_sigterm_logger()
+
+
 app.command()(initialize_new_integration)
 
 
@@ -317,15 +324,10 @@ for archiver in OPERATIONAL_ARCHIVERS:
 deploy_module.register_commands(app, DYNAMICAL_DATASETS, OPERATIONAL_ARCHIVERS)
 
 
-def main() -> None:
-    monitoring.install_sigterm_logger()
-    app()
-
-
 if not __debug__:
     raise RuntimeError(
         "This project relies on assert statements. Do not run with python -O."
     )
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/tests/common/deploy_test.py
+++ b/tests/common/deploy_test.py
@@ -1,4 +1,62 @@
+import subprocess
+import sys
+from importlib.metadata import distribution
+from unittest.mock import Mock
+
+import pytest
 from typer.testing import CliRunner
+
+from reformatters.common import monitoring
+
+
+def test_console_entrypoint_dispatch_installs_sigterm_logger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entrypoint = next(
+        entrypoint
+        for entrypoint in distribution("reformatters").entry_points
+        if entrypoint.group == "console_scripts" and entrypoint.name == "main"
+    )
+    assert entrypoint.value == "reformatters.__main__:app"
+
+    install_sigterm_logger = Mock()
+    monkeypatch.setattr(monitoring, "install_sigterm_logger", install_sigterm_logger)
+    result = CliRunner().invoke(
+        entrypoint.load(), ["noaa-hrrr-analysis-virtual", "dataset-urls"]
+    )
+
+    assert result.exit_code == 0, result.exception
+    install_sigterm_logger.assert_called_once_with()
+
+
+def test_direct_file_dispatch_installs_sigterm_logger() -> None:
+    code = """
+import runpy
+import sys
+from unittest.mock import Mock
+
+from reformatters.common import monitoring
+
+install_sigterm_logger = Mock()
+monitoring.install_sigterm_logger = install_sigterm_logger
+sys.argv = [
+    "src/reformatters/__main__.py",
+    "noaa-hrrr-analysis-virtual",
+    "dataset-urls",
+]
+try:
+    runpy.run_path("src/reformatters/__main__.py", run_name="__main__")
+except SystemExit as error:
+    assert error.code == 0
+install_sigterm_logger.assert_called_once_with()
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 class TestDeployCommandsRegistered:

--- a/tests/scripts/validation/manifest_scan_test.py
+++ b/tests/scripts/validation/manifest_scan_test.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from types import SimpleNamespace
 from typing import Any
 
@@ -20,6 +22,26 @@ from scripts.validation.manifest_scan import (
     result_availability_series,
 )
 from scripts.validation.scan_common import evenly_spaced_subset
+
+
+def test_find_registered_dataset_from_worker_thread() -> None:
+    code = """
+from concurrent.futures import ThreadPoolExecutor
+from scripts.validation.scan_common import find_registered_dataset
+
+with ThreadPoolExecutor(max_workers=1) as pool:
+    dataset = pool.submit(
+        find_registered_dataset, "noaa-hrrr-analysis-virtual"
+    ).result()
+assert dataset is not None
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 class _Coord:


### PR DESCRIPTION
## Summary
- install the SIGTERM telemetry handler from the Typer application callback
- preserve both existing entrypoints: the `main` console script still targets `reformatters.__main__:app`, and direct-file execution still calls `app()`
- keep registry imports safe in validation worker threads
- cover fresh worker-thread imports and real command dispatch through both entrypoints

## Failure mode
The concurrent manifest scan lazily imports `reformatters.__main__` from a `ThreadPoolExecutor` worker. Import-time SIGTERM setup called `signal.signal` in that worker and deterministically raised `ValueError`.

## Checks
- `uv run pytest tests/scripts/validation/manifest_scan_test.py tests/common/deploy_test.py -q` (16 passed)
- `uv run pytest tests/common/monitoring_test.py tests/common/deploy_test.py tests/datasets_test.py -q` (364 passed)
- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check --output-format concise`