### PR TITLE
Use the WeatherNext 2 bucket's real name, not its public hostname

### DIFF
--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -192,7 +192,7 @@ class Weathernext2IcechunkDatasetStorageConfig(StorageConfig):
     k8s secret, which holds `icechunk.s3_storage` kwargs.
     """
 
-    base_path: str = "s3://google-weathernext2"
+    base_path: str = "s3://dynamical-google-weathernext2"
     k8s_secret_name: str = "weathernext2-storage-options-key"  # noqa: S105
     format: DatasetFormat = DatasetFormat.ICECHUNK
 


### PR DESCRIPTION
Follow-up to #971, which got the bucket name wrong.

The R2 bucket is `dynamical-google-weathernext2`. `google-weathernext2` is the first label of the public hostname it is served at (`google-weathernext2.r2.dynamical.org`), not the bucket name. The S3 API path is `<endpoint>/dynamical-google-weathernext2`.

```diff
- base_path: str = "s3://google-weathernext2"
+ base_path: str = "s3://dynamical-google-weathernext2"
```

### Why it looked like a credentials problem

The `r2-wn2-rw` token is scoped to specific buckets (`dynamical-google-weathernext2`), so requests naming a bucket outside that scope come back `403 Forbidden` — an authorization error, not `NoSuchBucket`. That sent the diagnosis toward the token rather than the name. Verified with the cluster's own credentials against the account endpoint:

| Probe | Result |
|---|---|
| `HeadBucket google-weathernext2` | 403 Forbidden |
| `HeadObject` any key, `google-weathernext2` | 403 Forbidden |
| `HeadBucket dynamical-google-weathernext2` | 200 OK |

The bucket's public-read setting applies to anonymous requests over the custom hostname and grants nothing to a signed S3 API request, so it never masked this.

### The existing archive is intact

The historical store is present under the correct bucket at the path this change resolves to, so no re-backfill is needed:

```
s3://dynamical-google-weathernext2/google-weathernext2-forecast-historical-virtual/v0.1.0.icechunk/
  chunks/ manifests/ overwritten/ snapshots/ transactions/ repo
  2791 objects, 8,545,250,390 bytes
```

Full suite: 2416 passed, 14 skipped.

Unblocks the operational backfill in dynamical-org/meta#188.