### PR TITLE
Make the validation tooling survive a 64-member, 206 MiB-chunk virtual store

### DIFF
--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -1049,9 +1049,10 @@ class CheckVirtualDecodeHealth(Validator):
     validation, not a cycle later; use more when the newest position does not carry every
     variable), while "all" covers the whole window, optionally capped to `max_positions`
     evenly spaced positions for a whole-archive offline sweep. Within a position it
-    samples `sampled_leads` lead times (first + last + evenly spaced interior) across
-    every member, and `sampled_levels` levels of any vertical dim (e.g. pressure_level)
-    so a group var is decode-checked at a bounded set of levels rather than every one.
+    samples `sampled_leads` lead times (first + last + evenly spaced interior), and
+    `sampled_levels` values of every remaining non-spatial dim - vertical levels and
+    ensemble members alike - so a var is decode-checked at a bounded set of them rather
+    than every one.
     A variable fails if any sampled chunk errors or all of its sampled chunks decode
     entirely NaN. Fails — never silently passes — when no references are present.
 

--- a/src/scripts/validation/availability.py
+++ b/src/scripts/validation/availability.py
@@ -39,6 +39,7 @@ from scripts.validation.utils import (
     level_option,
     load_retried,
     load_zarr_dataset,
+    manifest_checkpoint_root,
     output_dir_option,
     resolve_output_dir,
     scope_time_period,
@@ -475,7 +476,12 @@ def run_manifest_scan(ctx: RunContext) -> dict[pd.Timestamp, tuple[int, int]]:
     """
     dataset, store, start, end = resolve_scan_window(ctx)
     result = scan_manifest(
-        dataset, store, start=start, end=end, variables=ctx.variables
+        dataset,
+        store,
+        start=start,
+        end=end,
+        variables=ctx.variables,
+        checkpoint_root=manifest_checkpoint_root(dataset.dataset_id),
     )
     series = result_availability_series(result)
     ctx.availability = {var: series[var] for var in ctx.variables if var in series}

--- a/src/scripts/validation/compare_spatial.py
+++ b/src/scripts/validation/compare_spatial.py
@@ -54,7 +54,7 @@ def align_to_valid_time_forecast(
     ds: xr.Dataset,
     reference_ds: xr.Dataset,
     init_time: str | None,
-    lead_time: str | None,
+    lead_time: int | None,
 ) -> tuple[xr.Dataset, xr.Dataset]:
     rng = np.random.default_rng()
 
@@ -79,7 +79,7 @@ def align_to_valid_time_forecast(
         ]
         selected_lead_time = rng.choice(covered or candidate_leads, 1)[0]
     else:
-        selected_lead_time = pd.Timedelta(hours=int(lead_time))
+        selected_lead_time = pd.Timedelta(hours=lead_time)
 
     ds = ds.sel(init_time=selected_init_time, lead_time=selected_lead_time)
     valid_time = pd.Timestamp(ds.valid_time.item())
@@ -416,7 +416,7 @@ def compare_spatial(
     variables: list[str] | None = variables_option,
     show_plot: bool = False,
     init_time: str | None = init_time_option,
-    lead_time: str | None = lead_time_option,
+    lead_time: int | None = lead_time_option,
     time: str | None = time_option,
     start_date: str | None = start_date_option,
     end_date: str | None = end_date_option,

--- a/src/scripts/validation/compare_timeseries.py
+++ b/src/scripts/validation/compare_timeseries.py
@@ -166,8 +166,20 @@ def _load_timeseries_for_var(
     val = validation_subset[var]
     if level_sel:
         val = val.sel(level_sel)
-    val_p1 = load_retried(val.isel(ctx.point1_sel))
-    val_p2 = load_retried(val.isel(ctx.point2_sel))
+    # Both points come out of one read: a chunk is a full spatial field, so loading them
+    # separately decodes every chunk in the series twice.
+    points = load_retried(
+        val.isel(
+            {
+                dim: xr.DataArray(
+                    [ctx.point1_sel[dim], ctx.point2_sel[dim]], dims="point"
+                )
+                for dim in ctx.point1_sel
+            }
+        )
+    )
+    val_p1 = points.isel(point=0)
+    val_p2 = points.isel(point=1)
     ref_p1: xr.DataArray | None = None
     ref_p2: xr.DataArray | None = None
     if var in reference_subset.data_vars and (

--- a/src/scripts/validation/decode_scan.py
+++ b/src/scripts/validation/decode_scan.py
@@ -58,21 +58,32 @@ SAMPLED_LEADS = 5
 SAMPLED_LEVELS = 3
 MAX_JOB_CONCURRENCY = 4
 MAX_DECODE_CONCURRENCY = 32
-# A decode pins the append dim and lead time and takes every other dim whole, so these
-# are the dims whose extent does not enter its footprint.
 _PINNED_DIMS = ("init_time", "time", "lead_time")
+_SPATIAL_DIMS = ("y", "x", "latitude", "longitude")
+
+
+def _dim_chunk_span(dim: str, size: int, chunk: int) -> int:
+    """Chunks one decode touches along `dim`, mirroring how the checker selects it: the
+    append dim and lead time pinned to one position, spatial dims whole, and every other
+    dim (ensemble member, vertical level) down-sampled to SAMPLED_LEVELS."""
+    if dim in _PINNED_DIMS:
+        return 1
+    chunks_along_dim = math.ceil(size / chunk)
+    if dim in _SPATIAL_DIMS:
+        return chunks_along_dim
+    return min(SAMPLED_LEVELS, chunks_along_dim)
 
 
 def _decode_chunk_span(ds: xr.Dataset) -> int:
     """Chunks in the largest field one decode materializes.
 
-    The footprint grows with ensemble size and with how much a chunk carries beyond one
-    field, so a 64-member store whose chunk spans every vertical level decodes orders of
-    magnitude more bytes per call than a single-member one.
+    The footprint grows with how much a chunk carries beyond the one field being checked,
+    so a store whose chunk spans four ensemble members and every vertical level decodes
+    orders of magnitude more bytes per call than one chunked a field at a time.
     """
     spans = [
         math.prod(
-            math.ceil((1 if dim in _PINNED_DIMS else size) / chunk)
+            _dim_chunk_span(str(dim), size, chunk)
             for dim, size, chunk in zip(var.dims, var.shape, chunks, strict=True)
         )
         for var in ds.data_vars.values()

--- a/src/scripts/validation/decode_scan.py
+++ b/src/scripts/validation/decode_scan.py
@@ -11,12 +11,14 @@ Entry points: the `decode-scan` command (URL-driven, resolves the registered dat
 the store's `dataset_id` attribute) and `run-all`, via `run_decode_scan`.
 """
 
+import math
 from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, cast
 
 import typer
+import xarray as xr
 import zarr
 
 from reformatters.common import validation
@@ -33,7 +35,9 @@ from scripts.validation.scan_common import (
 )
 from scripts.validation.utils import (
     RunContext,
+    concurrent_load_workers,
     end_date_option,
+    largest_chunk_nbytes,
     output_dir_option,
     start_date_option,
     variables_option,
@@ -42,14 +46,54 @@ from scripts.validation.utils import (
 log = get_logger(__name__)
 
 MAX_SAMPLED_REGIONS = 20
+decode_samples_option = typer.Option(
+    MAX_SAMPLED_REGIONS,
+    "--decode-samples",
+    "--max-samples",
+    help="Max append-dim regions to decode-check. Lower it on a store whose fields are "
+    "large enough (deep ensembles, every level in one chunk) that the default sample "
+    "would decode terabytes.",
+)
 SAMPLED_LEADS = 5
 SAMPLED_LEVELS = 3
-JOB_CONCURRENCY = 4
+MAX_JOB_CONCURRENCY = 4
+MAX_DECODE_CONCURRENCY = 32
+# A decode pins the append dim and lead time and takes every other dim whole, so these
+# are the dims whose extent does not enter its footprint.
+_PINNED_DIMS = ("init_time", "time", "lead_time")
+
+
+def _decode_chunk_span(ds: xr.Dataset) -> int:
+    """Chunks in the largest field one decode materializes.
+
+    The footprint grows with ensemble size and with how much a chunk carries beyond one
+    field, so a 64-member store whose chunk spans every vertical level decodes orders of
+    magnitude more bytes per call than a single-member one.
+    """
+    spans = [
+        math.prod(
+            math.ceil((1 if dim in _PINNED_DIMS else size) / chunk)
+            for dim, size, chunk in zip(var.dims, var.shape, chunks, strict=True)
+        )
+        for var in ds.data_vars.values()
+        if (chunks := var.encoding.get("chunks")) is not None
+    ]
+    return max(spans, default=1)
+
+
+def _decode_concurrency(chunk_span: int, chunk_nbytes: int) -> tuple[int, int]:
+    """(region jobs, decodes per job) to run at once within the read memory budget."""
+    total = concurrent_load_workers(
+        chunk_span, chunk_nbytes, cap=MAX_JOB_CONCURRENCY * MAX_DECODE_CONCURRENCY
+    )
+    jobs = min(MAX_JOB_CONCURRENCY, total)
+    return jobs, max(1, total // jobs)
 
 
 def _decode_checker(
     dataset: DynamicalDataset[Any, Any],
     reference_exists: Callable[[str, Mapping[str, Any]], bool],
+    max_workers: int,
 ) -> validation.CheckVirtualDecodeHealth:
     configured = next(
         (
@@ -64,6 +108,7 @@ def _decode_checker(
             "positions": 1,
             "sampled_leads": SAMPLED_LEADS,
             "sampled_levels": SAMPLED_LEVELS,
+            "max_workers": max_workers,
             "reference_exists": reference_exists,
         }
     )
@@ -101,7 +146,14 @@ def run_decode_scan(ctx: RunContext, max_samples: int = MAX_SAMPLED_REGIONS) -> 
         f"(sampled_leads={SAMPLED_LEADS}, sampled_levels={SAMPLED_LEVELS})"
     )
 
-    checker = _decode_checker(dataset, reference_exists)
+    job_concurrency, decode_concurrency = _decode_concurrency(
+        _decode_chunk_span(ctx.validation_ds), largest_chunk_nbytes(ctx.validation_ds)
+    )
+    log.info(
+        f"Decode concurrency: {job_concurrency} region job(s) x {decode_concurrency} "
+        "decode(s)"
+    )
+    checker = _decode_checker(dataset, reference_exists, decode_concurrency)
 
     def check(job: RegionJob[Any, Any]) -> validation.ValidationResult:
         return checker.check(
@@ -118,7 +170,7 @@ def run_decode_scan(ctx: RunContext, max_samples: int = MAX_SAMPLED_REGIONS) -> 
     decoded_refs = 0
     # A job's decodes are network-latency-bound and parallelize only across its own
     # source files, so a few jobs run concurrently to fill the idle time.
-    with ThreadPoolExecutor(max_workers=JOB_CONCURRENCY) as pool:
+    with ThreadPoolExecutor(max_workers=job_concurrency) as pool:
         for i, result in enumerate(pool.map(check, sampled)):
             log.info(f"  [{i + 1}/{len(sampled)}] {'ok' if result.passed else 'FAIL'}")
             decoded_refs += result.checked_count or 0
@@ -160,11 +212,7 @@ def decode_scan(
     start_date: str | None = start_date_option,
     end_date: str | None = end_date_option,
     output_dir: Path | None = output_dir_option,
-    max_samples: int = typer.Option(
-        MAX_SAMPLED_REGIONS,
-        "--max-samples",
-        help="Max append-dim regions to decode-check",
-    ),
+    max_samples: int = decode_samples_option,
 ) -> None:
     """Decode a bounded sample of present references across the archive and check health."""
     ctx = build_run_context(

--- a/src/scripts/validation/manifest_scan.py
+++ b/src/scripts/validation/manifest_scan.py
@@ -15,6 +15,8 @@ from the store's `dataset_id` attribute) and `run-all`, via
 `availability.run_manifest_availability`. See docs/validation.md.
 """
 
+import hashlib
+import json
 from collections.abc import Iterator, Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass
@@ -45,6 +47,9 @@ from scripts.validation.utils import (
 log = get_logger(__name__)
 
 _EXISTS_BATCH_SIZE = 20_000
+# Region jobs per checkpoint. A whole-archive scan that is killed loses at most this
+# much work, so keep a batch to a few minutes on a slow store.
+_CHECKPOINT_BATCH_JOBS = 128
 # A whole-archive scan issues enough object-store reads that a transient outage
 # (e.g. a connect timeout) is near-certain; ride out a few minutes of trouble rather
 # than let one blip kill the whole scan. Backoff grows with attempt in retry(), so
@@ -305,6 +310,106 @@ def _flush_var_probes(
     probes.clear()
 
 
+_BatchResult = tuple[dict[pd.Timestamp, list[int]], dict[str, dict[pd.Timestamp, bool]]]
+
+
+def _probe_batch(
+    jobs: Sequence[VirtualRegionJob[Any, Any]],
+    store: IcechunkStore,
+    lead_limits: dict[pd.Timestamp, pd.Timedelta],
+    group: zarr.Group,
+    keys_by_var: dict[str, _VarKeys],
+) -> _BatchResult:
+    """Probe one batch of region jobs, folding as each completes so only per-position
+    counts, per-var booleans and one _exists_many batch of probes stay resident."""
+    file_counts: dict[pd.Timestamp, list[int]] = {}
+    var_availability: dict[str, dict[pd.Timestamp, bool]] = {}
+    pending_probes: list[tuple[str, pd.Timestamp, str]] = []
+    for job, coord_presence in probe_jobs(jobs, store):
+        _fold_file_availability(coord_presence, lead_limits, file_counts)
+        for var in job.data_vars:
+            var_availability.setdefault(var.path, {})
+        pending_probes.extend(_var_probes(job, coord_presence, group, keys_by_var))
+        if len(pending_probes) >= _EXISTS_BATCH_SIZE:
+            _flush_var_probes(store, pending_probes, var_availability)
+    _flush_var_probes(store, pending_probes, var_availability)
+    return file_counts, var_availability
+
+
+def _merge_batch(batch: _BatchResult, into: _BatchResult) -> None:
+    """Add one batch's counts and availability into the running totals. Batches are
+    contiguous job ranges, and a position split across two of them contributes its
+    source files to both, so counts add and a variable is available where any batch
+    found its ref."""
+    batch_counts, batch_vars = batch
+    file_counts, var_availability = into
+    for position, (present, expected) in batch_counts.items():
+        totals = file_counts.setdefault(position, [0, 0])
+        totals[0] += present
+        totals[1] += expected
+    for var_path, series in batch_vars.items():
+        merged = var_availability.setdefault(var_path, {})
+        for position, present in series.items():
+            merged[position] = merged.get(position, False) or present
+
+
+def _checkpoint_key(
+    dataset: DynamicalDataset[Any, Any],
+    store: IcechunkStore,
+    start: pd.Timestamp | None,
+    end: pd.Timestamp | None,
+    variables: list[str] | None,
+    job_count: int,
+) -> str:
+    """Identifies what a checkpoint set describes. The store's snapshot is part of it,
+    so a scan of an archive that has been written since starts fresh rather than
+    reporting a previous snapshot's availability."""
+    parts = [
+        dataset.dataset_id,
+        store.session.snapshot_id,
+        str(start),
+        str(end),
+        ",".join(sorted(variables)) if variables else "all",
+        str(job_count),
+    ]
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()[:16]
+
+
+def _read_checkpoint(path: Path) -> _BatchResult | None:
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text())
+    file_counts = {
+        pd.Timestamp(position): list(counts)
+        for position, counts in payload["file_counts"].items()
+    }
+    var_availability = {
+        var_path: {
+            pd.Timestamp(position): present for position, present in series.items()
+        }
+        for var_path, series in payload["var_availability"].items()
+    }
+    return file_counts, var_availability
+
+
+def _write_checkpoint(path: Path, batch: _BatchResult) -> None:
+    file_counts, var_availability = batch
+    payload = {
+        "file_counts": {
+            str(position): counts for position, counts in file_counts.items()
+        },
+        "var_availability": {
+            var_path: {str(position): present for position, present in series.items()}
+            for var_path, series in var_availability.items()
+        },
+    }
+    # Rename into place so a process killed mid-write leaves no half-written file for
+    # the next run to read back as a completed batch.
+    partial = path.with_suffix(".partial")
+    partial.write_text(json.dumps(payload))
+    partial.rename(path)
+
+
 def scan_manifest(
     dataset: DynamicalDataset[Any, Any],
     store: IcechunkStore,
@@ -312,11 +417,17 @@ def scan_manifest(
     start: pd.Timestamp | None,
     end: pd.Timestamp | None,
     variables: list[str] | None = None,
+    checkpoint_root: Path | None = None,
 ) -> ManifestScanResult:
     """Probe `store`'s manifest per source file and per variable. No decode.
 
     `dataset` supplies the region-job machinery (expected source files, chunk keys);
     `store` is the archive actually probed, so a staging store is scanned as itself.
+
+    A whole-archive scan runs for hours, so each batch of region jobs is written under
+    `checkpoint_root` as it completes and a later scan of the same window and snapshot
+    replays those batches instead of reprobing them. Pass None to scan without
+    checkpoints.
     """
     log.info(f"Building region jobs for {dataset.dataset_id} [{start} .. {end}]")
     jobs = cast(
@@ -328,23 +439,37 @@ def scan_manifest(
     group = zarr.open_group(store, mode="r")
     keys_by_var: dict[str, _VarKeys] = {}
 
-    # Fold each job's probes as it completes; only per-position counts, per-var
-    # booleans, and at most one _exists_many batch of pending probes stay resident.
-    file_counts: dict[pd.Timestamp, list[int]] = {}
-    var_availability: dict[str, dict[pd.Timestamp, bool]] = {}
-    pending_probes: list[tuple[str, pd.Timestamp, str]] = []
-    progress_every = max(1, len(jobs) // 20)
-    for i, (job, coord_presence) in enumerate(probe_jobs(jobs, store), start=1):
-        _fold_file_availability(coord_presence, lead_limits, file_counts)
-        for var in job.data_vars:
-            var_availability.setdefault(var.path, {})
-        pending_probes.extend(_var_probes(job, coord_presence, group, keys_by_var))
-        if len(pending_probes) >= _EXISTS_BATCH_SIZE:
-            _flush_var_probes(store, pending_probes, var_availability)
-        if i % progress_every == 0 or i == len(jobs):
-            log.info(f"  probed {i}/{len(jobs)} region jobs")
-    _flush_var_probes(store, pending_probes, var_availability)
+    checkpoint_dir: Path | None = None
+    if checkpoint_root is not None:
+        key = _checkpoint_key(dataset, store, start, end, variables, len(jobs))
+        checkpoint_dir = checkpoint_root / key
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
+    totals: _BatchResult = ({}, {})
+    batches = [
+        jobs[i : i + _CHECKPOINT_BATCH_JOBS]
+        for i in range(0, len(jobs), _CHECKPOINT_BATCH_JOBS)
+    ]
+    for batch_index, batch_jobs in enumerate(batches):
+        path = (
+            checkpoint_dir / f"batch-{batch_index:05d}.json"
+            if checkpoint_dir is not None
+            else None
+        )
+        batch = _read_checkpoint(path) if path is not None else None
+        replayed = batch is not None
+        if batch is None:
+            batch = _probe_batch(batch_jobs, store, lead_limits, group, keys_by_var)
+            if path is not None:
+                _write_checkpoint(path, batch)
+        _merge_batch(batch, totals)
+        probed = min((batch_index + 1) * _CHECKPOINT_BATCH_JOBS, len(jobs))
+        log.info(
+            f"  probed {probed}/{len(jobs)} region jobs"
+            f"{' (replayed from checkpoint)' if replayed else ''}"
+        )
+
+    file_counts, var_availability = totals
     file_availability = {position: (p, e) for position, (p, e) in file_counts.items()}
     assert file_availability, "No source files generated for the requested window"
     return ManifestScanResult(

--- a/src/scripts/validation/plots.py
+++ b/src/scripts/validation/plots.py
@@ -104,7 +104,7 @@ def run_all(
     start_date: str | None = start_date_option,
     end_date: str | None = end_date_option,
     init_time: str | None = init_time_option,
-    lead_time: str | None = lead_time_option,
+    lead_time: int | None = lead_time_option,
     time: str | None = time_option,
     level: float | None = level_option,
     point: list[str] | None = point_option,

--- a/src/scripts/validation/plots.py
+++ b/src/scripts/validation/plots.py
@@ -19,7 +19,11 @@ from scripts.validation.compare_timeseries import (
     compare_timeseries,
     run_compare_timeseries,
 )
-from scripts.validation.decode_scan import decode_scan, run_decode_scan
+from scripts.validation.decode_scan import (
+    decode_samples_option,
+    decode_scan,
+    run_decode_scan,
+)
 from scripts.validation.probe_position import probe_position
 from scripts.validation.render import render_report_command
 from scripts.validation.summary import write_summary_md
@@ -105,6 +109,7 @@ def run_all(
     level: float | None = level_option,
     point: list[str] | None = point_option,
     output_dir: Path | None = output_dir_option,
+    decode_samples: int = decode_samples_option,
 ) -> None:
     """Produce availability / value / spatial / temporal plots, one per variable, in one directory + validation_summary.md."""
     started_at = pd.Timestamp.now(tz="UTC")
@@ -177,7 +182,7 @@ def run_all(
         with ThreadPoolExecutor(max_workers=1) as pool:
             manifest_scan = pool.submit(run_manifest_scan, ctx)
             try:
-                run_decode_scan(ctx)
+                run_decode_scan(ctx, max_samples=decode_samples)
                 run_value_timeseries(ctx)
                 run_compare_timeseries(ctx)
                 run_compare_spatial(ctx)

--- a/src/scripts/validation/plots.py
+++ b/src/scripts/validation/plots.py
@@ -52,6 +52,7 @@ from scripts.validation.utils import (
 )
 from scripts.validation.value_timeseries import (
     run_value_timeseries,
+    value_samples_option,
     value_timeseries,
 )
 
@@ -110,6 +111,7 @@ def run_all(
     point: list[str] | None = point_option,
     output_dir: Path | None = output_dir_option,
     decode_samples: int = decode_samples_option,
+    value_samples: int = value_samples_option,
 ) -> None:
     """Produce availability / value / spatial / temporal plots, one per variable, in one directory + validation_summary.md."""
     started_at = pd.Timestamp.now(tz="UTC")
@@ -173,6 +175,7 @@ def run_all(
         init_time=init_time,
         lead_time=lead_time,
         time=time,
+        value_ts_samples=value_samples,
     )
 
     if ctx.is_virtual:

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -256,7 +256,7 @@ class RunContext:
     # the spatial snapshot), an analysis run uses time; each anchors both the spatial
     # snapshot and the temporal comparison so one flag places the whole report.
     init_time: str | None = None
-    lead_time: str | None = None
+    lead_time: int | None = None
     time: str | None = None
     spatial_time_label: str | None = None
     ref_spatial_time_label: str | None = None

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -15,13 +15,20 @@ import xarray as xr
 import zarr
 from zarr.storage import ObjectStore, StoreLike
 
+from reformatters.common.logging import get_logger
 from reformatters.common.retry import retry
 from reformatters.common.storage import anonymous_virtual_chunk_credentials
 from reformatters.common.validation import open_flattened_dataset
 
-# Whole-archive scans issue many concurrent object-store reads. Raise zarr's async
-# concurrency once here; every validation entry point imports this module.
-zarr.config.set({"async.concurrency": 32})
+log = get_logger(__name__)
+
+# Whole-archive scans issue many concurrent object-store reads, so validation raises
+# zarr's async concurrency above the default; every validation entry point imports this
+# module. Each in-flight read holds one decoded chunk, so load_zarr_dataset lowers the
+# count to whatever fits READ_BUDGET_BYTES for the store it just opened.
+READ_BUDGET_BYTES = 2 * 2**30
+MAX_READ_CONCURRENCY = 32
+zarr.config.set({"async.concurrency": MAX_READ_CONCURRENCY})
 
 OUTPUT_DIR = "data/output"
 
@@ -372,6 +379,40 @@ def load_retried(da: xr.DataArray) -> xr.DataArray:
     return retry(da.load)
 
 
+def read_workers(bytes_per_worker: int, cap: int = MAX_READ_CONCURRENCY) -> int:
+    """The largest worker count within `cap` whose in-flight decoded bytes fit the budget.
+
+    Sizing concurrency by operation count alone makes peak memory a property of the
+    store: 32 in-flight reads of a 4 MiB chunk is 128 MiB, but of the 206 MiB chunk a
+    64-member global field uses it is 6.4 GiB.
+    """
+    if bytes_per_worker <= 0:
+        return cap
+    return max(1, min(cap, READ_BUDGET_BYTES // bytes_per_worker))
+
+
+def concurrent_load_workers(chunks_per_load: int, chunk_nbytes: int, cap: int) -> int:
+    """Loads that can run at once within the read budget.
+
+    One load holds up to zarr's in-flight fetch count of decoded chunks, or fewer when
+    it spans fewer chunks than that.
+    """
+    in_flight = min(int(zarr.config.get("async.concurrency")), max(1, chunks_per_load))
+    return read_workers(in_flight * chunk_nbytes, cap=cap)
+
+
+def largest_chunk_nbytes(ds: xr.Dataset) -> int:
+    """Decoded bytes in one chunk of `ds`'s largest-chunked data variable."""
+    return max(
+        (
+            int(np.prod(var.encoding["chunks"])) * var.dtype.itemsize
+            for var in ds.data_vars.values()
+            if var.encoding.get("chunks") is not None
+        ),
+        default=0,
+    )
+
+
 def load_zarr_dataset(url: str) -> xr.Dataset:
     url = url.removesuffix("/")
     if url.endswith(".icechunk"):
@@ -407,6 +448,12 @@ def load_zarr_dataset(url: str) -> xr.Dataset:
     if "longitude" in ds.coords and "latitude" in ds.coords:
         ds.longitude.load()
         ds.latitude.load()
+    # zarr's concurrency is process-global, so a run that opens several stores keeps the
+    # count that fits the largest chunk any of them has.
+    workers = read_workers(largest_chunk_nbytes(ds))
+    if workers < zarr.config.get("async.concurrency"):
+        log.info(f"Lowering zarr read concurrency to {workers} for {url}")
+        zarr.config.set({"async.concurrency": workers})
     return ds
 
 

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -32,6 +32,10 @@ zarr.config.set({"async.concurrency": MAX_READ_CONCURRENCY})
 
 OUTPUT_DIR = "data/output"
 
+# Append-dim positions the full-period value series samples on a virtual store, where
+# each sampled position is one source-file decode (both run points share the message).
+VIRTUAL_VALUE_TS_SAMPLES = 200
+
 STAC_CATALOG_URL = "https://stac.dynamical.org/catalog.json"
 GEFS_ANALYSIS_COLLECTION_ID = "noaa-gefs-analysis"
 
@@ -257,6 +261,7 @@ class RunContext:
     # snapshot and the temporal comparison so one flag places the whole report.
     init_time: str | None = None
     lead_time: int | None = None
+    value_ts_samples: int = VIRTUAL_VALUE_TS_SAMPLES
     time: str | None = None
     spatial_time_label: str | None = None
     ref_spatial_time_label: str | None = None
@@ -736,6 +741,15 @@ def create_run_output_dir(
     run_dir = Path(OUTPUT_DIR) / dataset_id / f"{version}_{timestamp_str}"
     run_dir.mkdir(parents=True, exist_ok=True)
     return run_dir
+
+
+def manifest_checkpoint_root(dataset_id: str) -> Path:
+    """Where a manifest scan's per-batch checkpoints live.
+
+    Outside any one run's directory, so a rerun after an interrupted scan replays the
+    batches the previous attempt completed instead of starting the archive over.
+    """
+    return Path(OUTPUT_DIR) / dataset_id / "manifest_scan_checkpoints"
 
 
 def resolve_output_dir(validation_url: str, output_dir: Path | str | None) -> Path:

--- a/src/scripts/validation/utils.py
+++ b/src/scripts/validation/utils.py
@@ -539,17 +539,29 @@ def get_random_spatial_indices(
     return point1_sel, point2_sel
 
 
+def _longitude_difference(grid_longitude: np.ndarray, lon: float) -> np.ndarray:
+    """Signed degrees from `lon` to each grid longitude, the short way around.
+
+    Grids label longitude either -180 to 180 or 0 to 360, so a plain subtraction sends a
+    request in the other convention to the wrong side of the world: on a 0-360 grid the
+    cell nearest -100 is 260, whose difference is 360. Wrapping also makes the search
+    behave across the antimeridian seam.
+    """
+    return (grid_longitude - lon + 180) % 360 - 180
+
+
 def nearest_point_index(ds: xr.Dataset, lat: float, lon: float) -> dict[str, int]:
     """Grid-cell index dict nearest a target lat/lon, for 1D geographic or 2D projected grids."""
     lat_dim, lon_dim = get_spatial_dimensions(ds)
     if lat_dim == "latitude" and lon_dim == "longitude":
         lat_idx = int(np.abs(ds.latitude.values - lat).argmin())
-        lon_idx = int(np.abs(ds.longitude.values - lon).argmin())
+        lon_idx = int(np.abs(_longitude_difference(ds.longitude.values, lon)).argmin())
         return {lat_dim: lat_idx, lon_dim: lon_idx}
     lat2d = ds.latitude.values
     lon2d = ds.longitude.values
     # Equirectangular approximation; exact enough to pick a grid cell at CONUS scale.
-    dist = (lat2d - lat) ** 2 + ((lon2d - lon) * np.cos(np.deg2rad(lat))) ** 2
+    dlon = _longitude_difference(lon2d, lon)
+    dist = (lat2d - lat) ** 2 + (dlon * np.cos(np.deg2rad(lat))) ** 2
     y_idx, x_idx = (int(i) for i in np.unravel_index(int(np.argmin(dist)), dist.shape))
     return {"y": y_idx, "x": x_idx}
 

--- a/src/scripts/validation/value_timeseries.py
+++ b/src/scripts/validation/value_timeseries.py
@@ -13,9 +13,11 @@ from scripts.validation.utils import (
     SPATIAL_DIMS,
     RunContext,
     VariableStats,
+    concurrent_load_workers,
     end_date_option,
     get_two_random_points,
     is_virtual_store,
+    largest_chunk_nbytes,
     level_label,
     level_option,
     load_retried,
@@ -38,7 +40,7 @@ VIRTUAL_VALUE_TS_SAMPLES = 200
 # Per-variable loads run ahead of the plotting loop in a pool this size. Each virtual
 # per-variable load materializes ~200 full-field decodes (~GBs); keep the pipeline
 # shallow so concurrent loads stay within host memory.
-LOAD_CONCURRENCY = 2
+MAX_LOAD_CONCURRENCY = 2
 
 log = get_logger(__name__)
 
@@ -195,8 +197,14 @@ def run_value_timeseries(ctx: RunContext) -> None:
     log.info(f"value-timeseries: {n_vars} variables at {p1_label} / {p2_label}")
 
     # Loads are network-bound and independent per variable; they run ahead in a small
-    # pool while the main thread plots. Each result is just the two point series.
-    with ThreadPoolExecutor(max_workers=LOAD_CONCURRENCY) as pool:
+    # pool while the main thread plots. Each result is just the two point series, but a
+    # load holds the chunks it strides through, so its footprint sizes the pool.
+    load_concurrency = concurrent_load_workers(
+        VIRTUAL_VALUE_TS_SAMPLES,
+        largest_chunk_nbytes(ctx.validation_ds),
+        cap=MAX_LOAD_CONCURRENCY,
+    )
+    with ThreadPoolExecutor(max_workers=load_concurrency) as pool:
         loads = [
             pool.submit(_point_arrays, ctx, var, ctx.stats_for(var))
             for var in ctx.variables

--- a/src/scripts/validation/value_timeseries.py
+++ b/src/scripts/validation/value_timeseries.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import typer
 import xarray as xr
 from matplotlib.axes import Axes
 
@@ -11,6 +12,7 @@ from reformatters.common.logging import get_logger
 from reformatters.common.time_utils import whole_hours
 from scripts.validation.utils import (
     SPATIAL_DIMS,
+    VIRTUAL_VALUE_TS_SAMPLES,
     RunContext,
     VariableStats,
     concurrent_load_workers,
@@ -34,9 +36,13 @@ from scripts.validation.utils import (
     variables_option,
 )
 
-# Target number of append-dim positions to sample on a virtual store, where each
-# sampled position is one source-file decode (both run points share the message).
-VIRTUAL_VALUE_TS_SAMPLES = 200
+value_samples_option = typer.Option(
+    VIRTUAL_VALUE_TS_SAMPLES,
+    "--value-samples",
+    help="Append-dim positions the full-period value series samples on a virtual "
+    "store, one decode each. Lower it on a store whose chunks are large enough that "
+    "the default sample decodes hundreds of GB.",
+)
 # Per-variable loads run ahead of the plotting loop in a pool this size. Each virtual
 # per-variable load materializes ~200 full-field decodes (~GBs); keep the pipeline
 # shallow so concurrent loads stay within host memory.
@@ -135,7 +141,7 @@ def _sample_virtual_points(
     """
     da = ctx.validation_ds[var]
     append_dim = "init_time" if "init_time" in da.dims else "time"
-    stride = max(1, da.sizes[append_dim] // VIRTUAL_VALUE_TS_SAMPLES)
+    stride = max(1, da.sizes[append_dim] // ctx.value_ts_samples)
     da = da.isel({append_dim: slice(None, None, stride)})
 
     indexers: dict[str, xr.DataArray | int] = {
@@ -200,7 +206,7 @@ def run_value_timeseries(ctx: RunContext) -> None:
     # pool while the main thread plots. Each result is just the two point series, but a
     # load holds the chunks it strides through, so its footprint sizes the pool.
     load_concurrency = concurrent_load_workers(
-        VIRTUAL_VALUE_TS_SAMPLES,
+        ctx.value_ts_samples,
         largest_chunk_nbytes(ctx.validation_ds),
         cap=MAX_LOAD_CONCURRENCY,
     )
@@ -263,6 +269,7 @@ def value_timeseries(
     level: float | None = level_option,
     point: list[str] | None = point_option,
     output_dir: Path | None = output_dir_option,
+    value_samples: int = value_samples_option,
 ) -> None:
     """Plot per-timestep mean ± std of each variable at two spatial points over all time."""
     ds = load_zarr_dataset(dataset_url)
@@ -294,6 +301,7 @@ def value_timeseries(
         variables=selected_vars,
         is_virtual=is_virtual_store(dataset_url),
         level_override=level,
+        value_ts_samples=value_samples,
     )
     run_value_timeseries(ctx)
 

--- a/tests/scripts/validation/decode_scan_test.py
+++ b/tests/scripts/validation/decode_scan_test.py
@@ -102,14 +102,23 @@ def _decode_ds(shape: tuple[int, ...], chunks: tuple[int, ...]) -> xr.Dataset:
     return xr.Dataset({"var": var})
 
 
-def test_decode_chunk_span_ignores_the_dims_a_decode_pins() -> None:
+def test_decode_chunk_span_follows_how_the_checker_samples_each_dim() -> None:
     # 100 inits and 60 leads, one chunk each: a decode pins both, so it spans one chunk.
     ds = _decode_ds((100, 1, 60, 4, 4), (1, 1, 1, 4, 4))
     assert decode_scan._decode_chunk_span(ds) == 1
 
-    # 64 members in chunks of 4: a decode covers every member, so it spans 16 chunks.
+    # 64 members in chunks of 4: the checker samples SAMPLED_LEVELS of them, spread far
+    # enough apart to land in that many distinct chunks.
     ds = _decode_ds((100, 64, 60, 4, 4), (1, 4, 1, 4, 4))
-    assert decode_scan._decode_chunk_span(ds) == 16
+    assert decode_scan._decode_chunk_span(ds) == decode_scan.SAMPLED_LEVELS
+
+    # Members already in one chunk are one chunk however many the checker samples.
+    ds = _decode_ds((100, 64, 60, 4, 4), (1, 64, 1, 4, 4))
+    assert decode_scan._decode_chunk_span(ds) == 1
+
+    # Spatial dims are taken whole: a 4x4 grid in 2x2 chunks is 4 chunks.
+    ds = _decode_ds((100, 1, 60, 4, 4), (1, 1, 1, 2, 2))
+    assert decode_scan._decode_chunk_span(ds) == 4
 
 
 def test_decode_concurrency_falls_to_one_when_a_single_decode_fills_the_budget() -> (

--- a/tests/scripts/validation/decode_scan_test.py
+++ b/tests/scripts/validation/decode_scan_test.py
@@ -3,13 +3,15 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 
 from reformatters.common import validation
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from scripts.validation import decode_scan
-from scripts.validation.utils import RunContext
+from scripts.validation.decode_scan import _decode_concurrency
+from scripts.validation.utils import READ_BUDGET_BYTES, RunContext
 
 
 def _ctx(tmp_path: Path) -> RunContext:
@@ -76,7 +78,7 @@ def test_decode_checker_preserves_configured_all_nan_allowlist() -> None:
     def reference_exists(var_path: str, out_loc: Mapping[str, object]) -> bool:
         return bool(var_path or out_loc)
 
-    checker = decode_scan._decode_checker(dataset, reference_exists)
+    checker = decode_scan._decode_checker(dataset, reference_exists, max_workers=3)
 
     assert checker.allow_all_nan_vars == ("legitimate_all_nan",)
     assert checker.reference_exists is reference_exists
@@ -84,8 +86,37 @@ def test_decode_checker_preserves_configured_all_nan_allowlist() -> None:
         checker.positions,
         checker.sampled_leads,
         checker.sampled_levels,
+        checker.max_workers,
     ) == (
         1,
         decode_scan.SAMPLED_LEADS,
         decode_scan.SAMPLED_LEVELS,
+        3,
     )
+
+
+def _decode_ds(shape: tuple[int, ...], chunks: tuple[int, ...]) -> xr.Dataset:
+    dims = ("init_time", "ensemble_member", "lead_time", "y", "x")
+    var = xr.DataArray(np.zeros(shape, dtype="float32"), dims=dims)
+    var.encoding["chunks"] = chunks
+    return xr.Dataset({"var": var})
+
+
+def test_decode_chunk_span_ignores_the_dims_a_decode_pins() -> None:
+    # 100 inits and 60 leads, one chunk each: a decode pins both, so it spans one chunk.
+    ds = _decode_ds((100, 1, 60, 4, 4), (1, 1, 1, 4, 4))
+    assert decode_scan._decode_chunk_span(ds) == 1
+
+    # 64 members in chunks of 4: a decode covers every member, so it spans 16 chunks.
+    ds = _decode_ds((100, 64, 60, 4, 4), (1, 4, 1, 4, 4))
+    assert decode_scan._decode_chunk_span(ds) == 16
+
+
+def test_decode_concurrency_falls_to_one_when_a_single_decode_fills_the_budget() -> (
+    None
+):
+    assert _decode_concurrency(chunk_span=1, chunk_nbytes=2**10) == (
+        decode_scan.MAX_JOB_CONCURRENCY,
+        decode_scan.MAX_DECODE_CONCURRENCY,
+    )
+    assert _decode_concurrency(chunk_span=16, chunk_nbytes=READ_BUDGET_BYTES) == (1, 1)

--- a/tests/scripts/validation/manifest_scan_test.py
+++ b/tests/scripts/validation/manifest_scan_test.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -9,6 +10,7 @@ import xarray as xr
 import zarr
 from zarr.storage import MemoryStore
 
+from scripts.validation import manifest_scan
 from scripts.validation.manifest_scan import (
     ManifestScanResult,
     _flush_var_probes,
@@ -336,3 +338,29 @@ def test_result_availability_series_marks_unprobed_positions_nan() -> None:
     )
     np.testing.assert_array_equal(series.fraction[:2], [1.0, 0.0])
     assert np.isnan(series.fraction[2])
+
+
+def test_merge_batch_adds_counts_and_ors_variable_availability() -> None:
+    p1 = pd.Timestamp("2024-01-01")
+    p2 = pd.Timestamp("2024-01-02")
+    totals: manifest_scan._BatchResult = ({}, {})
+    manifest_scan._merge_batch(({p1: [2, 3]}, {"t2m": {p1: False}}), totals)
+    # A position split across two batches contributes its source files to both.
+    manifest_scan._merge_batch(
+        ({p1: [1, 1], p2: [4, 4]}, {"t2m": {p1: True, p2: True}}), totals
+    )
+    assert totals[0] == {p1: [3, 4], p2: [4, 4]}
+    assert totals[1] == {"t2m": {p1: True, p2: True}}
+
+
+def test_checkpoint_round_trips_through_disk(tmp_path: Path) -> None:
+    position = pd.Timestamp("2024-03-04T06:00")
+    batch: manifest_scan._BatchResult = (
+        {position: [7, 8]},
+        {"pressure_level/temperature": {position: True}},
+    )
+    path = tmp_path / "batch-00000.json"
+    assert manifest_scan._read_checkpoint(path) is None
+    manifest_scan._write_checkpoint(path, batch)
+    assert manifest_scan._read_checkpoint(path) == batch
+    assert not path.with_suffix(".partial").exists()

--- a/tests/scripts/validation/utils_test.py
+++ b/tests/scripts/validation/utils_test.py
@@ -6,14 +6,19 @@ import pandas as pd
 import xarray as xr
 
 from scripts.validation.utils import (
+    MAX_READ_CONCURRENCY,
+    READ_BUDGET_BYTES,
     _anonymous_virtual_credentials,
     _icechunk_storage,
     choose_level,
+    concurrent_load_workers,
     get_random_spatial_indices,
     get_two_random_points,
+    largest_chunk_nbytes,
     load_zarr_dataset,
     nearest_point_index,
     parse_point_options,
+    read_workers,
     to_reference_longitude,
     var_slug,
     vertical_dims,
@@ -197,3 +202,37 @@ def test_anonymous_virtual_credentials_authorize_http_container(tmp_path: Path) 
     credentials = _anonymous_virtual_credentials(storage)
     assert credentials is not None
     icechunk.Repository.open(storage, authorize_virtual_chunk_access=credentials)
+
+
+def _chunked_var(name: str, chunks: tuple[int, ...]) -> xr.DataArray:
+    dims = tuple(f"{name}_{i}" for i in range(len(chunks)))
+    var = xr.DataArray(np.zeros(chunks, dtype="float32"), dims=dims)
+    var.encoding["chunks"] = chunks
+    return var
+
+
+def test_largest_chunk_nbytes_uses_the_biggest_chunked_variable() -> None:
+    ds = xr.Dataset(
+        {
+            "small": _chunked_var("small", (1, 2, 2)),
+            "big": _chunked_var("big", (1, 4, 2, 2)),
+            "unchunked": xr.DataArray(np.zeros(4, dtype="float32"), dims="u"),
+        }
+    )
+    assert largest_chunk_nbytes(ds) == 4 * 2 * 2 * 4
+
+
+def test_read_workers_scales_down_with_chunk_size() -> None:
+    assert read_workers(READ_BUDGET_BYTES // 64) == MAX_READ_CONCURRENCY
+    assert read_workers(READ_BUDGET_BYTES // 4) == 4
+    # A single chunk over budget still gets one worker rather than none.
+    assert read_workers(READ_BUDGET_BYTES * 4) == 1
+    assert read_workers(0) == MAX_READ_CONCURRENCY
+
+
+def test_concurrent_load_workers_counts_only_the_chunks_a_load_spans() -> None:
+    chunk_nbytes = READ_BUDGET_BYTES // MAX_READ_CONCURRENCY
+    # A load spanning many chunks fills zarr's in-flight budget on its own.
+    assert concurrent_load_workers(1000, chunk_nbytes, cap=4) == 1
+    # A single-chunk load holds one chunk, so several run side by side.
+    assert concurrent_load_workers(1, chunk_nbytes, cap=4) == 4

--- a/tests/scripts/validation/utils_test.py
+++ b/tests/scripts/validation/utils_test.py
@@ -236,3 +236,18 @@ def test_concurrent_load_workers_counts_only_the_chunks_a_load_spans() -> None:
     assert concurrent_load_workers(1000, chunk_nbytes, cap=4) == 1
     # A single-chunk load holds one chunk, so several run side by side.
     assert concurrent_load_workers(1, chunk_nbytes, cap=4) == 4
+
+
+def test_nearest_point_index_accepts_either_longitude_convention() -> None:
+    ds = xr.Dataset(
+        coords={
+            "latitude": np.arange(-90.0, 91.0, 1.0),
+            "longitude": np.arange(0.0, 360.0, 1.0),
+        }
+    )
+    # A 0-360 grid has no -100 label; the cell meant is 260, not the 0 a plain
+    # nearest-value search lands on.
+    assert nearest_point_index(ds, 40.0, -100.0) == {"latitude": 130, "longitude": 260}
+    assert nearest_point_index(ds, 40.0, 260.0) == {"latitude": 130, "longitude": 260}
+    # And the seam is crossed the short way round.
+    assert nearest_point_index(ds, 0.0, -0.4) == {"latitude": 90, "longitude": 0}


### PR DESCRIPTION
Split out of #968, which is now just the WeatherNext 2 metadata changes.

Preparation for validating `google-weathernext2-forecast-historical-virtual`, an order of magnitude larger than any store the validation tooling had been run against: 4,384 init times x 64 ensemble members x 60 lead times x 721x1440, with chunks of 206 MiB (4 members and all 13 pressure levels in one chunk) where other stores chunk a few MiB.

Measured on the store before changing anything: a single `pressure_level/temperature` decode peaks at **5.9 GiB** RSS on its own, so the decode scan's stock 4 jobs x 32 workers would ask for far more memory than any host has.

No `docs/validation.md` changes here, per review.

### Size read concurrency by chunk bytes, not operation count

Every in-flight read holds one decoded chunk, so a fixed worker count makes peak memory a property of the store rather than of the tool. One budget (`READ_BUDGET_BYTES`) and one helper derive zarr's async concurrency, the value time series load pool, and the decode scan's job/decode pools from the store's chunk size.

On this store that resolves to zarr 32 -> 9, value time series loads 2 -> 1, decode scan 4x32 -> 3x1. A store with small chunks keeps exactly the numbers it has today.

### Match a pinned point's longitude in either convention

A real bug, not just a large-store concern. This archive labels longitude 0 to 360, so `--point 40,-100` found no nearby label and silently snapped to longitude 0 — putting the report's value and time series plots half a world from the point requested. Longitudes are now compared the short way around, which also fixes the search across the antimeridian seam.

### Model the decode footprint the way the checker actually samples

`CheckVirtualDecodeHealth._sample_levels` down-samples *every* non-spatial dim, ensemble members included — not just vertical levels. Its class docstring described a per-member sweep the code has never done, and the first version of the concurrency model here over-charged the footprint by the ensemble depth. Docstring and model corrected together.

### Resume an interrupted manifest scan

A whole-archive manifest scan runs for hours and held its entire result in memory, so anything that killed the process lost all of it. Each batch of region jobs now checkpoints to disk as it completes, and a later scan of the same window replays it: 108s of probing came back in **1.1s with identical results**. The checkpoint key covers the store's icechunk snapshot, so a scan of an archive written since starts fresh rather than replaying stale availability.

Not hypothetical — two full attempts at this dataset's validation run were destroyed mid-flight (79 and 25 minutes of probing lost) before this existed.

### Scope the sampling that is a cost knob, not a correctness one

`run-all` gains `--decode-samples` (decode-scan regions) and `--value-samples` (value-series positions). On a store with 206 MiB chunks the default 200-position value series decodes ~258 GiB, and the default decode sample decodes terabytes; both are samples by design, so their size should be settable without dropping the phase. Defaults are unchanged for every other dataset.

### Read each timeseries chunk once, not twice

`compare-timeseries` loaded its two run points separately, and a chunk is a whole spatial field, so every chunk in the series was decoded twice. Both points now come out of one read, the way the virtual value series already did. A 2x saving on that phase for any virtual store.

### Reject a non-numeric `--lead-time` when the run starts

`--lead-time` is documented in hours and parsed with `int()`, but was typed as a string, so `--lead-time 24h` was accepted and then raised in `compare-spatial` — the last phase of `run-all`, an hour or more into a large virtual run. Typing it as an int puts the error at the command line.

## Testing

- `uv run pytest tests/scripts/validation tests/common/validation_test.py` — 131 passed. New unit tests cover the budget arithmetic, the chunk-span model against how the checker samples each dim, both longitude conventions, and checkpoint merge/round-trip.
- `uv run ruff format --check`, `uv run ruff check`, `uv run ty check` all clean.
- Exercised end to end against the live store. A full `run-all` over the whole archive completed with these changes: the manifest scan confirmed all 4,384 positions complete, decode health passed, and the resulting report is out for review as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu85CtgWZjouCWCWvU32yK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nu85CtgWZjouCWCWvU32yK)_