### PR TITLE
Document water-point behavior in AIFS Single virtual variables

### DIFF
--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/template_config.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/template_config.py
@@ -411,6 +411,7 @@ def _root_data_vars() -> list[EcmwfAifsSingleVirtualDataVar]:
             long_name="Snow cover",
             units="1",
             standard_name="surface_snow_area_fraction",
+            comment="Fraction (0-1) of the grid box covered by snow. Applies over land only; NaN over water.",
             date_available=AIFS_2026_UPGRADE_DATE,
         ),
         # tp/cp exist before AIFS_SINGLE_FORMAT_CHANGE_DATE too, but in metres;
@@ -453,6 +454,7 @@ def _root_data_vars() -> list[EcmwfAifsSingleVirtualDataVar]:
             long_name="Runoff water equivalent (surface plus subsurface)",
             units="kg m-2",
             standard_name="runoff_amount",
+            comment="Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
             date_available=AIFS_SINGLE_FORMAT_CHANGE_DATE,
         ),
         _root_var(
@@ -484,7 +486,7 @@ def _root_data_vars() -> list[EcmwfAifsSingleVirtualDataVar]:
             long_name="Soil temperature",
             units="degree_Celsius",
             standard_name="soil_temperature",
-            comment="ECMWF soil level 1, the uppermost soil layer.",
+            comment="ECMWF soil level 1, the uppermost soil layer. Over water this is the sea surface temperature, not a soil temperature.",
             date_available=AIFS_SINGLE_FORMAT_CHANGE_DATE,
         ),
         _root_var(
@@ -496,7 +498,7 @@ def _root_data_vars() -> list[EcmwfAifsSingleVirtualDataVar]:
             long_name="Soil temperature",
             units="degree_Celsius",
             standard_name="soil_temperature",
-            comment="ECMWF soil level 2, the second soil layer from the surface.",
+            comment="ECMWF soil level 2, the second soil layer from the surface. Over water this is the sea surface temperature, not a soil temperature.",
             date_available=AIFS_SINGLE_FORMAT_CHANGE_DATE,
         ),
         _root_var(
@@ -508,7 +510,7 @@ def _root_data_vars() -> list[EcmwfAifsSingleVirtualDataVar]:
             long_name="Volumetric soil moisture",
             units="1",
             standard_name="volume_fraction_of_condensed_water_in_soil",
-            comment="ECMWF soil level 1, the uppermost soil layer.",
+            comment="ECMWF soil level 1, the uppermost soil layer. Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
             date_available=AIFS_SINGLE_FORMAT_CHANGE_DATE,
         ),
         _root_var(
@@ -520,7 +522,7 @@ def _root_data_vars() -> list[EcmwfAifsSingleVirtualDataVar]:
             long_name="Volumetric soil moisture",
             units="1",
             standard_name="volume_fraction_of_condensed_water_in_soil",
-            comment="ECMWF soil level 2, the second soil layer from the surface.",
+            comment="ECMWF soil level 2, the second soil layer from the surface. Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
             date_available=AIFS_SINGLE_FORMAT_CHANGE_DATE,
         ),
         _root_var(

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/runoff_water_equivalent_run_total_surface/zarr.json
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/runoff_water_equivalent_run_total_surface/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "rowe",
     "standard_name": "runoff_amount",
     "units": "kg m-2",
+    "comment": "Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
     "step_type": "accum",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/snow_area_fraction_surface/zarr.json
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/snow_area_fraction_surface/zarr.json
@@ -39,6 +39,7 @@
     "short_name": "snowc",
     "standard_name": "surface_snow_area_fraction",
     "units": "1",
+    "comment": "Fraction (0-1) of the grid box covered by snow. Applies over land only; NaN over water.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/soil_temperature_layer_1/zarr.json
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/soil_temperature_layer_1/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "sot",
     "standard_name": "soil_temperature",
     "units": "degree_Celsius",
-    "comment": "ECMWF soil level 1, the uppermost soil layer.",
+    "comment": "ECMWF soil level 1, the uppermost soil layer. Over water this is the sea surface temperature, not a soil temperature.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/soil_temperature_layer_2/zarr.json
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/soil_temperature_layer_2/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "sot",
     "standard_name": "soil_temperature",
     "units": "degree_Celsius",
-    "comment": "ECMWF soil level 2, the second soil layer from the surface.",
+    "comment": "ECMWF soil level 2, the second soil layer from the surface. Over water this is the sea surface temperature, not a soil temperature.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/volumetric_soil_moisture_layer_1/zarr.json
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/volumetric_soil_moisture_layer_1/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vsw",
     "standard_name": "volume_fraction_of_condensed_water_in_soil",
     "units": "1",
-    "comment": "ECMWF soil level 1, the uppermost soil layer.",
+    "comment": "ECMWF soil level 1, the uppermost soil layer. Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/volumetric_soil_moisture_layer_2/zarr.json
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/volumetric_soil_moisture_layer_2/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vsw",
     "standard_name": "volume_fraction_of_condensed_water_in_soil",
     "units": "1",
-    "comment": "ECMWF soil level 2, the second soil layer from the surface.",
+    "comment": "ECMWF soil level 2, the second soil layer from the surface. Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/templates/latest.zarr/zarr.json
@@ -1781,6 +1781,7 @@
           "short_name": "rowe",
           "standard_name": "runoff_amount",
           "units": "kg m-2",
+          "comment": "Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
           "step_type": "accum",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1952,6 +1953,7 @@
           "short_name": "snowc",
           "standard_name": "surface_snow_area_fraction",
           "units": "1",
+          "comment": "Fraction (0-1) of the grid box covered by snow. Applies over land only; NaN over water.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2068,7 +2070,7 @@
           "short_name": "sot",
           "standard_name": "soil_temperature",
           "units": "degree_Celsius",
-          "comment": "ECMWF soil level 1, the uppermost soil layer.",
+          "comment": "ECMWF soil level 1, the uppermost soil layer. Over water this is the sea surface temperature, not a soil temperature.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2130,7 +2132,7 @@
           "short_name": "sot",
           "standard_name": "soil_temperature",
           "units": "degree_Celsius",
-          "comment": "ECMWF soil level 2, the second soil layer from the surface.",
+          "comment": "ECMWF soil level 2, the second soil layer from the surface. Over water this is the sea surface temperature, not a soil temperature.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2574,7 +2576,7 @@
           "short_name": "vsw",
           "standard_name": "volume_fraction_of_condensed_water_in_soil",
           "units": "1",
-          "comment": "ECMWF soil level 1, the uppermost soil layer.",
+          "comment": "ECMWF soil level 1, the uppermost soil layer. Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2630,7 +2632,7 @@
           "short_name": "vsw",
           "standard_name": "volume_fraction_of_condensed_water_in_soil",
           "units": "1",
-          "comment": "ECMWF soil level 2, the second soil layer from the surface.",
+          "comment": "ECMWF soil level 2, the second soil layer from the surface. Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="


### PR DESCRIPTION
Adds `comment` attributes to six `ecmwf-aifs-single-forecast-virtual` variables, found while validating the archive. No data or encoding changes — attributes only, plus the regenerated template.

Four variables are NaN over water, on 64.0% of grid cells, and nothing in their metadata said whether that means "no data" or "the quantity does not apply here". A reader had no way to tell the difference, or to know the NaN fraction is not an availability statistic.

| Variable | `comment` |
|---|---|
| `volumetric_soil_moisture_layer_1` | ECMWF soil level 1, the uppermost soil layer. Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it. |
| `volumetric_soil_moisture_layer_2` | ECMWF soil level 2, the second soil layer from the surface. Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it. |
| `runoff_water_equivalent_run_total_surface` | Applies over land only. Water points are NaN from init time 2026-05-12T06:00 and unmasked before it. |
| `snow_area_fraction_surface` | Fraction (0-1) of the grid box covered by snow. Applies over land only; NaN over water. |
| `soil_temperature_layer_1` | ECMWF soil level 1, the uppermost soil layer. Over water this is the sea surface temperature, not a soil temperature. |
| `soil_temperature_layer_2` | ECMWF soil level 2, the second soil layer from the surface. Over water this is the sea surface temperature, not a soil temperature. |

### Evidence

- Soil moisture and runoff water points switch from unmasked to NaN at init time **2026-05-12T06:00**. Confirmed at the source: the `20260512/00z` message for `vsw` carries no bitmap (water points read as values, almost all exactly 0), and the `06z` message carries one with a 9999 missing value. Both encodings are ECMWF's own and pass through the virtual store unchanged.
- `snow_area_fraction_surface` first appears at init 2026-05-13T00:00, after that boundary, so it is masked for its whole record and needs no era clause.
- Soil temperature is never masked: it has zero NaN in either era and reads 28.5-28.7 °C at 0°N 140°W with a seasonal but no diurnal cycle, i.e. sea surface temperature.
- `land_sea_mask_surface` is deliberately not referenced as the mask: `lsm == 0` disagrees with the real missing-value mask on 13,613 cells (10,376 masked cells have land fraction up to 0.648; 3,237 zero-land cells are not masked).

### Testing

`tests/common/common_template_config_subclasses_test.py` and `tests/common/datasets_cf_compliance_test.py` pass (358 tests); `ruff check` and `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBuGMPwJ1D7McKbXAuBacu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBuGMPwJ1D7McKbXAuBacu)_