### PR TITLE
Record two WeatherNext 2 variable quirks found while validating the historical archive

### DIFF
--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
@@ -64,7 +64,7 @@
     "short_name": "q",
     "standard_name": "specific_humidity",
     "units": "1",
-    "comment": "Small negative values are raw model artifacts.",
+    "comment": "Small negative values are raw model artifacts; set values < 0 to zero.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
@@ -64,6 +64,7 @@
     "short_name": "q",
     "standard_name": "specific_humidity",
     "units": "1",
+    "comment": "Small negative values are raw model artifacts.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
@@ -55,7 +55,7 @@
     "short_name": "sst",
     "standard_name": "sea_surface_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN over land where sea surface temperature does not apply. The underlying field changes once per 24 hours.",
+    "comment": "NaN over land where sea surface temperature does not apply. Value changes once every 24 hours.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
@@ -55,7 +55,7 @@
     "short_name": "sst",
     "standard_name": "sea_surface_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN over land where sea surface temperature does not apply.",
+    "comment": "NaN over land where sea surface temperature does not apply. The underlying field changes once per 24 hours.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/zarr.json
@@ -734,6 +734,7 @@
           "short_name": "q",
           "standard_name": "specific_humidity",
           "units": "1",
+          "comment": "Small negative values are raw model artifacts.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1377,7 +1378,7 @@
           "short_name": "sst",
           "standard_name": "sea_surface_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN over land where sea surface temperature does not apply.",
+          "comment": "NaN over land where sea surface temperature does not apply. The underlying field changes once per 24 hours.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/zarr.json
@@ -734,7 +734,7 @@
           "short_name": "q",
           "standard_name": "specific_humidity",
           "units": "1",
-          "comment": "Small negative values are raw model artifacts.",
+          "comment": "Small negative values are raw model artifacts; set values < 0 to zero.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1378,7 +1378,7 @@
           "short_name": "sst",
           "standard_name": "sea_surface_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN over land where sea surface temperature does not apply. The underlying field changes once per 24 hours.",
+          "comment": "NaN over land where sea surface temperature does not apply. Value changes once every 24 hours.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
@@ -51,6 +51,7 @@
     "short_name": "q",
     "standard_name": "specific_humidity",
     "units": "1",
+    "comment": "Small negative values are raw model artifacts.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
@@ -51,7 +51,7 @@
     "short_name": "q",
     "standard_name": "specific_humidity",
     "units": "1",
-    "comment": "Small negative values are raw model artifacts.",
+    "comment": "Small negative values are raw model artifacts; set values < 0 to zero.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
@@ -55,7 +55,7 @@
     "short_name": "sst",
     "standard_name": "sea_surface_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN over land where sea surface temperature does not apply. The underlying field changes once per 24 hours.",
+    "comment": "NaN over land where sea surface temperature does not apply. Value changes once every 24 hours.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
@@ -55,7 +55,7 @@
     "short_name": "sst",
     "standard_name": "sea_surface_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN over land where sea surface temperature does not apply.",
+    "comment": "NaN over land where sea surface temperature does not apply. The underlying field changes once per 24 hours.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/zarr.json
@@ -708,6 +708,7 @@
           "short_name": "q",
           "standard_name": "specific_humidity",
           "units": "1",
+          "comment": "Small negative values are raw model artifacts.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1299,7 +1300,7 @@
           "short_name": "sst",
           "standard_name": "sea_surface_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN over land where sea surface temperature does not apply.",
+          "comment": "NaN over land where sea surface temperature does not apply. The underlying field changes once per 24 hours.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/zarr.json
@@ -708,7 +708,7 @@
           "short_name": "q",
           "standard_name": "specific_humidity",
           "units": "1",
-          "comment": "Small negative values are raw model artifacts.",
+          "comment": "Small negative values are raw model artifacts; set values < 0 to zero.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1300,7 +1300,7 @@
           "short_name": "sst",
           "standard_name": "sea_surface_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN over land where sea surface temperature does not apply. The underlying field changes once per 24 hours.",
