### PR TITLE
Fix new integration naming convention

### DIFF
--- a/docs/implementation_guide.md
+++ b/docs/implementation_guide.md
@@ -46,7 +46,9 @@ uv run main initialize-new-integration <provider> <model> <variant> --kind <mate
 
 Provider, model and variant can contain letters, numbers and dashes (e.g. ICON-EU or analysis-hourly). Capitalization will be normalized for you. `--kind` selects the teaching template that is scaffolded.
 
-This adds a number of files within `src/reformatters/<provider>/<model>/<variant>` and `tests/<provider>/<model>/<variant>`.
+Materialized integrations use the variant unchanged in module and class names. Virtual integrations append `_virtual` to the module and `Virtual` to the classes; pass the base variant to the command and let `--kind virtual` add the suffix. For example, `initialize-new-integration noaa gfs forecast --kind virtual` creates `src/reformatters/noaa/gfs/forecast_virtual/` with classes such as `NoaaGfsForecastVirtualTemplateConfig` and `NoaaGfsForecastVirtualDataset`.
+
+The command adds files within `src/reformatters/<provider>/<model>/<module-variant>` and `tests/<provider>/<model>/<module-variant>`.
 
 These files contain placeholder implementations of the subclasses referenced above, commented with guidance specific to the kind you chose. Follow the rest of this doc to complete the implementations and integrate your new dataset.
 

--- a/src/reformatters/__main__.py
+++ b/src/reformatters/__main__.py
@@ -31,7 +31,7 @@ from reformatters.contrib.noaa.ndvi_cdr.analysis import (
 )
 from reformatters.contrib.uarizona.swann.analysis import UarizonaSwannAnalysisDataset
 from reformatters.dwd.icon_eu.forecast_5_day import DwdIconEuForecast5DayDataset
-from reformatters.eccc.hrdps.forecast import EcccHrdpsForecastDynamicalDataset
+from reformatters.eccc.hrdps.forecast import EcccHrdpsForecastDataset
 from reformatters.ecmwf.aifs_ens.forecast import (
     EcmwfAifsEnsForecastDataset,
 )
@@ -260,7 +260,7 @@ DYNAMICAL_DATASETS: Sequence[DynamicalDataset[Any, Any]] = [
         primary_storage_config=DwdIconEuIcechunkAwsOpenDataDatasetStorageConfig(),
     ),
     # ECCC
