### PR TITLE
Point WeatherNext 2 storage at the google-weathernext2 bucket

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -192,7 +192,7 @@ class Weathernext2IcechunkDatasetStorageConfig(StorageConfig):
     k8s secret, which holds `icechunk.s3_storage` kwargs.
     """
 
-    base_path: str = "s3://dynamical-wn2"
+    base_path: str = "s3://google-weathernext2"
     k8s_secret_name: str = "weathernext2-storage-options-key"  # noqa: S105
     format: DatasetFormat = DatasetFormat.ICECHUNK
 


### PR DESCRIPTION
The WeatherNext 2 R2 bucket was renamed to `google-weathernext2` (served at `google-weathernext2.r2.dynamical.org`) to match the naming pattern for future R2 data products. `base_path` still pointed at the old name, which no longer resolves.

Symptoms with the stale name:

- The operational backfill failed on every worker at `icechunk::repository::create` with `NoSuchBucket: The specified bucket does not exist`.
- The historical store — backfilled and validated successfully the day before — raised `RepositoryNotFoundError: the repository doesn't exist` at `icechunk::repository::open`.

The differing errors are the same cause seen from two paths: `create` writes and surfaces `NoSuchBucket` directly, while `open` looks up the repository, misses, and reports it as absent.

Ruled out before changing anything: the template version is unchanged at `0.1.0` and `dataset-urls` resolved to the same path that validated the day before, so no version bump moved the store; and the k8s secret predates the successful historical run, so credentials were not the variable. The same token covers the new bucket, so only the bucket name changes.

Store paths are now:

```
s3://google-weathernext2/google-weathernext2-forecast-historical-virtual/v0.1.0.icechunk
s3://google-weathernext2/google-weathernext2-forecast-operational-virtual/v0.1.0.icechunk
```

Full suite: 2416 passed, 14 skipped.

Unblocks the operational backfill in dynamical-org/meta#188.