### PR TITLE
Run ruff hooks from the uv env so its version is pinned in one place

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,16 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    # NOTE: keep this in sync with pyproject.toml
-    rev: v0.16.4
-    hooks:
-      # Run the linter.
-      - id: ruff-check
-      # Run the formatter.
-      - id: ruff-format
   - repo: local
     hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: "uv run ruff check --force-exclude --fix"
+        language: system
+        types_or: [python, pyi]
+      - id: ruff-format
+        name: ruff format
+        entry: "uv run ruff format --force-exclude"
+        language: system
+        types_or: [python, pyi]
       - id: ty
         name: ty
         entry: "uv run ty check"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
         entry: "uv run ty check"
         language: system
         types: [python]
+        pass_filenames: false
         require_serial: true
       - id: generate-manual-workflows
         name: generate manual workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dev = [
     "pytest~=9.1",
     "pytest-sugar~=1.0",
     "pytest-xdist~=3.8",
-    # NOTE: keep this in sync with .pre-commit-config.yaml
     "ruff==0.16.4",
     "ty~=0.0.65",
     "types-boto3>=1.43.5",


### PR DESCRIPTION
`.pre-commit-config.yaml` pinned ruff a second time via `ruff-pre-commit`'s `rev:`, kept in sync with `pyproject.toml` only by a pair of NOTE comments. Dependabot's `uv` group bumps only the pyproject pin, so the two drift on every ruff release — #956 shipped that drift and needed a manual follow-up commit.

This runs ruff as `local` hooks out of the uv env, matching how the `ty` and `generate-manual-workflows` hooks already work. `pyproject.toml` is now the only place ruff's version appears: every ruff invocation in the repo — the hooks, `code-quality.yml`, `deploy-staging.yml` — resolves through `uv run`, so Dependabot bumping the pyproject pin now updates hooks and CI together in one PR.

Tradeoff: hooks lose the isolated, tag-pinned hook env and pay `uv run`'s startup instead. In exchange local hooks can no longer disagree with CI about which ruff ran.

### Notes

- `--force-exclude` makes ruff honor its own `exclude`/`extend-exclude` config when pre-commit passes explicit filenames. It's what upstream `ruff-pre-commit` passes; a no-op today since the repo configures no excludes.
- Hooks stay scoped to changed files, as they were before. Ruff decides every rule from one file's AST plus config, so there is nothing for a whole-repo run to catch that a per-file run misses; cross-file breakage (a removed symbol leaving a dead import) is a type error that `ty` owns. CI runs whole-repo `ruff check` / `ruff format --check` regardless.

### Testing

- `uv run prek run --all-files` — all four hooks pass.
- Staged a file with an unused import, bad annotations, and bad spacing: `ruff check` auto-fixed the import and failed the run on the ANN errors; `ruff format` reformatted and failed with "files were modified by this hook". Both hooks block a commit exactly as the upstream ones did.

### Also: `pass_filenames: false` on the ty hook

ty resolves types across files, but the hook passed it only the changed ones, so it missed errors a change caused elsewhere and disagreed with CI's whole-project `uv run ty check`. Verified: with a return-type error introduced in `common/time_utils.py` and the hook run against only `src/scripts/generate_manual_workflows.py`, `uv run ty check <that one file>` reported "All checks passed!" while the hook now fails with the `invalid-return-type` diagnostic.

`types: [python]` still gates the hook, so it runs only when Python files change — it just checks the whole project when it does.
