### PR TITLE
Clear the warnings emitted by the test suite

### DIFF
--- a/src/reformatters/common/shared_memory_utils.py
+++ b/src/reformatters/common/shared_memory_utils.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Generator
 from concurrent.futures import ProcessPoolExecutor
 from contextlib import closing, contextmanager
@@ -182,10 +181,7 @@ def write_shard_to_zarr(
 
     assert_fill_values_set(processing_region_da_template)
 
-    with (
-        warnings.catch_warnings(),
-        closing(SharedMemory(name=shared_buffer_name)) as shared_memory,
-    ):
+    with closing(SharedMemory(name=shared_buffer_name)) as shared_memory:
         shared_array: ArrayFloat32 = np.ndarray(
             processing_region_da_template.shape,
             dtype=processing_region_da_template.dtype,
@@ -203,11 +199,6 @@ def write_shard_to_zarr(
         append_dim_slice = slice(append_dim_coords.min(), append_dim_coords.max())
         data_array = data_array.sel({append_dim: append_dim_slice})
 
-        warnings.filterwarnings(
-            "ignore",
-            message="In a future version of xarray decode_timedelta will default to False rather than None.",
-            category=FutureWarning,
-        )
         group, name = split_var_path(str(processing_region_da_template.name))
         data_array[shard_indexer].rename(name).to_zarr(
             store, group=group, region="auto", write_empty_chunks=True

--- a/src/reformatters/common/template_utils.py
+++ b/src/reformatters/common/template_utils.py
@@ -1,6 +1,7 @@
+import contextlib
 import json
 import warnings
-from collections.abc import Callable, Sized
+from collections.abc import Callable, Iterator, Sized
 from pathlib import Path
 from typing import Any, Literal
 
@@ -23,6 +24,22 @@ from reformatters.common.storage import StoreFactory, commit_if_icechunk
 from reformatters.common.zarr import assert_fill_values_set, copy_zarr_metadata
 
 log = get_logger(__name__)
+
+
+@contextlib.contextmanager
+def ignore_consolidated_metadata_spec_warning() -> Iterator[None]:
+    """Silence zarr's warning that consolidated metadata is not in the Zarr v3 spec.
+
+    Unconsolidated metadata is also written so adding consolidated metadata is
+    unlikely to impact interoperability.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Consolidated metadata is currently not part in the Zarr format 3 specification",
+            category=UserWarning,
+        )
+        yield
 
 
 def _to_zarr_metadata(
@@ -76,15 +93,7 @@ def write_metadata(
             "Use copy_zarr_metadata to update metadata on existing stores."
         )
 
-    with warnings.catch_warnings():
-        # Unconsolidated metadata is also written so adding
-        # consolidated metadata is unlikely to impact interoperability.
-        warnings.filterwarnings(
-            "ignore",
-            message="Consolidated metadata is currently not part in the Zarr format 3 specification",
-            category=UserWarning,
-        )
-
+    with ignore_consolidated_metadata_spec_warning():
         for replica_store in replica_stores:
             log.info(f"Writing metadata to replica {replica_store} with mode {mode}")
             _to_zarr_metadata(template_ds, replica_store, mode, consolidated)

--- a/src/reformatters/common/validation.py
+++ b/src/reformatters/common/validation.py
@@ -709,6 +709,10 @@ def _var_nan_fractions(
     da = ds[var_path]
     if "lead_time" in da.dims and var_path in skip_lead_time_0_vars:
         da = da.isel(lead_time=slice(1, None))
+    # An empty selection measures nothing; its mean is NaN, which is not > any
+    # threshold, so measuring it would report a pass.
+    if da.size == 0:
+        return None
     # Deep copy after slicing to force eager load of just the needed region
     # (helps avoid memory leaks observed iterating null checks across vars).
     da = da.copy(deep=True)
@@ -728,10 +732,6 @@ def _var_nan_fractions(
         fractions = null.mean(dim=reduce_dims)
 
     values = [float(value) for value in np.atleast_1d(fractions.compute().values)]
-    # An empty selection measures nothing; its mean is NaN, which is not > any
-    # threshold, so without this it would report a pass.
-    if not all(np.isfinite(value) for value in values):
-        return None
     # values run oldest-first along the append dim; recency 0 is the newest.
     return dict(enumerate(reversed(values)))
 

--- a/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py
@@ -82,7 +82,7 @@ class EcmwfIfsEnsForecast15Day025DegreeRegionJob(
             processing_region_ds["lead_time"].values,
             processing_region_ds["ensemble_member"].values,
         ):
-            if not group_has_hour_0_values and lead_time == np.timedelta64(0):
+            if not group_has_hour_0_values and lead_time == pd.Timedelta(0):
                 continue
 
             member = int(ensemble_member)

--- a/src/reformatters/ecmwf/ifs_ens/forecast_46_day_region_job.py
+++ b/src/reformatters/ecmwf/ifs_ens/forecast_46_day_region_job.py
@@ -175,7 +175,7 @@ class EcmwfIfsEns46DayRegionJob(
                 processing_region_ds["lead_time"].values,
                 processing_region_ds["ensemble_member"].values,
             )
-            if data_var.has_hour_0_values() or lead_time != np.timedelta64(0)
+            if data_var.has_hour_0_values() or lead_time != pd.Timedelta(0)
         ]
 
     def download_file(self, coord: EcmwfIfsEns46DaySourceFileCoord) -> Path:

--- a/tests/common/validation_test.py
+++ b/tests/common/validation_test.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from datetime import timedelta
 
 import icechunk
@@ -19,6 +18,7 @@ from reformatters.common.config_models import (
     DataVarAttrs,
     Encoding,
 )
+from reformatters.common.template_utils import ignore_consolidated_metadata_spec_warning
 
 
 class NanTestDataVar(DataVar[BaseInternalAttrs]):
@@ -1026,14 +1026,8 @@ def _write_test_store(rng: np.random.Generator) -> zarr.storage.MemoryStore:
     )
     store = zarr.storage.MemoryStore()
     # Match production stores, which carry consolidated metadata (see template_utils.write_metadata),
-    # so validate_dataset opens them without the consolidated-fallback warning. Writing it emits a
-    # spec-compatibility UserWarning that production suppresses too.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="Consolidated metadata is currently not part in the Zarr format 3 specification",
-            category=UserWarning,
-        )
+    # so validate_dataset opens them without the consolidated-fallback warning.
+    with ignore_consolidated_metadata_spec_warning():
         ds.to_zarr(store, mode="w")
     return store
 

--- a/tests/scripts/validation/conftest.py
+++ b/tests/scripts/validation/conftest.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from reformatters.common.template_utils import ignore_consolidated_metadata_spec_warning
+
 
 @pytest.fixture
 def geographic_xy_store(tmp_path: Path) -> str:
@@ -12,7 +14,7 @@ def geographic_xy_store(tmp_path: Path) -> str:
     y = np.arange(-90, 91, 45)
     x = np.arange(0, 360, 45)
     store_path = tmp_path / "wn2.zarr"
-    xr.Dataset(
+    ds = xr.Dataset(
         {
             "temperature_2m": (
                 ("y", "x"),
@@ -21,5 +23,9 @@ def geographic_xy_store(tmp_path: Path) -> str:
         },
         coords={"y": y, "x": x},
         attrs={"dataset_id": "google-weathernext2-forecast-operational-virtual"},
-    ).to_zarr(store_path, zarr_format=3, consolidated=True)
+    )
+    # Match production stores, which carry consolidated metadata; load_zarr_dataset
+    # opens a local store with consolidated=True.
+    with ignore_consolidated_metadata_spec_warning():
+        ds.to_zarr(store_path, zarr_format=3, consolidated=True)
     return str(store_path)


### PR DESCRIPTION
`uv run pytest` emitted 166 warnings across four sites. This fixes all of them at the source; `uv run pytest -W error` now passes on the affected files and the full suite runs clean.

## Changes

**`np.timedelta64(0)` deprecation (160 of the 166 warnings)** — `ecmwf/ifs_ens/forecast_15_day_0_25_degree/region_job.py` and `ecmwf/ifs_ens/forecast_46_day_region_job.py` compared `lead_time` against a bare `np.timedelta64(0)`. numpy deprecates the generic (unitless) timedelta and will raise on it in a future release. Both now compare against `pd.Timedelta(0)`, matching `ecmwf/aifs_single/forecast_virtual/region_job.py`.

**`RuntimeWarning: invalid value encountered in divide`** — `_var_nan_fractions` computed a mean over an empty selection (a non-instant variable whose only lead time is 0 gets its whole slice dropped), producing a 0/0 NaN that was then caught by an `isfinite` check on the result. It now returns early on `da.size == 0`, so the degenerate mean is never taken. The `isfinite` check is removed: with a non-empty selection the mean of a boolean `isnull()` array is always finite, so it could not fire for any other reason. Behaviour is unchanged — `test_check_recent_nans_empty_selection_fails` still fails the check rather than passing vacuously.

**`ZarrUserWarning` about consolidated metadata** — `write_metadata` already ignores this warning with a rationale, and `validation_test.py` carried a hand-copied duplicate of that filter. The filter moves into `template_utils.ignore_consolidated_metadata_spec_warning()`, used by production and by the two test stores that write consolidated metadata directly (including `tests/scripts/validation/conftest.py`, which was missing it). One place now explains why the warning is ignored instead of three.

**A dead warning suppression** — `shared_memory_utils.write_shard_to_zarr` filtered the FutureWarning "In a future version of xarray decode_timedelta will default to False rather than None". xarray 2026.7 no longer emits that message anywhere, so the filter silenced nothing. Removing it also drops a `warnings.catch_warnings` from a function that runs in worker processes, where `catch_warnings` is not thread safe. The suite stays warning-free without it.

## Checks

`uv run ruff format`, `uv run ruff check`, `uv run ty check`, and the full `uv run pytest` (2446 passed, 14 skipped, 0 warnings) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5LcREQC5nNFKZ1fMHacVS