### PR TITLE
Document GFS PV surface hemispheric gaps

### DIFF
--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/geopotential_height_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/pressure_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_0p5pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_0p5pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_1p5pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_1p5pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_1pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_1pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_2pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_2pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus0p5pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus0p5pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus1p5pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus1p5pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus1pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus1pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus2pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/temperature_minus2pvu/zarr.json
@@ -43,7 +43,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/vertical_speed_shear_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_u_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus0p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus1p5pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus1pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/wind_v_minus2pvu/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/zarr.json
@@ -2574,7 +2574,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2627,7 +2627,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2680,7 +2680,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2733,7 +2733,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2944,7 +2944,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2997,7 +2997,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -3050,7 +3050,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -3103,7 +3103,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -5876,7 +5876,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -5929,7 +5929,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -5982,7 +5982,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -6035,7 +6035,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -7484,7 +7484,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -7537,7 +7537,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -7590,7 +7590,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -7643,7 +7643,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -9975,7 +9975,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10324,7 +10324,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10383,7 +10383,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10500,7 +10500,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10849,7 +10849,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10908,7 +10908,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10967,7 +10967,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -11026,7 +11026,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -11887,7 +11887,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -11940,7 +11940,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -11993,7 +11993,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12046,7 +12046,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12099,7 +12099,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12152,7 +12152,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12205,7 +12205,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12258,7 +12258,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12838,7 +12838,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13203,7 +13203,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13256,7 +13256,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13361,7 +13361,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13830,7 +13830,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13883,7 +13883,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13936,7 +13936,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13989,7 +13989,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -14146,7 +14146,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -14511,7 +14511,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -14564,7 +14564,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -14669,7 +14669,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -15138,7 +15138,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -15191,7 +15191,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -15244,7 +15244,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -15297,7 +15297,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gfs/analysis_virtual/templates/latest.zarr/zarr.json
@@ -2574,7 +2574,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2627,7 +2627,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2680,7 +2680,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2733,7 +2733,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2944,7 +2944,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2997,7 +2997,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -3050,7 +3050,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -3103,7 +3103,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -5876,7 +5876,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -5929,7 +5929,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -5982,7 +5982,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -6035,7 +6035,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -7484,7 +7484,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -7537,7 +7537,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -7590,7 +7590,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -7643,7 +7643,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -9975,7 +9975,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10324,7 +10324,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10383,7 +10383,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10500,7 +10500,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10849,7 +10849,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10908,7 +10908,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -10967,7 +10967,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -11026,7 +11026,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -11887,7 +11887,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -11940,7 +11940,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -11993,7 +11993,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12046,7 +12046,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12099,7 +12099,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12152,7 +12152,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12205,7 +12205,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12258,7 +12258,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -12838,7 +12838,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13203,7 +13203,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13256,7 +13256,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13361,7 +13361,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13830,7 +13830,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13883,7 +13883,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13936,7 +13936,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -13989,7 +13989,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -14146,7 +14146,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -14511,7 +14511,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -14564,7 +14564,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -14669,7 +14669,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -15138,7 +15138,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -15191,7 +15191,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -15244,7 +15244,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -15297,7 +15297,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/geopotential_height_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "gh",
     "standard_name": "geopotential_height",
     "units": "m",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/pressure_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "pres",
     "standard_name": "air_pressure",
     "units": "Pa",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_0p5pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_0p5pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_1p5pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_1p5pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_1pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_1pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_2pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_2pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus0p5pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus0p5pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus1p5pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus1p5pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus1pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus1pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus2pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/temperature_minus2pvu/zarr.json
@@ -45,7 +45,7 @@
     "short_name": "t",
     "standard_name": "air_temperature",
     "units": "degree_Celsius",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/vertical_speed_shear_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "vwsh",
     "standard_name": "wind_speed_shear",
     "units": "s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_u_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "u",
     "standard_name": "eastward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus0p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus0p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus1p5pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus1p5pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus1pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus1pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus2pvu/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/wind_v_minus2pvu/zarr.json
@@ -39,7 +39,7 @@
     "short_name": "v",
     "standard_name": "northward_wind",
     "units": "m s-1",
