### PR TITLE
Translate force_path_style for the coordination filesystem

### DIFF
--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -325,17 +325,24 @@ def _icechunk_to_s3fs_storage_options(options: dict[str, Any]) -> dict[str, Any]
     """Translate `icechunk.s3_storage` option names to s3fs/fsspec ones."""
     translated: dict[str, Any] = {}
     client_kwargs: dict[str, Any] = dict(options.get("client_kwargs") or {})
+    config_kwargs: dict[str, Any] = dict(options.get("config_kwargs") or {})
     for k, v in options.items():
-        if k == "client_kwargs":
+        if k in {"client_kwargs", "config_kwargs"}:
             continue
         if k == "region":
             client_kwargs["region_name"] = v
+        elif k == "force_path_style":
+            # botocore, which s3fs builds on, spells this as an addressing style.
+            if v:
+                config_kwargs.setdefault("s3", {})["addressing_style"] = "path"
         elif k in _ICECHUNK_TO_S3FS_CREDENTIAL_KEYS:
             translated[_ICECHUNK_TO_S3FS_CREDENTIAL_KEYS[k]] = v
         else:
             translated[k] = v
     if client_kwargs:
         translated["client_kwargs"] = client_kwargs
+    if config_kwargs:
+        translated["config_kwargs"] = config_kwargs
     return translated
 
 

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -2,6 +2,7 @@ import json
 from typing import Any
 from unittest.mock import MagicMock
 
+import fsspec
 import icechunk
 import pytest
 import zarr
@@ -891,6 +892,33 @@ class TestIcechunkToS3fsStorageOptions:
         assert _icechunk_to_s3fs_storage_options({"endpoint_url": "https://x"}) == {
             "endpoint_url": "https://x"
         }
+
+    def test_force_path_style_becomes_addressing_style(self) -> None:
+        assert _icechunk_to_s3fs_storage_options({"force_path_style": True}) == {
+            "config_kwargs": {"s3": {"addressing_style": "path"}}
+        }
+
+    def test_force_path_style_false_is_dropped(self) -> None:
+        assert _icechunk_to_s3fs_storage_options({"force_path_style": False}) == {}
+
+    def test_force_path_style_merges_with_existing_config_kwargs(self) -> None:
+        assert _icechunk_to_s3fs_storage_options(
+            {"force_path_style": True, "config_kwargs": {"read_timeout": 5}}
+        ) == {"config_kwargs": {"read_timeout": 5, "s3": {"addressing_style": "path"}}}
+
+    def test_r2_options_construct_an_s3_filesystem(self) -> None:
+        """s3fs rejects `force_path_style`, so an R2 secret must reach it translated."""
+        options = _icechunk_to_s3fs_storage_options(
+            {
+                "access_key_id": "AKIA",
+                "secret_access_key": "shh",
+                "region": "auto",
+                "endpoint_url": "https://account.r2.cloudflarestorage.com",
+                "force_path_style": True,
+            }
+        )
+        fs = fsspec.filesystem("s3", **options)
+        assert fs.config_kwargs["s3"]["addressing_style"] == "path"
 
     def test_empty_options(self) -> None:
         assert _icechunk_to_s3fs_storage_options({}) == {}


### PR DESCRIPTION
The first WeatherNext 2 historical backfill died immediately — all 35 workers, before any work:

```
TypeError: AioSession.__init__() got an unexpected keyword argument 'force_path_style'
  reformatters/common/storage.py:292 in read_all_coordination_files
  s3fs/core.py:655 in set_session
```

### Cause

Coordination files on an icechunk primary go through fsspec/s3fs, so `_icechunk_to_s3fs_storage_options` translates the icechunk secret's option names. It translated the keys it knew about and passed everything else through verbatim:

```python
else:
    translated[k] = v
```

That was fine while every icechunk secret was plain AWS S3 — the leftover keys (`endpoint_url`) happen to be valid s3fs kwargs too. WeatherNext 2 is the first dataset on R2, and its secret carries `force_path_style`, which is an `icechunk.s3_storage` kwarg that aiobotocore rejects.

Icechunk itself was fine; only the s3fs side broke, so the failure surfaced as a worker crash rather than a storage misconfiguration.

### Fix

botocore spells the same setting as an s3 addressing style, so translate it into `config_kwargs` the way `region` is already folded into `client_kwargs`:

```python
elif k == "force_path_style":
    if v:
        config_kwargs.setdefault("s3", {})["addressing_style"] = "path"
```

### Tests

Added coverage for the translation (true, false, merging with existing `config_kwargs`) plus a case that builds a real `S3FileSystem` from an R2-shaped secret — that constructor is exactly what raised the `TypeError` in the pod, so it fails without this change.

Full suite: 2389 passed, 13 skipped.

The failed run left an empty icechunk repo (workers call `Repository.open_or_create` before coordination). `_open_existing_store` treats a repo with no dataset as absent, so re-running `create-new-store` is still correct.

Unblocks the historical backfill in dynamical-org/meta#188.