### PR TITLE
Delay HRDPS updates for source publication

### DIFF
--- a/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
+++ b/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
@@ -51,9 +51,11 @@ class EcccHrdpsForecastDataset(
             secret_names=["source-coop-storage-options-key"],
         )
 
-        # The Datamart has each complete run about 4 hours after its init time. We allow
-        # another 30 minutes for publication before reading it directly rather than
-        # waiting for the archive job above to mirror the run.
+        # Datamart timestamps for the final 48h temperature file across 29 runs from
+        # 2026-08-28 through 2026-09-04 range from init+3h33m to init+5h28m. This
+        # init+4h30m schedule covers 28 of 29, including the +4h26m run on 2026-09-04,
+        # but not the +5h28m outlier on 2026-09-02. We read the Datamart directly rather
+        # than waiting for the archive job above to mirror the run.
         # An update covers the newest init time and the previous one it reprocesses,
         # which shard into one job each.
         workers = 2

--- a/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
+++ b/src/reformatters/eccc/hrdps/forecast/dynamical_dataset.py
@@ -51,14 +51,15 @@ class EcccHrdpsForecastDataset(
             secret_names=["source-coop-storage-options-key"],
         )
 
-        # The Datamart has each complete run about 4 hours after its init time. We read it
-        # directly rather than waiting for the archive job above to mirror the run.
+        # The Datamart has each complete run about 4 hours after its init time. We allow
+        # another 30 minutes for publication before reading it directly rather than
+        # waiting for the archive job above to mirror the run.
         # An update covers the newest init time and the previous one it reprocesses,
         # which shard into one job each.
         workers = 2
         operational_update_cron_job = ReformatCronJob(
             name=f"{self.dataset_id}-update",
-            schedule="10 4,10,16,22 * * *",
+            schedule="30 4,10,16,22 * * *",
             pod_active_deadline=timedelta(minutes=30),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -73,7 +74,7 @@ class EcccHrdpsForecastDataset(
 
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
-            schedule="40 4,10,16,22 * * *",  # 30m (pod_active_deadline) after the update
+            schedule="0 5,11,17,23 * * *",  # 30m (pod_active_deadline) after the update
             pod_active_deadline=timedelta(minutes=10),
             image=image_tag,
             dataset_id=self.dataset_id,
@@ -91,8 +92,8 @@ class EcccHrdpsForecastDataset(
     def validators(self) -> Sequence[validation.Validator]:
         """Return the operational validation checks to run on this dataset."""
         return (
-            # The update ingests each init at init+4h10m; validation fires at init+4h40m.
-            validation.CheckCurrentData(max_delay=timedelta(hours=4, minutes=40)),
+            # The update ingests each init at init+4h30m; validation fires at init+5h.
+            validation.CheckCurrentData(max_delay=timedelta(hours=5)),
             # append_dim_window=4 covers a day of 6-hourly cycles, so a truncated or missing
             # forecast is caught even after newer cycles land.
             validation.CheckRecentNans(append_dim_window=4),

--- a/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
+++ b/tests/eccc/hrdps/forecast/dynamical_dataset_test.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -193,11 +194,13 @@ def test_operational_kubernetes_resources(
     assert archive_grib_files_job.suspend is False
 
     assert update_cron_job.name == f"{dataset.dataset_id}-update"
+    assert update_cron_job.schedule == "30 4,10,16,22 * * *"
     # One worker for the newest init time and one for the previous, which the update
     # reprocesses. Each is a whole shard, so neither splits further.
     assert update_cron_job.workers_total == 2
     assert update_cron_job.parallelism == 2
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
+    assert validation_cron_job.schedule == "0 5,11,17,23 * * *"
     assert update_cron_job.suspend is False
     assert validation_cron_job.suspend is False
 
@@ -207,8 +210,10 @@ def test_operational_kubernetes_resources(
 
 def test_validators(dataset: EcccHrdpsForecastDataset) -> None:
     validators = tuple(dataset.validators())
-    assert len(validators) == 2
-    assert all(isinstance(v, validation.Validator) for v in validators)
+    assert validators == (
+        validation.CheckCurrentData(max_delay=timedelta(hours=5)),
+        validation.CheckRecentNans(append_dim_window=4),
+    )
 
 
 def test_archive_grib_files_calls_copy_with_defaults(


### PR DESCRIPTION
## Summary

- move HRDPS operational updates from init+4h10m to init+4h30m
- keep validation 30 minutes after updates by moving it from init+4h40m to init+5h
- align CheckCurrentData max_delay with the new five-hour validation deadline
- pin the exact schedules and validator configuration in focused tests

## Rationale

The 2026-09-02 04:10 UTC update encountered widespread 404s for the new 00Z run from both the ECCC Datamart and the Source Co-Op fallback, then published an init with 97.96-100% NaNs. The 04:40 validation correctly failed in Sentry issue REFORMATTERS-JS. This was not a validation/update race: Kubernetes recorded the update complete at 04:11:24 UTC.

The HRDPS monitor has had two failed scheduled check-ins among 31 since operational validation started on 2026-08-25. Both were source-readiness failures, so the extra publication buffer should reduce alert noise while preserving the validation checks. The next six-hour update repaired the affected init and validation recovered.

Sentry: https://dynamical.sentry.io/issues/7706109497/

## Checks

- uv run pytest tests/eccc/hrdps/forecast/dynamical_dataset_test.py -m "not slow" (5 passed, 1 deselected)
- uv run ruff format
- uv run ruff check --fix
- uv run ty check --output-format concise
- commit hooks, including generated manual workflows