### PR TITLE
Document GEFS soil ice and helicity conventions

### DIFF
--- a/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
@@ -36,6 +36,7 @@
     "long_name": "Storm relative helicity",
     "short_name": "hlcy",
     "units": "m2 s-2",
+    "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/volumetric_soil_moisture_0_10cm/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/volumetric_soil_moisture_0_10cm/zarr.json
@@ -37,7 +37,7 @@
     "short_name": "vsw",
     "standard_name": "volume_fraction_of_condensed_water_in_soil",
     "units": "1",
-    "comment": "NaN over water.",
+    "comment": "NaN over water. Values are near 1 over permanent land ice, where they are placeholders rather than soil moisture measurements. Mask values >= 0.9.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/zarr.json
@@ -1623,6 +1623,7 @@
           "long_name": "Storm relative helicity",
           "short_name": "hlcy",
           "units": "m2 s-2",
+          "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="
@@ -2106,7 +2107,7 @@
           "short_name": "vsw",
           "standard_name": "volume_fraction_of_condensed_water_in_soil",
           "units": "1",
-          "comment": "NaN over water.",
+          "comment": "NaN over water. Values are near 1 over permanent land ice, where they are placeholders rather than soil moisture measurements. Mask values >= 0.9.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
@@ -40,6 +40,7 @@
     "long_name": "Storm relative helicity",
     "short_name": "hlcy",
     "units": "m2 s-2",
+    "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/volumetric_soil_moisture_0_10cm/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/volumetric_soil_moisture_0_10cm/zarr.json
@@ -41,7 +41,7 @@
     "short_name": "vsw",
     "standard_name": "volume_fraction_of_condensed_water_in_soil",
     "units": "1",
-    "comment": "NaN over water.",
+    "comment": "NaN over water. Values are near 1 over permanent land ice, where they are placeholders rather than soil moisture measurements. Mask values >= 0.9.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/zarr.json
@@ -2002,6 +2002,7 @@
           "long_name": "Storm relative helicity",
           "short_name": "hlcy",
           "units": "m2 s-2",
+          "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="
@@ -2535,7 +2536,7 @@
           "short_name": "vsw",
           "standard_name": "volume_fraction_of_condensed_water_in_soil",
           "units": "1",
-          "comment": "NaN over water.",
+          "comment": "NaN over water. Values are near 1 over permanent land ice, where they are placeholders rather than soil moisture measurements. Mask values >= 0.9.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/virtual_template_config.py
+++ b/src/reformatters/noaa/gefs/virtual_template_config.py
@@ -534,7 +534,11 @@ def _s_file_data_vars(
             long_name="Volumetric soil moisture",
             units="1",
             standard_name="volume_fraction_of_condensed_water_in_soil",
-            comment="NaN over water.",
+            comment=(
+                "NaN over water. Values are near 1 over permanent land ice, where they "
+                "are placeholders rather than soil moisture measurements. Mask values >= "
+                "0.9."
+            ),
         ),
         var(
             "snow_water_equivalent_surface",
@@ -819,6 +823,10 @@ def _s_file_data_vars(
             short_name="hlcy",
             long_name="Storm relative helicity",
             units="m2 s-2",
+            comment=(
+                "Uses a right-moving storm motion in both hemispheres, so southern "
+                "hemisphere values are positive-mean rather than mirrored."
+            ),
         ),
         var(
             "convective_available_potential_energy_180_0mb",


### PR DESCRIPTION
Documents the permanent-land-ice placeholder on `volumetric_soil_moisture_0_10cm` and the global right-moving storm-motion convention on `storm_relative_helicity_3000_0m`. Regenerates the analysis and 10-day forecast virtual templates. Both comments are byte-identical to their GFS equivalents.

## Evidence

**Soil moisture ice placeholder.** Established by a physical test rather than the value distribution, per the missing-value rule in AGENTS.md. At two times in the backfilled window, 100.0% of the marked cells (> 0.9) are sub-freezing by `soil_temperature_0_10cm`, against 14–38% of the remaining land cells; 90.7% lie south of 60S and 9.3% north of 59N, with the 40 low-latitude cells on high-altitude glaciers; every one of the 101,121 land cells south of 70S carries the value. The count moves by 16 cells between October and November, so it is a static mask rather than a weather field, and 1.0 exceeds any real soil porosity (~0.5) so it cannot be a volume fraction. Real soil tops out at 0.8980–0.9000, which is why the mask is stated at `>= 0.9`.

A cross-decoder check rules out the alternative explanation, a scaling error in our GRIB codec: the store's values match an independent rasterio/GDAL decode of the same GRIB message, byte range taken from the Icechunk manifest, element-wise over every cell of the 721×1440 grid at two times, with a negative control confirming the comparison discriminates.

**Helicity storm-motion convention.** Established from source, not from the sign statistics. Operational GEFS v12.3.22 pins its own `gefs_v12.3.22` UPP tag ([`a8bab1af`](https://github.com/NOAA-EMC/UPP/blob/a8bab1afe93b982106b0a138ebe9f48acf0ecdf1/sorc/ncep_post.fd/CALHEL.f#L329-L345)), where `CALHEL` uses the Bunkers method with an unconditional fixed 7.5 m/s right-moving deviation — no hemisphere branch and no latitude read — and `HELI(:,:,1)` is the requested 0–3 km slice this variable carries.

The convention holds across the whole archive, so the fact is intrinsic and belongs in a comment rather than a validation review note: 25 `-nco` release tags from before the archive start to the present resolve to five distinct postprocessor pins, all with this behaviour, cross-checked by blob SHA (`MISCLN.f` identical at all five; `CALHEL.f` identical from `gefs_v12.0.1` through `gefs_v12.3.20`, with v12.3.22's only difference a near-zero `DZ1`/`DZ2` guard that does not touch the storm-motion block). The comment deliberately says nothing about UPP `develop`, which selects a left-moving deviation south of the equator: that is a future version boundary, not a fact about this archive.

Cross-decoder agreement on this variable also rules out a codec sign error — the decoders' Southern Hemisphere medians and positive fractions match exactly.

## Tests

`uv run pytest tests/noaa/gefs/virtual_template_config_test.py tests/noaa/gefs/analysis_0_25_degree_virtual/template_config_test.py tests/noaa/gefs/forecast_10_day_0_25_degree_virtual/template_config_test.py tests/common/common_template_config_subclasses_test.py tests/common/datasets_cf_compliance_test.py` (492 passed)
