### PR TITLE
Document virtual backfill sizing

### DIFF
--- a/.github/workflows/manual-backfill.yml
+++ b/.github/workflows/manual-backfill.yml
@@ -67,12 +67,12 @@ name: 'Manual: Backfill'
         required: false
         type: string
       jobs_per_pod:
-        description: 'Region jobs per worker pod. Materialized: 2-4 for non-ensemble datasets, 1 for ensemble; virtual: 30. For all, aim for jobs that take 3-15 minutes to amortize startup time and reduce icechunk commit compare-and-set contention.'
+        description: 'Region jobs per worker pod. Materialized: 2-4 for non-ensemble datasets, 1 for ensemble. For virtual sizing, see docs/backfill.md#tuning-parallelism.'
         required: false
         type: string
         default: '2'
       max_parallelism:
-        description: 'Maximum concurrent worker pods. Materialized: 50-200 (go higher if needed, but check cluster quotas so operational updates can still schedule); some sources cap useful parallelism (s3://ecmwf-forecasts supports at most 8). Virtual: 10 — any higher risks heavy compare-and-set contention.'
+        description: 'Maximum concurrent worker pods. Materialized: 50-200 (check cluster quotas and source limits). Virtual: 6-10; see docs/backfill.md#tuning-parallelism.'
         required: false
         type: string
         default: '10'

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -36,7 +36,7 @@ Commit latency also depends on array count, because each commit read-modify-writ
 
 `jobs_per_pod` does not transfer between datasets, because refs per job spans orders of magnitude: 38 refs for an analysis position carrying one per array, against 95,000 for an ensemble forecast init carrying every lead time × ensemble member. Compute refs per job for the dataset in front of you.
 
-Where refs per commit is not the binding constraint, aim for the 3–15 minutes above rather than the smallest workable value. Pod startup costs about a minute whatever the job, so a pod holding under two minutes of work spends most of its life starting up.
+Where refs per commit is not the binding constraint, aim for the 3–15 minutes above rather than the smallest workable value.
 
 For the cpu / memory / shared-memory a dataset's jobs request, see the Kubernetes resource values in [implementation_guide.md](implementation_guide.md) §5.
 

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -27,8 +27,16 @@ Pick the operation by what you're doing (action operation name / equivalent CLI 
 
 ## Tuning parallelism
 
-- **jobs_per_pod** — aim for jobs that take 3–15 minutes, to amortize pod startup and reduce icechunk commit compare-and-set contention. Materialized: 2–4 for non-ensemble datasets, 1 for ensemble. Virtual: ~30.
-- **max_parallelism** — materialized: 20–50. Much higher (~200) is often fine, but verify first that the cluster can fit that many of this dataset's pods: compare both the cpu and the memory one pod requests against available capacity, since either can be the binding constraint and the limit may be a quota rather than a node count. Leave headroom so operational updates can still schedule, and watch for unschedulable pods once the job starts. Some sources cap useful parallelism (`s3://ecmwf-forecasts` supports at most 8). Virtual: 10 — higher risks heavy compare-and-set contention.
+- **jobs_per_pod** — aim for jobs that take 3–15 minutes, to amortize pod startup and reduce icechunk commit compare-and-set contention. Materialized: 2–4 for non-ensemble datasets, 1 for ensemble.
+- **max_parallelism** — materialized: 20–50. Much higher (~200) is often fine, but verify first that the cluster can fit that many of this dataset's pods: compare both the cpu and the memory one pod requests against available capacity, since either can be the binding constraint and the limit may be a quota rather than a node count. Leave headroom so operational updates can still schedule, and watch for unschedulable pods once the job starts. Some sources cap useful parallelism (`s3://ecmwf-forecasts` supports at most 8). Virtual: 6–10; higher risks compare-and-set contention because every worker commits to the same Icechunk branch.
+
+For virtual backfills, size `jobs_per_pod` by **refs per commit** — arrays touched × refs per active split, which during a backfill is `jobs_per_pod × refs per job` because a worker commits once. Keep it under roughly half a million refs; above that, commit latency grows faster than linearly.
+
+Commit latency also depends on array count, because each commit read-modify-writes one manifest per array it touches. The same refs per commit is cheaper on a 38-array dataset than on a 300-array one, so let a few-array dataset run above that range and hold a many-array one at or below it.
+
+`jobs_per_pod` does not transfer between datasets, because refs per job spans orders of magnitude: 38 refs for an analysis position carrying one per array, against 95,000 for an ensemble forecast init carrying every lead time × ensemble member. Compute refs per job for the dataset in front of you.
+
+Where refs per commit is not the binding constraint, aim for the 3–15 minutes above rather than the smallest workable value. Pod startup costs about a minute whatever the job, so a pod holding under two minutes of work spends most of its life starting up.
 
 For the cpu / memory / shared-memory a dataset's jobs request, see the Kubernetes resource values in [implementation_guide.md](implementation_guide.md) §5.
 


### PR DESCRIPTION
## Summary

- state virtual `jobs_per_pod` sizing as rules: refs per commit, the array-count dependence, the non-transferability between datasets, and the pod-startup floor
- point the manual workflow inputs at that section instead of carrying stale per-kind numbers

No requirement to run a trial backfill first, and no dated measurements in the doc — the numbers behind each rule are below.

## Numbers behind the rules

Refs per commit and its ceiling: a GFS forecast backfill at 4.4M refs/commit ran p50 26 s, p95 88 s, max 418 s; below ~0.5M refs/commit, commits stayed under about 10 s across the datasets checked.

Array count as a separate term, since each commit read-modify-writes one manifest per array touched: GFS analysis at ~298 arrays and 0.52M refs/commit ran p50 7.8 s, while GEFS 10-day at 38 arrays and 0.34M refs/commit ran median 1.7 s, max 3.1 s — comparable refs, very different latency.

Non-transferability: within one model family and source, sizing came out at 16 for a forecast with 95,418 refs per region job (lead times × ensemble members) and 3,000 for an analysis with 38 refs per job (one per array).

No pod-startup floor is claimed. A ~65 s figure from two GEFS test runs was withdrawn: it measured pod creation to first work on pods doing tiny amounts of work, which bundles scheduling, node provisioning, image pull, process start and store open into one number that was never decomposed. It does not support a statement about pod startup, and using it to argue for a large `jobs_per_pod` was unsound even where the conclusion held for other reasons. A decomposed measurement is in progress; any floor sentence waits for it.

## Verification

- `uv run prek run --all-files`
- `uv run python src/scripts/generate_manual_workflows.py` leaves the edited input descriptions intact (only the `dataset_id` / `cronjob_name` choice lists are generated)
