### PR TITLE
Fix HRRR model level ordering documentation

### DIFF
--- a/src/reformatters/noaa/hrrr/virtual_template_config.py
+++ b/src/reformatters/noaa/hrrr/virtual_template_config.py
@@ -44,7 +44,7 @@ _GRID_NX = 1799
 # 39 isobaric levels (hPa), descending like the GRIB order. The wrfprs 1013.2 mb
 # pseudo-level is excluded - it is not part of the dense 25 hPa column.
 PRESSURE_LEVELS = list(range(1000, 25, -25))  # 1000, 975, ..., 50
-# 50 native hybrid (sigma) model levels, 1 (top) .. 50 (near surface).
+# 50 native hybrid (sigma) model levels, 1 (near surface) .. 50 (top).
 MODEL_LEVELS = list(range(1, 51))
 
 # Air temperature and dew point are served in Celsius to match the materialized


### PR DESCRIPTION
## Summary
Corrected the documentation comment for the `MODEL_LEVELS` constant in the HRRR virtual template configuration to accurately reflect the actual level ordering.

## Changes
- Updated the comment for `MODEL_LEVELS` from "1 (top) .. 50 (near surface)" to "1 (near surface) .. 50 (top)" to correctly describe the vertical ordering of the 50 native hybrid (sigma) model levels

## Details
The comment was inverted relative to the actual model level convention. Model level 1 represents the near-surface level while level 50 represents the top of the atmosphere, which is now correctly documented.

https://claude.ai/code/session_01YDveBoBfpnPjr8xe3DLCFT