### PR TITLE
Match download quiet-window and NaN tolerance to known publish latency

### DIFF
--- a/src/reformatters/common/materialized_region_job.py
+++ b/src/reformatters/common/materialized_region_job.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import suppress
 from copy import deepcopy
+from datetime import timedelta
 from multiprocessing.shared_memory import SharedMemory
 from pathlib import Path
 from typing import Any, ClassVar, Generic, cast
@@ -48,6 +49,12 @@ class MaterializedRegionJob(
     # If value is less than len(data_vars), downloading, reading/recompressing, and writing steps
     # will be pipelined within a region job.
     max_vars_per_download_group: ClassVar[int | None] = None
+
+    # How long after its own timestamp a source file may still be unpublished
+    # without a download failure being logged as an error. Set this to match
+    # the dataset's CheckCurrentData(max_delay=...) validator so routine
+    # publication latency doesn't page.
+    expected_source_delay: ClassVar[timedelta] = timedelta(hours=48)
 
     # Subclasses can override this to control download parallelism
     # This particularly useful of the data source cannot handle a large number of concurrent requests
@@ -308,11 +315,11 @@ class MaterializedRegionJob(
                 # For recent files, we expect some files to not exist yet, just log the path
                 # else, log exception so it is caught by error reporting but doesn't stop processing
                 append_dim_coord = coord.append_dim_coord
-                two_days_ago = pd.Timestamp.now() - pd.Timedelta(hours=48)
+                delay_cutoff = pd.Timestamp.now() - self.expected_source_delay
                 if (
                     is_not_found(e)
                     and isinstance(append_dim_coord, np.datetime64 | pd.Timestamp)
-                    and append_dim_coord > two_days_ago
+                    and append_dim_coord > delay_cutoff
                 ):
                     log.info(" ".join(str(e).split("\n")[:2]))
                 else:

--- a/src/reformatters/contrib/nasa/smap/level3_36km_v9/region_job.py
+++ b/src/reformatters/contrib/nasa/smap/level3_36km_v9/region_job.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable, Sequence
+from datetime import timedelta
 from pathlib import Path
+from typing import ClassVar
 from urllib.parse import urlparse
 
 import numpy as np
@@ -46,6 +48,9 @@ class NasaSmapLevel336KmV9SourceFileCoord(SourceFileCoord):
 class NasaSmapLevel336KmV9RegionJob(
     MaterializedRegionJob[NasaSmapDataVar, NasaSmapLevel336KmV9SourceFileCoord]
 ):
+    # Matches the CheckCurrentData(max_delay=...) validator in dynamical_dataset.py.
+    expected_source_delay: ClassVar[timedelta] = timedelta(days=6)
+
     def generate_source_file_coords(
         self,
         processing_region_ds: xr.Dataset,

--- a/src/reformatters/dwd/icon_eu/forecast_5_day/dynamical_dataset.py
+++ b/src/reformatters/dwd/icon_eu/forecast_5_day/dynamical_dataset.py
@@ -100,7 +100,11 @@ class DwdIconEuForecast5DayDataset(
         return (
             # The update ingests each init at init+3h52m; validation fires at init+4h02m.
             validation.CheckCurrentData(max_delay=timedelta(hours=4, minutes=2)),
-            validation.CheckRecentNans(),
+            # DWD's transfer can still be trickling in the newest init's lead times when
+            # validation runs 10 minutes after the update; the next update cycle
+            # reprocesses and completes that init, so a partial newest position is
+            # expected, not a data quality problem. Older inits must be complete.
+            validation.CheckRecentNans(max_nan_fraction=(0.5, 0.0)),
         )
 
     def archive_grib_files(


### PR DESCRIPTION
## Summary

Sentry triage turned up two datasets that page on routine, expected publish latency rather than real failures:

- **REFORMATTERS-95** (NASA SMAP L3 36km v9, `nasa-smap-level3-36km-v9-update`): `_call_download_file` in `materialized_region_job.py` only suppresses "not published yet" 404 logging for source files less than **48h** old (hardcoded). SMAP's own `CheckCurrentData(max_delay=timedelta(days=6))` validator already documents that NSIDC can legitimately lag up to **6 days** (tuned upward across several past PRs without updating this window). Every routine 2–6 day-old gap was logged with `log.exception`, alerting Sentry on expected behavior. 1849 occurrences since 2025-10-14.
  - Fix: made the quiet window a `ClassVar[timedelta]` (`expected_source_delay`, default unchanged at 48h) on `MaterializedRegionJob`, and overrode it to 6 days on `NasaSmapLevel336KmV9RegionJob` to match its validator.

- **REFORMATTERS-JM / REFORMATTERS-E1** (`dwd-icon-eu-forecast-5-day-validate`): the validate cron runs only 10 minutes after the update cron, itself scheduled 3 minutes past DWD's documented p99 full-forecast availability. When a run trickles in slightly later than that p99 estimate, the newest `init_time` is briefly ~35% NaN (a fraction of lead times not yet ingested) — the next update cycle reprocesses and completes that same init_time, so this self-heals and isn't a data quality problem. `CheckRecentNans()` had no tolerance for this, so it paged on ~8.5% of the ~520 validate runs over the last 4 months.
  - Fix: added a leading NaN tolerance tier for the newest position only (`max_nan_fraction=(0.5, 0.0)`), mirroring the existing pattern already used for `noaa/gefs/forecast_35_day` for the same reason (partial newest position, complete older ones).

Both are genuine timing-margin bugs rather than pure Sentry-side noise — the underlying thresholds didn't track the dataset's actual/documented publish latency — so I fixed the code rather than muting the alerts. No open PR addressed either issue.

## Test plan

- [x] `uv run ruff format` / `uv run ruff check` / `uv run ty check` all pass
- [x] `uv run pytest -m "not slow"` — 2252 passed (full fast suite, plus targeted DWD ICON-EU / SMAP / region_job / validation tests)
- [x] Reviewed open PRs in this repo for overlap — none found

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5ZiWiQo82iDcbrC8QGffk)_