### PR TITLE
Honor overwrite-chunks on virtual datasets

### DIFF
--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -20,10 +20,10 @@ The Cartesian product of regions and variable groups produces the full job list,
 
 ## The worker-processing seam
 
-`RegionJob.process_worker_jobs(worker_jobs, store_factory, branch_name, worker_index)` is the single polymorphic call the coordinator (`DynamicalDataset._process_region_jobs`) drives every dataset variant through. Each variant owns its store/session lifecycle and commit cadence behind it:
+`RegionJob.process_worker_jobs(worker_jobs, store_factory, branch_name, worker_index, overwrite_chunks=...)` is the single polymorphic call the coordinator (`DynamicalDataset._process_region_jobs`) drives every dataset variant through. Each variant owns its store/session lifecycle and commit cadence behind it:
 
 - **Materialized** — opens stores once and writes all of the worker's jobs in a single commit.
-- **Virtual** — gathers the worker's not-already-present source files across all its jobs, then commits each batch its generator yields (a backfill yields once → one commit per worker, like materialized; an operational update yields per poll tick), because a committed icechunk session is read-only (see [virtual_datasets.md](virtual_datasets.md#the-write-loop)).
+- **Virtual** — gathers the worker's source files across all its jobs, dropping the already-present ones unless `overwrite_chunks` asks for a rewrite, then commits each batch its generator yields (a backfill yields once → one commit per worker, like materialized; an operational update yields per poll tick), because a committed icechunk session is read-only (see [virtual_datasets.md](virtual_datasets.md#the-write-loop)).
 
 The only fork outside this call is the coordination lifecycle: everything runs the parallel temp-branch flow below except virtual operational updates, which are single-writer (see below).
 

--- a/docs/virtual_datasets.md
+++ b/docs/virtual_datasets.md
@@ -24,7 +24,7 @@ Virtual datasets are *metadata-heavy*, not storage-heavy. One GRIB message — o
 `process_worker_jobs` gathers the not-already-present source files across all of a worker's region jobs (one readonly view, one filter pass) into `remaining`, then `VirtualRegionJob.process_virtual` runs the same write loop over that union for both backfills and operational updates; only the branch differs (a temp branch for backfill, `main` for operational):
 
 1. `generate_source_file_coords` lists candidate source files for each of the worker's region jobs.