-    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+    "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/zarr.json
@@ -2830,7 +2830,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2886,7 +2886,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2942,7 +2942,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2998,7 +2998,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3221,7 +3221,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3277,7 +3277,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3333,7 +3333,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3389,7 +3389,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6575,7 +6575,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6631,7 +6631,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6687,7 +6687,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6743,7 +6743,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -8425,7 +8425,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -8481,7 +8481,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -8537,7 +8537,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -8593,7 +8593,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11054,7 +11054,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11421,7 +11421,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11483,7 +11483,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11606,7 +11606,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11973,7 +11973,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -12035,7 +12035,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -12097,7 +12097,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -12159,7 +12159,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13123,7 +13123,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13179,7 +13179,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13235,7 +13235,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13291,7 +13291,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13347,7 +13347,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13403,7 +13403,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13459,7 +13459,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13515,7 +13515,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -14128,7 +14128,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -14514,7 +14514,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -14570,7 +14570,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -14681,7 +14681,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15177,7 +15177,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15233,7 +15233,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15289,7 +15289,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15345,7 +15345,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15511,7 +15511,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15897,7 +15897,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15953,7 +15953,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16064,7 +16064,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16560,7 +16560,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16616,7 +16616,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16672,7 +16672,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16728,7 +16728,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gfs/forecast_virtual/templates/latest.zarr/zarr.json
@@ -2830,7 +2830,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2886,7 +2886,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2942,7 +2942,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2998,7 +2998,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3221,7 +3221,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3277,7 +3277,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3333,7 +3333,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -3389,7 +3389,7 @@
           "short_name": "gh",
           "standard_name": "geopotential_height",
           "units": "m",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6575,7 +6575,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6631,7 +6631,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6687,7 +6687,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -6743,7 +6743,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -8425,7 +8425,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -8481,7 +8481,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -8537,7 +8537,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -8593,7 +8593,7 @@
           "short_name": "pres",
           "standard_name": "air_pressure",
           "units": "Pa",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11054,7 +11054,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11421,7 +11421,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11483,7 +11483,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11606,7 +11606,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -11973,7 +11973,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -12035,7 +12035,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -12097,7 +12097,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -12159,7 +12159,7 @@
           "short_name": "t",
           "standard_name": "air_temperature",
           "units": "degree_Celsius",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13123,7 +13123,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13179,7 +13179,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13235,7 +13235,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13291,7 +13291,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13347,7 +13347,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13403,7 +13403,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13459,7 +13459,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -13515,7 +13515,7 @@
           "short_name": "vwsh",
           "standard_name": "wind_speed_shear",
           "units": "s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -14128,7 +14128,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -14514,7 +14514,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -14570,7 +14570,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -14681,7 +14681,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15177,7 +15177,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15233,7 +15233,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15289,7 +15289,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15345,7 +15345,7 @@
           "short_name": "u",
           "standard_name": "eastward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15511,7 +15511,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15897,7 +15897,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -15953,7 +15953,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16064,7 +16064,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16560,7 +16560,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16616,7 +16616,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16672,7 +16672,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -16728,7 +16728,7 @@
           "short_name": "v",
           "standard_name": "northward_wind",
           "units": "m s-1",
