### PR TITLE
Upload validation reports concurrently

### DIFF
--- a/src/scripts/validation/upload.py
+++ b/src/scripts/validation/upload.py
@@ -1,5 +1,6 @@
 import mimetypes
 import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import boto3
@@ -12,6 +13,8 @@ from scripts.validation.render import REPORT_FILENAME, render_report
 log = get_logger(__name__)
 
 BUCKET = "dataset-validation-reports"
+# A report is hundreds of small files, so uploads are round-trip bound, not bandwidth bound.
+UPLOAD_CONCURRENCY = 32
 PUBLIC_BASE_URL = "https://dataset-validation-reports.dynamical.org"
 
 
@@ -49,16 +52,22 @@ def upload(run_dir: Path, publish: bool) -> str:
         region_name="auto",
     )
     files = [f for f in sorted(run_dir.rglob("*")) if f.is_file()]
+
+    def put(target: tuple[str, Path]) -> None:
+        prefix, f = target
+        client.upload_file(
+            str(f),
+            BUCKET,
+            f"{prefix}/{f.relative_to(run_dir).as_posix()}",
+            ExtraArgs={"ContentType": _content_type(f)},
+        )
+
+    targets = [(prefix, f) for prefix in prefixes for f in files]
+    with ThreadPoolExecutor(UPLOAD_CONCURRENCY) as pool:
+        # list() raises the first failure rather than discarding it with the iterator.
+        list(pool.map(put, targets))
     for prefix in prefixes:
-        for f in files:
-            key = f"{prefix}/{f.relative_to(run_dir).as_posix()}"
-            client.upload_file(
-                str(f),
-                BUCKET,
-                key,
-                ExtraArgs={"ContentType": _content_type(f)},
-            )
-            log.info(f"uploaded {key}")
+        log.info(f"uploaded {len(files)} files to {prefix}/")
     if publish:
         _trigger_pages_deploy()
     return f"{PUBLIC_BASE_URL}/{prefixes[0]}/{REPORT_FILENAME}"


### PR DESCRIPTION
## What

Upload a run directory's files through a thread pool instead of one at a time, and log one line per prefix instead of one per file.

## Why

A report is hundreds of small files, and each `upload_file` waited on the previous one's response. Publishing the 708-file `noaa-hrrr-analysis-virtual` report writes to both `latest/` and `published/<ts>/`, so 1,416 objects at roughly 250 ms each — about **380 seconds** to move 32 MB, an effective 90 KB/s. The work is round-trip bound, not bandwidth bound.

With a 32-way pool the same publish takes **14 seconds**, measured on the same run directory against the same bucket.

The per-file `log.info` also buried the result URL under 1,416 lines.

## Notes

`pool.map` is drained with `list()` so a failed upload raises rather than being discarded with the iterator. The boto3 client is shared across the pool, which is supported for client method calls.

Left alone deliberately: `--publish` still sends each file twice rather than doing a server-side copy for the second prefix. That would halve the bytes, but at 14 seconds it is no longer worth the extra code path.

## Checks

`ruff format`, `ruff check`, `ty check`, `pytest tests/scripts` (65 passed), plus a real publish of the HRRR analysis report end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDveBoBfpnPjr8xe3DLCFT)_