-2. `filter_already_present` drops files whose refs are already in the manifest; the survivors across the worker's jobs are unioned into `remaining`.
+2. `filter_already_present` drops files whose refs are already in the manifest; the survivors across the worker's jobs are unioned into `remaining`. An `overwrite_chunks` backfill skips this step, so refs pointing at the wrong source file are rewritten rather than treated as done.
 3. `process_virtual_refs(remaining)` — a concrete `VirtualRegionJob` generator — each tick asks `discover_available` which files are ready, builds their refs with `file_refs`, and yields batches of `(source file coord, its VirtualRefs)` pairs.
 4. Each yield is committed atomically: open fresh writable sessions (a committed icechunk session is read-only), grow the append dim if needed (`sync_dims_to`), `set_virtual_refs`, commit.
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -564,7 +564,7 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
         # ingesting. No-op commit-wise when the store already matches the template.
         job.refresh_metadata(self.store_factory, self._tmp_store())
         self.region_job_class.process_worker_jobs(
-            [job], self.store_factory, "main", worker_index
+            [job], self.store_factory, "main", worker_index, overwrite_chunks=False
         )
 
     def validate_dataset(

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -491,7 +491,8 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
                 self.store_factory,
                 branch_name,
                 worker_index,
-                overwrite_chunks=overwrite_chunks,
+                overwrite_chunks=overwrite_chunks
+                or self.region_job_class.rewrites_whole_region,
             )
             if worker_jobs
             else {}

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -487,7 +487,11 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
         # lifecycle and commit cadence behind this one call.
         worker_results: dict[str, list[SourceFileResult]] = (
             self.region_job_class.process_worker_jobs(
-                worker_jobs, self.store_factory, branch_name, worker_index
+                worker_jobs,
+                self.store_factory,
+                branch_name,
+                worker_index,
+                overwrite_chunks=overwrite_chunks,
             )
             if worker_jobs
             else {}

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -126,6 +126,8 @@ class MaterializedRegionJob(
         store_factory: storage.StoreFactory,
         branch_name: str,
         worker_index: int,
+        *,
+        overwrite_chunks: bool = False,  # noqa: ARG003 - always rewrites its region
     ) -> dict[str, list[SourceFileResult]]:
         """Write all of this worker's jobs to ``branch_name`` in a single commit."""
         # One commit per worker; an empty job set would make an empty icechunk

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -127,9 +127,12 @@ class MaterializedRegionJob(
         branch_name: str,
         worker_index: int,
         *,
-        overwrite_chunks: bool,  # noqa: ARG003 - always rewrites its region
+        overwrite_chunks: bool,
     ) -> dict[str, list[SourceFileResult]]:
         """Write all of this worker's jobs to ``branch_name`` in a single commit."""
+        assert overwrite_chunks, (
+            "Materialized jobs rewrite every chunk of their region; see rewrites_whole_region"
+        )
         # One commit per worker; an empty job set would make an empty icechunk
         # commit (which raises), so the caller must filter empty workers out.
         assert worker_jobs, "process_worker_jobs requires at least one job"

--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -127,7 +127,7 @@ class MaterializedRegionJob(
         branch_name: str,
         worker_index: int,
         *,
-        overwrite_chunks: bool = False,  # noqa: ARG003 - always rewrites its region
+        overwrite_chunks: bool,  # noqa: ARG003 - always rewrites its region
     ) -> dict[str, list[SourceFileResult]]:
         """Write all of this worker's jobs to ``branch_name`` in a single commit."""
         # One commit per worker; an empty job set would make an empty icechunk

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -464,9 +464,6 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         """Process one worker's region jobs against ``branch_name`` and
         return the per-variable source file results.
 
-        ``overwrite_chunks`` rewrites data the store already holds instead of
-        resuming: a variant that skips already-written work must not skip it.
-
         Materialized and virtual datasets each own their store/session lifecycle and
         commit cadence behind this one call (see "The worker-processing seam" in
         docs/parallel_processing.md). Callers must pass at least one job.

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -459,7 +459,7 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         branch_name: str,
         worker_index: int,
         *,
-        overwrite_chunks: bool = False,
+        overwrite_chunks: bool,
     ) -> dict[str, list[SourceFileResult]]:
         """Process one worker's region jobs against ``branch_name`` and
         return the per-variable source file results.

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -139,6 +139,10 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
     # Whether setup/finalize metadata writes embed zarr consolidated metadata.
     consolidated_metadata: ClassVar[bool] = True
 
+    # Whether a job writes every chunk of its region regardless of what the store
+    # already holds; such a variant is always driven with overwrite_chunks=True.
+    rewrites_whole_region: ClassVar[bool] = True
+
     @classmethod
     def source_file_var_groups(
         cls,

--- a/src/reformatters/common/region_job.py
+++ b/src/reformatters/common/region_job.py
@@ -458,9 +458,14 @@ class RegionJob(pydantic.BaseModel, Generic[DATA_VAR, SOURCE_FILE_COORD]):
         store_factory: storage.StoreFactory,
         branch_name: str,
         worker_index: int,
+        *,
+        overwrite_chunks: bool = False,
     ) -> dict[str, list[SourceFileResult]]:
         """Process one worker's region jobs against ``branch_name`` and
         return the per-variable source file results.
+
+        ``overwrite_chunks`` rewrites data the store already holds instead of
+        resuming: a variant that skips already-written work must not skip it.
 
         Materialized and virtual datasets each own their store/session lifecycle and
         commit cadence behind this one call (see "The worker-processing seam" in

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -313,11 +313,16 @@ class VirtualRegionJob(
         store_factory: storage.StoreFactory,
         branch_name: str,
         worker_index: int,  # noqa: ARG003 - per-batch commit messages don't carry it
+        *,
+        overwrite_chunks: bool = False,
     ) -> dict[str, list[SourceFileResult]]:
         """Drive the whole worker's virtual write loop on ``branch_name``.
 
-        Gathers the not-already-present source files across all the worker's jobs
-        against a single readonly view, then runs one write loop over their union:
+        Gathers the source files across all the worker's jobs against a single readonly
+        view, then runs one write loop over their union. Files whose refs the store
+        already holds are skipped unless ``overwrite_chunks`` asks for a rewrite --
+        without that, a variable whose refs all point at the wrong source file can
+        never be corrected, because its own stale refs mark every file as done.
         a backfill worker's generator yields a single batch (one commit for the
         whole worker), an update job's generator polls and commits per tick.
         Always returns an empty dict: virtual refs live in the icechunk manifest,