-          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the southern hemisphere and negative potential vorticity surfaces in the northern hemisphere.",
+          "comment": "NaN where this potential vorticity surface does not exist in the column; positive potential vorticity surfaces are largely absent in the extratropical southern hemisphere and negative potential vorticity surfaces in the extratropical northern hemisphere.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gfs/virtual_template_config.py
+++ b/src/reformatters/noaa/gfs/virtual_template_config.py
@@ -2209,7 +2209,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="eastward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2222,7 +2224,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="northward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2235,7 +2239,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_temperature",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2248,7 +2254,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="geopotential_height",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2261,7 +2269,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_pressure",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2274,7 +2284,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="wind_speed_shear",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2287,7 +2299,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="eastward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2300,7 +2314,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="northward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2313,7 +2329,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_temperature",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2326,7 +2344,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="geopotential_height",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2339,7 +2359,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_pressure",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2352,7 +2374,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="wind_speed_shear",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2616,7 +2640,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="eastward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2629,7 +2655,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="northward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2642,7 +2670,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_temperature",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2655,7 +2685,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="geopotential_height",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2668,7 +2700,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_pressure",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2681,7 +2715,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="wind_speed_shear",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2694,7 +2730,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="eastward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2707,7 +2745,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="northward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2720,7 +2760,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_temperature",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2733,7 +2775,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="geopotential_height",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2746,7 +2790,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_pressure",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2759,7 +2805,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="wind_speed_shear",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2772,7 +2820,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="eastward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2785,7 +2835,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="northward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2798,7 +2850,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_temperature",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2811,7 +2865,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="geopotential_height",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2824,7 +2880,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_pressure",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2837,7 +2895,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="wind_speed_shear",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2850,7 +2910,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="eastward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2863,7 +2925,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="northward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2876,7 +2940,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_temperature",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2889,7 +2955,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="geopotential_height",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2902,7 +2970,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_pressure",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2915,7 +2985,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="wind_speed_shear",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2928,7 +3000,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="eastward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2941,7 +3015,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="northward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2954,7 +3030,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_temperature",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2967,7 +3045,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="geopotential_height",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2980,7 +3060,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_pressure",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -2993,7 +3075,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="wind_speed_shear",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -3006,7 +3090,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="eastward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -3019,7 +3105,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="northward_wind",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -3032,7 +3120,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_temperature",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -3045,7 +3135,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="geopotential_height",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -3058,7 +3150,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="air_pressure",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(
@@ -3071,7 +3165,9 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             standard_name="wind_speed_shear",
             comment=(
                 "NaN where this potential vorticity surface does not exist in the "
-                "column."
+                "column; positive potential vorticity surfaces are largely absent in the "
+                "southern hemisphere and negative potential vorticity surfaces in the "
+                "northern hemisphere."
             ),
         ),
         root_var(

--- a/src/reformatters/noaa/gfs/virtual_template_config.py
+++ b/src/reformatters/noaa/gfs/virtual_template_config.py
@@ -55,6 +55,12 @@ _CELSIUS_ELEMENTS = frozenset(
 _WATER_KG_M2_TO_M_LWE = ScaleOffset(offset=0.0, scale=1000.0).to_dict()
 # Scale TOZNE from Dobson units to metres; 1 DU is 1e-5 m.
 _DOBSON_UNITS_TO_M = ScaleOffset(offset=0.0, scale=1e5).to_dict()
+_PV_SURFACE_COMMENT = (
+    "NaN where this potential vorticity surface does not exist in the column; positive "
+    "potential vorticity surfaces are largely absent in the extratropical southern "
+    "hemisphere and negative potential vorticity surfaces in the extratropical northern "
+    "hemisphere."
+)
 
 type WindowKind = Literal["instant", "max", "min", "avg", "acc_6h", "acc_run"]
 
@@ -2207,12 +2213,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="U component of wind",
             units="m s-1",
             standard_name="eastward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_v_2pvu",
@@ -2222,12 +2223,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="V component of wind",
             units="m s-1",
             standard_name="northward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "temperature_2pvu",
@@ -2237,12 +2233,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Temperature",
             units="degree_Celsius",
             standard_name="air_temperature",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "geopotential_height_2pvu",
@@ -2252,12 +2243,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "pressure_2pvu",
@@ -2267,12 +2253,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "vertical_speed_shear_2pvu",
@@ -2282,12 +2263,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Vertical speed shear",
             units="s-1",
             standard_name="wind_speed_shear",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_u_minus2pvu",
@@ -2297,12 +2273,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="U component of wind",
             units="m s-1",
             standard_name="eastward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_v_minus2pvu",
@@ -2312,12 +2283,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="V component of wind",
             units="m s-1",
             standard_name="northward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "temperature_minus2pvu",
@@ -2327,12 +2293,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Temperature",
             units="degree_Celsius",
             standard_name="air_temperature",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "geopotential_height_minus2pvu",
@@ -2342,12 +2303,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "pressure_minus2pvu",
@@ -2357,12 +2313,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "vertical_speed_shear_minus2pvu",
@@ -2372,12 +2323,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Vertical speed shear",
             units="s-1",
             standard_name="wind_speed_shear",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "uv_b_downward_solar_flux_surface",
@@ -2638,12 +2584,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="U component of wind",
             units="m s-1",
             standard_name="eastward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_v_0p5pvu",
@@ -2653,12 +2594,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="V component of wind",
             units="m s-1",
             standard_name="northward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "temperature_0p5pvu",
@@ -2668,12 +2604,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Temperature",
             units="degree_Celsius",
             standard_name="air_temperature",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "geopotential_height_0p5pvu",
@@ -2683,12 +2614,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "pressure_0p5pvu",
@@ -2698,12 +2624,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "vertical_speed_shear_0p5pvu",
@@ -2713,12 +2634,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Vertical speed shear",
             units="s-1",
             standard_name="wind_speed_shear",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_u_minus0p5pvu",
@@ -2728,12 +2644,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="U component of wind",
             units="m s-1",
             standard_name="eastward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_v_minus0p5pvu",
@@ -2743,12 +2654,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="V component of wind",
             units="m s-1",
             standard_name="northward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "temperature_minus0p5pvu",
@@ -2758,12 +2664,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Temperature",
             units="degree_Celsius",
             standard_name="air_temperature",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "geopotential_height_minus0p5pvu",
@@ -2773,12 +2674,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "pressure_minus0p5pvu",
@@ -2788,12 +2684,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "vertical_speed_shear_minus0p5pvu",
@@ -2803,12 +2694,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Vertical speed shear",
             units="s-1",
             standard_name="wind_speed_shear",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_u_1pvu",
@@ -2818,12 +2704,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="U component of wind",
             units="m s-1",
             standard_name="eastward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_v_1pvu",
@@ -2833,12 +2714,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="V component of wind",
             units="m s-1",
             standard_name="northward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "temperature_1pvu",
@@ -2848,12 +2724,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Temperature",
             units="degree_Celsius",
             standard_name="air_temperature",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "geopotential_height_1pvu",
@@ -2863,12 +2734,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "pressure_1pvu",
@@ -2878,12 +2744,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "vertical_speed_shear_1pvu",
@@ -2893,12 +2754,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Vertical speed shear",
             units="s-1",
             standard_name="wind_speed_shear",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_u_minus1pvu",
@@ -2908,12 +2764,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="U component of wind",
             units="m s-1",
             standard_name="eastward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_v_minus1pvu",
@@ -2923,12 +2774,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="V component of wind",
             units="m s-1",
             standard_name="northward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "temperature_minus1pvu",
@@ -2938,12 +2784,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Temperature",
             units="degree_Celsius",
             standard_name="air_temperature",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "geopotential_height_minus1pvu",
@@ -2953,12 +2794,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "pressure_minus1pvu",
@@ -2968,12 +2804,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "vertical_speed_shear_minus1pvu",
@@ -2983,12 +2814,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Vertical speed shear",
             units="s-1",
             standard_name="wind_speed_shear",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_u_1p5pvu",
@@ -2998,12 +2824,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="U component of wind",
             units="m s-1",
             standard_name="eastward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_v_1p5pvu",
@@ -3013,12 +2834,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="V component of wind",
             units="m s-1",
             standard_name="northward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "temperature_1p5pvu",
@@ -3028,12 +2844,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Temperature",
             units="degree_Celsius",
             standard_name="air_temperature",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "geopotential_height_1p5pvu",
@@ -3043,12 +2854,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "pressure_1p5pvu",
@@ -3058,12 +2864,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "vertical_speed_shear_1p5pvu",
@@ -3073,12 +2874,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Vertical speed shear",
             units="s-1",
             standard_name="wind_speed_shear",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_u_minus1p5pvu",
@@ -3088,12 +2884,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="U component of wind",
             units="m s-1",
             standard_name="eastward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "wind_v_minus1p5pvu",
@@ -3103,12 +2894,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="V component of wind",
             units="m s-1",
             standard_name="northward_wind",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "temperature_minus1p5pvu",
@@ -3118,12 +2904,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Temperature",
             units="degree_Celsius",
             standard_name="air_temperature",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "geopotential_height_minus1p5pvu",
@@ -3133,12 +2914,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Geopotential height",
             units="m",
             standard_name="geopotential_height",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "pressure_minus1p5pvu",
@@ -3148,12 +2924,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Pressure",
             units="Pa",
             standard_name="air_pressure",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "vertical_speed_shear_minus1p5pvu",
@@ -3163,12 +2934,7 @@ def _root_data_vars(chunks: tuple[int, ...]) -> list[NoaaDataVar]:
             long_name="Vertical speed shear",
             units="s-1",
             standard_name="wind_speed_shear",
-            comment=(
-                "NaN where this potential vorticity surface does not exist in the "
-                "column; positive potential vorticity surfaces are largely absent in the "
-                "southern hemisphere and negative potential vorticity surfaces in the "
-                "northern hemisphere."
-            ),
+            comment=_PV_SURFACE_COMMENT,
         ),
         root_var(
             "cloud_mixing_ratio_model_level_1",


### PR DESCRIPTION
## Summary

- Extend the existing NaN comment on all 48 GFS virtual PV-surface variables to describe the hemispheric structure: positive PV surfaces are largely absent in the southern hemisphere, and negative surfaces in the northern.
- Regenerate the shared catalog metadata into both the analysis and forecast virtual templates.
- This is metadata-only, rides an operational metadata refresh, and requires no re-backfill or re-ingest.

Two large backfills are currently running for these datasets. Opening this PR is safe, but this metadata change must not be deployed under those active backfills.

Neither GFS virtual dataset is currently in the production STAC catalog, so this additive attribute correction has no production backward-compatibility obligation.

## Verification

- Confirmed 48 variables: six quantities on each of the eight surfaces (`0p5`, `1`, `1p5`, `2` PVU and their negative counterparts).
- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check --output-format concise`
- `uv run pytest -m "not slow" -n 4` (2,624 passed)
- `uv run pytest tests/common/common_template_config_subclasses_test.py` (234 passed)
- `uv run pytest tests/common/datasets_cf_compliance_test.py` (225 passed)
- All nine GFS test modules containing slow tests, one module per invocation (237 passed total).