### PR TITLE
Note lead time 0 NaN in HRDPS cloud cover and precipitation type comments

### DIFF
--- a/src/reformatters/eccc/hrdps/forecast/template_config.py
+++ b/src/reformatters/eccc/hrdps/forecast/template_config.py
@@ -571,7 +571,7 @@ class EcccHrdpsForecastTemplateConfig(TemplateConfig[EcccHrdpsDataVar]):
                     long_name="Precipitation type",
                     units="1",
                     step_type="instant",
-                    comment="1=Rain; 2=Rain/snow; 3=Freezing rain; 4=Ice pellets; 5=Snow; 6=None; 7=Drizzle; 8=Freezing drizzle; 9=Freezing rain/ice pellets.",
+                    comment="1=Rain; 2=Rain/snow; 3=Freezing rain; 4=Ice pellets; 5=Snow; 6=None; 7=Drizzle; 8=Freezing drizzle; 9=Freezing rain/ice pellets. NaN at lead time 0.",
                     flag_values=(1, 2, 3, 4, 5, 6, 7, 8, 9),
                     flag_meanings="rain mixture_of_rain_and_snow freezing_rain ice_pellets snow no_precipitation drizzle freezing_drizzle mixture_of_freezing_rain_and_ice_pellets",
                 ),
@@ -636,6 +636,7 @@ class EcccHrdpsForecastTemplateConfig(TemplateConfig[EcccHrdpsDataVar]):
                     units="percent",
                     step_type="instant",
                     standard_name="cloud_area_fraction",
+                    comment="NaN at lead time 0.",
                 ),
                 internal_attrs=EcccHrdpsInternalAttrs(
                     grib_field="TCDC",

--- a/src/reformatters/eccc/hrdps/forecast/templates/latest.zarr/categorical_precipitation_type_surface/zarr.json
+++ b/src/reformatters/eccc/hrdps/forecast/templates/latest.zarr/categorical_precipitation_type_surface/zarr.json
@@ -71,7 +71,7 @@
     "long_name": "Precipitation type",
     "short_name": "ptype",
     "units": "1",
-    "comment": "1=Rain; 2=Rain/snow; 3=Freezing rain; 4=Ice pellets; 5=Snow; 6=None; 7=Drizzle; 8=Freezing drizzle; 9=Freezing rain/ice pellets.",
+    "comment": "1=Rain; 2=Rain/snow; 3=Freezing rain; 4=Ice pellets; 5=Snow; 6=None; 7=Drizzle; 8=Freezing drizzle; 9=Freezing rain/ice pellets. NaN at lead time 0.",
     "step_type": "instant",
     "flag_values": [
       1,

--- a/src/reformatters/eccc/hrdps/forecast/templates/latest.zarr/total_cloud_cover_atmosphere/zarr.json
+++ b/src/reformatters/eccc/hrdps/forecast/templates/latest.zarr/total_cloud_cover_atmosphere/zarr.json
@@ -72,6 +72,7 @@
     "short_name": "tcc",
     "standard_name": "cloud_area_fraction",
     "units": "percent",
+    "comment": "NaN at lead time 0.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/eccc/hrdps/forecast/templates/latest.zarr/zarr.json
+++ b/src/reformatters/eccc/hrdps/forecast/templates/latest.zarr/zarr.json
@@ -91,7 +91,7 @@
           "long_name": "Precipitation type",
           "short_name": "ptype",
           "units": "1",
-          "comment": "1=Rain; 2=Rain/snow; 3=Freezing rain; 4=Ice pellets; 5=Snow; 6=None; 7=Drizzle; 8=Freezing drizzle; 9=Freezing rain/ice pellets.",
+          "comment": "1=Rain; 2=Rain/snow; 3=Freezing rain; 4=Ice pellets; 5=Snow; 6=None; 7=Drizzle; 8=Freezing drizzle; 9=Freezing rain/ice pellets. NaN at lead time 0.",
           "step_type": "instant",
           "flag_values": [
             1,
@@ -1464,6 +1464,7 @@
           "short_name": "tcc",
           "standard_name": "cloud_area_fraction",
           "units": "percent",
+          "comment": "NaN at lead time 0.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length ingested_forecast_length latitude longitude spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="


### PR DESCRIPTION
Adds `NaN at lead time 0.` to the `comment` attr of `total_cloud_cover_atmosphere` and `categorical_precipitation_type_surface`, and regenerates `templates/latest.zarr`.

Both variables are `step_type: instant` and carry `hour_0_values_override=False`, so they are structurally NaN at lead time 0 — the source's lead-0 cloud field is zero everywhere, and precipitation type has no lead-0 field. Unlike the deaccumulated variables, whose "since the previous forecast step" comments imply the missing first step, nothing in these two variables' published metadata explained it. Surfaced during validation of `eccc-hrdps-forecast` v0.1.0, where the lead-0 NaN slice was confirmed against the store (all-NaN at lead 0, fully populated at lead 1).

For `categorical_precipitation_type_surface` the sentence is appended to the existing flag-code comment; `total_cloud_cover_atmosphere` had no comment and gains one.

This is an attribute addition only — no change to values, dtypes, chunking, or any existing attribute — so it is backward compatible for readers of the published store. The template diff is limited to the two `comment` entries.

## Checks

- `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check` all pass
- `uv run pytest tests/common/common_template_config_subclasses_test.py tests/common/datasets_cf_compliance_test.py tests/eccc` — 386 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WewbTQJZYRa5Mb8Zepost5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WewbTQJZYRa5Mb8Zepost5)_