### PR TITLE
Start operational updates for eccc-hrdps-forecast

### DIFF
--- a/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
+++ b/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
@@ -69,7 +69,6 @@ class EcccHrdpsForecastDynamicalDataset(
             secret_names=self.store_factory.k8s_secret_names(),
             workers_total=workers,
             parallelism=workers,
-            suspend=True,  # until the store is backfilled
         )
 
         validation_cron_job = ValidationCronJob(
@@ -81,7 +80,6 @@ class EcccHrdpsForecastDynamicalDataset(
             cpu="0.7",
             memory="3.5G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,  # until the store is backfilled
         )
 
         return [

--- a/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
+++ b/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
@@ -198,9 +198,8 @@ def test_operational_kubernetes_resources(
     assert update_cron_job.workers_total == 2
     assert update_cron_job.parallelism == 2
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
-    # Until the store is backfilled
-    assert update_cron_job.suspend is True
-    assert validation_cron_job.suspend is True
+    assert update_cron_job.suspend is False
+    assert validation_cron_job.suspend is False
 
     for cron_job in (archive_grib_files_job, update_cron_job, validation_cron_job):
         assert cron_job.schedule.endswith(" * * *")


### PR DESCRIPTION
The backfill is complete, so the update and validation cron jobs come out of `suspend=True`.

## Backfill verification

20/20 workers succeeded. Reading the store on `main`:

- 191 init times, 2026-07-09T00:00 to 2026-08-25T12:00, uniform 6 hour spacing
- 49 lead times, 0 to 48 hours
- all 17 variables present, no NaN at 10 init times sampled across the span
- NaN at lead time 0 for exactly the five variables that should have it: precipitation, precipitation type, both radiation fluxes, and total cloud cover

Spot checks are physically coherent: mean sea level pressure above surface pressure over elevated terrain, dew point below temperature, 80 m wind above 10 m wind, and short wave flux at 0 W m-2 where long wave is 367 W m-2 at a lead time landing at night.

## The trailing init time

`2026-08-25T12:00` is a coordinate with no data. The backfill ran at 12:44 UTC with `append_dim_end` defaulting to now, and the Datamart publishes a run about 4 hours after its init time, so that run did not exist yet.

It needs no separate backfill. `operational_update_jobs` sets `filter_start` to the store's maximum init time, so the first update processes 12Z and fills it.

## Schedules

Update at 4:10, 10:10, 16:10 and 22:10 UTC, each init time plus about 4 hours 10 minutes. Validation 30 minutes later, matching `CheckCurrentData(max_delay=4h40m)`.