### PR TITLE
Let the backfill action run overwrite-metadata

### DIFF
--- a/.github/workflows/manual-backfill.yml
+++ b/.github/workflows/manual-backfill.yml
@@ -170,9 +170,14 @@ jobs:
         #!/bin/bash
         set -euo pipefail
 
-        # The image this exact commit's deploy built (waited for above), so the
-        # workers run the same code the driver just validated with.
-        ARGS=(--docker-image "${DOCKER_IMAGE}")
+        ARGS=()
+        # overwrite-metadata alone rewrites metadata in place and launches no workers,
+        # so the CLI rejects the image those workers would have run.
+        if [ "${OPERATION}" != "overwrite-metadata" ]; then
+          # The image this exact commit's deploy built (waited for above), so the
+          # workers run the same code the driver just validated with.
+          ARGS+=(--docker-image "${DOCKER_IMAGE}")
+        fi
         ARGS+=(--jobs-per-pod "${JOBS_PER_POD}" --max-parallelism "${MAX_PARALLELISM}")
         case "${OPERATION}" in
           create-new-store) ;;


### PR DESCRIPTION
The `overwrite-metadata` operation the Manual: Backfill action offers could never succeed. The action always passed `--docker-image`, and the CLI asserts against it for that operation:

```
AssertionError: --overwrite-metadata without --overwrite-chunks refreshes metadata
in place without launching workers; the filter and --docker-image options would
have no effect
```

`overwrite-metadata` alone rewrites metadata in place and launches no workers, so there is no image for the workers to run.

Found running it for `eccc-hrdps-forecast` after #949 adjusted two variable comments: https://github.com/dynamical-org/reformatters/actions/runs/32970448518

`--jobs-per-pod` and `--max-parallelism` stay unconditional; the CLI accepts them. The filter options are already conditional on being non-empty, and the assertion is the right answer if someone does pass one, since a filter genuinely has no effect on an in-place metadata refresh.