### PR TITLE
Keep the WeatherNext 2 update template covering the whole store

### DIFF
--- a/src/reformatters/google/weathernext2/forecast_virtual/region_job.py
+++ b/src/reformatters/google/weathernext2/forecast_virtual/region_job.py
@@ -3,12 +3,13 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
-from typing import ClassVar, NamedTuple, Self
+from typing import ClassVar, NamedTuple, Self, cast
 
 import httpx
 import icechunk
 import pandas as pd
 import xarray as xr
+import zarr
 from pydantic import Field
 from zarr.abc.store import Store
 
@@ -203,7 +204,9 @@ class GoogleWeathernext2ForecastVirtualRegionJob(
             append_dim=append_dim,
             all_data_vars=all_data_vars,
             reformat_job_name=reformat_job_name,
-            job_fire_time=publication_cutoff,
+            job_fire_time=_end_covering_store(
+                get_template_fn, primary_store, append_dim, publication_cutoff
+            ),
         )
         (job,) = jobs
         assert isinstance(job, cls)
@@ -419,6 +422,27 @@ def _utc_now() -> Timestamp:
 
 def _current_publication_cutoff() -> Timestamp:
     return _utc_now() - _PUBLICATION_LAG
+
+
+def _end_covering_store(
+    get_template_fn: Callable[[DatetimeLike], xr.DataTree],
+    primary_store: Store,
+    append_dim: AppendDim,
+    end: Timestamp,
+) -> Timestamp:
+    """`end`, extended to cover every append dim label the store already holds.
+
+    The publication lag pulls this product's end backwards, and trimming a store is
+    never supported, so an end behind the store's newest label would fail every update
+    until the clock caught up to it.
+    """
+    index = get_template_fn(end).to_dataset().get_index(append_dim)
+    store_append_dim = zarr.open_group(primary_store, mode="r")[append_dim]
+    assert isinstance(store_append_dim, zarr.Array)
+    missing = int(store_append_dim.shape[0]) - len(index)
+    if missing <= 0:
+        return end
+    return cast("Timestamp", end + missing * (index[-1] - index[-2]))
 
 
 def _list_objects(

--- a/tests/google/weathernext2/forecast_virtual/native_region_job_test.py
+++ b/tests/google/weathernext2/forecast_virtual/native_region_job_test.py
@@ -6,6 +6,7 @@ import httpx
 import pandas as pd
 import pytest
 import xarray as xr
+import zarr
 from zarr.storage import MemoryStore
 
 from reformatters.google.weathernext2.forecast_historical_virtual.template_config import (
@@ -321,6 +322,12 @@ def test_historical_validation_job_uses_final_fixed_window() -> None:
     )
 
 
+def _store_with_init_times(count: int) -> MemoryStore:
+    store = MemoryStore()
+    zarr.create_group(store).create_array("init_time", shape=(count,), dtype="int64")
+    return store
+
+
 def test_direct_operational_update_uses_utc_clock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -329,7 +336,7 @@ def test_direct_operational_update_uses_utc_clock(
 
     jobs, template = (
         GoogleWeathernext2ForecastOperationalVirtualRegionJob.operational_update_jobs(
-            primary_store=MemoryStore(),
+            primary_store=_store_with_init_times(0),
             tmp_store=Path("unused.zarr"),
             get_template_fn=OPERATIONAL.get_template,
             append_dim="init_time",
@@ -379,3 +386,29 @@ def test_object_listing_retries_transient_response() -> None:
         )
     }
     assert client.get.call_count == 2
+
+
+def test_operational_update_template_never_trims_the_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A backfill can leave initializations the publication lag now puts in the future.
+    # refresh_store_metadata refuses to trim, so the update must still cover them.
+    now = pd.Timestamp("2025-03-20T12:00")
+    monkeypatch.setattr(region_job_module, "_utc_now", lambda: now)
+    cutoff = now - pd.Timedelta("48h")
+    at_cutoff = len(
+        OPERATIONAL.get_template(cutoff).to_dataset().get_index("init_time")
+    )
+
+    _jobs, template = (
+        GoogleWeathernext2ForecastOperationalVirtualRegionJob.operational_update_jobs(
+            primary_store=_store_with_init_times(at_cutoff + 3),
+            tmp_store=Path("unused.zarr"),
+            get_template_fn=OPERATIONAL.get_template,
+            append_dim="init_time",
+            all_data_vars=OPERATIONAL.data_vars,
+            reformat_job_name="test",
+        )
+    )
+
+    assert len(template.to_dataset().get_index("init_time")) == at_cutoff + 3


### PR DESCRIPTION
Every operational update has been failing since the publication lag moved to the append dim end:

```
ValueError: Template is not safe to write over the existing store:
- /: template has 2416 init_time steps but the store has 2419;
  trimming an existing store is never supported
```

The store was backfilled with an end of "now", so its newest initialization is `2026-08-28 12:00`. The update's end is now the publication cutoff, which is 48 hours behind the fire time, so the template stops three positions short of the store and `assert_safe_overwrite` rejects it.

Left alone this clears itself once the cutoff passes the store's newest initialization — about 16 hours — but every update in between fails, and any future change to the lag, or any backfill that runs ahead of the cutoff, reproduces it.

`operational_update_jobs` now extends the end to cover whatever the store already holds, so the template never proposes a trim.

### Scope

The clamp lives in the WeatherNext 2 region job rather than `VirtualRegionJob`, because this is the only virtual product whose end moves backwards — the others end at their fire time, which never regresses. `VirtualRegionJob.operational_update_jobs` keeps `primary_store` unused, and the tests that pass a `Mock()` for it are untouched.

### Tests

`test_operational_update_template_never_trims_the_store` gives the update a store holding three more initializations than the cutoff would cover and asserts the returned template still spans all of them. `test_direct_operational_update_uses_utc_clock` now passes a store with a real `init_time` array rather than an empty `MemoryStore`.

Full suite: 2426 passed, 14 skipped.

Tracked in dynamical-org/meta#188.