### PR TITLE
Run ECMWF 46-day operational updates and validation

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/dynamical_dataset.py
@@ -26,12 +26,11 @@ class EcmwfIfsEnsForecast46Day15DegreeDataset(
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
-        reformat_suspend = True
         workers = self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
             schedule="0 9 * * *",
-            suspend=reformat_suspend,
+            suspend=False,
             pod_active_deadline=timedelta(hours=3),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -46,7 +45,7 @@ class EcmwfIfsEnsForecast46Day15DegreeDataset(
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
             schedule="0 12 * * *",
-            suspend=reformat_suspend,
+            suspend=False,
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,

--- a/tests/ecmwf/ifs_ens/forecast_46_day_dynamical_dataset_test.py
+++ b/tests/ecmwf/ifs_ens/forecast_46_day_dynamical_dataset_test.py
@@ -33,6 +33,19 @@ def test_validators_check_masked_variables_are_not_all_nan(
     assert validators[2].spatial_sampling == "quarter"
 
 
+def test_operational_cron_jobs_are_not_suspended(
+    dataset: EcmwfIfsEnsForecast46Day15DegreeDataset,
+) -> None:
+    update_cron_job, validation_cron_job = dataset.operational_kubernetes_resources(
+        "test-image-tag"
+    )
+
+    assert update_cron_job.name == f"{dataset.dataset_id}-update"
+    assert update_cron_job.suspend is False
+    assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
+    assert validation_cron_job.suspend is False
+
+
 def test_archive_contains_every_dataset_source_variable(
     dataset: EcmwfIfsEnsForecast46Day15DegreeDataset,
 ) -> None:


### PR DESCRIPTION
Part of #932 (Phase 2). Turns on real-time operational updates and validation for
`ecmwf-ifs-ens-forecast-46-day-1-5-degree` so the store tracks the GRIB archive
frontier as inits are issued.

One `reformat_suspend` flag held both cron jobs suspended. Removing it leaves the
dataset matching its 15-day sibling.

## Why the update is safe to run

Verified by firing the deployed cron job manually (`...-update-mrshll-d3`, image
`662aa4e9`, 35/35 complete in 5 minutes):

- It planned 140 jobs over 4 regions — 2026-08-23 (the store's end, reprocessed),
  2026-08-24 (archived), and 2026-08-25 / 2026-08-26 (not yet published by ECDS).
- The two unpublished inits failed their index downloads, and
  `update_template_with_results` trimmed the axis back to the newest init actually
  written. `init_time` ends at **2026-08-24**, not the 2026-08-26 the template
  declared. An init with no source is never declared.
- Missing-source downloads inside 48 hours log at info, not exception, so a normal
  run produces no Sentry noise.
- All 35 variables (29 root + 6 `pressure_level`) hold real data at 2026-08-24,
  with NaN fractions identical to the verified 08-22 / 08-23 inits: 0.662 land
  mask on runoff and soil, 0.338 sea mask on SST and sea ice, 0.300 on
  `pressure_level/specific_humidity`, 0.000 elsewhere.

## Validation runs, and will fail until the history lands

Ran the full operational validator set in-process against the store:

```
PASS CheckCurrentData          latest is 2026-08-24, inside the 4 day deadline
PASS CheckRecentNans(exclude)  3 of 3 recent inits within (0.0,)
PASS CheckRecentNans(include)  3 of 3 recent inits within (0.9999,)
FAIL CheckExpectedShards       1123 missing per variable
```

Every data check passes. `CheckExpectedShards` fails structurally: the declared
`init_time` axis starts at `append_dim_start = 2023-06-28` and holds 1154
positions, of which 31 are written (2026-07-25 → 2026-08-24). 1154 − 31 = 1123.
The manually fired `...-validate-mrshll-7f` job failed for exactly this reason.

This is accepted noise, not a green light — the daily `-validate` failure will
persist until the axis is written. Of the 1123 missing positions, 137 are archived
and being backfilled now; the other 986 are gated on the ECDS history walk, about
four weeks out at the observed 35-40 inits/day.

Deliberately not recorded as a code comment: "validation currently fails" is a
time-windowed fact about the archive, so it belongs in #932 and the validation
report rather than in code that would go stale.

## Residual risk worth knowing

`operational_update_jobs` sets `filter_start` to the store's max init, and the
trim advances that max to the newest init written. A hole strictly between them —
the archive holding D but not D-1 — would be skipped permanently, and because an
all-fill shard still gets written, `CheckExpectedShards` would not see it either.
The archiver's `init_times_back = 3` makes a persistent frontier hole unlikely,
and the floor backfills sweep the whole archived range, which repairs one if it
happens. Not changed here.

## Test

`test_operational_cron_jobs_are_not_suspended` pins that both cron jobs are live,
mirroring the assertions on the AIFS single virtual dataset.
