### PR TITLE
Add cooldown for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 5
     groups:
       all:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

- run GitHub Actions version updates monthly instead of weekly
- require action releases to age for five days before Dependabot proposes them
- leave Python updates weekly; uv already enforces the five-day PyPI window through tool.uv exclude-newer

## Validation

- uv run ruff format
- uv run ruff check --fix
- uv run ty check --output-format concise
- parsed the Dependabot YAML and asserted the Actions schedule and cooldown values