### PR TITLE
Apply the WeatherNext 2 publication lag to initialization time

### DIFF
--- a/src/reformatters/google/weathernext2/forecast_virtual/region_job.py
+++ b/src/reformatters/google/weathernext2/forecast_virtual/region_job.py
@@ -195,6 +195,7 @@ class GoogleWeathernext2ForecastVirtualRegionJob(
                 job_fire_time=PER_INIT_STORE_DATE,
             )
         fire_time = job_fire_time or _utc_now()
+        publication_cutoff = fire_time - _PUBLICATION_LAG
         jobs, template_ds = super().operational_update_jobs(
             primary_store=primary_store,
             tmp_store=tmp_store,
@@ -202,12 +203,12 @@ class GoogleWeathernext2ForecastVirtualRegionJob(
             append_dim=append_dim,
             all_data_vars=all_data_vars,
             reformat_job_name=reformat_job_name,
-            job_fire_time=fire_time,
+            job_fire_time=publication_cutoff,
         )
         (job,) = jobs
         assert isinstance(job, cls)
         return [
-            job.model_copy(update={"publication_cutoff": fire_time - _PUBLICATION_LAG})
+            job.model_copy(update={"publication_cutoff": publication_cutoff})
         ], template_ds
 
     def generate_source_file_coords(
@@ -222,13 +223,13 @@ class GoogleWeathernext2ForecastVirtualRegionJob(
                 self.source_layout == "operational"
             ):
                 continue
+            if (
+                self.source_layout == "operational"
+                and init_time >= self.publication_cutoff
+            ):
+                continue
             for lead_time_value in processing_region_ds["lead_time"].values:
                 lead_time = pd.Timedelta(lead_time_value)
-                if (
-                    self.source_layout == "operational"
-                    and init_time + lead_time >= self.publication_cutoff
-                ):
-                    continue
                 coords.extend(
                     GoogleWeathernext2ForecastVirtualSourceFileCoord(
                         source_layout=self.source_layout,

--- a/tests/google/weathernext2/forecast_virtual/native_region_job_test.py
+++ b/tests/google/weathernext2/forecast_virtual/native_region_job_test.py
@@ -211,22 +211,32 @@ def test_operational_refs_keep_singleton_member_and_level_chunks(
     )
 
 
-def test_operational_generation_enforces_strict_valid_time_cutoff() -> None:
+def test_operational_generation_enforces_strict_init_time_cutoff() -> None:
     init_time = pd.Timestamp("2025-03-01T00:00")
     template = OPERATIONAL.get_template(init_time + pd.Timedelta("6h"))
     var = _var(OPERATIONAL, "temperature_2m")
-    job = _job(
-        GoogleWeathernext2ForecastOperationalVirtualRegionJob,
-        OPERATIONAL,
-        template,
-        [var],
-        publication_cutoff=init_time + pd.Timedelta("12h"),
-    )
     region = template.to_dataset().sel(init_time=[init_time])
+    all_lead_times = list(OPERATIONAL.dimension_coordinates()["lead_time"])
 
-    coords = job.generate_source_file_coords(region, [var])
+    def coords_with_cutoff(cutoff: pd.Timestamp) -> list[pd.Timedelta]:
+        job = _job(
+            GoogleWeathernext2ForecastOperationalVirtualRegionJob,
+            OPERATIONAL,
+            template,
+            [var],
+            publication_cutoff=cutoff,
+        )
+        return [
+            coord.lead_time for coord in job.generate_source_file_coords(region, [var])
+        ]
 
-    assert [coord.lead_time for coord in coords] == [pd.Timedelta("6h")]
+    # An initialization before the cutoff publishes every lead time, however far ahead
+    # it forecasts; one at the cutoff publishes nothing.
+    assert (
+        coords_with_cutoff(init_time + OPERATIONAL.append_dim_frequency)
+        == all_lead_times
+    )
+    assert coords_with_cutoff(init_time) == []
 
 
 def test_source_file_coords_are_independent_per_variable() -> None:
@@ -255,7 +265,7 @@ def test_source_file_coords_are_independent_per_variable() -> None:
     }
 
 
-def test_operational_backfill_jobs_share_strict_valid_time_cutoff(
+def test_operational_backfill_jobs_share_strict_init_time_cutoff(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     init_time = pd.Timestamp("2025-01-01T00:00")
@@ -281,7 +291,9 @@ def test_operational_backfill_jobs_share_strict_valid_time_cutoff(
         region,
         [_var(OPERATIONAL, "temperature_2m")],
     )
-    assert [coord.lead_time for coord in coords] == [pd.Timedelta("6h")]
+    assert [coord.lead_time for coord in coords] == list(
+        OPERATIONAL.dimension_coordinates()["lead_time"]
+    )
 
 
 def test_historical_validation_job_uses_final_fixed_window() -> None:
@@ -329,7 +341,10 @@ def test_direct_operational_update_uses_utc_clock(
     [job] = jobs
     assert isinstance(job, GoogleWeathernext2ForecastOperationalVirtualRegionJob)
     assert job.publication_cutoff == now - pd.Timedelta("48h")
-    assert template.to_dataset().get_index("init_time")[-1] == now - pd.Timedelta("6h")
+    # The newest initialization kept is the newest one outside the publication lag.
+    last_init = template.to_dataset().get_index("init_time")[-1]
+    assert last_init < job.publication_cutoff
+    assert last_init + OPERATIONAL.append_dim_frequency >= job.publication_cutoff
 
 
 def test_object_listing_retries_transient_response() -> None:


### PR DESCRIPTION
The 48 hour publication lag was applied per lead time, against each reference's valid time. That withheld most of every recent forecast: the newest initialization carried a single lead time, a complete 15 day forecast appeared only once an initialization was about 17 days old, and the newest nine initializations were coordinates with no data behind them.

This applies the lag to initialization time instead, so an initialization older than the lag publishes every lead time it carries.

```
                         before                after
last init_time           now - 54h             now - 48h
newest complete forecast init ~17 days old     the newest init
trailing empty positions ~9                    none
```

With `fire_time = 2026-08-29 12:55`, every initialization in the update window is complete:

```
  init_time            age_at_fire     leads
  2026-08-27 12:00     2 days 00:55    60/60
  2026-08-26 12:00     3 days 00:55    60/60
  2026-08-25 12:00     4 days 00:55    60/60
```

The filter no longer varies with lead time, so it moves up to the initialization loop and `generate_source_file_coords` loses a branch from its inner loop. The append dim ends at the cutoff, which is now an initialization that publishes in full.

The 18 day update window is unchanged and still spans every initialization the window is meant to cover; it now trails the cutoff rather than the wall clock.

### Existing store

The store carries initializations that were truncated under the previous rule. The update window covers them, so the remaining lead times are ingested by the next few updates rather than needing a re-backfill.

### Tests

The two cutoff tests are renamed from `..._valid_time_cutoff` to `..._init_time_cutoff` and pin the boundary from both sides: an initialization before the cutoff yields every lead time, one at the cutoff yields none. `test_direct_operational_update_uses_utc_clock` pins the append dim ending at the cutoff.

Full suite: 2425 passed, 14 skipped.