@@ -335,8 +340,12 @@ class VirtualRegionJob(
         remaining = [
             coord
             for job in jobs
-            for coord in job.filter_already_present(
-                job.source_file_coords(), readonly_store
+            for coord in (
+                job.source_file_coords()
+                if overwrite_chunks
+                else job.filter_already_present(
+                    job.source_file_coords(), readonly_store
+                )
             )
         ]
         # An all-already-present worker writes nothing; an empty icechunk commit

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -314,7 +314,7 @@ class VirtualRegionJob(
         branch_name: str,
         worker_index: int,  # noqa: ARG003 - per-batch commit messages don't carry it
         *,
-        overwrite_chunks: bool = False,
+        overwrite_chunks: bool,
     ) -> dict[str, list[SourceFileResult]]:
         """Drive the whole worker's virtual write loop on ``branch_name``.
 

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -67,6 +67,10 @@ class VirtualRegionJob(
     # see "Metadata refresh" in docs/virtual_datasets.md.
     consolidated_metadata: ClassVar[bool] = False
 
+    # Virtual jobs resume: files whose refs the store already holds are skipped unless
+    # the caller asks for a rewrite.
+    rewrites_whole_region: ClassVar[bool] = False
+
     # Updates wait for source files as the provider publishes them, backfills check once
     processing_mode: Literal["backfill", "update"] = "backfill"
 

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -320,10 +320,8 @@ class VirtualRegionJob(
 
         Gathers the source files across all the worker's jobs against a single readonly
         view, then runs one write loop over their union. Files whose refs the store
-        already holds are skipped unless ``overwrite_chunks`` asks for a rewrite --
-        without that, a variable whose refs all point at the wrong source file can
-        never be corrected, because its own stale refs mark every file as done.
-        a backfill worker's generator yields a single batch (one commit for the
+        already holds are skipped unless ``overwrite_chunks`` asks for a rewrite.
+        A backfill worker's generator yields a single batch (one commit for the
         whole worker), an update job's generator polls and commits per tick.
         Always returns an empty dict: virtual refs live in the icechunk manifest,
         so there is nothing to thread back to finalize.

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -1037,6 +1037,30 @@ def test_filter_skips_already_present_refs(tmp_path: Path) -> None:
     assert job.filter_already_present(candidates, readonly) == []
 
 
+def test_overwrite_chunks_rewrites_already_present_refs(tmp_path: Path) -> None:
+    """Without this, a variable whose refs all point at the wrong source file could
+    never be corrected: its own stale refs mark every file as already done."""
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+    job = _make_region_job(template_ds, region=slice(0, 4))
+
+    _process_virtual(job, repo)
+    snapshots_after_first = _snapshot_count(repo)
+
+    # Resuming skips everything, which is what a plain re-run should do.
+    VirtualTestRegionJob.process_worker_jobs([job], dataset.store_factory, "main", 0)
+    assert _snapshot_count(repo) == snapshots_after_first
+
+    # Asking for a rewrite writes the refs again rather than skipping them.
+    VirtualTestRegionJob.process_worker_jobs(
+        [job], dataset.store_factory, "main", 0, overwrite_chunks=True
+    )
+    assert _snapshot_count(repo) > snapshots_after_first
+    _assert_store_values(repo.readonly_session("main").store, n_inits=4)
+
+
 def test_filter_already_present_mixed_candidates(tmp_path: Path) -> None:
     # One filter call over a mix: already-emitted (dropped), not-yet-emitted (kept),
     # and an out-of-template label whose chunk_key is None (kept as remaining).

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -1050,7 +1050,9 @@ def test_overwrite_chunks_rewrites_already_present_refs(tmp_path: Path) -> None:
     snapshots_after_first = _snapshot_count(repo)
 
     # Resuming skips everything, which is what a plain re-run should do.
-    VirtualTestRegionJob.process_worker_jobs([job], dataset.store_factory, "main", 0)
+    VirtualTestRegionJob.process_worker_jobs(
+        [job], dataset.store_factory, "main", 0, overwrite_chunks=False
+    )
     assert _snapshot_count(repo) == snapshots_after_first
 
     # Asking for a rewrite writes the refs again rather than skipping them.
@@ -1191,7 +1193,11 @@ def test_backfill_worker_commits_once_across_multiple_jobs(tmp_path: Path) -> No
 
     before = _snapshot_count(repo)
     results = VirtualTestRegionJob.process_worker_jobs(
-        worker_jobs, dataset.store_factory, "main", worker_index=0
+        worker_jobs,
+        dataset.store_factory,
+        "main",
+        worker_index=0,
+        overwrite_chunks=False,
     )
     assert results == {}
     assert _snapshot_count(repo) - before == 1
@@ -1211,12 +1217,20 @@ def test_all_present_worker_makes_no_commit(tmp_path: Path) -> None:
         _make_region_job(template_ds, region=slice(i, i + 1)) for i in range(4)
     ]
     VirtualTestRegionJob.process_worker_jobs(
-        worker_jobs, dataset.store_factory, "main", worker_index=0
+        worker_jobs,
+        dataset.store_factory,
+        "main",
+        worker_index=0,
+        overwrite_chunks=False,
     )
     after_first = _snapshot_count(repo)
 
     VirtualTestRegionJob.process_worker_jobs(
-        worker_jobs, dataset.store_factory, "main", worker_index=0
+        worker_jobs,
+        dataset.store_factory,
+        "main",
+        worker_index=0,
+        overwrite_chunks=False,
     )
     assert _snapshot_count(repo) == after_first
 
@@ -1254,7 +1268,11 @@ def test_batched_driver_region_is_poisoned(tmp_path: Path) -> None:
     ]
     with pytest.raises(AssertionError, match=r"self\.region"):
         RegionReadingJob.process_worker_jobs(
-            worker_jobs, dataset.store_factory, "main", worker_index=0
+            worker_jobs,
+            dataset.store_factory,
+            "main",
+            worker_index=0,
+            overwrite_chunks=False,
         )
 
 
@@ -1295,6 +1313,7 @@ def test_driver_receives_the_stores_ingested_through(tmp_path: Path) -> None:
             dataset.store_factory,
             "main",
             worker_index=0,
+            overwrite_chunks=False,
         )
 
     init_times = full_template.to_dataset().get_index("init_time")
@@ -2115,7 +2134,9 @@ def test_update_window_ends_at_the_scheduled_fire(
     monkeypatch.setattr(
         VirtualTestRegionJob,
         "process_worker_jobs",
-        classmethod(lambda cls, worker_jobs, *args: driven.extend(worker_jobs) or {}),
+        classmethod(
+            lambda cls, worker_jobs, *args, **kwargs: driven.extend(worker_jobs) or {}
+        ),
     )
 
     dataset.update("test-update")
@@ -2261,7 +2282,9 @@ def test_operational_update_passes_poll_deadline_to_the_write_loop(
     monkeypatch.setattr(
         VirtualTestRegionJob,
         "process_worker_jobs",
-        classmethod(lambda cls, worker_jobs, *args: driven.extend(worker_jobs) or {}),
+        classmethod(
+            lambda cls, worker_jobs, *args, **kwargs: driven.extend(worker_jobs) or {}
+        ),
     )
     dataset._run_virtual_operational_update([job], worker_index=0, workers_total=1)
 


### PR DESCRIPTION
A virtual backfill decided its work by asking the store which source files it already had refs for, regardless of what the caller asked for. `--overwrite-chunks` reached the safety guards and the metadata write, but never the write loop:

```python
remaining = [
    coord
    for job in jobs
    for coord in job.filter_already_present(job.source_file_coords(), readonly_store)
]
```

`grep overwrite` over `virtual_region_job.py` returned only an unrelated comment.

## Why it matters

It makes a whole class of correction impossible. A variable whose refs all point at the **wrong source file** can never be repointed, because its own stale refs mark every file as already done. The rewrite is skipped, no commit is made, and **the job reports success.**

This is not hypothetical. #950 changed four HRRR analysis variables to source forecast hour 1 instead of hour 0, where HRRR writes them as constant-zero messages. Two `--overwrite-chunks` backfills ran to completion — 37/37 and 50/51 workers, zero failures — and changed nothing:

```
lightning_threat_1m                   2024-07-15T18:00  nonzero=0  (still empty)
aerosol_optical_thickness_atmosphere  2024-07-15T18:00  nonzero=0  (still empty)
lightning_threat_2m  (control, untouched)               nonzero=18576  max=6.478
```

The only way to make progress was to delete 417,372 refs by hand first, so that `filter_already_present` had nothing to find.

## The change

`process_worker_jobs` takes `overwrite_chunks` across the worker-processing seam, and the virtual variant uses every coord rather than the filtered set when it is set. `set_virtual_refs` already replaces a ref at a chunk index, so rewriting is exactly what the flag promises. The materialized variant accepts and ignores it — it has always rewritten its whole region.

Resuming is unchanged: without the flag, an interrupted backfill still skips what it already wrote, and an operational update still skips files it has ingested.

## Test

`test_overwrite_chunks_rewrites_already_present_refs` pins both halves: a plain re-run makes no new commit, and a re-run with `overwrite_chunks=True` writes the refs again and the values still read back correctly.

`uv run pytest -m "not slow"` 2118 passed; ruff and ty clean.

## Related

Two other sharp edges from the same session, not addressed here:

- `representative_var` can pick a variable that does not exist over the filtered range, killing a job mid-run — separate PR.
- `append_dim_end` is frozen at submission, so an operational update landing before worker 0's guard makes a job permanently unrecoverable with a "trimming an existing store" error. Every retry reuses the stale value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
