### PR TITLE
Warn, don't abort, when a file misses its probe chunk

### DIFF
--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -410,21 +410,29 @@ class VirtualRegionJob(
     def _assert_probe_chunk_covered(
         self, coord: SOURCE_FILE_COORD, file_refs: Sequence[VirtualRef]
     ) -> None:
-        """A file's refs must cover the chunk filter_already_present probes
-        (representative_var at the file's representative_probe_loc)."""
+        """Check the file's refs cover the chunk filter_already_present probes.
+
+        A file that contributed nothing is a hard error: something is wrong with the
+        source or the index. A file that contributed refs but not the probed chunk is
+        only wasteful -- the refs it did build are written, and the filter will offer
+        the file again next run -- so it warns rather than killing the job. That case
+        is a poor representative_var, not bad data: a variable the source did not
+        carry this early is a normal thing for a long archive to contain.
+        """
         assert file_refs, f"empty refs for source file {coord}"
         rep = self.representative_var(coord)
         probe_loc = self.representative_probe_loc(coord, rep)
         probe = self.chunk_key(probe_loc, rep)
-        assert any(
+        if not any(
             ref.data_var.path == rep.path and self.chunk_key(ref.out_loc, rep) == probe
             for ref in file_refs
-        ), (
-            f"refs for {coord} do not cover representative chunk "
-            f"({rep.name}, {dict(probe_loc)}); the filter would re-ingest "
-            "this file forever. Override representative_var or "
-            "representative_probe_loc to name a cell the file actually contains."
-        )
+        ):
+            log.warning(
+                f"{coord.get_url()} built {len(file_refs)} refs but none cover the "
+                f"probed chunk ({rep.name}, {dict(probe_loc)}), so this file will be "
+                "offered again on every run. Override representative_var or "
+                "representative_probe_loc to name a cell the file actually contains."
+            )
 
     def _emit_refs(
         self, stores: Sequence[IcechunkStore], refs: Sequence[VirtualRef]

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -11,6 +11,7 @@ expansion without the decode-only codec ever being invoked.
 
 import asyncio
 import json
+import logging
 import time
 from collections.abc import Iterator, Mapping, Sequence
 from datetime import timedelta
@@ -862,9 +863,12 @@ def test_process_virtual_rejects_empty_batch(tmp_path: Path) -> None:
         _process_virtual(job, repo)
 
 
-def test_process_virtual_rejects_refs_missing_probe_chunk(tmp_path: Path) -> None:
-    # A file's refs must cover the chunk filter_already_present probes, or the
-    # filter never sees the file land and re-ingests it forever.
+def test_process_virtual_warns_when_refs_miss_the_probe_chunk(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The file still contributed refs, so they are written; the filter will just offer
+    # the file again next run. Warn rather than kill the job: a variable the source did
+    # not carry this early is a normal thing for a long archive to contain.
     dataset = _make_dataset(tmp_path)
     template_ds = _create_template_ds(4)
     template_utils.write_metadata(template_ds, dataset.store_factory)
@@ -896,8 +900,11 @@ def test_process_virtual_rejects_refs_missing_probe_chunk(tmp_path: Path) -> Non
         region=slice(0, 4),
         reformat_job_name="test",
     )
-    with pytest.raises(AssertionError, match="do not cover representative chunk"):
+    with caplog.at_level(logging.WARNING):
         _process_virtual(job, repo)
+    assert "will be offered again on every run" in caplog.text
+    # The refs it did build are committed rather than discarded.
+    assert _snapshot_count(repo) > 1
 
 
 def test_emit_refs_rejects_unregistered_container_location(tmp_path: Path) -> None:


### PR DESCRIPTION
`filter_already_present` decides a source file is done by probing one designated variable — `representative_var`, the first instant variable in the group. The write loop then **asserts** the file's refs cover that variable's chunk, on the reasoning that otherwise the filter "would re-ingest this file forever".

The check is right; killing the job is not.

## What it costs today

A long archive normally contains variables the source added, renamed, or moved partway through. When a job's variable group is narrow — a variable-filtered backfill, say — the designated probe can easily be one that era simply lacks. The assert then fires deep in the write loop, **after the pods have started**, and no retry can fix it because every retry rebuilds the same refs.

Two jobs died this way in one session backfilling `noaa-hrrr-analysis-virtual`:

```
refs for <2014-10-01 f01> do not cover representative chunk
  (lightning_threat_1m, {'time': 2014-10-01 00:00:00})
```
LTNGSD does not appear in HRRR until 2022-06-28.

```
refs for <2014-10-01 f01> do not cover representative chunk
  (lightning_atmosphere, {'time': 2014-10-01 00:00:00})
```
LTNG is present from the start, but under the level string `surface`; it becomes `entire atmosphere` at the HRRRv2 upgrade on 2016-08-23 12Z, and the config only declares the later spelling.

In both cases the *other* variables in the group built perfectly good refs, which were thrown away along with the job.

## The change

An empty ref set stays a hard error — that means the source or its index is broken. A file that built refs but missed the probed chunk now logs a warning naming the variable, the chunk, and the consequence, and the refs it did build are committed.

The condition is waste, not corruption: re-offering a file costs a re-read, and the warning makes that visible instead of trading it for a dead job.

## Alternatives considered

- **Probe every variable of the coord, treating any hit as present.** Correct and removes the concept of a designated probe entirely, but the probe count scales with group size — roughly 100 variables x 104k coords for one HRRR analysis group — so it trades a rare failure for a large constant cost on every run.
- **Probe the representative first, fall back to the rest only on a miss.** Keeps the fast path, but on a first backfill everything misses, so the fallback runs for every coord.
- **Choose a representative with full append-dim coverage.** Nothing in the config knows which variables the source carried in which era; neither failure above was predictable from the template.

Happy to take any of these instead if the re-read cost matters more than the constant cost.

## Test

`test_process_virtual_warns_when_refs_miss_the_probe_chunk` (was `..._rejects_...`) asserts the warning is logged and that the refs are still committed. The empty-batch assert keeps its own test.

`uv run pytest -m "not slow"` 2118 passed; ruff and ty clean.

## Related

Stacked conceptually on #952, which fixes `--overwrite-chunks` being a silent no-op on virtual datasets. Independent changes; either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
