### PR TITLE
Unsuspend the GFS and GEFS virtual dataset cron jobs

### DIFF
--- a/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/dynamical_dataset.py
@@ -58,7 +58,6 @@ class NoaaGefsAnalysis025DegreeVirtualDataset(
             secret_names=self.store_factory.k8s_secret_names(),
             workers_total=1,
             parallelism=1,
-            suspend=True,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
@@ -71,7 +70,6 @@ class NoaaGefsAnalysis025DegreeVirtualDataset(
             cpu="1.3",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/dynamical_dataset.py
@@ -56,7 +56,6 @@ class NoaaGefsForecast10Day025DegreeVirtualDataset(
             secret_names=self.store_factory.k8s_secret_names(),
             workers_total=1,
             parallelism=1,
-            suspend=True,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{cron_job_name_prefix}-validate",
@@ -68,7 +67,6 @@ class NoaaGefsForecast10Day025DegreeVirtualDataset(
             cpu="1.3",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/gfs/analysis_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/analysis_virtual/dynamical_dataset.py
@@ -58,7 +58,6 @@ class NoaaGfsAnalysisVirtualDataset(
             cpu="4",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
@@ -71,7 +70,6 @@ class NoaaGfsAnalysisVirtualDataset(
             cpu="1.5",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/src/reformatters/noaa/gfs/forecast_virtual/dynamical_dataset.py
+++ b/src/reformatters/noaa/gfs/forecast_virtual/dynamical_dataset.py
@@ -59,7 +59,6 @@ class NoaaGfsForecastVirtualDataset(
             cpu="3.5",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
         validation_cron_job = ValidationCronJob(
             name=f"{self.dataset_id}-validate",
@@ -72,7 +71,6 @@ class NoaaGfsForecastVirtualDataset(
             cpu="1.5",
             memory="7G",
             secret_names=self.store_factory.k8s_secret_names(),
-            suspend=True,
         )
 
         return [operational_update_cron_job, validation_cron_job]

--- a/tests/noaa/gefs/analysis_0_25_degree_virtual/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/analysis_0_25_degree_virtual/dynamical_dataset_test.py
@@ -198,9 +198,8 @@ def test_operational_kubernetes_resources(
         for minute in _fire_minutes(update_cron_job.schedule)
     ]
 
-    # Both stay suspended until the archive is backfilled.
-    assert update_cron_job.suspend
-    assert validation_cron_job.suspend
+    assert not update_cron_job.suspend
+    assert not validation_cron_job.suspend
 
 
 def test_operational_update_window_spans_three_update_fires(

--- a/tests/noaa/gefs/forecast_10_day_0_25_degree_virtual/dynamical_dataset_test.py
+++ b/tests/noaa/gefs/forecast_10_day_0_25_degree_virtual/dynamical_dataset_test.py
@@ -243,9 +243,8 @@ def test_operational_kubernetes_resources(
     # Without this the 6 hour default returns and a stuck validation overlaps its next fire.
     assert validation_cron_job.pod_active_deadline == timedelta(minutes=30)
 
-    # Both stay suspended until the archive is backfilled.
-    assert update_cron_job.suspend
-    assert validation_cron_job.suspend
+    assert not update_cron_job.suspend
+    assert not validation_cron_job.suspend
 
 
 def test_operational_update_window_spans_three_update_fires(

--- a/tests/noaa/gfs/analysis_virtual/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/analysis_virtual/dynamical_dataset_test.py
@@ -200,8 +200,8 @@ def test_operational_kubernetes_resources(
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert validation_cron_job.schedule == "14 4,10,16,22 * * *"
     assert len(update_cron_job.secret_names) > 0
-    assert update_cron_job.suspend
-    assert validation_cron_job.suspend
+    assert not update_cron_job.suspend
+    assert not validation_cron_job.suspend
 
 
 def test_validators(dataset: NoaaGfsAnalysisVirtualDataset) -> None:

--- a/tests/noaa/gfs/forecast_virtual/dynamical_dataset_test.py
+++ b/tests/noaa/gfs/forecast_virtual/dynamical_dataset_test.py
@@ -273,8 +273,8 @@ def test_operational_kubernetes_resources(
     assert validation_cron_job.name == f"{dataset.dataset_id}-validate"
     assert validation_cron_job.schedule == "59 5,11,17,23 * * *"
     assert len(update_cron_job.secret_names) > 0
-    assert update_cron_job.suspend
-    assert validation_cron_job.suspend
+    assert not update_cron_job.suspend
+    assert not validation_cron_job.suspend
 
 
 def test_validators(dataset: NoaaGfsForecastVirtualDataset) -> None:


### PR DESCRIPTION
Drops `suspend=True` from the update and validate cron jobs of the four virtual datasets whose archives are now fully backfilled and verified:

- `noaa-gfs-analysis-virtual`
- `noaa-gfs-forecast-virtual`
- `noaa-gefs-analysis-0-25-degree-virtual`
- `noaa-gefs-forecast-10-day-0-25-degree-virtual`

Each store was backfilled over its whole extent and verified by reading it: real decoded values across the extent, era boundaries behaving, and the documented gaps confirmed as exactly the expected positions. Metadata on each store matches its template. The tests that pinned "suspended until the archive is backfilled" now pin the opposite.

Nothing else changes: schedules, deadlines, resources and validators are untouched, and `suspend` defaults to `False` in `CronJob`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
