### PR TITLE
Sweep 24 hours of newly publishable WeatherNext 2 initializations

### DIFF
--- a/src/reformatters/google/weathernext2/forecast_virtual/region_job.py
+++ b/src/reformatters/google/weathernext2/forecast_virtual/region_job.py
@@ -406,7 +406,9 @@ class GoogleWeathernext2ForecastOperationalVirtualRegionJob(
     source_layout: ClassVar[SourceLayout] = "operational"
     # A 32-init batch would construct about 11.2 million virtual refs in memory.
     manifest_init_split: ClassVar[int] = OPERATIONAL_PRESSURE_MANIFEST_INIT_SPLIT
-    operational_update_window: ClassVar[Timedelta] = pd.Timedelta("18D")
+    operational_update_window: ClassVar[Timedelta] = (
+        pd.Timedelta("24h") + _PUBLICATION_LAG
+    )
 
 
 def _store_key(url: str) -> str:

--- a/src/reformatters/google/weathernext2/forecast_virtual/region_job.py
+++ b/src/reformatters/google/weathernext2/forecast_virtual/region_job.py
@@ -406,9 +406,7 @@ class GoogleWeathernext2ForecastOperationalVirtualRegionJob(
     source_layout: ClassVar[SourceLayout] = "operational"
     # A 32-init batch would construct about 11.2 million virtual refs in memory.
     manifest_init_split: ClassVar[int] = OPERATIONAL_PRESSURE_MANIFEST_INIT_SPLIT
-    operational_update_window: ClassVar[Timedelta] = (
-        pd.Timedelta("24h") + _PUBLICATION_LAG
-    )
+    operational_update_window: ClassVar[Timedelta] = pd.Timedelta("24h")
 
 
 def _store_key(url: str) -> str:

--- a/tests/google/weathernext2/forecast_virtual/native_region_job_test.py
+++ b/tests/google/weathernext2/forecast_virtual/native_region_job_test.py
@@ -345,7 +345,7 @@ def test_direct_operational_update_uses_utc_clock(
     last_init = template.to_dataset().get_index("init_time")[-1]
     assert last_init < job.publication_cutoff
     assert last_init + OPERATIONAL.append_dim_frequency >= job.publication_cutoff
-    window_start = job.publication_cutoff - pd.Timedelta("72h")
+    window_start = job.publication_cutoff - pd.Timedelta("24h")
     oldest_init = min(coord.init_time for coord in job.source_file_coords())
     assert oldest_init >= window_start
     assert oldest_init - OPERATIONAL.append_dim_frequency < window_start

--- a/tests/google/weathernext2/forecast_virtual/native_region_job_test.py
+++ b/tests/google/weathernext2/forecast_virtual/native_region_job_test.py
@@ -345,6 +345,10 @@ def test_direct_operational_update_uses_utc_clock(
     last_init = template.to_dataset().get_index("init_time")[-1]
     assert last_init < job.publication_cutoff
     assert last_init + OPERATIONAL.append_dim_frequency >= job.publication_cutoff
+    window_start = job.publication_cutoff - pd.Timedelta("72h")
+    oldest_init = min(coord.init_time for coord in job.source_file_coords())
+    assert oldest_init >= window_start
+    assert oldest_init - OPERATIONAL.append_dim_frequency < window_start
 
 
 def test_object_listing_retries_transient_response() -> None:


### PR DESCRIPTION
Sets `GoogleWeathernext2ForecastOperationalVirtualRegionJob.operational_update_window` to `24h`, down from `18D`. The 18 day window existed because the publication lag was applied per lead time, so a forecast only became complete about 17 days after its initialization. With the lag applied to initialization time, an initialization is complete as soon as it clears the lag.

`operational_update_jobs` passes `publication_cutoff` (fire time − 48h) as the window's end, so a 24 hour window reaches back 72 hours from each fire: the newest 24 hours of initializations that have cleared the 48 hour lag. At the 6 hourly initialization frequency that is four initializations of overlap per fire, and the update cron fires four times a day.

The historical job's `1D` window is unchanged.

Testing: added assertions to `test_direct_operational_update_uses_utc_clock` pinning the oldest initialization the sweep reaches. `uv run ruff check`, `uv run ty check`, and `uv run pytest -m "not slow"` all pass.