### PR TITLE
Enforce the cron job name limit where datasets actually build names

### DIFF
--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -227,8 +227,13 @@ class Job(pydantic.BaseModel):
         }
 
 
+# Kubernetes appends up to 11 characters when it names a cron job's jobs, so the
+# cron job's own name must stay within 63 - 11.
+CronJobName = Annotated[str, pydantic.Field(min_length=1, max_length=52)]
+
+
 class CronJob(Job):
-    name: Annotated[str, pydantic.Field(min_length=1, max_length=52)]
+    name: CronJobName
     schedule: Annotated[str, pydantic.Field(min_length=1)]
     ttl: timedelta = timedelta(hours=12)
     suspend: bool = False
@@ -269,7 +274,7 @@ class CronJob(Job):
 
 
 class ReformatCronJob(CronJob):
-    name: Annotated[str, pydantic.Field(pattern=r".+-update$")]
+    name: Annotated[CronJobName, pydantic.Field(pattern=r".+-update$")]
     command: Sequence[str] = ["update"]
     # Operational updates expect a single worker
     workers_total: int = 1
@@ -277,7 +282,7 @@ class ReformatCronJob(CronJob):
 
 
 class ValidationCronJob(CronJob):
-    name: Annotated[str, pydantic.Field(pattern=r".+-validate$")]
+    name: Annotated[CronJobName, pydantic.Field(pattern=r".+-validate$")]
     command: Sequence[str] = ["validate"]
     workers_total: int = 1
     parallelism: int = 1

--- a/src/reformatters/common/staging.py
+++ b/src/reformatters/common/staging.py
@@ -32,9 +32,12 @@ def staging_cronjob_name(dataset_id: str, version: str, suffix: str) -> str:
 def rename_cronjob_for_staging(
     cronjob: CronJob, dataset_id: str, version: str
 ) -> CronJob:
-    """Create a copy of a CronJob with a staging-prefixed name."""
-    assert cronjob.name.startswith(f"{dataset_id}-")
-    suffix = cronjob.name.removeprefix(f"{dataset_id}-")
+    """Create a copy of a CronJob with a staging-prefixed name.
+
+    The suffix comes from the cron job's command, so a dataset whose cron job names
+    are abbreviated to fit `CronJobName` stages under the same suffix as any other.
+    """
+    suffix = "-".join(cronjob.command)
     new_name = staging_cronjob_name(dataset_id, version, suffix)
     return replace(cronjob, name=new_name)
 

--- a/tests/common/staging_test.py
+++ b/tests/common/staging_test.py
@@ -1,7 +1,10 @@
 from datetime import timedelta
+from typing import Any
 
 import pytest
 
+from reformatters.__main__ import DYNAMICAL_DATASETS
+from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.kubernetes import CronJob, ReformatCronJob, ValidationCronJob
 from reformatters.common.staging import (
     _MAX_KUBERNETES_NAME_LENGTH,
@@ -76,10 +79,10 @@ class TestRenameCronjobForStaging:
         assert result.dataset_id == cronjob.dataset_id
         assert result.cpu == cronjob.cpu
 
-    def test_asserts_on_unexpected_name_prefix(self) -> None:
-        cronjob = _make_cronjob("wrong-prefix-update")
-        with pytest.raises(AssertionError):
-            rename_cronjob_for_staging(cronjob, "noaa-gfs-forecast", "0.3.0")
+    def test_uses_the_command_not_the_name_as_the_suffix(self) -> None:
+        cronjob = _make_cronjob("abbreviated-name-update")
+        result = rename_cronjob_for_staging(cronjob, "unabbreviated-id", "0.3.0")
+        assert result.name == "stage-unabbreviated-id-v0-3-0-update"
 
     def test_longest_real_dataset_id_fits(self) -> None:
         # ecmwf-ifs-ens-forecast-15-day-0-25-degree is currently the longest
@@ -87,6 +90,30 @@ class TestRenameCronjobForStaging:
         cronjob = _make_cronjob(f"{dataset_id}-update")
         result = rename_cronjob_for_staging(cronjob, dataset_id, "0.3.0")
         assert len(result.name) <= _MAX_KUBERNETES_NAME_LENGTH
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    DYNAMICAL_DATASETS,
+    ids=[d.dataset_id for d in DYNAMICAL_DATASETS],
+)
+def test_every_dataset_stages_within_the_kubernetes_limit(
+    dataset: DynamicalDataset[Any, Any],
+) -> None:
+    version = dataset.template_config.version
+    staged = [
+        rename_cronjob_for_staging(cronjob, dataset.dataset_id, version)
+        for cronjob in dataset.operational_kubernetes_resources("test:latest")
+    ]
+    for cronjob in staged:
+        assert len(cronjob.name) <= _MAX_KUBERNETES_NAME_LENGTH
+        assert cronjob.dataset_id == dataset.dataset_id
+
+    # cleanup-staging deletes the names it rebuilds from the dataset id, so they must
+    # be the names a staging deploy applies.
+    assert set(staging_cronjob_names(dataset.dataset_id, version)) <= {
+        cronjob.name for cronjob in staged
+    }
 
 
 class TestStagingCronjobNames:

--- a/tests/common/test_kubernetes.py
+++ b/tests/common/test_kubernetes.py
@@ -175,11 +175,11 @@ def test_as_kubernetes_object_comprehensive() -> None:
     assert k8s_obj["spec"] == expected_spec
 
 
-def _cron_job_with_name(name: str) -> CronJob:
-    return CronJob(
+def _cron_job_with_name(name: str, cron_job_class: type[CronJob] = CronJob) -> CronJob:
+    return cron_job_class(
         name=name,
         schedule="0 * * * *",
-        command=["archive-grib-files"],
+        command=[name.rsplit("-", maxsplit=1)[-1]],
         image="img:v1",
         dataset_id="archive",
         cpu="1",
@@ -189,10 +189,25 @@ def _cron_job_with_name(name: str) -> CronJob:
     )
 
 
-def test_cron_job_name_respects_kubernetes_length_limit() -> None:
-    _cron_job_with_name("a" * 52)
+@pytest.mark.parametrize(
+    ("cron_job_class", "suffix"),
+    [
+        (CronJob, "-update"),
+        (ReformatCronJob, "-update"),
+        (ValidationCronJob, "-validate"),
+    ],
+)
+def test_cron_job_name_respects_kubernetes_length_limit(
+    cron_job_class: type[CronJob], suffix: str
+) -> None:
+    """Every operational cron job class must enforce the limit, not just the base class.
+
+    A subclass that redeclares `name` without nesting `CronJobName` silently drops
+    the constraint.
+    """
+    _cron_job_with_name("a" * (52 - len(suffix)) + suffix, cron_job_class)
     with pytest.raises(ValidationError, match="at most 52 characters"):
-        _cron_job_with_name("a" * 53)
+        _cron_job_with_name("a" * (53 - len(suffix)) + suffix, cron_job_class)
 
 
 def test_do_not_disrupt_annotation_on_every_job() -> None:


### PR DESCRIPTION
Follow-up to #959. That PR reverted the plumbing; this closes the hole that let a too-long cron job name reach `kubectl apply`.

Three tests covered that name and none could fail:

- `test_cron_job_name_respects_kubernetes_length_limit` built a bare `CronJob`, which no dataset instantiates.
- Every per-dataset test asserts `name == f"{dataset.dataset_id}-update"` against source that says `name=f"{self.dataset_id}-update"` — it restates the implementation.
- `test_cronjob_names_are_consistent` asserted `dataset_id in name`, true by construction.

The first is the interesting failure: it passed on the base class while the subclasses had silently dropped the constraint, so it read as coverage.

### 1. Enforce the limit on the classes datasets use (`550102f`)

Pydantic replaces a parent field's metadata when a subclass redeclares it, so before this change:

```
CronJob            [MinLen(min_length=1), MaxLen(max_length=52)]
ReformatCronJob    [_PydanticGeneralMetadata(pattern='.+-update$')]
ValidationCronJob  [_PydanticGeneralMetadata(pattern='.+-validate$')]
```

Restores #957's `CronJobName` alias — its mechanism was right, the `cron_job_name_prefix` hook was the part reverted — and parametrizes the length test over `[CronJob, ReformatCronJob, ValidationCronJob]`. Dropping the nesting again fails 2 of the 3 cases; the base still passes, which is the blind spot.

### 2. Cover staging renaming for every dataset (`de1db0f`)

`rename_cronjob_for_staging` recovered the suffix by stripping the dataset id off the name, assuming every cron job name starts with its dataset id — which the abbreviated WeatherNext 2 names break (the assert I flagged on #959). It now takes the suffix from `cronjob.command`, which is `update` / `validate` / `archive-grib-files` and matches the current name suffix for all 50 cron jobs across all 25 registered datasets. That also removes the need for #957's `name_prefix` parameter, so there's one way to do this rather than two.

The staging tests only ever ran against hand-built cron jobs. Now parametrized over `DYNAMICAL_DATASETS`, asserting staged names fit `_MAX_KUBERNETES_NAME_LENGTH` and include the names `cleanup-staging` rebuilds and deletes. Reinstating the old prefix-strip fails exactly the two WeatherNext 2 cases.

`test_asserts_on_unexpected_name_prefix` is replaced by a test of the new behavior — that assertion is intentionally gone.

### Surfaced, not fixed here

- **`cleanup-staging` doesn't delete a staged `archive-grib-files` cron.** `staging_cronjob_names` hardcodes `update` and `validate`, so staging `dwd-icon-eu-forecast-5-day` or `eccc-hrdps-forecast` leaves its archive cron behind. The new test asserts subset, not equality, to avoid failing on this.
- **`u-arizona-swann-analysis` and `noaa-ndvi-cdr-analysis` have no `operational_kubernetes_resources` test** — covered only by the parametrized tests in `datasets_test.py`.
- **`tests/ecmwf/ifs_ens/forecast_46_day_dynamical_dataset_test.py` doesn't mirror `src/`** — should be `forecast_46_day_1_5_degree/dynamical_dataset_test.py`.
- The ~30 tautological per-dataset name assertions are left alone; worth converting to literals as those files are touched.

`ruff check`, `ruff format`, `ty check`, and the fast suite pass. Two unrelated local failures in `tests/scripts/validation/` are a matplotlib GUI-backend abort that reproduces on `main` and passes with `MPLBACKEND=Agg`.