-    EcccHrdpsForecastDynamicalDataset(
+    EcccHrdpsForecastDataset(
         primary_storage_config=EcccHrdpsIcechunkAwsOpenDataDatasetStorageConfig(),
     ),
     # Google

--- a/src/reformatters/common/initialize_new_integration.py
+++ b/src/reformatters/common/initialize_new_integration.py
@@ -49,11 +49,11 @@ def initialize_new_integration(
     provider = _sanitize_identifier(provider)
     model = _sanitize_identifier(model)
     variant = _sanitize_identifier(variant)
-    if variant == "virtual" or variant.endswith("_virtual"):
+    if "virtual" in variant:
         message = (
-            "variant must omit the 'virtual' suffix when --kind virtual is used"
+            "variant must omit 'virtual' when --kind virtual is used"
             if kind is DatasetKind.virtual
-            else "variant cannot use the 'virtual' suffix with --kind materialized"
+            else "variant cannot use 'virtual' with --kind materialized"
         )
         raise typer.BadParameter(
             message,

--- a/src/reformatters/common/initialize_new_integration.py
+++ b/src/reformatters/common/initialize_new_integration.py
@@ -20,17 +20,9 @@ class DatasetKind(StrEnum):
     virtual = "virtual"
 
 
-_EXAMPLE_DIRS: dict[DatasetKind, str] = {
-    DatasetKind.materialized: "example_materialized",
-    DatasetKind.virtual: "example_virtual",
-}
-
-# A dataset's class names encode how it is used, not how it is built: materialized
-# datasets are time-optimized (Temporal), virtual datasets are spatial-optimized
-# (Spatial). The teaching templates are named to match.
-_KIND_INFIX: dict[DatasetKind, str] = {
-    DatasetKind.materialized: "Temporal",
-    DatasetKind.virtual: "Spatial",
+_EXAMPLES: dict[DatasetKind, tuple[str, str]] = {
+    DatasetKind.materialized: ("example_materialized", "Temporal"),
+    DatasetKind.virtual: ("example_virtual", "Spatial"),
 }
 
 
@@ -57,14 +49,23 @@ def initialize_new_integration(
     provider = _sanitize_identifier(provider)
     model = _sanitize_identifier(model)
     variant = _sanitize_identifier(variant)
+    if kind is DatasetKind.virtual and (
+        variant == "virtual" or variant.endswith("_virtual")
+    ):
+        raise typer.BadParameter(
+            "variant must omit the 'virtual' suffix when --kind virtual is used",
+            param_hint="variant",
+        )
+
+    module_variant = f"{variant}_virtual" if kind is DatasetKind.virtual else variant
 
     # Convert to PascalCase for class names
     provider_pascal = _pascal_case(provider)
     model_pascal = _pascal_case(model)
-    variant_pascal = _pascal_case(variant)
+    module_variant_pascal = _pascal_case(module_variant)
 
     # Set up paths
-    dataset_path = f"{provider}/{model}/{variant}"
+    dataset_path = f"{provider}/{model}/{module_variant}"
     src_path = Path("src/reformatters") / dataset_path
     test_path = Path("tests") / dataset_path
 
@@ -81,7 +82,7 @@ def initialize_new_integration(
             (current / "__init__.py").touch(exist_ok=True)
 
     # Copy from the chosen example template
-    example_dirname = _EXAMPLE_DIRS[kind]
+    example_dirname, example_class_prefix = _EXAMPLES[kind]
     example_src = Path("src/reformatters") / example_dirname
     example_test = Path("tests") / example_dirname
 
@@ -93,23 +94,16 @@ def initialize_new_integration(
         if file.is_file():
             shutil.copy(file, test_path / file.name)
 
-    # Perform renames in copied files. The dataset class names carry the kind's infix
-    # (Temporal / Spatial); DataVar and InternalAttrs are model-level config models
-    # shared across a model's datasets, so they stay {provider}{model}-scoped. The
-    # import-prefix key uses the chosen example package so virtual copies aren't
-    # half-renamed by a "reformatters.example" prefix match.
-    infix = _KIND_INFIX[kind]
-    dataset_class_name = (
-        f"{provider_pascal}{model_pascal}{variant_pascal}{infix}DynamicalDataset"
-    )
+    class_prefix = f"{provider_pascal}{model_pascal}{module_variant_pascal}"
+    dataset_class_name = f"{class_prefix}Dataset"
     example_to_actual_mappings = {
-        f"Example{infix}DynamicalDataset": dataset_class_name,
-        f"Example{infix}TemplateConfig": f"{provider_pascal}{model_pascal}{variant_pascal}{infix}TemplateConfig",
-        f"Example{infix}RegionJob": f"{provider_pascal}{model_pascal}{variant_pascal}{infix}RegionJob",
-        f"Example{infix}SourceFileCoord": f"{provider_pascal}{model_pascal}{variant_pascal}{infix}SourceFileCoord",
+        f"Example{example_class_prefix}DynamicalDataset": dataset_class_name,
+        f"Example{example_class_prefix}TemplateConfig": f"{class_prefix}TemplateConfig",
+        f"Example{example_class_prefix}RegionJob": f"{class_prefix}RegionJob",
+        f"Example{example_class_prefix}SourceFileCoord": f"{class_prefix}SourceFileCoord",
         "ExampleDataVar": f"{provider_pascal}{model_pascal}DataVar",
         "ExampleInternalAttrs": f"{provider_pascal}{model_pascal}InternalAttrs",
-        f"reformatters.{example_dirname}": f"reformatters.{provider}.{model}.{variant}",
+        f"reformatters.{example_dirname}": f"reformatters.{provider}.{model}.{module_variant}",
     }
 
     # Process all Python files in both src and test directories

--- a/src/reformatters/common/initialize_new_integration.py
+++ b/src/reformatters/common/initialize_new_integration.py
@@ -49,11 +49,14 @@ def initialize_new_integration(
     provider = _sanitize_identifier(provider)
     model = _sanitize_identifier(model)
     variant = _sanitize_identifier(variant)
-    if kind is DatasetKind.virtual and (
-        variant == "virtual" or variant.endswith("_virtual")
-    ):
+    if variant == "virtual" or variant.endswith("_virtual"):
+        message = (
+            "variant must omit the 'virtual' suffix when --kind virtual is used"
+            if kind is DatasetKind.virtual
+            else "variant cannot use the 'virtual' suffix with --kind materialized"
+        )
         raise typer.BadParameter(
-            "variant must omit the 'virtual' suffix when --kind virtual is used",
+            message,
             param_hint="variant",
         )
 
@@ -101,6 +104,8 @@ def initialize_new_integration(
         f"Example{example_class_prefix}TemplateConfig": f"{class_prefix}TemplateConfig",
         f"Example{example_class_prefix}RegionJob": f"{class_prefix}RegionJob",
         f"Example{example_class_prefix}SourceFileCoord": f"{class_prefix}SourceFileCoord",
+        # DataVar and InternalAttrs are model-level config models shared across a
+        # model's datasets, so they stay {provider}{model}-scoped.
         "ExampleDataVar": f"{provider_pascal}{model_pascal}DataVar",
         "ExampleInternalAttrs": f"{provider_pascal}{model_pascal}InternalAttrs",
         f"reformatters.{example_dirname}": f"reformatters.{provider}.{model}.{module_variant}",

--- a/src/reformatters/common/initialize_new_integration.py
+++ b/src/reformatters/common/initialize_new_integration.py
@@ -100,7 +100,7 @@ def initialize_new_integration(
     class_prefix = f"{provider_pascal}{model_pascal}{module_variant_pascal}"
     dataset_class_name = f"{class_prefix}Dataset"
     example_to_actual_mappings = {
-        f"Example{example_class_prefix}DynamicalDataset": dataset_class_name,
+        f"Example{example_class_prefix}Dataset": dataset_class_name,
         f"Example{example_class_prefix}TemplateConfig": f"{class_prefix}TemplateConfig",
         f"Example{example_class_prefix}RegionJob": f"{class_prefix}RegionJob",
         f"Example{example_class_prefix}SourceFileCoord": f"{class_prefix}SourceFileCoord",

--- a/src/reformatters/common/initialize_new_integration.py
+++ b/src/reformatters/common/initialize_new_integration.py
@@ -21,8 +21,8 @@ class DatasetKind(StrEnum):
 
 
 _EXAMPLES: dict[DatasetKind, tuple[str, str]] = {
-    DatasetKind.materialized: ("example_materialized", "Temporal"),
-    DatasetKind.virtual: ("example_virtual", "Spatial"),
+    DatasetKind.materialized: ("example_materialized", ""),
+    DatasetKind.virtual: ("example_virtual", "Virtual"),
 }
 
 
@@ -85,7 +85,7 @@ def initialize_new_integration(
             (current / "__init__.py").touch(exist_ok=True)
 
     # Copy from the chosen example template
-    example_dirname, example_class_prefix = _EXAMPLES[kind]
+    example_dirname, example_class_suffix = _EXAMPLES[kind]
     example_src = Path("src/reformatters") / example_dirname
     example_test = Path("tests") / example_dirname
 
@@ -100,10 +100,10 @@ def initialize_new_integration(
     class_prefix = f"{provider_pascal}{model_pascal}{module_variant_pascal}"
     dataset_class_name = f"{class_prefix}Dataset"
     example_to_actual_mappings = {
-        f"Example{example_class_prefix}Dataset": dataset_class_name,
-        f"Example{example_class_prefix}TemplateConfig": f"{class_prefix}TemplateConfig",
-        f"Example{example_class_prefix}RegionJob": f"{class_prefix}RegionJob",
-        f"Example{example_class_prefix}SourceFileCoord": f"{class_prefix}SourceFileCoord",
+        f"Example{example_class_suffix}Dataset": dataset_class_name,
+        f"Example{example_class_suffix}TemplateConfig": f"{class_prefix}TemplateConfig",
+        f"Example{example_class_suffix}RegionJob": f"{class_prefix}RegionJob",
+        f"Example{example_class_suffix}SourceFileCoord": f"{class_prefix}SourceFileCoord",
         # DataVar and InternalAttrs are model-level config models shared across a
         # model's datasets, so they stay {provider}{model}-scoped.
         "ExampleDataVar": f"{provider_pascal}{model_pascal}DataVar",

--- a/src/reformatters/eccc/hrdps/forecast/__init__.py
+++ b/src/reformatters/eccc/hrdps/forecast/__init__.py
@@ -1,3 +1,1 @@
-from .dynamical_dataset import (
-    EcccHrdpsForecastDynamicalDataset as EcccHrdpsForecastDynamicalDataset,
-)
+from .dynamical_dataset import EcccHrdpsForecastDataset as EcccHrdpsForecastDataset

--- a/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
+++ b/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
@@ -18,7 +18,7 @@ from .region_job import (
 from .template_config import EcccHrdpsDataVar, EcccHrdpsForecastTemplateConfig
 
 
-class EcccHrdpsForecastDynamicalDataset(
+class EcccHrdpsForecastDataset(
     DynamicalDataset[EcccHrdpsDataVar, EcccHrdpsForecastSourceFileCoord]
 ):
     template_config: EcccHrdpsForecastTemplateConfig = EcccHrdpsForecastTemplateConfig()

--- a/src/reformatters/example_materialized/__init__.py
+++ b/src/reformatters/example_materialized/__init__.py
@@ -1,3 +1,1 @@
-from .dynamical_dataset import (
-    ExampleTemporalDynamicalDataset as ExampleTemporalDynamicalDataset,
-)
+from .dynamical_dataset import ExampleTemporalDataset as ExampleTemporalDataset

--- a/src/reformatters/example_materialized/__init__.py
+++ b/src/reformatters/example_materialized/__init__.py
@@ -1,1 +1,1 @@
-from .dynamical_dataset import ExampleTemporalDataset as ExampleTemporalDataset
+from .dynamical_dataset import ExampleDataset as ExampleDataset

--- a/src/reformatters/example_materialized/dynamical_dataset.py
+++ b/src/reformatters/example_materialized/dynamical_dataset.py
@@ -13,7 +13,7 @@ from .region_job import ExampleTemporalRegionJob, ExampleTemporalSourceFileCoord
 from .template_config import ExampleDataVar, ExampleTemporalTemplateConfig
 
 
-class ExampleTemporalDynamicalDataset(
+class ExampleTemporalDataset(
     DynamicalDataset[ExampleDataVar, ExampleTemporalSourceFileCoord]
 ):
     template_config: ExampleTemporalTemplateConfig = ExampleTemporalTemplateConfig()

--- a/src/reformatters/example_materialized/dynamical_dataset.py
+++ b/src/reformatters/example_materialized/dynamical_dataset.py
@@ -9,15 +9,13 @@ from reformatters.common.kubernetes import (  # noqa: F401
     ValidationCronJob,
 )
 
-from .region_job import ExampleTemporalRegionJob, ExampleTemporalSourceFileCoord
-from .template_config import ExampleDataVar, ExampleTemporalTemplateConfig
+from .region_job import ExampleRegionJob, ExampleSourceFileCoord
+from .template_config import ExampleDataVar, ExampleTemplateConfig
 
 
-class ExampleTemporalDataset(
-    DynamicalDataset[ExampleDataVar, ExampleTemporalSourceFileCoord]
-):
-    template_config: ExampleTemporalTemplateConfig = ExampleTemporalTemplateConfig()
-    region_job_class: type[ExampleTemporalRegionJob] = ExampleTemporalRegionJob
+class ExampleDataset(DynamicalDataset[ExampleDataVar, ExampleSourceFileCoord]):
+    template_config: ExampleTemplateConfig = ExampleTemplateConfig()
+    region_job_class: type[ExampleRegionJob] = ExampleRegionJob
 
     def operational_kubernetes_resources(self, image_tag: str) -> Sequence[CronJob]:
         """Return the kubernetes cron job definitions to operationally update and validate this dataset."""

--- a/src/reformatters/example_materialized/region_job.py
+++ b/src/reformatters/example_materialized/region_job.py
@@ -24,7 +24,7 @@ from .template_config import ExampleDataVar
 log = get_logger(__name__)
 
 
-class ExampleTemporalSourceFileCoord(SourceFileCoord):
+class ExampleSourceFileCoord(SourceFileCoord):
     """Coordinates of a single source file to process."""
 
     def get_url(self) -> str:
@@ -48,9 +48,7 @@ class ExampleTemporalSourceFileCoord(SourceFileCoord):
         return super().out_loc()
 
 
-class ExampleTemporalRegionJob(
-    MaterializedRegionJob[ExampleDataVar, ExampleTemporalSourceFileCoord]
-):
+class ExampleRegionJob(MaterializedRegionJob[ExampleDataVar, ExampleSourceFileCoord]):
     # Optionally, limit the number of variables downloaded together.
     # If set to a value less than len(data_vars), downloading, reading/recompressing,
     # and uploading steps will be pipelined within a region job.
@@ -91,10 +89,10 @@ class ExampleTemporalRegionJob(
 
     def generate_source_file_coords(
         self, processing_region_ds: xr.Dataset, data_var_group: Sequence[ExampleDataVar]
-    ) -> Sequence[ExampleTemporalSourceFileCoord]:
+    ) -> Sequence[ExampleSourceFileCoord]:
         """Return a sequence of coords, one for each source file required to process the data covered by processing_region_ds."""
         # return [
-        #     ExampleTemporalSourceFileCoord(
+        #     ExampleSourceFileCoord(
         #         init_time=init_time,
         #         lead_time=lead_time,
         #     )
@@ -107,7 +105,7 @@ class ExampleTemporalRegionJob(
             "Return a sequence of SourceFileCoord objects, one for each source file required to process the data covered by processing_region_ds."
         )
 
-    def download_file(self, coord: ExampleTemporalSourceFileCoord) -> Path:
+    def download_file(self, coord: ExampleSourceFileCoord) -> Path:
         """Download the file for the given coordinate and return the local path."""
         # return http_download_to_disk(coord.get_url(), self.dataset_id)
         raise NotImplementedError(
@@ -116,7 +114,7 @@ class ExampleTemporalRegionJob(
 
     def read_data(
         self,
-        coord: ExampleTemporalSourceFileCoord,
+        coord: ExampleSourceFileCoord,
         data_var: ExampleDataVar,
     ) -> ArrayFloat32:
         """Read and return an array of data for the given variable and source file coordinate."""
@@ -224,7 +222,7 @@ class ExampleTemporalRegionJob(
         all_data_vars: Sequence[ExampleDataVar],
         reformat_job_name: str,
     ) -> tuple[
-        Sequence[RegionJob[ExampleDataVar, ExampleTemporalSourceFileCoord]], xr.DataTree
+        Sequence[RegionJob[ExampleDataVar, ExampleSourceFileCoord]], xr.DataTree
     ]:
         """
         Return the sequence of RegionJob instances necessary to update the dataset
@@ -260,7 +258,7 @@ class ExampleTemporalRegionJob(
 
         Returns
         -------
-        Sequence[RegionJob[ExampleDataVar, ExampleTemporalSourceFileCoord]]
+        Sequence[RegionJob[ExampleDataVar, ExampleSourceFileCoord]]
             RegionJob instances that need processing for operational updates.
         xr.Dataset
             The template_ds for the operational update.

--- a/src/reformatters/example_materialized/template_config.py
+++ b/src/reformatters/example_materialized/template_config.py
@@ -42,7 +42,7 @@ class ExampleDataVar(DataVar[ExampleInternalAttrs]):
     pass
 
 
-class ExampleTemporalTemplateConfig(TemplateConfig[ExampleDataVar]):
+class ExampleTemplateConfig(TemplateConfig[ExampleDataVar]):
     # Single-level dataset: all vars live at the root. To add a vertical group, add an
     # entry whose key is the group/dimension name and whose dims are the root dims plus
     # that dimension, then set group=... on the group's DataVars (their zarr path becomes

--- a/src/reformatters/example_virtual/__init__.py
+++ b/src/reformatters/example_virtual/__init__.py
@@ -1,3 +1,1 @@
-from .dynamical_dataset import (
-    ExampleSpatialDynamicalDataset as ExampleSpatialDynamicalDataset,
-)
+from .dynamical_dataset import ExampleSpatialDataset as ExampleSpatialDataset

--- a/src/reformatters/example_virtual/__init__.py
+++ b/src/reformatters/example_virtual/__init__.py
@@ -1,1 +1,1 @@
-from .dynamical_dataset import ExampleSpatialDataset as ExampleSpatialDataset
+from .dynamical_dataset import ExampleVirtualDataset as ExampleVirtualDataset

--- a/src/reformatters/example_virtual/dynamical_dataset.py
+++ b/src/reformatters/example_virtual/dynamical_dataset.py
@@ -22,7 +22,7 @@ from .region_job import ExampleSpatialRegionJob, ExampleSpatialSourceFileCoord
 from .template_config import ExampleDataVar, ExampleSpatialTemplateConfig
 
 
-class ExampleSpatialDynamicalDataset(
+class ExampleSpatialDataset(
     DynamicalDataset[ExampleDataVar, ExampleSpatialSourceFileCoord]
 ):
     template_config: ExampleSpatialTemplateConfig = ExampleSpatialTemplateConfig()

--- a/src/reformatters/example_virtual/dynamical_dataset.py
+++ b/src/reformatters/example_virtual/dynamical_dataset.py
@@ -16,17 +16,17 @@ from reformatters.common.storage import (  # noqa: F401
     manifest_append_dim_split,
 )
 
-from .region_job import ExampleSpatialRegionJob, ExampleSpatialSourceFileCoord
+from .region_job import ExampleVirtualRegionJob, ExampleVirtualSourceFileCoord
 
 # from .region_job import _SOURCE_PREFIX, _SOURCE_REGION
-from .template_config import ExampleDataVar, ExampleSpatialTemplateConfig
+from .template_config import ExampleDataVar, ExampleVirtualTemplateConfig
 
 
-class ExampleSpatialDataset(
-    DynamicalDataset[ExampleDataVar, ExampleSpatialSourceFileCoord]
+class ExampleVirtualDataset(
+    DynamicalDataset[ExampleDataVar, ExampleVirtualSourceFileCoord]
 ):
-    template_config: ExampleSpatialTemplateConfig = ExampleSpatialTemplateConfig()
-    region_job_class: type[ExampleSpatialRegionJob] = ExampleSpatialRegionJob
+    template_config: ExampleVirtualTemplateConfig = ExampleVirtualTemplateConfig()
+    region_job_class: type[ExampleVirtualRegionJob] = ExampleVirtualRegionJob
 
     # A virtual dataset MUST set icechunk_virtual_config (a materialized dataset
     # leaves it None). It declares which source buckets the refs are allowed to point

--- a/src/reformatters/example_virtual/region_job.py
+++ b/src/reformatters/example_virtual/region_job.py
@@ -33,7 +33,7 @@ log = get_logger(__name__)
 # _SOURCE_REGION = "us-east-1"
 
 
-class ExampleSpatialSourceFileCoord(SourceFileCoord):
+class ExampleVirtualSourceFileCoord(SourceFileCoord):
     """Coordinates of a single source file, plus the data variables it packs.
 
     A virtual dataset turns each source GRIB message into one chunk reference, so a
@@ -84,12 +84,12 @@ class ExampleSpatialSourceFileCoord(SourceFileCoord):
         )
 
 
-class ExampleSpatialRegionJob(
-    VirtualRegionJob[ExampleDataVar, ExampleSpatialSourceFileCoord]
+class ExampleVirtualRegionJob(
+    VirtualRegionJob[ExampleDataVar, ExampleVirtualSourceFileCoord]
 ):
     def generate_source_file_coords(
         self, processing_region_ds: xr.Dataset, data_var_group: Sequence[ExampleDataVar]
-    ) -> Sequence[ExampleSpatialSourceFileCoord]:
+    ) -> Sequence[ExampleVirtualSourceFileCoord]:
         """One coord per source file covering the data in processing_region_ds.
 
         Reused by operational validation to probe the manifest, so it must list exactly
@@ -97,7 +97,7 @@ class ExampleSpatialRegionJob(
         accumulated variables at hour 0).
         """
         # return [
-        #     ExampleSpatialSourceFileCoord(
+        #     ExampleVirtualSourceFileCoord(
         #         init_time=pd.Timestamp(init_time),
         #         lead_time=pd.Timedelta(lead_time),
         #         data_vars=data_var_group,
@@ -110,8 +110,8 @@ class ExampleSpatialRegionJob(
         )
 
     def discover_available(
-        self, pending: list[ExampleSpatialSourceFileCoord]
-    ) -> list[tuple[ExampleSpatialSourceFileCoord, int]]:
+        self, pending: list[ExampleVirtualSourceFileCoord]
+    ) -> list[tuple[ExampleVirtualSourceFileCoord, int]]:
         """Of the not-yet-ingested files, the subset fetchable now, each with its size.
 
         The write loop calls this each tick (once for a backfill, repeatedly while an
@@ -132,7 +132,7 @@ class ExampleSpatialRegionJob(
         )
 
     def file_refs(
-        self, coord: ExampleSpatialSourceFileCoord, file_size: int
+        self, coord: ExampleVirtualSourceFileCoord, file_size: int
     ) -> list[VirtualRef]:
         """Every virtual ref a single source file contributes (or [] to skip it).
 
@@ -177,7 +177,7 @@ class ExampleSpatialRegionJob(
     # variable the file carries. Override only if that variable's chunk isn't a reliable
     # proxy for "the whole file was ingested":
     #
-    # def representative_var(self, coord: ExampleSpatialSourceFileCoord) -> ExampleDataVar:
+    # def representative_var(self, coord: ExampleVirtualSourceFileCoord) -> ExampleDataVar:
     #     return next(v for v in self.data_vars if v.name == "temperature_2m")
 
     # The recent append-dim window each operational update fire re-sweeps. The base

--- a/src/reformatters/example_virtual/template_config.py
+++ b/src/reformatters/example_virtual/template_config.py
@@ -50,7 +50,7 @@ class ExampleDataVar(DataVar[ExampleInternalAttrs]):
     pass
 
 
-class ExampleSpatialTemplateConfig(TemplateConfig[ExampleDataVar]):
+class ExampleVirtualTemplateConfig(TemplateConfig[ExampleDataVar]):
     # Single-level dataset: all vars live at the root. To add a vertical group, add an
     # entry whose key is the group/dimension name and whose dims are the root dims plus
     # that dimension, then set group=... on the group's DataVars (their zarr path becomes

--- a/tests/common/initialize_new_integration_test.py
+++ b/tests/common/initialize_new_integration_test.py
@@ -30,8 +30,6 @@ def scaffold_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "module_variant",
         "class_prefix",
         "example_class_prefix",
-        "dataset_id_example",
-        "dataset_name_example",
     ),
     [
         (
@@ -39,16 +37,12 @@ def scaffold_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
             "forecast",
             "NoaaGfsForecast",
             "ExampleTemporal",
-            'dataset_id="producer-model-variant"',
-            'name="Producer Model Variant"',
         ),
         (
             DatasetKind.virtual,
             "forecast_virtual",
             "NoaaGfsForecastVirtual",
             "ExampleSpatial",
-            'dataset_id="producer-model-variant-virtual"',
-            'name="Producer Model Variant, virtual"',
         ),
     ],
 )
@@ -58,8 +52,6 @@ def test_initialize_new_integration_names_follow_dataset_id(
     module_variant: str,
     class_prefix: str,
     example_class_prefix: str,
-    dataset_id_example: str,
-    dataset_name_example: str,
 ) -> None:
     initialize_new_integration("noaa", "gfs", "forecast", kind)
 
@@ -79,22 +71,32 @@ def test_initialize_new_integration_names_follow_dataset_id(
     assert f"class {class_prefix}SourceFileCoord(" in generated_python
     assert example_class_prefix not in generated_python
     assert f"reformatters.noaa.gfs.{module_variant}" in generated_python
-    template_config = (source_path / "template_config.py").read_text()
-    assert dataset_id_example in template_config
-    assert dataset_name_example in template_config
     assert (source_path / "__init__.py").read_text() == (
         f"from .dynamical_dataset import {class_prefix}Dataset as {class_prefix}Dataset\n"
     )
 
 
-def test_virtual_variant_rejects_virtual_suffix(scaffold_root: Path) -> None:
+@pytest.mark.parametrize(
+    ("kind", "message"),
+    [
+        (
+            DatasetKind.materialized,
+            "variant cannot use the 'virtual' suffix with --kind materialized",
+        ),
+        (
+            DatasetKind.virtual,
+            "variant must omit the 'virtual' suffix when --kind virtual is used",
+        ),
+    ],
+)
+def test_variant_rejects_virtual_suffix(
+    scaffold_root: Path, kind: DatasetKind, message: str
+) -> None:
     with pytest.raises(
         typer.BadParameter,
-        match="variant must omit the 'virtual' suffix when --kind virtual is used",
+        match=message,
     ):
-        initialize_new_integration(
-            "noaa", "gfs", "forecast_virtual", DatasetKind.virtual
-        )
+        initialize_new_integration("noaa", "gfs", "forecast-virtual", kind)
 
     assert not (scaffold_root / "src/reformatters/noaa").exists()
     assert not (scaffold_root / "tests/noaa").exists()

--- a/tests/common/initialize_new_integration_test.py
+++ b/tests/common/initialize_new_integration_test.py
@@ -29,20 +29,20 @@ def scaffold_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "kind",
         "module_variant",
         "class_prefix",
-        "example_class_prefix",
+        "example_dataset_class_name",
     ),
     [
         (
             DatasetKind.materialized,
             "forecast",
             "NoaaGfsForecast",
-            "ExampleTemporal",
+            "ExampleDataset",
         ),
         (
             DatasetKind.virtual,
             "forecast_virtual",
             "NoaaGfsForecastVirtual",
-            "ExampleSpatial",
+            "ExampleVirtualDataset",
         ),
     ],
 )
@@ -51,7 +51,7 @@ def test_initialize_new_integration_names_follow_dataset_id(
     kind: DatasetKind,
     module_variant: str,
     class_prefix: str,
-    example_class_prefix: str,
+    example_dataset_class_name: str,
 ) -> None:
     initialize_new_integration("noaa", "gfs", "forecast", kind)
 
@@ -69,7 +69,7 @@ def test_initialize_new_integration_names_follow_dataset_id(
     assert f"class {class_prefix}TemplateConfig(" in generated_python
     assert f"class {class_prefix}RegionJob(" in generated_python
     assert f"class {class_prefix}SourceFileCoord(" in generated_python
-    assert example_class_prefix not in generated_python
+    assert f"class {example_dataset_class_name}(" not in generated_python
     assert f"reformatters.noaa.gfs.{module_variant}" in generated_python
     assert (source_path / "__init__.py").read_text() == (
         f"from .dynamical_dataset import {class_prefix}Dataset as {class_prefix}Dataset\n"

--- a/tests/common/initialize_new_integration_test.py
+++ b/tests/common/initialize_new_integration_test.py
@@ -81,22 +81,23 @@ def test_initialize_new_integration_names_follow_dataset_id(
     [
         (
             DatasetKind.materialized,
-            "variant cannot use the 'virtual' suffix with --kind materialized",
+            "variant cannot use 'virtual' with --kind materialized",
         ),
         (
             DatasetKind.virtual,
-            "variant must omit the 'virtual' suffix when --kind virtual is used",
+            "variant must omit 'virtual' when --kind virtual is used",
         ),
     ],
 )
-def test_variant_rejects_virtual_suffix(
-    scaffold_root: Path, kind: DatasetKind, message: str
+@pytest.mark.parametrize("variant", ["forecast-virtual", "virtual, forecast"])
+def test_variant_rejects_virtual(
+    scaffold_root: Path, kind: DatasetKind, message: str, variant: str
 ) -> None:
     with pytest.raises(
         typer.BadParameter,
         match=message,
     ):
-        initialize_new_integration("noaa", "gfs", "forecast-virtual", kind)
+        initialize_new_integration("noaa", "gfs", variant, kind)
 
     assert not (scaffold_root / "src/reformatters/noaa").exists()
     assert not (scaffold_root / "tests/noaa").exists()

--- a/tests/common/initialize_new_integration_test.py
+++ b/tests/common/initialize_new_integration_test.py
@@ -1,0 +1,100 @@
+import shutil
+from pathlib import Path
+
+import pytest
+import typer
+
+from reformatters.common.initialize_new_integration import (
+    DatasetKind,
+    initialize_new_integration,
+)
+
+PROJECT_ROOT = Path(__file__).parents[2]
+
+
+@pytest.fixture
+def scaffold_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    for example_dirname in ("example_materialized", "example_virtual"):
+        for package_root in ("src/reformatters", "tests"):
+            source = PROJECT_ROOT / package_root / example_dirname
+            destination = tmp_path / package_root / example_dirname
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(source, destination)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    (
+        "kind",
+        "module_variant",
+        "class_prefix",
+        "example_class_prefix",
+        "dataset_id_example",
+        "dataset_name_example",
+    ),
+    [
+        (
+            DatasetKind.materialized,
+            "forecast",
+            "NoaaGfsForecast",
+            "ExampleTemporal",
+            'dataset_id="producer-model-variant"',
+            'name="Producer Model Variant"',
+        ),
+        (
+            DatasetKind.virtual,
+            "forecast_virtual",
+            "NoaaGfsForecastVirtual",
+            "ExampleSpatial",
+            'dataset_id="producer-model-variant-virtual"',
+            'name="Producer Model Variant, virtual"',
+        ),
+    ],
+)
+def test_initialize_new_integration_names_follow_dataset_id(
+    scaffold_root: Path,
+    kind: DatasetKind,
+    module_variant: str,
+    class_prefix: str,
+    example_class_prefix: str,
+    dataset_id_example: str,
+    dataset_name_example: str,
+) -> None:
+    initialize_new_integration("noaa", "gfs", "forecast", kind)
+
+    source_path = scaffold_root / "src/reformatters/noaa/gfs" / module_variant
+    test_path = scaffold_root / "tests/noaa/gfs" / module_variant
+    assert source_path.is_dir()
+    assert test_path.is_dir()
+
+    generated_python = "\n".join(
+        path.read_text()
+        for generated_path in (source_path, test_path)
+        for path in generated_path.glob("*.py")
+    )
+    assert f"class {class_prefix}Dataset(" in generated_python
+    assert f"class {class_prefix}TemplateConfig(" in generated_python
+    assert f"class {class_prefix}RegionJob(" in generated_python
+    assert f"class {class_prefix}SourceFileCoord(" in generated_python
+    assert example_class_prefix not in generated_python
+    assert f"reformatters.noaa.gfs.{module_variant}" in generated_python
+    template_config = (source_path / "template_config.py").read_text()
+    assert dataset_id_example in template_config
+    assert dataset_name_example in template_config
+    assert (source_path / "__init__.py").read_text() == (
+        f"from .dynamical_dataset import {class_prefix}Dataset as {class_prefix}Dataset\n"
+    )
+
+
+def test_virtual_variant_rejects_virtual_suffix(scaffold_root: Path) -> None:
+    with pytest.raises(
+        typer.BadParameter,
+        match="variant must omit the 'virtual' suffix when --kind virtual is used",
+    ):
+        initialize_new_integration(
+            "noaa", "gfs", "forecast_virtual", DatasetKind.virtual
+        )
+
+    assert not (scaffold_root / "src/reformatters/noaa").exists()
+    assert not (scaffold_root / "tests/noaa").exists()

--- a/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
+++ b/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from reformatters.common import validation
 from reformatters.eccc.hrdps.forecast.dynamical_dataset import (
-    EcccHrdpsForecastDynamicalDataset,
+    EcccHrdpsForecastDataset,
 )
 from tests.chunk_utils import shrink_chunks_and_shards
 from tests.common.dynamical_dataset_test import (
@@ -33,12 +33,12 @@ NO_LEAD_TIME_0_VARIABLE_NAMES = [
 
 
 @pytest.fixture
-def dataset() -> EcccHrdpsForecastDynamicalDataset:
+def dataset() -> EcccHrdpsForecastDataset:
     return _make_dataset()
 
 
-def _make_dataset() -> EcccHrdpsForecastDynamicalDataset:
-    return EcccHrdpsForecastDynamicalDataset(primary_storage_config=NOOP_STORAGE_CONFIG)
+def _make_dataset() -> EcccHrdpsForecastDataset:
+    return EcccHrdpsForecastDataset(primary_storage_config=NOOP_STORAGE_CONFIG)
 
 
 def _point_values(ds: xr.Dataset, init_time: str) -> xr.Dataset:
@@ -178,7 +178,7 @@ def test_backfill_local_and_operational_update(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_operational_kubernetes_resources(
-    dataset: EcccHrdpsForecastDynamicalDataset,
+    dataset: EcccHrdpsForecastDataset,
 ) -> None:
     archive_grib_files_job, update_cron_job, validation_cron_job = (
         dataset.operational_kubernetes_resources("test-image-tag")
@@ -205,14 +205,14 @@ def test_operational_kubernetes_resources(
         assert cron_job.schedule.endswith(" * * *")
 
 
-def test_validators(dataset: EcccHrdpsForecastDynamicalDataset) -> None:
+def test_validators(dataset: EcccHrdpsForecastDataset) -> None:
     validators = tuple(dataset.validators())
     assert len(validators) == 2
     assert all(isinstance(v, validation.Validator) for v in validators)
 
 
 def test_archive_grib_files_calls_copy_with_defaults(
-    dataset: EcccHrdpsForecastDynamicalDataset,
+    dataset: EcccHrdpsForecastDataset,
 ) -> None:
     mock_copy = Mock()
     with (
@@ -239,7 +239,7 @@ def test_archive_grib_files_calls_copy_with_defaults(
 
 
 def test_archive_grib_files_passes_s3_credentials(
-    dataset: EcccHrdpsForecastDynamicalDataset,
+    dataset: EcccHrdpsForecastDataset,
 ) -> None:
     mock_copy = Mock()
     secret = {"key": "test-key", "secret": "test-secret"}
@@ -262,7 +262,7 @@ def test_archive_grib_files_passes_s3_credentials(
 
 
 def test_get_cli_has_archive_command(
-    dataset: EcccHrdpsForecastDynamicalDataset,
+    dataset: EcccHrdpsForecastDataset,
 ) -> None:
     cli = dataset.get_cli()
     callback_names = [

--- a/tests/example_materialized/dynamical_dataset_test.py
+++ b/tests/example_materialized/dynamical_dataset_test.py
@@ -4,7 +4,7 @@
 # import xarray as xr
 
 # from reformatters.common import validation
-# from reformatters.example_materialized.dynamical_dataset import ExampleTemporalDataset
+# from reformatters.example_materialized.dynamical_dataset import ExampleDataset
 # from tests.common.dynamical_dataset_test import (
 #     NOOP_STORAGE_CONFIG,
 #     assert_configured_validators,
@@ -12,13 +12,13 @@
 
 
 # @pytest.fixture
-# def dataset() -> ExampleTemporalDataset:
-#     return ExampleTemporalDataset(primary_storage_config=NOOP_STORAGE_CONFIG)
+# def dataset() -> ExampleDataset:
+#     return ExampleDataset(primary_storage_config=NOOP_STORAGE_CONFIG)
 
 
 # @pytest.mark.slow
 # def test_backfill_local_and_operational_update(
-#     monkeypatch: pytest.MonkeyPatch, dataset: ExampleTemporalDataset
+#     monkeypatch: pytest.MonkeyPatch, dataset: ExampleDataset
 # ) -> None:
 #     # Local backfill reformat
 #     dataset.backfill_local(append_dim_end=pd.Timestamp("2000-01-02"))
@@ -59,7 +59,7 @@
 
 
 # def test_operational_kubernetes_resources(
-#     dataset: ExampleTemporalDataset,
+#     dataset: ExampleDataset,
 # ) -> None:
 #     cron_jobs = dataset.operational_kubernetes_resources("test-image-tag")
 
@@ -75,7 +75,7 @@
 #     ]
 
 
-# def test_validators(dataset: ExampleTemporalDataset) -> None:
+# def test_validators(dataset: ExampleDataset) -> None:
 #     validators = tuple(dataset.validators())
 #     assert len(validators) == 2
 #     assert all(isinstance(v, validation.Validator) for v in validators)

--- a/tests/example_materialized/dynamical_dataset_test.py
+++ b/tests/example_materialized/dynamical_dataset_test.py
@@ -4,7 +4,7 @@
 # import xarray as xr
 
 # from reformatters.common import validation
-# from reformatters.example_materialized.dynamical_dataset import ExampleTemporalDynamicalDataset
+# from reformatters.example_materialized.dynamical_dataset import ExampleTemporalDataset
 # from tests.common.dynamical_dataset_test import (
 #     NOOP_STORAGE_CONFIG,
 #     assert_configured_validators,
@@ -12,13 +12,13 @@
 
 
 # @pytest.fixture
-# def dataset() -> ExampleTemporalDynamicalDataset:
-#     return ExampleTemporalDynamicalDataset(primary_storage_config=NOOP_STORAGE_CONFIG)
+# def dataset() -> ExampleTemporalDataset:
+#     return ExampleTemporalDataset(primary_storage_config=NOOP_STORAGE_CONFIG)
 
 
 # @pytest.mark.slow
 # def test_backfill_local_and_operational_update(
-#     monkeypatch: pytest.MonkeyPatch, dataset: ExampleTemporalDynamicalDataset
+#     monkeypatch: pytest.MonkeyPatch, dataset: ExampleTemporalDataset
 # ) -> None:
 #     # Local backfill reformat
 #     dataset.backfill_local(append_dim_end=pd.Timestamp("2000-01-02"))
@@ -59,7 +59,7 @@
 
 
 # def test_operational_kubernetes_resources(
-#     dataset: ExampleTemporalDynamicalDataset,
+#     dataset: ExampleTemporalDataset,
 # ) -> None:
 #     cron_jobs = dataset.operational_kubernetes_resources("test-image-tag")
 
@@ -75,7 +75,7 @@
 #     ]
 
 
-# def test_validators(dataset: ExampleTemporalDynamicalDataset) -> None:
+# def test_validators(dataset: ExampleTemporalDataset) -> None:
 #     validators = tuple(dataset.validators())
 #     assert len(validators) == 2
 #     assert all(isinstance(v, validation.Validator) for v in validators)

--- a/tests/example_materialized/region_job_test.py
+++ b/tests/example_materialized/region_job_test.py
@@ -3,21 +3,21 @@
 # import pandas as pd
 
 # from reformatters.example_materialized.region_job import (
-#     ExampleTemporalRegionJob,
-#     ExampleTemporalSourceFileCoord,
+#     ExampleRegionJob,
+#     ExampleSourceFileCoord,
 # )
-# from reformatters.example_materialized.template_config import ExampleTemporalTemplateConfig
+# from reformatters.example_materialized.template_config import ExampleTemplateConfig
 
 # def test_source_file_coord_get_url() -> None:
-#     coord = ExampleTemporalSourceFileCoord(time=pd.Timestamp("2000-01-01"))
+#     coord = ExampleSourceFileCoord(time=pd.Timestamp("2000-01-01"))
 #     assert coord.get_url() == "https://example.com/data/2000-01-01.grib2"
 
 
 # def test_region_job_generete_source_file_coords() -> None:
-#     template_config = ExampleTemporalTemplateConfig()
+#     template_config = ExampleTemplateConfig()
 #     template_ds = template_config.get_template(pd.Timestamp("2000-01-23"))
 
-#     region_job = ExampleTemporalRegionJob(
+#     region_job = ExampleRegionJob(
 #         tmp_store=Mock(),
 #         template_ds=template_ds,
 #         data_vars=[Mock(), Mock()],

--- a/tests/example_materialized/template_config_test.py
+++ b/tests/example_materialized/template_config_test.py
@@ -8,15 +8,15 @@
 # from pathlib import Path
 # from unittest.mock import Mock
 #
-# from reformatters.example_materialized.region_job import ExampleTemporalRegionJob, ExampleTemporalSourceFileCoord
-# from reformatters.example_materialized.template_config import ExampleTemporalTemplateConfig
+# from reformatters.example_materialized.region_job import ExampleRegionJob, ExampleSourceFileCoord
+# from reformatters.example_materialized.template_config import ExampleTemplateConfig
 #
 #
 # @pytest.fixture(scope="session")
 # def example_first_message_path() -> Path:
-#     cfg = ExampleTemporalTemplateConfig()
-#     coord = ExampleTemporalSourceFileCoord(...)  # fill in per dataset
-#     region_job = ExampleTemporalRegionJob.model_construct(
+#     cfg = ExampleTemplateConfig()
+#     coord = ExampleSourceFileCoord(...)  # fill in per dataset
+#     region_job = ExampleRegionJob.model_construct(
 #         tmp_store=Mock(),
 #         template_ds=cfg.get_template(cfg.append_dim_start),
 #         data_vars=cfg.data_vars,
@@ -29,7 +29,7 @@
 #
 # @pytest.mark.slow
 # def test_spatial_ref_matches_grib(example_first_message_path: Path) -> None:
-#     cfg = ExampleTemporalTemplateConfig()
+#     cfg = ExampleTemplateConfig()
 #     ds = cfg.get_template(cfg.append_dim_start)
 #     ds_raster = xr.open_dataset(example_first_message_path, engine="rasterio")
 #
@@ -43,7 +43,7 @@
 # def test_lat_lon_pixel_centers_from_source_grib(
 #     example_first_message_path: Path,
 # ) -> None:
-#     cfg = ExampleTemporalTemplateConfig()
+#     cfg = ExampleTemplateConfig()
 #     coords = cfg.dimension_coordinates()
 #
 #     with rasterio.open(example_first_message_path) as reader:

--- a/tests/example_virtual/dynamical_dataset_test.py
+++ b/tests/example_virtual/dynamical_dataset_test.py
@@ -7,15 +7,15 @@
 
 # from reformatters.common import validation
 # from reformatters.common.storage import DatasetFormat, StorageConfig
-# from reformatters.example_virtual.dynamical_dataset import ExampleSpatialDataset
+# from reformatters.example_virtual.dynamical_dataset import ExampleVirtualDataset
 # from tests.common.dynamical_dataset_test import assert_configured_validators
 
 
 # @pytest.fixture
-# def dataset(tmp_path: Path) -> ExampleSpatialDataset:
+# def dataset(tmp_path: Path) -> ExampleVirtualDataset:
 #     # A virtual dataset's primary store must be ICECHUNK, and icechunk_virtual_config
-#     # (set on ExampleSpatialDataset) registers the source buckets the refs may point into.
-#     return ExampleSpatialDataset(
+#     # (set on ExampleVirtualDataset) registers the source buckets the refs may point into.
+#     return ExampleVirtualDataset(
 #         primary_storage_config=StorageConfig(
 #             base_path=str(tmp_path), format=DatasetFormat.ICECHUNK
 #         ),
@@ -24,7 +24,7 @@
 
 # @pytest.mark.slow
 # def test_backfill_local_and_operational_update(
-#     monkeypatch: pytest.MonkeyPatch, dataset: ExampleSpatialDataset
+#     monkeypatch: pytest.MonkeyPatch, dataset: ExampleVirtualDataset
 # ) -> None:
 #     # Keep the test small: trim the template to a couple lead times (and ensemble
 #     # members, if any) so the backfill fetches few files. Do NOT shrink chunks - a
@@ -89,7 +89,7 @@
 #     # atomicity, per-group append-dim growth).
 
 
-# def test_operational_kubernetes_resources(dataset: ExampleSpatialDataset) -> None:
+# def test_operational_kubernetes_resources(dataset: ExampleVirtualDataset) -> None:
 #     cron_jobs = dataset.operational_kubernetes_resources("test-image-tag")
 #     assert len(cron_jobs) == 2
 #     update_cron_job, validation_cron_job = cron_jobs
@@ -97,7 +97,7 @@
 #     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
 
 
-# def test_validators_include_virtual_checks(dataset: ExampleSpatialDataset) -> None:
+# def test_validators_include_virtual_checks(dataset: ExampleVirtualDataset) -> None:
 #     validators = tuple(dataset.validators())
 #     # The two virtual-specific validators need manifest/store access
 #     # (requires_virtual_dataset).

--- a/tests/example_virtual/dynamical_dataset_test.py
+++ b/tests/example_virtual/dynamical_dataset_test.py
@@ -7,15 +7,15 @@
 
 # from reformatters.common import validation
 # from reformatters.common.storage import DatasetFormat, StorageConfig
-# from reformatters.example_virtual.dynamical_dataset import ExampleSpatialDynamicalDataset
+# from reformatters.example_virtual.dynamical_dataset import ExampleSpatialDataset
 # from tests.common.dynamical_dataset_test import assert_configured_validators
 
 
 # @pytest.fixture
-# def dataset(tmp_path: Path) -> ExampleSpatialDynamicalDataset:
+# def dataset(tmp_path: Path) -> ExampleSpatialDataset:
 #     # A virtual dataset's primary store must be ICECHUNK, and icechunk_virtual_config
-#     # (set on ExampleSpatialDynamicalDataset) registers the source buckets the refs may point into.
-#     return ExampleSpatialDynamicalDataset(
+#     # (set on ExampleSpatialDataset) registers the source buckets the refs may point into.
+#     return ExampleSpatialDataset(
 #         primary_storage_config=StorageConfig(
 #             base_path=str(tmp_path), format=DatasetFormat.ICECHUNK
 #         ),
@@ -24,7 +24,7 @@
 
 # @pytest.mark.slow
 # def test_backfill_local_and_operational_update(
-#     monkeypatch: pytest.MonkeyPatch, dataset: ExampleSpatialDynamicalDataset
+#     monkeypatch: pytest.MonkeyPatch, dataset: ExampleSpatialDataset
 # ) -> None:
 #     # Keep the test small: trim the template to a couple lead times (and ensemble
 #     # members, if any) so the backfill fetches few files. Do NOT shrink chunks - a
@@ -89,7 +89,7 @@
 #     # atomicity, per-group append-dim growth).
 
 
-# def test_operational_kubernetes_resources(dataset: ExampleSpatialDynamicalDataset) -> None:
+# def test_operational_kubernetes_resources(dataset: ExampleSpatialDataset) -> None:
 #     cron_jobs = dataset.operational_kubernetes_resources("test-image-tag")
 #     assert len(cron_jobs) == 2
 #     update_cron_job, validation_cron_job = cron_jobs
@@ -97,7 +97,7 @@
 #     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
 
 
-# def test_validators_include_virtual_checks(dataset: ExampleSpatialDynamicalDataset) -> None:
+# def test_validators_include_virtual_checks(dataset: ExampleSpatialDataset) -> None:
 #     validators = tuple(dataset.validators())
 #     # The two virtual-specific validators need manifest/store access
 #     # (requires_virtual_dataset).

--- a/tests/example_virtual/region_job_test.py
+++ b/tests/example_virtual/region_job_test.py
@@ -3,14 +3,14 @@
 # import pandas as pd
 
 # from reformatters.example_virtual.region_job import (
-#     ExampleSpatialRegionJob,
-#     ExampleSpatialSourceFileCoord,
+#     ExampleVirtualRegionJob,
+#     ExampleVirtualSourceFileCoord,
 # )
-# from reformatters.example_virtual.template_config import ExampleSpatialTemplateConfig
+# from reformatters.example_virtual.template_config import ExampleVirtualTemplateConfig
 
 
 # def test_source_file_coord_url_uses_container_prefix() -> None:
-#     coord = ExampleSpatialSourceFileCoord(
+#     coord = ExampleVirtualSourceFileCoord(
 #         init_time=pd.Timestamp("2020-01-01"),
 #         lead_time=pd.Timedelta("3h"),
 #         data_vars=[Mock()],
@@ -22,7 +22,7 @@
 
 
 # def test_out_loc_excludes_non_dim_fields() -> None:
-#     coord = ExampleSpatialSourceFileCoord(
+#     coord = ExampleVirtualSourceFileCoord(
 #         init_time=pd.Timestamp("2020-01-01"),
 #         lead_time=pd.Timedelta("3h"),
 #         data_vars=[Mock()],
@@ -32,10 +32,10 @@
 
 
 # def test_generate_source_file_coords() -> None:
-#     template_config = ExampleSpatialTemplateConfig()
+#     template_config = ExampleVirtualTemplateConfig()
 #     template_ds = template_config.get_template(pd.Timestamp("2020-01-02"))
 
-#     region_job = ExampleSpatialRegionJob(
+#     region_job = ExampleVirtualRegionJob(
 #         tmp_store=Mock(),
 #         template_ds=template_ds,
 #         data_vars=template_config.data_vars,

--- a/tests/example_virtual/template_config_test.py
+++ b/tests/example_virtual/template_config_test.py
@@ -1,13 +1,13 @@
 # import numpy as np
 
-# from reformatters.example_virtual.template_config import ExampleSpatialTemplateConfig
+# from reformatters.example_virtual.template_config import ExampleVirtualTemplateConfig
 
 
 # def test_data_var_encoding_is_one_chunk_per_message() -> None:
 #     # The defining property of a virtual dataset: each data var chunk is exactly one
 #     # source message, so chunk size is 1 along the per-message dims and full-width along
 #     # the spatial dims, with no shards and no compressors of our own - just a serializer.
-#     config = ExampleSpatialTemplateConfig()
+#     config = ExampleVirtualTemplateConfig()
 #     dim_coords = config.dimension_coordinates()
 #     var = next(v for v in config.data_vars if v.name == "temperature_2m")
 
@@ -26,7 +26,7 @@
 #     # Virtual chunks decode the raw message, so the grid must match the codec's decoded
 #     # grid (not a regridded one): north-first latitude and, for a global grid,
 #     # adjust_longitude_range's monotonic -180..+180 longitude.
-#     config = ExampleSpatialTemplateConfig()
+#     config = ExampleVirtualTemplateConfig()
 #     dim_coords = config.dimension_coordinates()
 #     assert dim_coords["latitude"][0] > dim_coords["latitude"][-1]
 #     assert dim_coords["longitude"].min() >= -180


### PR DESCRIPTION
## Summary

New integration names now mirror the dataset_id policy:

- Materialized datasets add no kind word to module or class names.
- Virtual datasets append _virtual to the module and Virtual to class names; callers pass the base variant and --kind virtual adds the suffix.
- Variants already ending in _virtual are rejected with a kind-specific error instead of producing a misleading or doubled suffix.
- Every concrete DynamicalDataset subclass uses the XxxxDataset suffix, including the ECCC and teaching classes.
- Teaching names mirror generated names: Example* for materialized integrations and ExampleVirtual* for virtual integrations.

| Example | Before | After |
| --- | --- | --- |
| Materialized noaa-gfs-forecast | src/reformatters/noaa/gfs/forecast/; NoaaGfsForecastTemporalDynamicalDataset | src/reformatters/noaa/gfs/forecast/; NoaaGfsForecastDataset |
| Virtual noaa-gfs-forecast-virtual | src/reformatters/noaa/gfs/forecast/; NoaaGfsForecastSpatialDynamicalDataset | src/reformatters/noaa/gfs/forecast_virtual/; NoaaGfsForecastVirtualDataset |

No shipped dataset uses the old Temporal or Spatial class-name infix. Concrete and teaching DynamicalDataset subclasses now consistently use the Dataset suffix rather than DynamicalDataset.

## Validation

- uv run ruff format
- uv run ruff check --fix
- uv run ty check
- uv run pytest -m "not slow" -n 4 (2256 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)