### PR TITLE
Move WeatherNext 2 variable quirks into comment attrs

### DIFF
--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
@@ -64,6 +64,7 @@
     "short_name": "q",
     "standard_name": "specific_humidity",
     "units": "1",
+    "comment": "Small negative values are raw model artifacts; set values < 0 to zero.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
@@ -55,7 +55,7 @@
     "short_name": "sst",
     "standard_name": "sea_surface_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN over land where sea surface temperature does not apply.",
+    "comment": "NaN over land where sea surface temperature does not apply. Value changes once every 24 hours.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_historical_virtual/templates/latest.zarr/zarr.json
@@ -734,6 +734,7 @@
           "short_name": "q",
           "standard_name": "specific_humidity",
           "units": "1",
+          "comment": "Small negative values are raw model artifacts; set values < 0 to zero.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1377,7 +1378,7 @@
           "short_name": "sst",
           "standard_name": "sea_surface_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN over land where sea surface temperature does not apply.",
+          "comment": "NaN over land where sea surface temperature does not apply. Value changes once every 24 hours.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/pressure_level/specific_humidity/zarr.json
@@ -51,6 +51,7 @@
     "short_name": "q",
     "standard_name": "specific_humidity",
     "units": "1",
+    "comment": "Small negative values are raw model artifacts; set values < 0 to zero.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/sea_surface_temperature/zarr.json
@@ -55,7 +55,7 @@
     "short_name": "sst",
     "standard_name": "sea_surface_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN over land where sea surface temperature does not apply.",
+    "comment": "NaN over land where sea surface temperature does not apply. Value changes once every 24 hours.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/google/weathernext2/forecast_operational_virtual/templates/latest.zarr/zarr.json
@@ -708,6 +708,7 @@
           "short_name": "q",
           "standard_name": "specific_humidity",
           "units": "1",
+          "comment": "Small negative values are raw model artifacts; set values < 0 to zero.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -1299,7 +1300,7 @@
           "short_name": "sst",
           "standard_name": "sea_surface_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN over land where sea surface temperature does not apply.",
+          "comment": "NaN over land where sea surface temperature does not apply. Value changes once every 24 hours.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/google/weathernext2/forecast_virtual/template_config.py
+++ b/src/reformatters/google/weathernext2/forecast_virtual/template_config.py
@@ -476,6 +476,7 @@ def _pressure_var(
     units: str,
     source_layout: SourceLayout,
     standard_name: str | None = None,
+    comment: str | None = None,
     filters: Sequence[CodecConfig] = (),
 ) -> GoogleWeathernext2DataVar:
     return _var(
@@ -487,7 +488,7 @@ def _pressure_var(
         units=units,
         standard_name=standard_name,
         step_type="instant",
-        comment=None,
+        comment=comment,
         date_available=None,
         filters=filters,
         source_layout=source_layout,
@@ -558,7 +559,10 @@ def _root_data_vars(source_layout: SourceLayout) -> list[GoogleWeathernext2DataV
             long_name="Sea surface temperature",
             units="degree_Celsius",
             standard_name="sea_surface_temperature",
-            comment="NaN over land where sea surface temperature does not apply.",
+            comment=(
+                "NaN over land where sea surface temperature does not apply. "
+                "Value changes once every 24 hours."
+            ),
             filters=[_KELVIN_TO_CELSIUS],
             source_layout=source_layout,
         ),
@@ -638,6 +642,9 @@ def _pressure_data_vars(
             long_name="Specific humidity",
             units="1",
             standard_name="specific_humidity",
+            comment=(
+                "Small negative values are raw model artifacts; set values < 0 to zero."
+            ),
             source_layout=source_layout,
         ),
     ]


### PR DESCRIPTION
Validating `google-weathernext2-forecast-operational-virtual` surfaced two variable quirks that had been living in the historical dataset's validation report review notes. Both are intrinsic, always-true facts about the variables, so per the comment-vs-review-note rule in AGENTS.md they belong in each variable's `comment` attr, where they travel with the data instead of going stale in a report.

## Changes

- **`pressure_level/specific_humidity` gains a `comment`**: "Small negative values are raw model artifacts; set values < 0 to zero." Wording matches the existing sentence on `total_precipitation_surface`, which has the same artifact.
- **`sea_surface_temperature`'s `comment` gains a sentence**: "Value changes once every 24 hours." — it is a daily field, clearly visible as 24-hour steps in the validation report's time series. Its existing land-NaN sentence is unchanged.
- **`_pressure_var` gains the `comment` parameter** `_root_var` already had; it previously hard-coded `comment=None`, so no pressure-level variable could carry one.

Templates regenerated for both WeatherNext 2 datasets, which share this template config. The only attribute diffs are the two comments above.

## Validation

- `uv run ruff format && uv run ruff check --fix && uv run ty check` — all pass
- `uv run pytest tests/common/common_template_config_subclasses_test.py tests/common/datasets_cf_compliance_test.py` — 391 passed

Both quirks were confirmed against real data in this validation run rather than carried over on trust: specific humidity reaches −7.6e-4 in the sampled 500 hPa field, and sea surface temperature's point time series steps in flat 24-hour segments.

The next operational update will push these attrs to the store. The validation report already reflects the new wording, so it runs a few hours ahead of the store until then.

Draft validation report: https://dataset-validation-reports.dynamical.org/google-weathernext2-forecast-operational-virtual/drafts/v0.1.0_2026-08-28T21-28/validation_report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLiGAuwZuzVoD9SNoGxD1K

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLiGAuwZuzVoD9SNoGxD1K)_