### PR TITLE
Raise the GEFS precipitation deaccumulation clamp allowance

### DIFF
--- a/src/reformatters/common/deaccumulation.py
+++ b/src/reformatters/common/deaccumulation.py
@@ -19,6 +19,8 @@ RADIATION_INVALID_BELOW_THRESHOLD = -50.0  # W/m^2 aka J/m^2/s
 # mismatched source field, which deaccumulates to thousands of W/m^2, goes beyond this.
 DIRECT_RADIATION_INVALID_BELOW_THRESHOLD = -1000.0
 
+DEFAULT_EXPECTED_CLAMP_FRACTION = 0.05
+
 # How the input values along `dim` should be interpreted:
 #   - "accumulated": values are cumulative totals (e.g. J m-2 since forecast start).
 #     Step rate = (A_t - A_{t-1}) / dt.
@@ -42,7 +44,7 @@ def deaccumulate_to_rates_inplace(
     skip_step: Array1D[np.bool] | None = None,
     invalid_below_threshold_rate: float = PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD,
     expected_invalid_fraction: float = 0.0,
-    expected_clamp_fraction: float = 0.05,
+    expected_clamp_fraction: float = DEFAULT_EXPECTED_CLAMP_FRACTION,
     accumulation_type: AccumulationType = "accumulated",
 ) -> xr.DataArray:
     """

--- a/src/reformatters/eccc/hrdps/forecast/template_config.py
+++ b/src/reformatters/eccc/hrdps/forecast/template_config.py
@@ -18,6 +18,7 @@ from reformatters.common.config_models import (
     StatisticsApproximate,
 )
 from reformatters.common.deaccumulation import (
+    DEFAULT_EXPECTED_CLAMP_FRACTION,
     PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD,
     RADIATION_INVALID_BELOW_THRESHOLD,
 )
@@ -57,7 +58,7 @@ class EcccHrdpsInternalAttrs(BaseInternalAttrs):
     deaccumulation_invalid_below_threshold_rate: float = (
         PRECIPITATION_RATE_INVALID_BELOW_THRESHOLD
     )
-    deaccumulation_expected_clamp_fraction: float = 0.05
+    deaccumulation_expected_clamp_fraction: float = DEFAULT_EXPECTED_CLAMP_FRACTION
 
 
 class EcccHrdpsDataVar(DataVar[EcccHrdpsInternalAttrs]):

--- a/src/reformatters/noaa/gefs/analysis/region_job.py
+++ b/src/reformatters/noaa/gefs/analysis/region_job.py
@@ -182,6 +182,7 @@ class GefsAnalysisRegionJob(
                         dim="time",
                         reset_frequency=reset_freq,
                         skip_step=expected_missing,
+                        expected_clamp_fraction=data_var.internal_attrs.deaccumulation_expected_clamp_fraction,
                     )
                 except ValueError:
                     log.exception(f"Error deaccumulating {data_var.name}")

--- a/src/reformatters/noaa/gefs/common_gefs_template_config.py
+++ b/src/reformatters/noaa/gefs/common_gefs_template_config.py
@@ -439,6 +439,11 @@ def get_shared_data_var_configs(
                 include_lead_time_suffix=True,
                 deaccumulate_to_rate=True,
                 window_reset_frequency=pd.Timedelta("6h"),
+                # In cycles with high global precipitation the 0-6 hour APCP message is
+                # packed to 0.1mm while the 0-3 hour message keeps 0.01mm, so the 3-6 hour
+                # step reads negative by up to one 0.1mm quantum (-9e-6 mm s-1, far above
+                # the invalid threshold) across ~13% of its values.
+                deaccumulation_expected_clamp_fraction=0.15,
                 keep_mantissa_bits=keep_mantissa_bits_default,
             ),
         ),

--- a/src/reformatters/noaa/gefs/forecast_35_day/region_job.py
+++ b/src/reformatters/noaa/gefs/forecast_35_day/region_job.py
@@ -121,6 +121,7 @@ class GefsForecast35DayRegionJob(
                     data_array,
                     dim="lead_time",
                     reset_frequency=reset_freq,
+                    expected_clamp_fraction=data_var.internal_attrs.deaccumulation_expected_clamp_fraction,
                 )
             except ValueError:
                 log.exception(f"Error deaccumulating {data_var.name}")

--- a/src/reformatters/noaa/gefs/gefs_config_models.py
+++ b/src/reformatters/noaa/gefs/gefs_config_models.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from reformatters.common.config_models import DataVar, EnsembleStatistic
+from reformatters.common.deaccumulation import DEFAULT_EXPECTED_CLAMP_FRACTION
 from reformatters.common.region_job import CoordinateValue, InitLeadSourceFileCoord
 from reformatters.common.types import Dim, Timestamp
 from reformatters.noaa.models import NoaaInternalAttrs
@@ -41,6 +42,7 @@ GEFS_B22_TRANSITION_DATE = pd.Timestamp("2022-10-18T12:00")
 class NoaaGefsInternalAttrs(NoaaInternalAttrs):
     gefs_file_type: GEFSFileType
     available_from: Timestamp | None = None
+    deaccumulation_expected_clamp_fraction: float = DEFAULT_EXPECTED_CLAMP_FRACTION
 
 
 class NoaaGefsDataVar(DataVar[NoaaGefsInternalAttrs]):

--- a/tests/noaa/gefs/analysis/region_job_test.py
+++ b/tests/noaa/gefs/analysis/region_job_test.py
@@ -1,3 +1,4 @@
+import logging
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -11,6 +12,7 @@ import pytest
 import xarray as xr
 
 from reformatters.common.config_models import DataVarAttrs, Encoding
+from reformatters.common.deaccumulation import DEFAULT_EXPECTED_CLAMP_FRACTION
 from reformatters.common.pydantic import replace
 from reformatters.common.region_job import SourceFileResult, SourceFileStatus
 from reformatters.common.storage import (
@@ -32,6 +34,12 @@ from reformatters.noaa.gefs.gefs_config_models import (
 from reformatters.noaa.noaa_utils import (
     NOMADS_RETRY_STATUS_CODES,
     nomads_rate_limiter,
+)
+
+PRECIPITATION_SURFACE = next(
+    data_var
+    for data_var in GefsAnalysisTemplateConfig().data_vars
+    if data_var.name == "precipitation_surface"
 )
 
 
@@ -531,6 +539,65 @@ def test_apply_data_transformations(template_ds: xr.Dataset) -> None:
     # Data should be modified in place (exact changes depend on rounding)
     assert data_array.dtype == np.float32
     # The binary rounding should have been applied
+
+
+# A 6 hourly bucket whose 0-6 hour accumulation reads 0.05mm below its 0-3 hour
+# accumulation, the shape the coarser 0-6 hour packing produces. The dip is a negative
+# step rate above the invalid threshold, so it clamps to 0: one of sixteen values, 6.25%.
+APCP_WITH_ONE_CLAMPED_STEP = [0.0, 0.05] + [0.0] * 14
+
+
+def deaccumulation_errors(
+    template_ds: xr.Dataset,
+    data_var: NoaaGefsDataVar,
+    caplog: pytest.LogCaptureFixture,
+) -> list[str]:
+    data_array = xr.DataArray(
+        np.array(APCP_WITH_ONE_CLAMPED_STEP, dtype=np.float32),
+        dims=["time"],
+        coords={
+            "time": pd.date_range(
+                "2026-09-05T00:00", periods=len(APCP_WITH_ONE_CLAMPED_STEP), freq="3h"
+            )
+        },
+        attrs={"units": data_var.attrs.units},
+    )
+    job = GefsAnalysisRegionJob(
+        tmp_store=get_local_tmp_store(),
+        template_ds=xr.DataTree.from_dict({"/": template_ds}),
+        data_vars=[data_var],
+        append_dim="time",
+        region=slice(0, len(APCP_WITH_ONE_CLAMPED_STEP)),
+        reformat_job_name="test-job",
+    )
+
+    with caplog.at_level(logging.ERROR):
+        job.apply_data_transformations(data_array, data_var)
+
+    assert data_array[2] == 0.0  # the dip clamped rather than going negative
+    return [record.message for record in caplog.records]
+
+
+def test_precipitation_allows_the_clamping_coarse_apcp_packing_produces(
+    template_ds: xr.Dataset, caplog: pytest.LogCaptureFixture
+) -> None:
+    assert deaccumulation_errors(template_ds, PRECIPITATION_SURFACE, caplog) == []
+
+
+def test_precipitation_clamp_allowance_comes_from_the_variable(
+    template_ds: xr.Dataset, caplog: pytest.LogCaptureFixture
+) -> None:
+    default_allowance_var = replace(
+        PRECIPITATION_SURFACE,
+        internal_attrs=replace(
+            PRECIPITATION_SURFACE.internal_attrs,
+            deaccumulation_expected_clamp_fraction=DEFAULT_EXPECTED_CLAMP_FRACTION,
+        ),
+    )
+    assert any(
+        "Error deaccumulating precipitation_surface" in message
+        for message in deaccumulation_errors(template_ds, default_allowance_var, caplog)
+    )
 
 
 @patch("xarray.open_zarr")


### PR DESCRIPTION
Fixes REFORMATTERS-JY — `noaa-gefs-analysis-update` logging `Over 5% (11160329 total, 5.0%) values were clamped to 0` for `precipitation_surface`.

## What's happening

The 0.25 degree GEFS files pack the two APCP messages the analysis differences at **different decimal precisions**, and which precision each gets varies cycle to cycle:

| cycle | q(0-3h) | q(0-6h) | clamped |
|---|---|---|---|
| 2026-09-06 00z | 0.01 mm | 0.1 mm | 11.7% |
| 2026-09-02 00z | 0.1 mm | 0.1 mm | 0.0% |
| 2026-08-29 00z | 0.01 mm | 0.01 mm | 0.0% |

When the 0-6 hour message is packed to 0.1 mm and the 0-3 hour message keeps 0.01 mm, every cell whose 0-3 hour value sits above the 0-6 hour value's rounding produces a small negative 3-6 hour step. Every negative diff is a multiple of 0.01 mm and bounded at exactly -0.09 mm — one 0.1 mm quantum — i.e. `-8.3e-6 mm s-1`, an order of magnitude inside the `-7e-5 mm s-1` invalid threshold. The coarse scale appears in cycles with high global 6-hour maxima (~110-170 mm), which is why this started firing now.

## Not an interpretation problem

Verified against real source messages before changing the threshold:

- The index labels are `0-3 hour acc fcst` and `0-6 hour acc fcst`, so `window_reset_frequency=6h` and the bucket arithmetic are correct. A bucket mismatch would produce diffs near `-A3` and register as *invalid* rather than clamped.
- Over 36 consecutive cycles (2026-08-29 through 2026-09-06) the invalid fraction was 0.000% in every one.
- The analysis alternates lead-3 steps (never negative, the bucket resets before them) with lead-6 steps, so the array-wide clamped fraction is about half the per-step rate: **mean 5.2%, max 6.7%** — straddling the 5% shared default.
- GFS is not exposed: it packs both messages at 1/16 mm consistently and produces zero negative steps.

## The change

`precipitation_surface` carries `deaccumulation_expected_clamp_fraction=0.15`, roughly 2x the observed worst case. `expected_invalid_fraction` stays at 0, so a genuine bucket or interpretation regression still surfaces.

The allowance lives on the variable — matching how ECCC HRDPS and DWD ICON-EU already tune theirs — so `noaa-gefs-forecast-35-day` picks it up from the same shared config. That dataset differences the same message pair at leads 6, 12, … ≤ 240h and reaches ~4.5% at the observed worst case, so it was one bad week from the same alert. The literal `0.05` default is now the single `DEFAULT_EXPECTED_CLAMP_FRACTION` constant that `deaccumulate_to_rates_inplace` defaults to, and HRDPS's duplicate of it is pointed at that constant.

Templates regenerated: no diff, as internal attrs are not written to the store.

## Testing

`uv run ruff format`, `uv run ruff check`, `uv run ty check` clean; full `uv run pytest -m "not slow"` suite passes (2626 tests). Two new tests in `tests/noaa/gefs/analysis/region_job_test.py` pin a 6.25% clamped series passing quietly for the real variable, and the same series still being reported when the variable carries the default allowance.

## Worth a look separately

- `precipitation_surface` has `keep_mantissa_bits=7`, where the convention for a precipitation flux/rate is 8. Left alone: it changes lossy encoding on a published dataset.
- `deaccumulation_invalid_below_threshold_rate` is declared independently in four provider config modules, three of which make it `Optional` purely so their region jobs can assert-and-unwrap it. Consolidating both deaccumulation knobs onto `BaseInternalAttrs` would delete that machinery, but it touches five datasets' transformation paths and did not belong in this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBbugFgKSZ2TT6Wg3Hy6X2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBbugFgKSZ2TT6Wg3Hy6X2)_