### PR TITLE
Make the non-S3 virtual stores readable and scannable by the validation tooling

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -15,11 +15,6 @@ uv run src/scripts/validation/plots.py run-all <DATASET_URL>
 - `s3://dynamical-noaa-hrrr/noaa-hrrr-analysis/v0.1.0.icechunk`
 - `s3://dynamical-dwd-icon-eu/dwd-icon-eu-forecast-5-day/v0.2.0.icechunk`
 
-An icechunk store whose bucket serves no anonymous S3 read (e.g. WeatherNext 2 in the
-private `dynamical-wn2` R2 bucket) is instead reached by its public https URL, which
-these commands accept in the same position:
-`https://pub-<id>.r2.dev/<dataset-id>/<version>.icechunk`.
-
 To look up the URLs for a dataset, run `uv run main <dataset-id> dataset-urls`. It prints the primary and replica URLs; pass `--format json` for a machine-readable form.
 
 Expect the run to take ~30–60 seconds per variable, mostly bounded by S3 reads (a ~20-variable dataset finishes in ~10–15 minutes). Progress is logged: one line per variable per plot type. Virtual stores are slower and their runtime scales differently — see [Virtual and multi-level datasets](#virtual-and-multi-level-datasets) below.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -15,6 +15,11 @@ uv run src/scripts/validation/plots.py run-all <DATASET_URL>
 - `s3://dynamical-noaa-hrrr/noaa-hrrr-analysis/v0.1.0.icechunk`
 - `s3://dynamical-dwd-icon-eu/dwd-icon-eu-forecast-5-day/v0.2.0.icechunk`
 
+An icechunk store whose bucket serves no anonymous S3 read (e.g. WeatherNext 2 in the
+private `dynamical-wn2` R2 bucket) is instead reached by its public https URL, which
+these commands accept in the same position:
+`https://pub-<id>.r2.dev/<dataset-id>/<version>.icechunk`.
+
 To look up the URLs for a dataset, run `uv run main <dataset-id> dataset-urls`. It prints the primary and replica URLs; pass `--format json` for a machine-readable form.
 
 Expect the run to take ~30–60 seconds per variable, mostly bounded by S3 reads (a ~20-variable dataset finishes in ~10–15 minutes). Progress is logged: one line per variable per plot type. Virtual stores are slower and their runtime scales differently — see [Virtual and multi-level datasets](#virtual-and-multi-level-datasets) below.

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -601,20 +601,29 @@ def _repository_config_and_credentials(
     # manifest versions (multi-GB OOM). A virtual ref is ~180 B, so 1M refs ≈ 200 MB.
     config.caching = icechunk.CachingConfig(num_chunk_refs=1_000_000)
 
-    # Our S3 and S3-compatible sources (NOAA NODD, ECMWF, Source Coop) are all
-    # anonymous-read; authenticated transform proxies use HTTP; local-filesystem
-    # containers (dev/test) need no credentials. Map each container to the right
-    # credential explicitly rather than silently handing an S3 credential to a
-    # GCS/Azure container. To support a requester-pays or otherwise private object
-    # store, add an optional per-container credentials field to
-    # IcechunkVirtualConfig and prefer it over these defaults.
+    return config, anonymous_virtual_chunk_credentials(virtual_config.containers)
+
+
+def anonymous_virtual_chunk_credentials(
+    containers: Sequence[icechunk.VirtualChunkContainer],
+) -> dict[str, Any]:
+    """Anonymous authorize map for virtual chunk containers, keyed by url prefix.
+
+    Our S3 and S3-compatible sources (NOAA NODD, ECMWF, Source Coop) are all
+    anonymous-read; authenticated transform proxies use HTTP; local-filesystem
+    containers (dev/test) need no credentials. Each container gets the credential kind
+    its store accepts -- an S3 credential handed to an HTTP container is an error, not a
+    no-op. To support a requester-pays or otherwise private object store, add an
+    optional per-container credentials field to IcechunkVirtualConfig and prefer it over
+    these defaults.
+    """
     s3_compatible_stores = (
         icechunk.ObjectStoreConfig.S3,
         icechunk.ObjectStoreConfig.S3Compatible,
         icechunk.ObjectStoreConfig.Tigris,
     )
     credentials_by_prefix: dict[str, Any] = {}
-    for container in virtual_config.containers:
+    for container in containers:
         if isinstance(container.store, s3_compatible_stores):
             credentials_by_prefix[container.url_prefix] = (
                 icechunk.s3_anonymous_credentials()
@@ -635,8 +644,7 @@ def _repository_config_and_credentials(
                 "explicit credentials to IcechunkVirtualConfig."
             )
 
-    credentials = icechunk.containers_credentials(credentials_by_prefix)
-    return config, credentials
+    return icechunk.containers_credentials(credentials_by_prefix)
 
 
 # IcechunkVirtualConfig is defined below StoreFactory (which references it), so

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -349,8 +349,18 @@ def open_icechunk_readonly(url: str) -> icechunk.IcechunkStore:
     """
     storage = _icechunk_storage(url)
     assert storage is not None, url
+    config = (
+        icechunk.Repository.fetch_config(storage) or icechunk.RepositoryConfig.default()
+    )
+    # A whole-archive scan probes refs from many threads at once. A cache that cannot
+    # hold one manifest split makes every thread materialize its own copy of it, so peak
+    # memory scales with thread count instead of split size — 14 GB on a store whose
+    # splits hold ~1.7M refs. A ref is ~180 B, so 8M refs caches the largest split we
+    # write (see manifest_split in each virtual dataset) in well under 2 GB.
+    config.caching = icechunk.CachingConfig(num_chunk_refs=8_000_000)
     repo = icechunk.Repository.open(
         storage,
+        config=config,
         authorize_virtual_chunk_access=_anonymous_virtual_credentials(storage),
     )
     return repo.readonly_session("main").store

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -16,6 +16,7 @@ import zarr
 from zarr.storage import ObjectStore, StoreLike
 
 from reformatters.common.retry import retry
+from reformatters.common.storage import anonymous_virtual_chunk_credentials
 from reformatters.common.validation import open_flattened_dataset
 
 # Whole-archive scans issue many concurrent object-store reads. Raise zarr's async
@@ -310,34 +311,44 @@ def _anonymous_virtual_credentials(
 
     A virtual icechunk store decodes chunks from source files, which requires authorizing
     access to the source buckets. The container set is persisted in the repo config (see
-    docs/virtual_datasets.md); every dynamical source is public S3, so anonymous S3
-    credentials per container prefix suffice. Returns None for a materialized store.
+    docs/virtual_datasets.md). Returns None for a materialized store.
     """
     config = icechunk.Repository.fetch_config(storage)
     containers = config.virtual_chunk_containers if config is not None else None
     if not containers:
         return None
     items = containers.values() if isinstance(containers, dict) else containers
-    prefixes = [c.url_prefix if hasattr(c, "url_prefix") else c for c in items]
-    return icechunk.containers_credentials(
-        {prefix: icechunk.s3_anonymous_credentials() for prefix in prefixes}
+    return anonymous_virtual_chunk_credentials(list(items))
+
+
+def _icechunk_storage(url: str) -> icechunk.Storage | None:
+    """Anonymous read storage for an icechunk store URL, or None if `url` isn't one.
+
+    An `https://` URL reads the store over plain HTTP, which is how a store whose bucket
+    serves no anonymous S3 access is published.
+    """
+    url = url.removesuffix("/")
+    if not url.endswith(".icechunk"):
+        return None
+    if url.startswith(("https://", "http://")):
+        return icechunk.http_storage(url)
+    if not url.startswith("s3://"):
+        return None
+    bucket, _, prefix = url.removeprefix("s3://").partition("/")
+    assert prefix, url
+    return icechunk.s3_storage(
+        bucket=bucket, prefix=prefix, anonymous=True, region="us-west-2"
     )
 
 
 def open_icechunk_readonly(url: str) -> icechunk.IcechunkStore:
-    """Open an s3 icechunk store read-only and anonymously (virtual chunk access included).
+    """Open an icechunk store read-only and anonymously (virtual chunk access included).
 
     Unlike StoreFactory.primary_store this needs no credentials or Kubernetes secret
-    access, so offline validation runs anywhere the bucket is publicly readable.
+    access, so offline validation runs anywhere the store is publicly readable.
     """
-    assert url.startswith("s3://"), url
-    assert url.endswith(".icechunk"), url
-    path = url.removeprefix("s3://")
-    assert "/" in path
-    bucket, prefix = path.split("/", 1)
-    storage = icechunk.s3_storage(
-        bucket=bucket, prefix=prefix, anonymous=True, region="us-west-2"
-    )
+    storage = _icechunk_storage(url)
+    assert storage is not None, url
     repo = icechunk.Repository.open(
         storage,
         authorize_virtual_chunk_access=_anonymous_virtual_credentials(storage),
@@ -353,7 +364,7 @@ def load_retried(da: xr.DataArray) -> xr.DataArray:
 
 def load_zarr_dataset(url: str) -> xr.Dataset:
     url = url.removesuffix("/")
-    if url.startswith("s3://") and url.endswith(".icechunk"):
+    if url.endswith(".icechunk"):
         store: StoreLike = open_icechunk_readonly(url)
         consolidated = False
     elif url.startswith("s3://"):
@@ -612,16 +623,8 @@ def level_label(stats: VariableStats) -> str:
 
 def is_virtual_store(url: str) -> bool:
     """True if `url` is an icechunk store with persisted virtual chunk containers."""
-    url = url.removesuffix("/")
-    if not (url.startswith("s3://") and url.endswith(".icechunk")):
-        return False
-    path = url.removeprefix("s3://")
-    assert "/" in path
-    bucket, prefix = path.split("/", 1)
-    storage = icechunk.s3_storage(
-        bucket=bucket, prefix=prefix, anonymous=True, region="us-west-2"
-    )
-    return _anonymous_virtual_credentials(storage) is not None
+    storage = _icechunk_storage(url)
+    return storage is not None and _anonymous_virtual_credentials(storage) is not None
 
 
 def extract_variable_metadata(ds: xr.Dataset, var: str) -> dict[str, Any]:

--- a/tests/scripts/validation/utils_test.py
+++ b/tests/scripts/validation/utils_test.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+
+import icechunk
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 from scripts.validation.utils import (
+    _anonymous_virtual_credentials,
+    _icechunk_storage,
     choose_level,
     get_random_spatial_indices,
     get_two_random_points,
@@ -160,3 +165,35 @@ def test_to_reference_longitude() -> None:
     assert to_reference_longitude(180.0) == -180.0
     # Already in the reference convention, so unchanged.
     assert to_reference_longitude(-110.0) == -110.0
+
+
+def test_icechunk_storage_routes_by_url_scheme() -> None:
+    https_url = "https://pub-abc.r2.dev/some-dataset/v0.1.0.icechunk"
+    s3_url = "s3://some-bucket/some-dataset/v0.1.0.icechunk"
+    assert _icechunk_storage(https_url) is not None
+    assert _icechunk_storage(s3_url) is not None
+    assert _icechunk_storage("s3://some-bucket/some-dataset/v0.1.0.zarr") is None
+    assert _icechunk_storage("https://example.com/report.html") is None
+
+
+def test_anonymous_virtual_credentials_authorize_http_container(tmp_path: Path) -> None:
+    """An HTTP virtual chunk container needs HttpAccess; icechunk rejects an S3
+    credential handed to one, so a wrong credential kind fails the store open."""
+    container = icechunk.VirtualChunkContainer(
+        "https://example.com/chunks/", icechunk.http_store()
+    )
+    config = icechunk.RepositoryConfig.default()
+    config.set_virtual_chunk_container(container)
+    storage = icechunk.local_filesystem_storage(str(tmp_path / "repo.icechunk"))
+    repo = icechunk.Repository.create(
+        storage,
+        config=config,
+        authorize_virtual_chunk_access={
+            container.url_prefix: icechunk.Credentials.HttpAccess()
+        },
+    )
+    repo.save_config()
+
+    credentials = _anonymous_virtual_credentials(storage)
+    assert credentials is not None
+    icechunk.Repository.open(storage, authorize_virtual_chunk_access=credentials)


### PR DESCRIPTION
Found while running a validation for `google-weathernext2-forecast-historical-virtual`. Each of the three changes was a hard blocker for that dataset.

## What

- **HTTP virtual chunk containers could not be authorized.** `scripts/validation/utils._anonymous_virtual_credentials` handed every persisted container an S3 anonymous credential. icechunk rejects that for an HTTP container — `StorageError: http storage does not support credentials yet` — so both WeatherNext 2 virtual products (container `https://wn.dynamical.org/chunks/`) failed at `Repository.open`. The per-store-type dispatch `StoreFactory` already builds is extracted as `storage.anonymous_virtual_chunk_credentials` and used by both call sites, so one place maps a container to the credential kind its store accepts.
- **https icechunk URLs are now accepted** wherever `s3://` ones were. A store in a bucket that serves no anonymous S3 read is reachable only by its public URL, which is the case for the private `dynamical-wn2` bucket. This also removes the duplicated `s3_storage(...)` construction between `open_icechunk_readonly` and `is_virtual_store`.
- **The whole-archive scan was OOM-killed.** This store's manifest splits hold ~1.7M chunk refs, above the 1M-ref read cache the repo config persists, so each of the manifest scan's 48 probe threads materialized its own copy of a split and peak memory scaled with thread count instead of split size. `open_icechunk_readonly` now sizes the read cache to hold one split.

## Verification

- Against the real store over its public URL: the previous credential map reproduces `http storage does not support credentials yet`; the shared helper opens the store and reads all 14 variables across 4384 init times.
- Memory, whole-archive manifest scan, measured before and after the cache change: peak worker RSS **13.9 GB → 1.9 GB**, with unchanged throughput (~79 region jobs/min, so ~55 min for 4384 jobs). Before the change the kernel recorded `Memory cgroup out of memory: Killed process (python3) anon-rss:13910332kB`; after it, available memory held at ~13 GB.
- `run-all` completes end to end over the https URL (scoped run: one variable, three days — availability, decode scan, value/spatial/temporal plots, summary).
- Serial reads of five representative variables, including two `pressure_level` group variables, decode to physically plausible fields (500 mb geopotential height 4676–5926 m, 500 mb temperature −48.7–1.2 °C, SST −1.85–32.5 °C with 33.9% NaN over land).
- New tests pin the URL-scheme routing and the HTTP-container credential kind. `uv run ruff format && uv run ruff check --fix && uv run ty check` clean; `tests/scripts/validation/utils_test.py` passes (14).

## Docs

`docs/validation.md` §1 notes the https URL form alongside the `s3://` examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bvF5dZVPCmtNgazf9G1cy