### PR TITLE
Temporarily skip the AIFS Single virtual integration test

### DIFF
--- a/tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py
+++ b/tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py
@@ -65,6 +65,9 @@ def dataset(tmp_path: Path) -> EcmwfAifsSingleForecastVirtualDataset:
 
 
 @pytest.mark.slow
+@pytest.mark.skip(
+    reason="Temporary (2026-08-26): s3://ecmwf-forecasts answers reads with 503 SlowDown too often"
+)
 def test_backfill_local_and_operational_update(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py
+++ b/tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py
@@ -66,7 +66,7 @@ def dataset(tmp_path: Path) -> EcmwfAifsSingleForecastVirtualDataset:
 
 @pytest.mark.slow
 @pytest.mark.skip(
-    reason="Temporary (2026-08-26): s3://ecmwf-forecasts answers reads with 503 SlowDown too often"
+    reason="Temporary (2026-08-26): s3://ecmwf-forecasts answers reads with 503 SlowDown too often. Must be re-enabled before ecmwf-aifs-single-forecast-virtual ships to production."
 )
 def test_backfill_local_and_operational_update(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
`s3://ecmwf-forecasts` answers reads with 503 SlowDown often enough that `test_backfill_local_and_operational_update` in `tests/ecmwf/aifs_single/forecast_virtual/dynamical_dataset_test.py` flakes CI. Marked it `pytest.mark.skip` with a dated temporary reason, matching the existing precedent in `tests/contrib/uarizona/swann/dataset_integration_test.py`.

This is the only AIFS Single virtual test that touches the source bucket — the rest of the module and `region_job_test.py` run offline (recorded `.index`, mocked listing), and all 35 still pass.

**The test must be re-enabled before `ecmwf-aifs-single-forecast-virtual` is shipped to production** — reverting this PR is the whole change. The skip reason itself says so, and it is tracked as a checklist item on the release checklist in dynamical-org/reformatters#831.