### PR TITLE
Run WeatherNext 2 operational updates and validation

### DIFF
--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/dynamical_dataset.py
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/dynamical_dataset.py
@@ -50,7 +50,6 @@ class GoogleWeathernext2ForecastOperationalVirtualDataset(
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         cron_job_name_prefix = self.dataset_id.replace("weathernext2", "wn2")
-        suspend = True
         update = ReformatCronJob(
             name=f"{cron_job_name_prefix}-update",
             schedule="55 0,6,12,18 * * *",
@@ -60,7 +59,6 @@ class GoogleWeathernext2ForecastOperationalVirtualDataset(
             cpu="1.7",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=suspend,
         )
         validate = ValidationCronJob(
             name=f"{cron_job_name_prefix}-validate",
@@ -71,7 +69,6 @@ class GoogleWeathernext2ForecastOperationalVirtualDataset(
             cpu="1.3",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=suspend,
         )
         return [update, validate]
 

--- a/tests/google/weathernext2/forecast_virtual/dynamical_dataset_test.py
+++ b/tests/google/weathernext2/forecast_virtual/dynamical_dataset_test.py
@@ -69,8 +69,8 @@ def test_operational_product_has_lag_aware_crons_and_splits(tmp_path: Path) -> N
     assert update.workers_total == 1
     assert update.parallelism == 1
     assert update.pod_active_deadline < timedelta(hours=6)
-    assert update.suspend is True
-    assert validate.suspend is True
+    assert update.suspend is False
+    assert validate.suspend is False
     (current,) = [
         item
         for item in dataset.validators()


### PR DESCRIPTION
The `google-weathernext2-forecast-operational-virtual` backfill is complete and validated, so its cron jobs can come off `suspend`.

```
81/81 workers succeeded
2412 inits, 2025-01-01 -> 2026-08-28T12:00
31,596 objects / 139 GB
```

Validation on `main` passes all three checks, including `CheckCurrentData` — the newest position due after the 48-hour publication lag is present — so the cutoff behaves correctly on a fresh store and the update job has a well-formed archive to append to.

Removed the `suspend` lines rather than setting `suspend=False`, matching the pattern the example templates document (`# suspend = True  # Defaults to False, remove after backfilling to run operational updates and validation`) and the majority of datasets, which omit the argument.

Resulting cron jobs:

```
suspend=False  55 0,6,12,18 * * *   google-wn2-forecast-operational-virtual-update
suspend=False  55 1,7,13,19 * * *   google-wn2-forecast-operational-virtual-validate
suspend=True   0 0 * * *            google-wn2-forecast-historical-virtual-update
suspend=True   0 0 * * *            google-wn2-forecast-historical-virtual-validate
```

The historical product stays suspended deliberately: its archive is a fixed 2022–2024 range, so its `-update` cron has nothing to append. Whether to enable its `-validate` alone is left as a separate decision.

Full suite: 2416 passed, 14 skipped.

Tracked in dynamical-org/meta#188.

### Two follow-ups this does not cover

- The whole-archive completeness scan (`availability --min-fraction 1.0`) has not been run for either product. The operational `-validate` check samples only the region job's recent window — 63 of 2412 positions on this run — and its own docstring points at `manifest_scan` for whole-archive coverage.
- Four orphaned cron jobs from the #957 → #959 rename are still in the cluster (`weathernext2-forecast-*`, suspended) and should be deleted.