### PR TITLE
Opt every job out of node consolidation, not just updates

### DIFF
--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -38,7 +38,10 @@ class Job(pydantic.BaseModel):
     pod_active_deadline: timedelta = timedelta(hours=6)
     ttl: timedelta = timedelta(days=1)
 
-    pod_annotations: dict[str, str] = pydantic.Field(default_factory=dict)
+    # A worker evicted mid-run restarts from the beginning of its jobs, so opt out of
+    # consolidation. Karpenter evicts an underutilized node's pods whatever they are
+    # doing, and a job's own tail makes its remaining nodes underutilized.
+    pod_annotations: dict[str, str] = {"karpenter.sh/do-not-disrupt": "true"}
 
     secret_names: Sequence[str] = pydantic.Field(default_factory=list)
 
@@ -273,8 +276,6 @@ class ReformatCronJob(CronJob):
     # Operational updates expect a single worker
     workers_total: int = 1
     parallelism: int = 1
-    # A mid-run eviction restarts the whole job, so opt out of consolidation.
-    pod_annotations: dict[str, str] = {"karpenter.sh/do-not-disrupt": "true"}
 
 
 class ValidationCronJob(CronJob):

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -38,9 +38,7 @@ class Job(pydantic.BaseModel):
     pod_active_deadline: timedelta = timedelta(hours=6)
     ttl: timedelta = timedelta(days=1)
 
-    # A worker evicted mid-run restarts from the beginning of its jobs, so opt out of
-    # consolidation. Karpenter evicts an underutilized node's pods whatever they are
-    # doing, and a job's own tail makes its remaining nodes underutilized.
+    # Opt out of consolidation. Quick jobs have minimal impact and we'd rather not interrupt and restart longer jobs.
     pod_annotations: dict[str, str] = {"karpenter.sh/do-not-disrupt": "true"}
 
     secret_names: Sequence[str] = pydantic.Field(default_factory=list)

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -63,7 +63,7 @@ def test_as_kubernetes_object_comprehensive() -> None:
             ]
         },
         "template": {
-            "metadata": {"annotations": {}},
+            "metadata": {"annotations": {"karpenter.sh/do-not-disrupt": "true"}},
             "spec": {
                 "containers": [
                     {
@@ -195,7 +195,7 @@ def test_cron_job_name_respects_kubernetes_length_limit() -> None:
         _cron_job_with_name("a" * 53)
 
 
-def test_do_not_disrupt_annotation_only_on_reformat_jobs() -> None:
+def test_do_not_disrupt_annotation_on_every_job() -> None:
     reformat = ReformatCronJob(
         name="weather-data-update",
         schedule="0 * * * *",
@@ -229,11 +229,11 @@ def test_do_not_disrupt_annotation_only_on_reformat_jobs() -> None:
     def annotations(obj: dict[str, Any], *, cron: bool) -> dict[str, str]:
         return pod_template(obj, cron=cron)["metadata"]["annotations"]
 
-    assert annotations(reformat.as_kubernetes_object(), cron=True) == {
-        "karpenter.sh/do-not-disrupt": "true"
-    }
-    assert annotations(validate.as_kubernetes_object(), cron=True) == {}
-    assert annotations(backfill.as_kubernetes_object(), cron=False) == {}
+    do_not_disrupt = {"karpenter.sh/do-not-disrupt": "true"}
+    assert annotations(reformat.as_kubernetes_object(), cron=True) == do_not_disrupt
+    assert annotations(validate.as_kubernetes_object(), cron=True) == do_not_disrupt
+    # A backfill worker carries many region jobs, so it loses the most to an eviction.
+    assert annotations(backfill.as_kubernetes_object(), cron=False) == do_not_disrupt
 
 
 def test_kubernetes_job_name() -> None:


### PR DESCRIPTION
Backfill and validation pods carried no `karpenter.sh/do-not-disrupt` annotation, so Karpenter could evict them mid-run to consolidate an underutilized node. `ReformatCronJob` already opted out, with a comment giving the reason that applies just as well to the others: a worker evicted mid-run restarts from the beginning of its jobs.

This moves the annotation to `Job`, so every job carries it, and drops the now-redundant override.

## What prompted it

The `eccc-hrdps-forecast` backfill (20 workers, 10 region jobs each) logged:

| eviction reason | count |
|---|---:|
| `Underutilized` (Karpenter consolidation) | 19 |
| `Forceful Termination` (spot interruption) | 2 |

So the churn was overwhelmingly consolidation, not spot.

The effect compounds toward the end of a job. A worker needs ~27 minutes for its 10 region jobs, but as the job's tail drains, the few remaining pods are by definition the only thing on their nodes — which is exactly what makes those nodes eligible for consolidation. One index was evicted five times, each after ~7 minutes, restarting its region jobs from scratch every time, while workers that happened to share a busy node finished untouched.

The evictions are correctness-neutral (`podFailurePolicy` ignores `DisruptionTarget`, and `backoffLimit` is effectively unlimited), so they cost wall-clock and duplicated source downloads rather than data.

## Notes

- Validation jobs get the annotation too. They are short, so it changes little, but there is no reason to want one interrupted either, and one default beats three.
- `test_do_not_disrupt_annotation_only_on_reformat_jobs` asserted the previous behavior and is updated to assert the new one.