+          "comment": "NaN over land where sea surface temperature does not apply. Value changes once every 24 hours.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_virtual/template_config.py
+++ b/src/reformatters/google/weathernext2/forecast_virtual/template_config.py
@@ -560,8 +560,8 @@ def _root_data_vars(source_layout: SourceLayout) -> list[GoogleWeathernext2DataV
             units="degree_Celsius",
             standard_name="sea_surface_temperature",
             comment=(
-                "NaN over land where sea surface temperature does not apply. The "
-                "underlying field changes once per 24 hours."
+                "NaN over land where sea surface temperature does not apply. "
+                "Value changes once every 24 hours."
             ),
             filters=[_KELVIN_TO_CELSIUS],
             source_layout=source_layout,
@@ -642,7 +642,9 @@ def _pressure_data_vars(
             long_name="Specific humidity",
             units="1",
             standard_name="specific_humidity",
-            comment="Small negative values are raw model artifacts.",
+            comment=(
+                "Small negative values are raw model artifacts; set values < 0 to zero."
+            ),
             source_layout=source_layout,
         ),
     ]

--- a/src/reformatters/google/weathernext2/forecast_virtual/template_config.py
+++ b/src/reformatters/google/weathernext2/forecast_virtual/template_config.py
@@ -476,6 +476,7 @@ def _pressure_var(
     units: str,
     source_layout: SourceLayout,
     standard_name: str | None = None,
+    comment: str | None = None,
     filters: Sequence[CodecConfig] = (),
 ) -> GoogleWeathernext2DataVar:
     return _var(
@@ -487,7 +488,7 @@ def _pressure_var(
         units=units,
         standard_name=standard_name,
         step_type="instant",
-        comment=None,
+        comment=comment,
         date_available=None,
         filters=filters,
         source_layout=source_layout,
@@ -558,7 +559,10 @@ def _root_data_vars(source_layout: SourceLayout) -> list[GoogleWeathernext2DataV
             long_name="Sea surface temperature",
             units="degree_Celsius",
             standard_name="sea_surface_temperature",
-            comment="NaN over land where sea surface temperature does not apply.",
+            comment=(
+                "NaN over land where sea surface temperature does not apply. The "
+                "underlying field changes once per 24 hours."
+            ),
             filters=[_KELVIN_TO_CELSIUS],
             source_layout=source_layout,
         ),
@@ -638,6 +642,7 @@ def _pressure_data_vars(
             long_name="Specific humidity",
             units="1",
             standard_name="specific_humidity",
+            comment="Small negative values are raw model artifacts.",
             source_layout=source_layout,
         ),
     ]


### PR DESCRIPTION
Validating `google-weathernext2-forecast-historical-virtual` turned up two intrinsic variable facts the metadata did not carry. Both were verified against the store rather than assumed, and both apply to the historical and operational datasets.

The validation tooling changes this work also needed are now split out into #976; this PR is metadata only.

### Specific humidity holds small negative values

0.09% to 0.45% of cells at a given time, down to -6e-4 kg/kg, present in every year and at both short and long leads. Total precipitation already documents the same class of raw-model artifact; specific humidity now says so too.

### Sea surface temperature is a daily field

Across three inits and two points it steps once per 24 hours and varies negligibly between steps — up to 2312x the mean step size at the daily boundary versus within it — so a reader looking for a sub-daily signal finds none.

This is not rounding: virtual chunks keep full float32 precision, and observed steps run down to 3e-5 degrees.

## Notes

- Both are additions or extensions to a `comment` attribute on a dataset that is in neither the production nor the staging catalog, so the backward-compatibility policy does not apply.
- `_pressure_var` gained a `comment` parameter, which it previously hard-coded to `None`.

## Testing

- `uv run main DATASET_ID update-template` re-run for both the historical and operational datasets; the only template changes are the two comments.
- `uv run pytest tests/common/common_template_config_subclasses_test.py tests/common/datasets_cf_compliance_test.py tests/google` — 412 passed.
- `uv run ruff format --check`, `uv run ruff check`, `uv run ty check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu85CtgWZjouCWCWvU32yK