### PR TITLE
Describe the ECMWF 46-day snow mask by snowpack, not land

### DIFF
--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/template_config.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/template_config.py
@@ -695,7 +695,7 @@ class EcmwfIfsEnsForecast46Day15DegreeTemplateConfig(
                     long_name="Snow density",
                     units="kg m-3",
                     step_type="avg",
-                    comment="Mean snow density over the previous 24 hours. Land points only; sea points are missing.",
+                    comment="Mean snow density over the previous 24 hours. Missing where the surface carries no snowpack, including snow-free land.",
                 ),
                 internal_attrs=EcmwfIfsEns46DayInternalAttrs(
                     ecds_variable="snow_density",
@@ -714,7 +714,7 @@ class EcmwfIfsEnsForecast46Day15DegreeTemplateConfig(
                     long_name="Snow albedo",
                     units="percent",
                     step_type="avg",
-                    comment="Mean snow albedo over the previous 24 hours. Land points only; sea points are missing.",
+                    comment="Mean snow albedo over the previous 24 hours. Missing where the surface carries no snowpack, including snow-free land.",
                 ),
                 internal_attrs=EcmwfIfsEns46DayInternalAttrs(
                     ecds_variable="snow_albedo",

--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/templates/latest.zarr/snow_albedo_surface/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/templates/latest.zarr/snow_albedo_surface/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "Snow albedo",
     "short_name": "asn",
     "units": "percent",
-    "comment": "Mean snow albedo over the previous 24 hours. Land points only; sea points are missing.",
+    "comment": "Mean snow albedo over the previous 24 hours. Missing where the surface carries no snowpack, including snow-free land.",
     "step_type": "avg",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/templates/latest.zarr/snow_density_surface/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/templates/latest.zarr/snow_density_surface/zarr.json
@@ -74,7 +74,7 @@
     "long_name": "Snow density",
     "short_name": "rsn",
     "units": "kg m-3",
-    "comment": "Mean snow density over the previous 24 hours. Land points only; sea points are missing.",
+    "comment": "Mean snow density over the previous 24 hours. Missing where the surface carries no snowpack, including snow-free land.",
     "step_type": "avg",
     "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/templates/latest.zarr/zarr.json
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_1_5_degree/templates/latest.zarr/zarr.json
@@ -3396,7 +3396,7 @@
           "long_name": "Snow albedo",
           "short_name": "asn",
           "units": "percent",
-          "comment": "Mean snow albedo over the previous 24 hours. Land points only; sea points are missing.",
+          "comment": "Mean snow albedo over the previous 24 hours. Missing where the surface carries no snowpack, including snow-free land.",
           "step_type": "avg",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3488,7 +3488,7 @@
           "long_name": "Snow density",
           "short_name": "rsn",
           "units": "kg m-3",
-          "comment": "Mean snow density over the previous 24 hours. Land points only; sea points are missing.",
+          "comment": "Mean snow density over the previous 24 hours. Missing where the surface carries no snowpack, including snow-free land.",
           "step_type": "avg",
           "coordinates": "expected_forecast_length ingested_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="


### PR DESCRIPTION
Found while validating the `ecmwf-ifs-ens-forecast-46-day-1-5-degree` backfill.

`snow_albedo_surface` and `snow_density_surface` both carried the comment *"Land points only; sea points are missing."* That is wrong: their missing values mark cells the forecast carries no snowpack for, not sea points. A reader following the old wording reads a summer NaN over Wyoming as an outage.

## What the data shows

Measured on the published store (`s3://dynamical-ecmwf-ifs-ens/ecmwf-ifs-ens-forecast-46-day-1-5-degree/v0.1.0.icechunk`), with the land/sea mask derived from `sea_surface_temperature`:

- **The mask is dynamic, so it cannot be geographic.** At init 2026-06-15 it differs from the (lead 240 h, member 9) mask by 305 cells at member 50, 595 cells at lead 24 h, and 2302 cells at lead 1104 h.
- **It tracks the seasonal snowpack.** On NH mid-latitude land (30–66°N) presence falls from 65.6% at init 2026-03-15 to 4.1% at init 2026-06-15, agreeing with `snow_water_equivalent_surface > 0` on 96.0% and 97.8% of those cells respectively. At 45°N, 105°W both variables report values through mid-May and then drop out entirely as the snow melts.
- **Every present cell has snow or ice cover** (100% at both sampled inits), and values do appear over sea ice, which is not land.
- **The fill-value handling itself is correct.** Stored NaN matches `raw == 9999` in the source GRIB exactly (agreement 1.000), so only the wording changes here.

The two variables share one identical NaN mask, so both get the same wording.

The new text deliberately does not describe how sea-ice cells are treated: presence over sea ice varies between the sampled inits in a way this validation did not pin down, and the snowpack statement is what the measurements support.

## Not changed

The sibling land/sea comments are accurate and left alone — `soil_temperature_*`, `soil_moisture_*` and `runoff_*` are present on 100% of land and 0% of sea cells, and `sea_surface_temperature` and `sea_ice_area_fraction` are the exact converse.

## Note for deploy

`templates/latest.zarr` is regenerated, so the existing store still carries the old comment in its metadata until the next operational update writes the template.

## Checks

`ruff format`, `ruff check --fix`, `ty check` all clean; `tests/common/common_template_config_subclasses_test.py` + `tests/common/datasets_cf_compliance_test.py` (391 passed) and `tests/ecmwf -m "not slow"` (259 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8B7B2fNJGiU4gS5CuHtmj


---
_Generated by [Claude Code](https://claude.ai/code/session_01C8B7B2fNJGiU4gS5CuHtmj)_