### PR TITLE
Resubmit a failed ECDS job after a growing wait instead of aborting the archive run

### DIFF
--- a/src/reformatters/ecmwf/archive_gribs/ecds_client.py
+++ b/src/reformatters/ecmwf/archive_gribs/ecds_client.py
@@ -32,6 +32,12 @@ TERMINAL_FAILURE_STATUSES: Final[frozenset[str]] = frozenset(
 REQUEST_TIMEOUT_SECONDS: Final[float] = 60
 DOWNLOAD_TIMEOUT_SECONDS: Final[float] = 120
 MAXIMUM_POLL_BACKOFF_EXPONENT: Final[int] = 6
+RESUBMIT_WAIT_SECONDS: Final[float] = 60
+RESUBMIT_BUDGET_SECONDS: Final[float] = 3600
+
+
+class EcdsJobFailedError(Exception):
+    """ECDS ran the job and ended it in a terminal failure status."""
 
 
 @dataclass
@@ -145,12 +151,18 @@ class EcdsRequest:
         target: Path,
         poll_seconds: float = 30,
         maximum_polls: int = 240,
+        resubmit_wait_seconds: float = RESUBMIT_WAIT_SECONDS,
+        resubmit_budget_seconds: float = RESUBMIT_BUDGET_SECONDS,
     ) -> Path:
         """Submit `payload` if it is not already in flight, then download to `target`.
 
         A blob already downloaded for `payload` is kept rather than fetched again: an
         ECDS result expires without a published SLA, so a second download of the same
         result may be impossible.
+
+        A job ECDS fails is submitted again after `resubmit_wait_seconds`, doubling each
+        time. No job is submitted once `resubmit_budget_seconds` have passed since this
+        call began; the failure is raised as `EcdsJobFailedError` instead.
         """
         state = self.state_store.read_if_exists()
         if state is None or state.payload != dict(payload):
@@ -160,7 +172,19 @@ class EcdsRequest:
             return target
         elif state.status in TERMINAL_FAILURE_STATUSES:
             self.submit(payload)
-        _, result_url = self.poll_until_complete(poll_seconds, maximum_polls)
+        deadline = time.monotonic() + resubmit_budget_seconds
+        wait_seconds = resubmit_wait_seconds
+        while True:
+            try:
+                _, result_url = self.poll_until_complete(poll_seconds, maximum_polls)
+                break
+            except EcdsJobFailedError as e:
+                if time.monotonic() + wait_seconds >= deadline:
+                    raise
+                log.warning("%s; submitting it again in %.0f s", e, wait_seconds)
+                time.sleep(wait_seconds)
+                self.submit(payload)
+                wait_seconds *= 2
         self.download(target, result_url)
         return target
 
@@ -251,7 +275,7 @@ class EcdsRequest:
                 _sleep_bounded(backoff_seconds, deadline)
                 continue
             if state.status in TERMINAL_FAILURE_STATUSES:
-                raise RuntimeError(
+                raise EcdsJobFailedError(
                     f"ECDS job {state.request_id} ended with status {state.status}: "
                     f"{state.errors[-1] if state.errors else ''}"
                 )

--- a/tests/ecmwf/archive_gribs/archive_test.py
+++ b/tests/ecmwf/archive_gribs/archive_test.py
@@ -11,6 +11,7 @@ from reformatters.ecmwf.archive_gribs.archive import (
     check_available,
     format_init_time,
 )
+from reformatters.ecmwf.archive_gribs.ecds_client import EcdsJobFailedError
 from reformatters.ecmwf.archive_gribs.grib_inventory import INDEX_SUFFIX
 from reformatters.ecmwf.archive_gribs.request_shards import (
     EcdsSelection,
@@ -253,6 +254,21 @@ def test_an_incomplete_blob_is_not_uploaded_and_its_work_is_kept(
     assert (
         tmp_path / "2026-08-10" / SELECTIONS[0].file_name / SELECTIONS[0].file_name
     ).exists()
+
+
+def test_a_selection_whose_jobs_keep_failing_is_not_retrieved_again(
+    tmp_path: Path, archive_bucket: dict[str, MagicMock]
+) -> None:
+    """`EcdsRequest.retrieve` owns the resubmission budget, so the outer retry must not multiply it."""
+    archive_bucket["request"].return_value.retrieve.side_effect = EcdsJobFailedError(
+        "ended with status failed"
+    )
+
+    with pytest.raises(EcdsJobFailedError, match="ended with status failed"):
+        archive(tmp_path, SELECTIONS[:1])
+
+    archive_bucket["request"].return_value.retrieve.assert_called_once()
+    archive_bucket["copy_local_file"].assert_not_called()
 
 
 def test_check_available_queries_constraints_without_the_keys_it_checks() -> None:

--- a/tests/ecmwf/archive_gribs/ecds_client_test.py
+++ b/tests/ecmwf/archive_gribs/ecds_client_test.py
@@ -8,6 +8,7 @@ import requests
 
 from reformatters.ecmwf.archive_gribs import ecds_client
 from reformatters.ecmwf.archive_gribs.ecds_client import (
+    EcdsJobFailedError,
     EcdsRequest,
     RequestState,
     StateStore,
@@ -171,7 +172,7 @@ def test_polling_raises_on_a_terminal_failure(tmp_path: Path) -> None:
     session = session_mock()
     session.get.return_value = response({"status": "dismissed"})
 
-    with pytest.raises(RuntimeError, match="ended with status dismissed"):
+    with pytest.raises(EcdsJobFailedError, match="ended with status dismissed"):
         EcdsRequest(state_store, session=session).poll_until_complete(0, 3)
 
 
@@ -444,6 +445,58 @@ def test_retrieve_resubmits_after_a_terminal_failure(tmp_path: Path) -> None:
 
     session.post.assert_called_once()
     assert state_store.read().request_id == "job-2"
+
+
+def test_retrieve_submits_a_failed_job_again_after_a_wait(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    payload = {"variable": ["total_precipitation"]}
+    state_store = StateStore(tmp_path / "state.json")
+    session = session_mock()
+    session.post.side_effect = [
+        response({"jobID": "job-1"}),
+        response({"jobID": "job-2"}),
+    ]
+    download_response = response({})
+    download_response.iter_content.return_value = [grib_message()]
+    session.get.side_effect = [
+        response({"status": "failed"}),
+        response({"status": "successful", "asset": {"value": {"href": "blob"}}}),
+        download_response,
+    ]
+
+    EcdsRequest(state_store, session=session).retrieve(
+        payload, tmp_path / "blob.grib2", poll_seconds=0, resubmit_wait_seconds=60
+    )
+
+    assert clock.sleeps == [60]
+    assert session.post.call_count == 2
+    assert state_store.read().request_id == "job-2"
+    assert (tmp_path / "blob.grib2").exists()
+
+
+def test_retrieve_waits_longer_after_each_failed_job_until_the_budget_is_spent(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    payload = {"variable": ["total_precipitation"]}
+    state_store = StateStore(tmp_path / "state.json")
+    session = session_mock()
+    session.post.side_effect = [response({"jobID": f"job-{n}"}) for n in range(1, 10)]
+    session.get.return_value = response({"status": "failed"})
+
+    with pytest.raises(EcdsJobFailedError, match="job-4 ended with status failed"):
+        EcdsRequest(state_store, session=session).retrieve(
+            payload,
+            tmp_path / "blob.grib2",
+            poll_seconds=0,
+            resubmit_wait_seconds=10,
+            resubmit_budget_seconds=100,
+        )
+
+    assert clock.sleeps == [10, 20, 40]
+    assert session.post.call_count == 4
+    assert state_store.read().status == "failed"
+    assert not (tmp_path / "blob.grib2").exists()
 
 
 def test_constraints_retries_a_transient_server_error() -> None:


### PR DESCRIPTION
## Why

The ECMWF IFS ENS 46-day GRIB history walk (the manual `archive-grib-files` process on `ecmwf-backfill`) died with:

```
RuntimeError: ECDS job a82423e4-3974-45df-8310-4015fd6f7bdf ended with status failed: {"instance": ".../jobs/a82423e4-.../results", "status": 400, "title": "The job has failed", "traceback": "", "type": "job results failed"}
```

**Root cause: an ECDS backend incident, amplified by the code.** ECDS ended three consecutive jobs for the same selection in `failed` with an empty traceback. The only resubmission path was the outer `retry` in `archive.py`, three attempts about a second apart, so a source failure lasting more than a few seconds was fatal to the whole run. The walk had finished topping up 2026-03-05 at 2026-09-03T01:02Z, wrote nothing for 35 hours, and was restarted manually at ~2026-09-04T11:45Z; the identical requests for 2026-03-04 then succeeded within minutes, which confirms the failure was transient. Not the instance (clean Python traceback, not a kill) and not the data (the availability gate and cost check pass for that date).

## What

- `EcdsRequest.retrieve` owns resubmission: a failed job is submitted again after `resubmit_wait_seconds` (60 s), doubling each time, and no job is submitted once `resubmit_budget_seconds` (1 h) have passed since the call began.
- A terminal job failure raises `EcdsJobFailedError` rather than `RuntimeError`, so the transport/rclone retry in `archive.py` does not run the budget three times over.
- Tests: client-level resubmit-then-succeed and budget exhaustion with the fake clock; archive-level test pinning that `retrieve` is called once on `EcdsJobFailedError`. Both client tests fail against the previous code.

Worst case per selection is now ~1 h of failed jobs plus one 2 h poll, against 3 × 2 h before. The 2 h poll bound is unchanged.

## Plan

- [x] Root cause from the log and a bucket timeline
- [x] Resubmission with a doubling wait and a wall-clock budget in the ECDS client
- [x] Distinct exception at the `archive.py` boundary, with a test pinning it
- [x] `ruff format`, `ruff check`, `ty check`, `pytest -m "not slow"` (2264 passed before the last two review edits; archiver tests 77 passed after)
- [x] Reviewed by a Codex reviewer; two findings taken, one declined (bounding the poll deadline by the resubmission budget: the poll bound is pre-existing and the docstring now states what the budget governs)
- [x] Review + merge
- [ ] Deploy, then restart the EC2 walk on this code

## Not in this PR

- An expired result URL (403/404 on download) is retried but never resubmitted, so it would also exhaust; a separate change.
- Continuing to older initializations when one fails (the plan 922 open question). A broad ECDS incident would multiply load across dates; wants a circuit breaker if added.
- The walk has no supervisor. A systemd unit with `Restart=on-failure` and a `RestartSec` of minutes would turn an outage longer than the budget into a minutes-long gap instead of 35 hours.

## Log

### 2026-09-04 — diagnosed and fixed

Bucket timeline reconstructed from a recursive listing in UTC (`aws s3 ls` prints local time otherwise). The frontier cron was healthy throughout (2026-09-01 and 09-02 landed at 06 UTC). The 22 partial inits 2026-02-12 → 03-03 are the pre-#978 12-blob layout awaiting their six new blobs; 2026-02-11 holds only four control blobs from the walk interrupted on 2026-08-28.

https://claude.ai/code/session_01UcoaTYxcvg2nfQqtmxeAD8
