### PR TITLE
Shorten WeatherNext 2 cron job names instead of adding a prefix hook

### DIFF
--- a/.github/workflows/manual-create-job-from-cronjob.yml
+++ b/.github/workflows/manual-create-job-from-cronjob.yml
@@ -26,6 +26,10 @@ name: 'Manual: Create Job from CronJob'
         - ecmwf-ifs-ens-forecast-15-day-0-25-degree-validate
         - ecmwf-ifs-ens-forecast-46-day-1-5-degree-update
         - ecmwf-ifs-ens-forecast-46-day-1-5-degree-validate
+        - google-weathernext2-forecast-historical-virtual-update
+        - google-weathernext2-forecast-historical-virtual-validate
+        - google-weathernext2-forecast-operational-virtual-update
+        - google-weathernext2-forecast-operational-virtual-validate
         - nasa-imerg-analysis-early-update
         - nasa-imerg-analysis-early-validate
         - nasa-imerg-analysis-late-update
@@ -56,10 +60,6 @@ name: 'Manual: Create Job from CronJob'
         - noaa-ndvi-cdr-analysis-validate
         - u-arizona-swann-analysis-update
         - u-arizona-swann-analysis-validate
-        - weathernext2-forecast-historical-virtual-update
-        - weathernext2-forecast-historical-virtual-validate
-        - weathernext2-forecast-operational-virtual-update
-        - weathernext2-forecast-operational-virtual-validate
 concurrency:
   group: k8s-manual-${{ github.actor }}-${{ github.run_id }}
   cancel-in-progress: false

--- a/.github/workflows/manual-create-job-from-cronjob.yml
+++ b/.github/workflows/manual-create-job-from-cronjob.yml
@@ -26,10 +26,10 @@ name: 'Manual: Create Job from CronJob'
         - ecmwf-ifs-ens-forecast-15-day-0-25-degree-validate
         - ecmwf-ifs-ens-forecast-46-day-1-5-degree-update
         - ecmwf-ifs-ens-forecast-46-day-1-5-degree-validate
-        - google-weathernext2-forecast-historical-virtual-update
-        - google-weathernext2-forecast-historical-virtual-validate
-        - google-weathernext2-forecast-operational-virtual-update
-        - google-weathernext2-forecast-operational-virtual-validate
+        - google-wn2-forecast-historical-virtual-update
+        - google-wn2-forecast-historical-virtual-validate
+        - google-wn2-forecast-operational-virtual-update
+        - google-wn2-forecast-operational-virtual-validate
         - nasa-imerg-analysis-early-update
         - nasa-imerg-analysis-early-validate
         - nasa-imerg-analysis-late-update

