### PR TITLE
Fix ECMWF 46-day pressure level axis order

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_region_job.py
@@ -212,10 +212,10 @@ class EcmwfIfsEns46DayRegionJob(
             bands = iter(present)
             values = np.stack(
                 [missing if level is None else next(bands) for level in coord.levels],
-                axis=-1,
+                axis=0,
             )
-        assert values.shape[:2] == GRID_SHAPE, (
-            f"Expected a {GRID_SHAPE} grid, found {values.shape[:2]}"
+        assert values.shape[-2:] == GRID_SHAPE, (
+            f"Expected a {GRID_SHAPE} grid, found {values.shape[-2:]}"
         )
         mask_source_fill_value_inplace(values, data_var.internal_attrs)
         return values

--- a/tests/ecmwf/ifs_ens/forecast_46_day_dynamical_dataset_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_46_day_dynamical_dataset_test.py
@@ -1,10 +1,15 @@
+import numpy as np
+import pandas as pd
 import pytest
+import xarray as xr
 
 from reformatters.common import validation
+from reformatters.common.types import DatetimeLike
 from reformatters.ecmwf.archive_gribs.forecast_46_day_archiver import ECDS_VARIABLES
 from reformatters.ecmwf.ifs_ens.forecast_46_day_1_5_degree.dynamical_dataset import (
     EcmwfIfsEnsForecast46Day15DegreeDataset,
 )
+from tests.chunk_utils import shrink_chunks_and_shards
 from tests.common.dynamical_dataset_test import NOOP_STORAGE_CONFIG
 
 
@@ -35,3 +40,89 @@ def test_archive_contains_every_dataset_source_variable(
         data_var.internal_attrs.ecds_variable
         for data_var in dataset.template_config.data_vars
     } == set(ECDS_VARIABLES)
+
+
+LEVELS = (1000, 925, 850, 700, 500, 300, 200, 100, 50, 10)
+
+
+@pytest.mark.slow
+def test_backfill_local_writes_pressure_levels(
+    monkeypatch: pytest.MonkeyPatch, dataset: EcmwfIfsEnsForecast46Day15DegreeDataset
+) -> None:
+    """A pressure level variable lands on its declared axis, with real values."""
+    root_var, pressure_var = "pressure_surface", "temperature"
+    monkeypatch.setattr(
+        type(dataset.template_config),
+        "data_vars",
+        [
+            var
+            for var in dataset.template_config.data_vars
+            if var.name in (root_var, pressure_var)
+        ],
+    )
+
+    orig_get_template = dataset.template_config.get_template
+
+    def small_template(self: object, end_time: DatetimeLike) -> xr.DataTree:
+        tree = orig_get_template(end_time).sel(
+            lead_time=slice("0h", "24h"), ensemble_member=slice(0, 0)
+        )
+        # Leave init_time at production geometry: one shard per init, so
+        # filter_start scopes the run to a single initialization.
+        return shrink_chunks_and_shards(
+            xr.DataTree.from_dict(
+                {
+                    "/": tree.to_dataset()[[root_var]],
+                    "pressure_level": tree["pressure_level"].to_dataset()[
+                        [pressure_var]
+                    ],
+                }
+            ),
+            dims=(
+                "lead_time",
+                "ensemble_member",
+                "pressure_level",
+                "latitude",
+                "longitude",
+            ),
+        )
+
+    monkeypatch.setattr(type(dataset.template_config), "get_template", small_template)
+
+    dataset.backfill_local(
+        append_dim_end=pd.Timestamp("2026-08-11T00:00"),
+        filter_start=pd.Timestamp("2026-08-10T00:00"),
+    )
+
+    store = dataset.store_factory.primary_store()
+    root = xr.open_zarr(store, chunks=None)
+    levels = xr.open_zarr(store, group="pressure_level", chunks=None)
+
+    init = np.datetime64("2026-08-10T00:00:00")
+    assert init in root.init_time.values
+    assert np.isfinite(root[root_var].sel(init_time=init).values).any()
+
+    temperature = (
+        levels[pressure_var].sel(init_time=init).isel(lead_time=0, ensemble_member=0)
+    )
+    assert temperature.dims == ("pressure_level", "latitude", "longitude")
+    assert np.isfinite(temperature.values).all()
+
+    # Global mean per level, coldest at the 100 hPa tropopause and warming above it.
+    np.testing.assert_allclose(
+        [float(temperature.sel(pressure_level=level).mean()) for level in LEVELS],
+        [
+            10.936,
+            7.364,
+            4.457,
+            -2.785,
+            -17.292,
+            -41.806,
+            -55.184,
+            -65.717,
+            -62.399,
+            -49.726,
+        ],
+        atol=1e-3,
+        rtol=0,
+    )

--- a/tests/ecmwf/ifs_ens/forecast_46_day_region_job_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_46_day_region_job_test.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 
 from reformatters.common.iterating import item
+from reformatters.common.types import Group
 from reformatters.ecmwf.archive_gribs.forecast_46_day_archiver import ECDS_VARIABLES
 from reformatters.ecmwf.archive_gribs.request_shards import (
     DAILY_LEAD_TIMES,
@@ -29,6 +30,16 @@ from tests.ecmwf.s2s_fixtures import blob_record, extract_messages
 
 INIT_TIME = pd.Timestamp("2026-08-10T00:00")
 DAILY_CONFIG = EcmwfIfsEnsForecast46Day15DegreeTemplateConfig()
+
+
+# read_data fills one (init_time, lead_time, ensemble_member) slot of the output, so
+# its axes are the group's remaining dims, in the order the template declares them.
+SLOT_DIMS = ("init_time", "lead_time", "ensemble_member")
+
+
+def expected_read_shape(group: Group, level_count: int) -> tuple[int, ...]:
+    sizes = {"pressure_level": level_count, "latitude": 121, "longitude": 240}
+    return tuple(sizes[dim] for dim in DAILY_CONFIG.dims[group] if dim not in SLOT_DIMS)
 
 
 def daily_var(name: str) -> EcmwfIfsEns46DayDataVar:
@@ -107,10 +118,10 @@ def test_reads_a_pressure_level_message_into_its_output_level(tmp_path: Path) ->
 
     values = region_job(data_var, tmp_path).read_data(coord, data_var)
 
-    assert values.shape == (121, 240, len(levels))
+    assert values.shape == expected_read_shape("pressure_level", len(levels))
     level_index = levels.index("500_hpa")
-    assert values[60, 120, level_index] == pytest.approx(270.1207, abs=1e-3)
-    assert np.isnan(values[:, :, levels.index(None)]).all()
+    assert values[level_index, 60, 120] == pytest.approx(270.1207, abs=1e-3)
+    assert np.isnan(values[levels.index(None)]).all()
 
 
 def test_masks_the_land_only_sentinel(tmp_path: Path) -> None:


### PR DESCRIPTION
Every `pressure_level` variable in the ECMWF 46-day store is being written entirely as NaN. Found during the Phase 1 test backfill (#932); Sentry `REFORMATTERS-HY` is the same bug.

## Cause

`read_data` stacked levels on `axis=-1`, returning `(latitude, longitude, pressure_level)`. The template declares

```
(init_time, lead_time, ensemble_member, pressure_level, latitude, longitude)
```

so the output slot is `(pressure_level, latitude, longitude)`. Assignment raised

```
could not broadcast input array from shape (121,240,10) into shape (10,121,240)
```

`_read_into_data_array` catches per-coord exceptions and marks the coord `ReadFailed`, so the pod exited 0 and the Kubernetes job reported no failures. The surface variables were unaffected, which is why the run looked healthy.

## Fix

- Stack on `axis=0`.
- Check the trailing two axes for the grid shape instead of the leading two. The old check passed for the wrong order; the new one covers both the single-level and multi-level branches and fails inside `read_data` rather than surviving to the assignment.

## Tests

Two gaps let this through, both closed here.

**The unit test asserted the bug.** `test_reads_a_pressure_level_message_into_its_output_level` expected `values.shape == (121, 240, len(levels))` — the shape the implementation produced, not the one the template declares — so it passed throughout. It now derives the expected axes from `DAILY_CONFIG.dims[group]`, the same declaration the write path keys on.

**Nothing exercised a vertical group end to end.** `forecast_46_day_dynamical_dataset_test.py` had no backfill test, unlike every comparable dataset. Added one that backfills a single initialization of one root and one pressure level variable and pins the global mean at each level:

```
1000  925   850   700    500     300     200     100     50      10  hPa
10.9  7.4   4.5  -2.8  -17.3   -41.8   -55.2   -65.7  -62.4   -49.7  degC
```

A tropospheric lapse profile through the 100 hPa tropopause, warming into the stratosphere above it — a shape that only comes out right if levels are on the axis the template declares.

Both tests verified red/green: restoring `axis=-1` fails the unit test with `Expected a (121, 240) grid, found (240, 10)` and turns the integration test's whole group to NaN, reproducing the production failure including the swallowed `Read failed` log.

One detail worth flagging for reviewers: the integration test leaves `init_time` at production chunk geometry and shrinks only the other dims. Shrinking the append dim caps it at two shards across the full declared 1153-init axis, so a single job reaches for initializations that predate the GRIB archive.

## Checks

`ruff format`, `ruff check`, `ty check` clean. `pytest tests/ecmwf`: 267 passed, slow tests included.
