### PR TITLE
Fix GFS pgrb2b ingestion probe

### DIFF
--- a/src/reformatters/noaa/gfs/virtual_region_job.py
+++ b/src/reformatters/noaa/gfs/virtual_region_job.py
@@ -113,9 +113,8 @@ _REPRESENTATIVE_VARS: dict[NoaaGfsFileType, tuple[str, ...]] = {
 
 # A vertical level each product publishes for every variable of the group it carries.
 # The products split every vertical coordinate, so a group's first level is a chunk the
-# other product never fills and probing it would re-ingest that file forever. One
-# constant per (group, product) holds because each product's level inventory is uniform
-# across the group's elements.
+# other product never fills and probing it would re-ingest that file forever. pgrb2b's
+# 125 hPa level is present in every carried pressure-level variable's inventory.
 _PROBE_VERTICAL_LEVEL: dict[Dim, dict[NoaaGfsFileType, float]] = {
     "pressure_level": {"pgrb2": 1000.0, "pgrb2b": 125.0},
     "height_above_mean_sea_level": {"pgrb2": 1829.0, "pgrb2b": 305.0},

--- a/src/reformatters/noaa/gfs/virtual_region_job.py
+++ b/src/reformatters/noaa/gfs/virtual_region_job.py
@@ -103,12 +103,12 @@ class NoaaGfsVirtualSourceFileCoord(
         return f"s3://{NODD_BUCKET}/" + url.removeprefix(NODD_HTTPS_PREFIX)
 
 
-# The variables a source file's ingestion is probed by, in preference order. Each is
-# published in every era of the archive and carried only by its own product. A coord
-# holding only the variables without hour 0 values falls through to the second entry.
+# The variables a source file's ingestion is probed by, in preference order. Each probe
+# cell is published in every era of the archive and carried only by its own product. A
+# coord holding only the variables without hour 0 values falls through to the second.
 _REPRESENTATIVE_VARS: dict[NoaaGfsFileType, tuple[str, ...]] = {
     "pgrb2": ("temperature_2m", "total_precipitation_surface"),
-    "pgrb2b": ("geopotential_height_0p5pvu", "uv_b_downward_solar_flux_surface"),
+    "pgrb2b": ("geopotential_height", "uv_b_downward_solar_flux_surface"),
 }
 
 # A vertical level each product publishes for every variable of the group it carries.
@@ -117,7 +117,7 @@ _REPRESENTATIVE_VARS: dict[NoaaGfsFileType, tuple[str, ...]] = {
 # constant per (group, product) holds because each product's level inventory is uniform
 # across the group's elements.
 _PROBE_VERTICAL_LEVEL: dict[Dim, dict[NoaaGfsFileType, float]] = {
-    "pressure_level": {"pgrb2": 1000.0, "pgrb2b": 875.0},
+    "pressure_level": {"pgrb2": 1000.0, "pgrb2b": 125.0},
     "height_above_mean_sea_level": {"pgrb2": 1829.0, "pgrb2b": 305.0},
 }
 

--- a/src/reformatters/noaa/gfs/virtual_region_job.py
+++ b/src/reformatters/noaa/gfs/virtual_region_job.py
@@ -113,8 +113,7 @@ _REPRESENTATIVE_VARS: dict[NoaaGfsFileType, tuple[str, ...]] = {
 
 # A vertical level each product publishes for every variable of the group it carries.
 # The products split every vertical coordinate, so a group's first level is a chunk the
-# other product never fills and probing it would re-ingest that file forever. pgrb2b's
-# 125 hPa level is present in every carried pressure-level variable's inventory.
+# other product never fills and probing it would re-ingest that file forever.
 _PROBE_VERTICAL_LEVEL: dict[Dim, dict[NoaaGfsFileType, float]] = {
     "pressure_level": {"pgrb2": 1000.0, "pgrb2b": 125.0},
     "height_above_mean_sea_level": {"pgrb2": 1829.0, "pgrb2b": 305.0},

--- a/src/reformatters/noaa/gfs/virtual_region_job.py
+++ b/src/reformatters/noaa/gfs/virtual_region_job.py
@@ -143,7 +143,8 @@ class NoaaGfsVirtualRegionJob(
         return (element, level) not in PGRB2_PREFERRED_MESSAGES
 
     def representative_var(self, coord: GFS_VIRTUAL_COORD) -> NoaaDataVar:
-        """A variable this file fills, preferring one whose chunk needs no level pick."""
+        """A variable this file fills, preferring product-specific probes published in
+        every archive era."""
         by_name = {var.name: var for var in coord.data_vars}
         candidates = [
             *(

--- a/tests/noaa/gfs/analysis_virtual/region_job_test.py
+++ b/tests/noaa/gfs/analysis_virtual/region_job_test.py
@@ -149,10 +149,10 @@ def test_which_instant_variables_lack_hour_0_values() -> None:
     assert all(get_var(name).has_hour_0_values() for name in present_at_hour_0)
 
 
-def test_representative_var_is_carried_only_by_its_own_product(
+def test_representative_probe_is_filled_only_by_its_own_product(
     template_ds: xr.DataTree,
 ) -> None:
-    """A probe on a variable the file does not fill would never be marked ingested."""
+    """A probe on a cell the file does not fill would never be marked ingested."""
     data_vars = TEMPLATE_CONFIG.data_vars
     coords = coords_for_times(
         template_ds, data_vars, [pd.Timestamp("2021-05-03T12:00")]
@@ -168,15 +168,16 @@ def test_representative_var_is_carried_only_by_its_own_product(
     assert picked == {
         ("pgrb2", True): "temperature_2m",
         ("pgrb2", False): "total_precipitation_surface",
-        ("pgrb2b", True): "geopotential_height_0p5pvu",
+        ("pgrb2b", True): "geopotential_height",
         ("pgrb2b", False): "uv_b_downward_solar_flux_surface",
     }
     for coord in coords:
         var = job.representative_var(coord)
         assert var in coord.data_vars
-        assert dict(job.representative_probe_loc(coord, var)) == {
-            "time": coord.valid_time()
-        }
+        expected_loc = {"time": coord.valid_time()}
+        if coord.file_type == "pgrb2b" and var.name == "geopotential_height":
+            expected_loc["pressure_level"] = 125.0
+        assert dict(job.representative_probe_loc(coord, var)) == expected_loc
 
 
 def test_operational_update_jobs_single_polling_job(

--- a/tests/noaa/gfs/forecast_virtual/region_job_test.py
+++ b/tests/noaa/gfs/forecast_virtual/region_job_test.py
@@ -170,10 +170,10 @@ def test_which_variables_hour_0_drops(
     )
 
 
-def test_representative_var_is_carried_only_by_its_own_product(
+def test_representative_probe_is_filled_only_by_its_own_product(
     template_ds: xr.DataTree,
 ) -> None:
-    """A probe on a variable the file does not fill would never be marked ingested."""
+    """A probe on a cell the file does not fill would never be marked ingested."""
     job = make_job(template_ds, TEMPLATE_CONFIG.data_vars)
     coords = coords_for(
         template_ds,
@@ -189,16 +189,19 @@ def test_representative_var_is_carried_only_by_its_own_product(
     assert picked == {
         ("pgrb2", pd.Timedelta(0)): "temperature_2m",
         ("pgrb2", pd.Timedelta("9h")): "temperature_2m",
-        ("pgrb2b", pd.Timedelta(0)): "geopotential_height_0p5pvu",
-        ("pgrb2b", pd.Timedelta("9h")): "geopotential_height_0p5pvu",
+        ("pgrb2b", pd.Timedelta(0)): "geopotential_height",
+        ("pgrb2b", pd.Timedelta("9h")): "geopotential_height",
     }
     for coord in coords:
         var = job.representative_var(coord)
         assert var in coord.data_vars
-        assert dict(job.representative_probe_loc(coord, var)) == {
+        expected_loc = {
             "init_time": coord.init_time,
             "lead_time": coord.lead_time,
         }
+        if coord.file_type == "pgrb2b":
+            expected_loc["pressure_level"] = 125.0
+        assert dict(job.representative_probe_loc(coord, var)) == expected_loc
 
 
 def test_operational_update_jobs_single_polling_job(
@@ -471,7 +474,7 @@ def test_a_job_filtered_to_a_pressure_level_variable_probes_a_level_it_fills(
     levels = {dict(ref.out_loc)["pressure_level"] for ref in refs}
     assert len(levels) == (41 if file_type == "pgrb2" else 16)
     assert dict(job.representative_probe_loc(coord, var))["pressure_level"] == (
-        1000.0 if file_type == "pgrb2" else 875.0
+        1000.0 if file_type == "pgrb2" else 125.0
     )
     job._assert_probe_chunk_covered(coord, refs)
 


### PR DESCRIPTION
## Summary

Change the GFS pgrb2b representative resume probe from geopotential height on the +0.5 PVU surface to pressure-level geopotential height at 125 hPa.

This is config-only. It does not change which refs `file_refs` builds, chunk contents, or source byte ranges. It changes only the cell used by `filter_already_present` and the probe-coverage assertion.

## Root cause and measured selection

The public upstream object at init 2024-10-20 18:00 UTC, lead 249 hours is a consistently truncated publication, not a systematic lead or era omission:

- Data object: 71,229,440 bytes, versus 238,663,733 at f246 and 238,092,315 at f252.
- Index: 112 lines, versus 349 at normal nonzero leads. It ends at HGT 375 hPa.
- A range read from the final indexed offset finds one complete HGT 375 hPa message of 701,575 bytes, followed by only 386,509 of the next TMP 375 hPa message, whose declared length is 737,601 bytes. No complete unindexed tail messages exist.

A sweep covered 5,643 real pgrb2b indexes: all 209 scheduled leads, f000 through f120 hourly and f123 through f384 three-hourly, across 27 sampled cycles in every year from 2021 through 2026, including the incident cycle. The former +0.5 PVU HGT probe was present in 5,642/5,643 and absent only in the truncated f249 index. The replacement HGT 125 hPa cell was present in 5,643/5,643.

HGT 125 hPa is line 42/349, 12.0% through a normal index. The old probe is normally line 317/349, 90.8% through it. The earlier probe therefore survives truncations that remove most of the file rather than only truncations after roughly 91%.

## Result for the truncated forecast position

With this probe, the file is accepted and contributes exactly the refs represented by its short index. `file_refs` builds 77 pgrb2b-owned refs instead of the normal 308; 231 chunks remain absent. The difference from the 237 absent source messages is six trailing messages duplicated from pgrb2 and intentionally owned by that product.

All 80 variables supplied by pgrb2b are affected, out of 274 catalog variables:

- All 63 root variables are absent: 36 PV-surface fields across six signed PV levels, 25 fields across the five 60-30 through 180-150 hPa layers, and both UV-B flux fields.
- The three height-above-mean-sea-level variables have no pgrb2b refs at 305, 457, 610, 914, or 4572 m.
- All 14 pressure-level variables are partial. Geopotential height is absent at the ten pgrb2b levels 425 through 875 hPa; the other 13 variables are absent at the eleven pgrb2b levels 375 through 875 hPa.

The final indexed HGT 375 hPa ref spans the partial TMP fragment because the last index range ends at the object size. Gribberish decodes that oversized ref identically to the exact 701,575-byte HGT message, so HGT 375 hPa remains readable. The missing cells are an honest representation of data that the upstream archive did not publish completely.

The absence is **unflagged**: no validator, log line, or alert reports the 231 absent chunks. A reader learns about them only from the dataset validation report's external **Review notes — noaa-gfs-forecast-virtual**, under **Unavailable data**. That note, maintained outside this code diff, discloses:

> The 80 variables carried by the secondary source product are absent at init time 2024-10-20 18:00, lead time 249 hours. NOAA published that source file at 30% of its normal size, so 231 of its 308 chunks are missing: every single-level and layer field it supplies, its height-above-mean-sea-level levels, and its pressure levels from 375 hPa (425 hPa for geopotential height) through 875 hPa. The truncation is in the published data itself rather than in its byte index, so backfill is not possible from the upstream archive. No other instance appeared in a sweep of 5,643 source indexes spanning 2021 to 2026.

The position is not sealed, but it is **no longer self-healing**. [#952](https://github.com/dynamical-org/reformatters/pull/952) made `process_virtual_refs` bypass `filter_already_present` under `overwrite_chunks`, so a republished complete object remains recoverable through a deliberate overwrite-chunks run aimed at this position. An ordinary resume will see the representative chunk and never revisit it automatically.

## Incident-path effect and detection gap

On the incident path this change is purely assertion suppression. The failed backfill ran with `overwrite_chunks`, so `filter_already_present` was never in play and the resume-probe half of the change did nothing there. Moving the probe only lets `_assert_probe_chunk_covered` accept the partial ref set, instead of killing one worker before it commits any of its 8,360 files for 20 init times and permanently blocking finalization of the 391-pod run.

Probe depth was never a truncation detector: a truncation at 95% would also have passed the old probe at 90.8%. This change widens an existing silence rather than creating one.

The actual detection gap is at neither probe level. Nothing checks source-object size or index line count against expectation during ingest, and the manifest scan is file-granularity, so a partially ingested file is indistinguishable from a complete one. Detecting and flagging partial source ingestion is a follow-up; this PR deliberately does not change assertion behavior or add that ingest/validation mechanism.

## Related probe exposure, not changed here

- GFS analysis shares the instant pgrb2b probe, so this shared fix also moves that probe to line 42. Its windowed-only pgrb2b coord was generated from the real template and contains exactly two data variables: DUVB at line 272/349 (77.9%) and CDUVB at line 273/349 (78.2%). Both were present in 162/162 real indexes across every analysis lead f001-f006, 27 cycles, and every archive year from 2021 through 2026. DUVB is already the earliest covered probe, so no config-only move exists and this path remains exposed by design rather than oversight. The follow-up remedy is to relax the data-cell coupling with an explicit per-source-file ingestion marker written atomically with the refs and used for resume.
- HRRR sampled in 2018 and 2024: the surface instant probe is line 1, 0.6-0.7%; the analysis surface-windowed CRAIN probe is 54.7-58.8%; the forecast pressure probe is 76.3-77.4%; the analysis pressure probe is 75.3-76.4%; and the native-level probe is 1.2-1.3%.
- GEFS sampled in 2021 and 2024: the instant GUST probe is 4.5-7.7%; the analysis windowed TMAX probe is 32.4-34.2%. GEFS also asserts that every coord variable matched a ref, so a truncation dropping any catalog variable fails independently of representative probe depth.

No HRRR or GEFS behavior is changed.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check --output-format concise`
- `uv run pytest -m "not slow" -n 4`: 2,624 passed
- Every GFS module containing slow tests, one `.py` path per invocation: 185 passed across nine modules
- Focused forecast and analysis representative-probe tests: 2 passed



## Interaction with the assert-classification work

Moving the probe to 12% of the index means a truncated file no longer trips anything. The
incident file passes this probe, passes the last-offset header check, and is accepted with
77 of its 308 refs: no rejection, no ERROR, no skipped-file count, and because those partial
refs land in the manifest the position is not re-offered on a later run. Recovery needs a
deliberate `overwrite-chunks` run aimed at it.

So until an ingest-time check on object size and index line count exists, this class of
source damage is accepted silently and no detector fires. That check is being raised as its
own PR, ahead of #1029, because #1029 cannot supply it: probe absence is not the signal, and
after this change it is not a truncation signal at all.

The bound on that silence is measured rather than assumed: one such file in 2,925,247
ingested in a single full backfill, and none in a sweep of 5,643 source indexes spanning
2021 to 2026.