--- a/src/reformatters/common/deploy.py
+++ b/src/reformatters/common/deploy.py
@@ -93,9 +93,7 @@ def register_commands(
         staging.validate_version_differs_from_main(dataset, version)
 
         def transform(cronjob: kubernetes.CronJob) -> kubernetes.CronJob:
-            return staging.rename_cronjob_for_staging(
-                cronjob, dataset_id, version, name_prefix=dataset.cron_job_name_prefix
-            )
+            return staging.rename_cronjob_for_staging(cronjob, dataset_id, version)
 
         deploy_operational_resources(
             datasets,

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -72,7 +72,7 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
         Implementations should look similar to this:
         ```
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule=_OPERATIONAL_CRON_SCHEDULE,
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -84,7 +84,7 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule=_VALIDATION_CRON_SCHEDULE,
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
@@ -123,14 +123,6 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
     @property
     def dataset_id(self) -> str:
         return self.template_config.dataset_id
-
-    @property
-    def cron_job_name_prefix(self) -> str:
-        """Base for this dataset's cron job names.
-
-        Override when `{dataset_id}-validate` would exceed the `CronJobName` limit.
-        """
-        return self.dataset_id
 
     def update_template(self) -> None:
         """Generate and persist the dataset template using the template_config."""

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -227,13 +227,8 @@ class Job(pydantic.BaseModel):
         }
 
 
-# Kubernetes appends up to 11 characters when it names a cron job's jobs, so the
-# cron job's own name must stay within 63 - 11.
-CronJobName = Annotated[str, pydantic.Field(min_length=1, max_length=52)]
-
-
 class CronJob(Job):
-    name: CronJobName
+    name: Annotated[str, pydantic.Field(min_length=1, max_length=52)]
     schedule: Annotated[str, pydantic.Field(min_length=1)]
     ttl: timedelta = timedelta(hours=12)
     suspend: bool = False
@@ -274,7 +269,7 @@ class CronJob(Job):
 
 
 class ReformatCronJob(CronJob):
-    name: Annotated[CronJobName, pydantic.Field(pattern=r".+-update$")]
+    name: Annotated[str, pydantic.Field(pattern=r".+-update$")]
     command: Sequence[str] = ["update"]
     # Operational updates expect a single worker
     workers_total: int = 1
@@ -282,7 +277,7 @@ class ReformatCronJob(CronJob):
 
 
 class ValidationCronJob(CronJob):
-    name: Annotated[CronJobName, pydantic.Field(pattern=r".+-validate$")]
+    name: Annotated[str, pydantic.Field(pattern=r".+-validate$")]
     command: Sequence[str] = ["validate"]
     workers_total: int = 1
     parallelism: int = 1

--- a/src/reformatters/common/staging.py
+++ b/src/reformatters/common/staging.py
@@ -30,15 +30,11 @@ def staging_cronjob_name(dataset_id: str, version: str, suffix: str) -> str:
 
 
 def rename_cronjob_for_staging(
-    cronjob: CronJob, dataset_id: str, version: str, *, name_prefix: str
+    cronjob: CronJob, dataset_id: str, version: str
 ) -> CronJob:
-    """Create a copy of a CronJob with a staging-prefixed name.
-
-    `name_prefix` is the dataset's `cron_job_name_prefix`, which its cron job names
-    are built from and which is only the `dataset_id` when that fits `CronJobName`.
-    """
-    assert cronjob.name.startswith(f"{name_prefix}-")
-    suffix = cronjob.name.removeprefix(f"{name_prefix}-")
+    """Create a copy of a CronJob with a staging-prefixed name."""
+    assert cronjob.name.startswith(f"{dataset_id}-")
+    suffix = cronjob.name.removeprefix(f"{dataset_id}-")
     new_name = staging_cronjob_name(dataset_id, version, suffix)
     return replace(cronjob, name=new_name)
 

--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/dynamical_dataset.py
@@ -25,7 +25,7 @@ class NasaSmapLevel336KmV9Dataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             # New data comes 1x per day, usually around 5:45 but sometimes later, more like 14:00
             # Run twice to pick up the later data too (updates only take a couple minutes)
             schedule="0 6,18 * * *",
@@ -40,7 +40,7 @@ class NasaSmapLevel336KmV9Dataset(
             secret_names=[*self.store_factory.k8s_secret_names(), "nasa-earthdata"],
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="10 6,18 * * *",  # 10m (pod_active_deadline) after reformat at :00
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/noaa/ndvi_cdr/analysis/dynamical_dataset.py
@@ -20,7 +20,7 @@ class NoaaNdviCdrAnalysisDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 20 * * *",
             pod_active_deadline=timedelta(minutes=30),  # runs take <24 min
             image=image_tag,
@@ -32,7 +32,7 @@ class NoaaNdviCdrAnalysisDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="30 20 * * *",  # 30m (pod_active_deadline) after reformat at :00
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
+++ b/src/reformatters/contrib/uarizona/swann/analysis/dynamical_dataset.py
@@ -52,7 +52,7 @@ class UarizonaSwannAnalysisDataset(
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 20 * * *",
             pod_active_deadline=timedelta(minutes=10),  # runs take <4 min
             image=image_tag,
@@ -64,7 +64,7 @@ class UarizonaSwannAnalysisDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="10 20 * * *",  # 10m (pod_active_deadline) after reformat at :00
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/dynamical_dataset.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/dynamical_dataset.py
@@ -65,7 +65,7 @@ class DwdIconEuForecast5DayDataset(
         # download_file falls back to reading directly from DWD.
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="52 3,9,15,21 * * *",
             pod_active_deadline=timedelta(minutes=10),  # runs take <5 min
             image=image_tag,
@@ -80,7 +80,7 @@ class DwdIconEuForecast5DayDataset(
         )
 
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="2 4,10,16,22 * * *",  # 10m (pod_active_deadline) after reformat at :52
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
+++ b/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
@@ -57,7 +57,7 @@ class EcccHrdpsForecastDynamicalDataset(
         # which shard into one job each.
         workers = 2
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="10 4,10,16,22 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -72,7 +72,7 @@ class EcccHrdpsForecastDynamicalDataset(
         )
 
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="40 4,10,16,22 * * *",  # 30m (pod_active_deadline) after the update
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_ens/forecast/dynamical_dataset.py
@@ -26,7 +26,7 @@ class EcmwfAifsEnsForecastDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             # AIFS-ENS full completion (wxopticon external-ecmwf-aifs-ens-aws, 365d):
             # last file p50 H+5h56m, p95 H+7h11m. Fire at H+7h00m (01/07/13/19 UTC);
             # late leads download last, so they land before the run reaches them.
@@ -44,7 +44,7 @@ class EcmwfAifsEnsForecastDataset(
             parallelism=min(workers, 20),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             # Validation runs 30 minutes after each update run: 01:30, 07:30, 13:30, and 19:30.
             schedule="30 1,7,13,19 * * *",
             pod_active_deadline=timedelta(minutes=10),

--- a/src/reformatters/ecmwf/aifs_single/forecast/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast/dynamical_dataset.py
@@ -26,7 +26,7 @@ class EcmwfAifsSingleForecastDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             # AIFS-single f360 (last lead) ecmwf-forecasts S3 p99 ~init+6h10m (recent
             # files land 5h25m-6h03m), so fetch at init+6h13m.
             schedule="13 */6 * * *",
@@ -42,7 +42,7 @@ class EcmwfAifsSingleForecastDataset(
             parallelism=workers,
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="23 */6 * * *",  # 10m (pod_active_deadline) after reformat at :13
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/dynamical_dataset.py
@@ -61,7 +61,7 @@ class EcmwfAifsSingleForecastVirtualDataset(
         # bounds waiting on a cycle that never publishes, and keeps fires from
         # overlapping.
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="20 5,11,17,23 * * *",
             pod_active_deadline=timedelta(hours=1),
             image=image_tag,
@@ -71,7 +71,7 @@ class EcmwfAifsSingleForecastVirtualDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             # After each update (init+5h20m) + its 1h deadline.
             schedule="20 0,6,12,18 * * *",
             pod_active_deadline=timedelta(minutes=30),

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/dynamical_dataset.py
@@ -28,7 +28,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
 
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             # Gating lead group f360 typically lands ~08:00-08:09 UTC (recent days;
             # wxopticon external-ecmwf-ifs-ens-long-aws p99 08:26); pod spin-up adds
             # a head start before late-lead downloads, so fire at 08:05.
@@ -46,7 +46,7 @@ class EcmwfIfsEnsForecast15Day025DegreeDataset(
             parallelism=min(workers, 20),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="40 8 * * *",  # 35m (pod_active_deadline) after reformat at 08:05
             suspend=False,
             pod_active_deadline=timedelta(minutes=10),

--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/dynamical_dataset.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/dynamical_dataset.py
@@ -28,7 +28,7 @@ class EcmwfIfsEnsForecast46Day15DegreeDataset(
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         workers = self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 9 * * *",
             suspend=False,
             pod_active_deadline=timedelta(hours=3),
@@ -43,7 +43,7 @@ class EcmwfIfsEnsForecast46Day15DegreeDataset(
             parallelism=workers,
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="0 12 * * *",
             suspend=False,
             pod_active_deadline=timedelta(minutes=30),

--- a/src/reformatters/example_materialized/dynamical_dataset.py
+++ b/src/reformatters/example_materialized/dynamical_dataset.py
@@ -24,7 +24,7 @@ class ExampleTemporalDynamicalDataset(
         # suspend = True  # Defaults to False, remove after backfilling to run operational updates and validation
         # workers = self.num_variable_groups()  # set if max_vars_per_job is set on RegionJob
         # operational_update_cron_job = ReformatCronJob(
-        #     name=f"{self.cron_job_name_prefix}-update",
+        #     name=f"{self.dataset_id}-update",
         #     schedule="0 0 * * *",
         #     pod_active_deadline=timedelta(minutes=30),
         #     image=image_tag,
@@ -39,7 +39,7 @@ class ExampleTemporalDynamicalDataset(
         #     suspend=suspend,
         # )
         # validation_cron_job = ValidationCronJob(
-        #     name=f"{self.cron_job_name_prefix}-validate",
+        #     name=f"{self.dataset_id}-validate",
         #     schedule="30 0 * * *",
         #     pod_active_deadline=timedelta(minutes=10),
         #     image=image_tag,

--- a/src/reformatters/example_virtual/dynamical_dataset.py
+++ b/src/reformatters/example_virtual/dynamical_dataset.py
@@ -60,7 +60,7 @@ class ExampleSpatialDynamicalDataset(
         """
         # suspend = True  # Defaults to False, remove after backfilling to run operational updates and validation
         # operational_update_cron_job = ReformatCronJob(
-        #     name=f"{self.cron_job_name_prefix}-update",
+        #     name=f"{self.dataset_id}-update",
         #     schedule="0 6 * * *",
         #     # Sets how long a fire chases its own source files (the poll deadline is
         #     # the fire plus this, less a small grace); keep it under the gap
@@ -74,7 +74,7 @@ class ExampleSpatialDynamicalDataset(
         #     suspend=suspend,
         # )
         # validation_cron_job = ValidationCronJob(
-        #     name=f"{self.cron_job_name_prefix}-validate",
+        #     name=f"{self.dataset_id}-validate",
         #     # After the update's fire + its deadline.
         #     schedule="0 8 * * *",
         #     pod_active_deadline=timedelta(minutes=30),

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/dynamical_dataset.py
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/dynamical_dataset.py
@@ -45,8 +45,9 @@ class GoogleWeathernext2ForecastHistoricalVirtualDataset(
     )
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+        cron_job_name_prefix = self.dataset_id.replace("weathernext2", "wn2")
         update = ReformatCronJob(
-            name=f"{self.dataset_id}-update",
+            name=f"{cron_job_name_prefix}-update",
             schedule="0 0 * * *",
             pod_active_deadline=timedelta(hours=6),
             image=image_tag,
@@ -57,7 +58,7 @@ class GoogleWeathernext2ForecastHistoricalVirtualDataset(
             suspend=True,
         )
         validate = ValidationCronJob(
-            name=f"{self.dataset_id}-validate",
+            name=f"{cron_job_name_prefix}-validate",
             schedule="0 0 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/dynamical_dataset.py
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/dynamical_dataset.py
@@ -44,14 +44,9 @@ class GoogleWeathernext2ForecastHistoricalVirtualDataset(
         )
     )
 
-    @property
-    def cron_job_name_prefix(self) -> str:
-        # With the "google-" prefix these names exceed the CronJobName limit.
-        return self.dataset_id.removeprefix("google-")
-
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         update = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="0 0 * * *",
             pod_active_deadline=timedelta(hours=6),
             image=image_tag,
@@ -62,7 +57,7 @@ class GoogleWeathernext2ForecastHistoricalVirtualDataset(
             suspend=True,
         )
         validate = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="0 0 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/dynamical_dataset.py
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/dynamical_dataset.py
@@ -49,9 +49,10 @@ class GoogleWeathernext2ForecastOperationalVirtualDataset(
     )
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
+        cron_job_name_prefix = self.dataset_id.replace("weathernext2", "wn2")
         suspend = True
         update = ReformatCronJob(
-            name=f"{self.dataset_id}-update",
+            name=f"{cron_job_name_prefix}-update",
             schedule="55 0,6,12,18 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -62,7 +63,7 @@ class GoogleWeathernext2ForecastOperationalVirtualDataset(
             suspend=suspend,
         )
         validate = ValidationCronJob(
-            name=f"{self.dataset_id}-validate",
+            name=f"{cron_job_name_prefix}-validate",
             schedule="55 1,7,13,19 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/dynamical_dataset.py
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/dynamical_dataset.py
@@ -48,15 +48,10 @@ class GoogleWeathernext2ForecastOperationalVirtualDataset(
         )
     )
 
-    @property
-    def cron_job_name_prefix(self) -> str:
-        # With the "google-" prefix these names exceed the CronJobName limit.
-        return self.dataset_id.removeprefix("google-")
-
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         suspend = True
         update = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="55 0,6,12,18 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -67,7 +62,7 @@ class GoogleWeathernext2ForecastOperationalVirtualDataset(
             suspend=suspend,
         )
         validate = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="55 1,7,13,19 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,

--- a/src/reformatters/nasa/imerg/dynamical_dataset.py
+++ b/src/reformatters/nasa/imerg/dynamical_dataset.py
@@ -29,7 +29,7 @@ class NasaImergAnalysisMaterializedDataset(
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule=self.update_schedule,
             pod_active_deadline=timedelta(minutes=60),
             image=image_tag,
@@ -46,7 +46,7 @@ class NasaImergAnalysisMaterializedDataset(
             ],
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule=self.validate_schedule,
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,

--- a/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/analysis/dynamical_dataset.py
@@ -22,7 +22,7 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
         # Using num_variable_groups() would create way more parallelism than is useful
         workers = 2
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             # GEFS f006 (last lead time used) NOMADS last-modified ~init+3h48m. +3 min buffer.
             schedule="51 3,9,15,21 * * *",
             pod_active_deadline=timedelta(minutes=30),  # runs take <22 min
@@ -37,7 +37,7 @@ class GefsAnalysisDataset(DynamicalDataset[GEFSDataVar, GefsAnalysisSourceFileCo
             parallelism=workers,
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="21 4,10,16,22 * * *",  # 30m (pod_active_deadline) after reformat at :51
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/noaa/gefs/forecast_35_day/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/dynamical_dataset.py
@@ -22,7 +22,7 @@ class GefsForecast35DayDataset(
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             # A 00z init's lead times through GEFS_PRE_EXTENSION_MAX are all on the
             # source by ~init+6h40m, occasionally as late as ~init+6h48m; starting at
             # init+6h45m catches the slowest members instead of racing them. The prior
@@ -41,7 +41,7 @@ class GefsForecast35DayDataset(
             parallelism=workers,
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="5 7 * * *",  # 20m (pod_active_deadline) after reformat at 06:45
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/noaa/gfs/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/analysis/dynamical_dataset.py
@@ -26,7 +26,7 @@ class NoaaGfsAnalysisDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
         # GFS f006 (last lead time used) NOMADS last-modified ~init+3h36m. +3 min buffer.
         workers = self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="40 3,9,15,21 * * *",
             pod_active_deadline=timedelta(minutes=10),  # runs take <3 min
             image=image_tag,
@@ -41,7 +41,7 @@ class NoaaGfsAnalysisDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
         )
 
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="50 3,9,15,21 * * *",  # 10m (pod_active_deadline) after reformat at :40
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/forecast/dynamical_dataset.py
@@ -19,7 +19,7 @@ class NoaaGfsForecastDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             # GFS f384 (full forecast) NOMADS p99 ~init+5h35m (recent files land
             # 5h13m-5h24m, drifting later), so fetch at init+5h38m.
             schedule="38 5,11,17,23 * * *",
@@ -35,7 +35,7 @@ class NoaaGfsForecastDataset(DynamicalDataset[NoaaDataVar, NoaaGfsSourceFileCoor
             parallelism=workers,
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="48 5,11,17,23 * * *",  # 10m (pod_active_deadline) after reformat at :38
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis/dynamical_dataset.py
@@ -27,7 +27,7 @@ class NoaaHrrrAnalysisDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Define Kubernetes cron jobs for operational updates and validation."""
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             # Every 3 hours at 57 minutes past the hour.
             # HRRR f001 (last lead time used) NOMADS last-modified ~init+53m (max ~55m;
             # we try S3 first to spare NOMADS, but NOMADS publishes first, by ~10 min at
@@ -44,7 +44,7 @@ class NoaaHrrrAnalysisDataset(
         )
 
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             # 20m (pod_active_deadline) after reformat at :57 = :77 = :17 of the next hour.
             # "17 1-23/3 * * *" gives 01:17, 04:17, 07:17, ... matching reformat at 00:57, 03:57, 06:57, ...
             schedule="17 1-23/3 * * *",

--- a/src/reformatters/noaa/hrrr/analysis_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/analysis_virtual/dynamical_dataset.py
@@ -53,7 +53,7 @@ class NoaaHrrrAnalysisVirtualDataset(
         # cycle's f01 is already out (~init+53m), so a :50 fire commits the hour's
         # files within minutes; a late cycle rolls to the next fire.
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="50 * * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
@@ -63,7 +63,7 @@ class NoaaHrrrAnalysisVirtualDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             # The update's fire plus its pod_active_deadline, so the run being
             # validated has always stopped writing.
             schedule="20 * * * *",

--- a/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_18_hour_virtual/dynamical_dataset.py
@@ -49,7 +49,7 @@ class NoaaHrrrForecast18HourVirtualDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         # Race the current init: f00 arrives near :51 and f18 normally by init + 86m.
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="50 * * * *",
             pod_active_deadline=timedelta(minutes=59),
             image=image_tag,
@@ -59,7 +59,7 @@ class NoaaHrrrForecast18HourVirtualDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             # The update's fire plus its pod_active_deadline, so the run being
             # validated has always stopped writing.
             schedule="49 * * * *",

--- a/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour/dynamical_dataset.py
@@ -35,7 +35,7 @@ class NoaaHrrrForecast48HourDataset(
         # first to spare NOMADS, but NOMADS publishes first). +3 min buffer.
         workers = 2 * self.num_variable_groups()
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="53 1,7,13,19 * * *",
             pod_active_deadline=timedelta(minutes=10),  # usually takes <2 min
             image=image_tag,
@@ -50,7 +50,7 @@ class NoaaHrrrForecast48HourDataset(
         )
 
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="3 2,8,14,20 * * *",  # 10m (pod_active_deadline) after reformat at :53
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/hrrr/forecast_48_hour_virtual/dynamical_dataset.py
@@ -57,7 +57,7 @@ class NoaaHrrrForecast48HourVirtualDataset(
         # window is fully ingested; the deadline bounds waiting on a file that never
         # publishes and stays well under the 6h gap so fires never overlap.
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="50 0,6,12,18 * * *",
             pod_active_deadline=timedelta(hours=1, minutes=40),
             image=image_tag,
@@ -67,7 +67,7 @@ class NoaaHrrrForecast48HourVirtualDataset(
             secret_names=self.store_factory.k8s_secret_names(),
         )
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             # After each update (:50) + its 1h40m deadline.
             schedule="40 2,8,14,20 * * *",
             pod_active_deadline=timedelta(minutes=30),

--- a/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
+++ b/src/reformatters/noaa/mrms/conus_analysis_hourly/dynamical_dataset.py
@@ -24,7 +24,7 @@ class NoaaMrmsConusAnalysisHourlyDataset(
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         # Pass 2 has ~60-min latency. Update hourly, 3 min after Pass 2 is expected.
         operational_update_cron_job = ReformatCronJob(
-            name=f"{self.cron_job_name_prefix}-update",
+            name=f"{self.dataset_id}-update",
             schedule="3 * * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
@@ -37,7 +37,7 @@ class NoaaMrmsConusAnalysisHourlyDataset(
         )
 
         validation_cron_job = ValidationCronJob(
-            name=f"{self.cron_job_name_prefix}-validate",
+            name=f"{self.dataset_id}-validate",
             schedule="13 * * * *",
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,

--- a/tests/common/staging_test.py
+++ b/tests/common/staging_test.py
@@ -60,23 +60,17 @@ class TestStagingCronjobName:
 class TestRenameCronjobForStaging:
     def test_renames_update_cronjob(self) -> None:
         cronjob = _make_cronjob("noaa-gfs-forecast-update")
-        result = rename_cronjob_for_staging(
-            cronjob, "noaa-gfs-forecast", "0.3.0", name_prefix="noaa-gfs-forecast"
-        )
+        result = rename_cronjob_for_staging(cronjob, "noaa-gfs-forecast", "0.3.0")
         assert result.name == "stage-noaa-gfs-forecast-v0-3-0-update"
 
     def test_renames_validate_cronjob(self) -> None:
         cronjob = _make_cronjob("noaa-gfs-forecast-validate")
-        result = rename_cronjob_for_staging(
-            cronjob, "noaa-gfs-forecast", "0.3.0", name_prefix="noaa-gfs-forecast"
-        )
+        result = rename_cronjob_for_staging(cronjob, "noaa-gfs-forecast", "0.3.0")
         assert result.name == "stage-noaa-gfs-forecast-v0-3-0-validate"
 
     def test_preserves_other_fields(self) -> None:
         cronjob = _make_cronjob("test-dataset-update")
-        result = rename_cronjob_for_staging(
-            cronjob, "test-dataset", "1.0.0", name_prefix="test-dataset"
-        )
+        result = rename_cronjob_for_staging(cronjob, "test-dataset", "1.0.0")
         assert result.schedule == cronjob.schedule
         assert result.image == cronjob.image
         assert result.dataset_id == cronjob.dataset_id
@@ -85,28 +79,13 @@ class TestRenameCronjobForStaging:
     def test_asserts_on_unexpected_name_prefix(self) -> None:
         cronjob = _make_cronjob("wrong-prefix-update")
         with pytest.raises(AssertionError):
-            rename_cronjob_for_staging(
-                cronjob, "noaa-gfs-forecast", "0.3.0", name_prefix="noaa-gfs-forecast"
-            )
-
-    def test_uses_name_prefix_when_it_differs_from_dataset_id(self) -> None:
-        cronjob = _make_cronjob("weathernext2-forecast-historical-virtual-update")
-        result = rename_cronjob_for_staging(
-            cronjob,
-            "google-weathernext2-forecast-historical-virtual",
-            "0.3.0",
-            name_prefix="weathernext2-forecast-historical-virtual",
-        )
-        assert result.name.startswith("stage-")
-        assert result.name.endswith("-update")
+            rename_cronjob_for_staging(cronjob, "noaa-gfs-forecast", "0.3.0")
 
     def test_longest_real_dataset_id_fits(self) -> None:
         # ecmwf-ifs-ens-forecast-15-day-0-25-degree is currently the longest
         dataset_id = "ecmwf-ifs-ens-forecast-15-day-0-25-degree"
         cronjob = _make_cronjob(f"{dataset_id}-update")
-        result = rename_cronjob_for_staging(
-            cronjob, dataset_id, "0.3.0", name_prefix=dataset_id
-        )
+        result = rename_cronjob_for_staging(cronjob, dataset_id, "0.3.0")
         assert len(result.name) <= _MAX_KUBERNETES_NAME_LENGTH
 
 

--- a/tests/datasets_test.py
+++ b/tests/datasets_test.py
@@ -212,11 +212,16 @@ def test_cronjob_commands_match_cli_commands(
 def test_cronjob_names_are_consistent(
     dataset: DynamicalDataset[Any, Any],
 ) -> None:
-    """CronJob names should contain the dataset ID for traceability."""
+    """CronJobs should be traceable to their dataset and fit kubernetes name limits."""
     cron_jobs = list(dataset.operational_kubernetes_resources("test-image"))
     for cron_job in cron_jobs:
-        assert dataset.dataset_id in cron_job.name, (
-            f"CronJob name '{cron_job.name}' doesn't contain dataset_id '{dataset.dataset_id}'"
+        assert cron_job.dataset_id == dataset.dataset_id, (
+            f"CronJob '{cron_job.name}' carries dataset_id '{cron_job.dataset_id}', "
+            f"expected '{dataset.dataset_id}'"
+        )
+        # Kubernetes appends up to 11 characters when naming a cron job's jobs.
+        assert len(cron_job.name) <= 63 - 11, (
+            f"CronJob name '{cron_job.name}' is too long for kubernetes"
         )
 
 

--- a/tests/datasets_test.py
+++ b/tests/datasets_test.py
@@ -212,19 +212,11 @@ def test_cronjob_commands_match_cli_commands(
 def test_cronjob_names_are_consistent(
     dataset: DynamicalDataset[Any, Any],
 ) -> None:
-    """CronJob names should be traceable to the dataset ID."""
+    """CronJob names should contain the dataset ID for traceability."""
     cron_jobs = list(dataset.operational_kubernetes_resources("test-image"))
-    assert dataset.dataset_id.endswith(dataset.cron_job_name_prefix), (
-        f"cron_job_name_prefix '{dataset.cron_job_name_prefix}' is not a tail of "
-        f"dataset_id '{dataset.dataset_id}'"
-    )
     for cron_job in cron_jobs:
-        assert cron_job.name.startswith(dataset.cron_job_name_prefix), (
-            f"CronJob name '{cron_job.name}' doesn't start with "
-            f"cron_job_name_prefix '{dataset.cron_job_name_prefix}'"
-        )
-        assert cron_job.dataset_id == dataset.dataset_id, (
-            f"CronJob '{cron_job.name}' carries dataset_id '{cron_job.dataset_id}'"
+        assert dataset.dataset_id in cron_job.name, (
+            f"CronJob name '{cron_job.name}' doesn't contain dataset_id '{dataset.dataset_id}'"
         )
 
 

--- a/tests/google/weathernext2/forecast_virtual/dynamical_dataset_test.py
+++ b/tests/google/weathernext2/forecast_virtual/dynamical_dataset_test.py
@@ -37,9 +37,9 @@ def test_historical_product_is_fixed_and_has_virtual_health_checks(
     )
 
     update, validate = dataset.operational_kubernetes_resources("test")
-    assert update.name == f"{dataset.cron_job_name_prefix}-update"
+    assert update.name == f"{dataset.dataset_id}-update"
     assert update.suspend is True
-    assert validate.name == f"{dataset.cron_job_name_prefix}-validate"
+    assert validate.name == f"{dataset.dataset_id}-validate"
     assert validate.suspend is True
     assert not any(
         isinstance(item, validation.CheckCurrentData) for item in dataset.validators()
@@ -65,7 +65,7 @@ def test_operational_product_has_lag_aware_crons_and_splits(tmp_path: Path) -> N
     )
 
     update, validate = dataset.operational_kubernetes_resources("test")
-    assert update.name == f"{dataset.cron_job_name_prefix}-update"
+    assert update.name == f"{dataset.dataset_id}-update"
     assert update.workers_total == 1
     assert update.parallelism == 1
     assert update.pod_active_deadline < timedelta(hours=6)

--- a/tests/google/weathernext2/forecast_virtual/dynamical_dataset_test.py
+++ b/tests/google/weathernext2/forecast_virtual/dynamical_dataset_test.py
@@ -37,9 +37,9 @@ def test_historical_product_is_fixed_and_has_virtual_health_checks(
     )
 
     update, validate = dataset.operational_kubernetes_resources("test")
-    assert update.name == f"{dataset.dataset_id}-update"
+    assert update.name == "google-wn2-forecast-historical-virtual-update"
     assert update.suspend is True
-    assert validate.name == f"{dataset.dataset_id}-validate"
+    assert validate.name == "google-wn2-forecast-historical-virtual-validate"
     assert validate.suspend is True
     assert not any(
         isinstance(item, validation.CheckCurrentData) for item in dataset.validators()
@@ -65,7 +65,7 @@ def test_operational_product_has_lag_aware_crons_and_splits(tmp_path: Path) -> N
     )
 
     update, validate = dataset.operational_kubernetes_resources("test")
-    assert update.name == f"{dataset.dataset_id}-update"
+    assert update.name == "google-wn2-forecast-operational-virtual-update"
     assert update.workers_total == 1
     assert update.parallelism == 1
     assert update.pod_active_deadline < timedelta(hours=6)


### PR DESCRIPTION
Per https://github.com/dynamical-org/reformatters/pull/957#pullrequestreview-5034836655.

1. Revert #957 in full (`9db474e`) — the `CronJobName` alias, the `DynamicalDataset.cron_job_name_prefix` hook, the `name_prefix` argument threaded through staging, and the call-site changes across every dataset.
2. Shorten the two WeatherNext 2 cron job names where they're built (`1af3fa6`):

```python
cron_job_name_prefix = self.dataset_id.replace("weathernext2", "wn2")
```

Names are now `google-wn2-forecast-{historical,operational}-virtual-{update,validate}` (48 chars at the longest, under the 52 limit). `dataset_id`, store paths, and product ids are untouched, and the cron jobs still carry the full `dataset_id`.

Also in this PR:

- `tests/datasets_test.py::test_cronjob_names_are_consistent` now asserts the cron job carries the dataset's `dataset_id` and that its name fits `63 - 11`. The revert restores the pydantic hole where `ReformatCronJob`/`ValidationCronJob` redeclare `name` and drop `CronJob`'s `max_length`, so this assert is what keeps a too-long name failing in CI rather than at `kubectl apply`.
- Regenerated `manual-create-job-from-cronjob.yml` for the new names.

Two things worth a look:

- `rename_cronjob_for_staging` again asserts the cron job name starts with `dataset_id`, so `deploy-operational-updates --staging` for either WeatherNext 2 dataset would now hit that assert. Both are internal-demo and suspended, so nothing is staged today.
- The existing WeatherNext 2 cron jobs in the cluster are named `google-weathernext2-...`. They were never applied successfully (that was the #957 bug), so there should be nothing orphaned, but worth confirming before the next deploy.

Full fast suite passes (2214), plus `ruff check`, `ruff format`, `ty check`.