### PR TITLE
Probe an all-era variable for HRRR analysis file presence

### DIFF
--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -168,9 +168,10 @@ class VirtualRegionJob(
         be a variable the file's refs actually cover. Default: the first instant var
         (most likely to have data at every step) among the vars the file carries —
         `coord.data_vars` if it declares which subset it packs, else all of
-        self.data_vars — falling back to the first such var. Override only for a
-        packing neither rule captures (e.g. one variable per file keyed off the
-        coord rather than its data_vars).
+        self.data_vars — falling back to the first such var. Override for a packing
+        neither rule captures (e.g. one variable per file keyed off the coord rather
+        than its data_vars), or to name variables the source has published in every
+        era when the default pick would land on one it added partway through.
         """
         file_vars = getattr(coord, "data_vars", None) or self.data_vars
         return next(

--- a/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
+++ b/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
@@ -7,6 +7,7 @@ import xarray as xr
 
 from reformatters.common.iterating import group_by, item
 from reformatters.common.region_job import CoordinateValue
+from reformatters.common.time_utils import whole_hours
 from reformatters.common.types import Dim, Timedelta, Timestamp
 from reformatters.noaa.hrrr.hrrr_config_models import NoaaHrrrDataVar
 from reformatters.noaa.hrrr.virtual_region_job import (
@@ -67,6 +68,31 @@ class NoaaHrrrAnalysisVirtualRegionJob(
                     )
                 )
         return coords
+
+    def representative_var(
+        self, coord: NoaaHrrrAnalysisVirtualSourceFileCoord
+    ) -> NoaaHrrrDataVar:
+        """Probe a variable HRRR has consistently available across all time periods;
+        the base class's first-instant pick can land on a slot the source only began
+        publishing partway through the archive."""
+        match (coord.file_type, whole_hours(coord.lead_time)):
+            case ("sfc", 0):
+                paths = ("composite_reflectivity", "temperature_2m")
+            case ("sfc", 1):
+                paths = ("categorical_rain_surface", "total_precipitation_surface")
+            case ("prs", 0):
+                paths = ("pressure_level/temperature", "pressure_level/wind_u")
+            case ("nat", 0):
+                paths = ("model_level/temperature", "model_level/wind_u")
+            case unexpected:
+                raise AssertionError(f"No representative variable for {unexpected}")
+        by_path = {var.path: var for var in coord.data_vars}
+        # A variable-filtered job may carry none of them; the write loop's
+        # probe-coverage assert catches a pick the file doesn't hold.
+        return next(
+            (by_path[path] for path in paths if path in by_path),
+            coord.data_vars[0],
+        )
 
     def discover_available(
         self, pending: list[NoaaHrrrAnalysisVirtualSourceFileCoord]

--- a/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
+++ b/src/reformatters/noaa/hrrr/analysis_virtual/region_job.py
@@ -72,9 +72,7 @@ class NoaaHrrrAnalysisVirtualRegionJob(
     def representative_var(
         self, coord: NoaaHrrrAnalysisVirtualSourceFileCoord
     ) -> NoaaHrrrDataVar:
-        """Probe a variable HRRR has consistently available across all time periods;
-        the base class's first-instant pick can land on a slot the source only began
-        publishing partway through the archive."""
+        """Specific representative vars known to be present continuously throughout the archive."""
         match (coord.file_type, whole_hours(coord.lead_time)):
             case ("sfc", 0):
                 paths = ("composite_reflectivity", "temperature_2m")

--- a/tests/noaa/hrrr/analysis_virtual/region_job_test.py
+++ b/tests/noaa/hrrr/analysis_virtual/region_job_test.py
@@ -212,6 +212,28 @@ def test_full_catalog_sources_four_files_per_time(template_ds: xr.DataTree) -> N
         assert all(v.has_hour_0_values() == from_f00 for v in coord.data_vars)
 
 
+def test_representative_var_is_available_in_every_era(
+    template_ds: xr.DataTree,
+) -> None:
+    """The probe variable is never one the source began publishing partway through."""
+    data_vars = TEMPLATE_CONFIG.data_vars
+    job = make_job(template_ds, data_vars=data_vars)
+    region_ds = template_ds.to_dataset().isel(time=slice(0, 1))
+
+    coords = job.generate_source_file_coords(region_ds, data_vars)
+
+    assert {
+        (c.file_type, c.lead_time): job.representative_var(c).path for c in coords
+    } == {
+        ("sfc", pd.Timedelta("0h")): "composite_reflectivity",
+        ("sfc", pd.Timedelta("1h")): "categorical_rain_surface",
+        ("prs", pd.Timedelta("0h")): "pressure_level/temperature",
+        ("nat", pd.Timedelta("0h")): "model_level/temperature",
+    }
+    for coord in coords:
+        assert job.representative_var(coord).internal_attrs.analysis_usable_from is None
+
+
 def test_a_variable_is_not_sourced_before_its_analysis_usable_from(
     template_ds: xr.DataTree,
 ) -> None:


### PR DESCRIPTION
## What

Override `representative_var` on `NoaaHrrrAnalysisVirtualRegionJob` to name, per source file, a variable HRRR has published in every era.

## Why

`VirtualRegionJob.representative_var` defaults to the first `step_type="instant"` variable a source file carries. For the analysis dataset's `(sfc, has_hour_0_values()==False)` group of 39 variables that is `lightning_threat_1m`, whose GRIB slot `LTNGSD:1 m above ground` HRRR only began publishing at the 2022-06-28T12Z cycle. Verified against the source indexes: `hrrr.20190615/conus/hrrr.t12z.wrfsfcf01.grib2.idx` has no such line; the 2023 equivalent does.

Two consequences:

1. **Write path.** `filter_already_present` judges every pre-2022 `wrfsfcf01` file absent no matter how many times it is ingested, so a historical re-backfill would re-fetch them indefinitely. `_assert_probe_chunk_covered` fires on those files today (34 refs from 37 declared variables, none for the representative) — the guard landed after the backfill, which is why this was never caught.
2. **Validation.** `manifest_scan` never probes those positions, and unprobed counts as incomplete, so the validation report claims all 39 of that group's variables are `36485/104346` complete starting 2022-06-28T13:00. The data is present: direct store reads of `total_precipitation_surface`, `categorical_rain_surface` and `maximum_wind_speed_10m` return 0% NaN at 2015-06-01, 2019-06-15 and 2021-07-15.

Only the analysis dataset is affected. The forecast virtual datasets keep all 142 `sfc` variables in one group, so their representative resolves to `composite_reflectivity`.

## Chosen variables

| file | lead | probe |
| --- | --- | --- |
| `wrfsfc` | 0h | `composite_reflectivity`, then `temperature_2m` |
| `wrfsfc` | 1h | `categorical_rain_surface`, then `total_precipitation_surface` |
| `wrfprs` | 0h | `pressure_level/temperature`, then `pressure_level/wind_u` |
| `wrfnat` | 0h | `model_level/temperature`, then `model_level/wind_u` |

Every slot above was confirmed present in the source `.idx` for 2014-10-01, 2015-06-01, 2016-06-01, 2017-06-01, 2018-07-13, 2019-06-15, 2021-07-15, 2023-06-01 and 2026-08-01. A variable-filtered job may carry none of them, so the lookup falls through to the coord's first variable; the write loop's probe-coverage assert catches a pick the file doesn't hold.

## Verification

Re-running the validation manifest scan on the shipped code reproduces the corrected availability picture:

```
2014-10-01..08  160/168 complete    2018-07-09..16  156/168
2015-06-01..08  161/168             2019-06-15..22  168/168
2016-08-20..27   63/168             2020-12-01..08  168/168
2017-06-01..08  164/168             2021-07-15..22  168/168
                                    2022-06-25..07-02 168/168
```

Per-variable era starts now come out right too: `lightning_threat_1m` 0/168 before 2022 and 83/168 across the cutover week, `maximum_{up,down}ward_vertical_velocity_100_1000mb` 131/131 from 2020-12-02, `maximum_hail_diameter_surface` 0/168 in 2019. The remaining incompleteness is genuine source outages, clustered in 2014-2018 around the HRRRv2 upgrade week.

`uv run pytest tests/noaa/hrrr/` passes (147), along with `ruff format`, `ruff check` and `ty check` repo-wide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDveBoBfpnPjr8xe3DLCFT)_