### PR TITLE
Bound parallel worker waits by the pod deadline

### DIFF
--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -73,7 +73,7 @@ For `workers_total > 1`, workers coordinate via files in an object store directo
 
 ### Setup signal
 
-Worker 0 writes `setup/ready.json` after completing setup (creating branches, writing metadata). Workers 1+ poll for this file before proceeding.
+Worker 0 writes `setup/ready.json` after completing setup (creating branches, writing metadata). Workers 1+ poll for this file before proceeding. This poll shares the same deadline as processing and result coordination; if worker 0 never reports readiness, each waiting worker raises an error naming index 0 while the live store remains untouched.
 
 ### Results
 
@@ -105,6 +105,8 @@ On restart, worker 0 retries setup:
 - `setup/ready.json` is written (or overwritten) when setup completes
 
 Workers 1+ that were polling for setup will proceed once the file appears.
+
+If worker 0 never reaches readiness before exhausting its retries, those workers stop polling at the shared coordination deadline and report that index 0 did not complete setup.
 
 ### Last worker dies during finalization
 

--- a/docs/parallel_processing.md
+++ b/docs/parallel_processing.md
@@ -79,6 +79,8 @@ Worker 0 writes `setup/ready.json` after completing setup (creating branches, wr
 
 Each worker writes `results/worker-{N}.json` containing its `process_results` dict. The last worker (by index) polls until all result files are present, then aggregates them. For updates, the aggregated results drive `update_template_with_results` to trim the template based on what was actually processed.
 
+The wait shares the pod's active deadline: worker execution and result coordination must finish before that single deadline, with the pod's termination grace period reserved for reporting a Python failure. If any indexes have not written results by then, the last worker raises an error naming them. Finalization does not run, so Zarr metadata and Icechunk `main` remain unchanged and the temporary branch and coordination files remain available for inspection.
+
 ### Cleanup
 
 After successful finalization, the last worker deletes the `_internal/{job_name}/` directory and the temp icechunk branch.
@@ -115,7 +117,7 @@ In all cases, `main` either hasn't moved (safe) or has moved to the correct fina
 
 ### Worker exhausts per-index retry limit
 
-The entire Kubernetes job fails. The team is notified and can run a fresh job. Since the fresh job has a different job name, it gets a clean `_internal/` namespace and a new branch — no interference from the failed run.
+The entire Kubernetes job fails. If the last index is still alive, its result wait raises before Kubernetes reaches the pod deadline and names every index that never reported. The team is notified and can run a fresh job. Since the fresh job has a different job name, it gets a clean `_internal/` namespace and a new branch — no interference from the failed run.
 
 ### Concurrent jobs writing to the same dataset
 

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -151,6 +151,9 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
         workers_total: Annotated[int, typer.Argument(envvar="WORKERS_TOTAL")] = 1,
     ) -> None:
         """Update an existing dataset with the latest data."""
+        coordination_deadline = (
+            parallel_coordination.coordination_deadline_from_environment(workers_total)
+        )
         is_first = worker_index == 0
         is_last = worker_index == workers_total - 1
         with self._monitor(
@@ -181,6 +184,7 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
                     template_ds=template_ds,
                     tmp_store=tmp_store,
                     update_template_with_results=True,
+                    coordination_deadline=coordination_deadline,
                 )
 
         log.info(
@@ -379,6 +383,9 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
         overwrite_metadata: bool = False,
     ) -> None:
         """Orchestrate running RegionJob instances."""
+        coordination_deadline = (
+            parallel_coordination.coordination_deadline_from_environment(workers_total)
+        )
         template_ds = self._get_template(append_dim_end)
         tmp_store = self._tmp_store()
 
@@ -404,6 +411,7 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
             template_ds=template_ds,
             tmp_store=tmp_store,
             update_template_with_results=False,
+            coordination_deadline=coordination_deadline,
             overwrite_chunks=overwrite_chunks,
             overwrite_metadata=overwrite_metadata,
         )
@@ -418,6 +426,7 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
         tmp_store: Path,
         *,
         update_template_with_results: bool,
+        coordination_deadline: float | None,
         overwrite_chunks: bool = False,
         overwrite_metadata: bool = False,
     ) -> None:
@@ -427,6 +436,8 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
         - Icechunk stores: uses a temp branch so readers on "main" never see partial data
         - Zarr v3 stores: defers metadata write until all workers finish
         """
+        if workers_total > 1:
+            assert coordination_deadline is not None
         is_first = worker_index == 0
         is_last = worker_index == workers_total - 1
         worker_jobs = get_worker_jobs(
@@ -510,13 +521,19 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
             if update_template_with_results:
                 if workers_total > 1:
                     merged_results = parallel_coordination.collect_results(
-                        self.store_factory, reformat_job_name, workers_total
+                        self.store_factory,
+                        reformat_job_name,
+                        workers_total,
+                        coordination_deadline,
                     )
                 else:
                     merged_results = worker_results
             else:
                 parallel_coordination.wait_for_workers(
-                    self.store_factory, reformat_job_name, workers_total
+                    self.store_factory,
+                    reformat_job_name,
+                    workers_total,
+                    coordination_deadline,
                 )
                 merged_results = {}
             parallel_coordination.finalize(

--- a/src/reformatters/common/dynamical_dataset.py
+++ b/src/reformatters/common/dynamical_dataset.py
@@ -491,6 +491,7 @@ class DynamicalDataset(OperationalResources, Generic[DATA_VAR, SOURCE_FILE_COORD
             tmp_store=tmp_store,
             icechunk_repos=icechunk_repos,
             consolidated=self.region_job_class.consolidated_metadata,
+            deadline=coordination_deadline,
             exclude_coord_value_chunks=exclude_coord_value_chunks,
         )
 

--- a/src/reformatters/common/kubernetes.py
+++ b/src/reformatters/common/kubernetes.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Self
 
 import pydantic
 from kubernetes import client, config
@@ -36,12 +36,23 @@ class Job(pydantic.BaseModel):
     parallelism: Annotated[int, pydantic.Field(ge=1)]
 
     pod_active_deadline: timedelta = timedelta(hours=6)
+    pod_termination_grace_period: timedelta = timedelta(seconds=30)
     ttl: timedelta = timedelta(days=1)
 
     # Opt out of consolidation. Quick jobs have minimal impact and we'd rather not interrupt and restart longer jobs.
     pod_annotations: dict[str, str] = {"karpenter.sh/do-not-disrupt": "true"}
 
     secret_names: Sequence[str] = pydantic.Field(default_factory=list)
+
+    @pydantic.model_validator(mode="after")
+    def deadline_allows_graceful_termination(self) -> Self:
+        assert self.pod_termination_grace_period >= timedelta(0), (
+            "pod_termination_grace_period must not be negative"
+        )
+        assert int(self.pod_active_deadline.total_seconds()) > int(
+            self.pod_termination_grace_period.total_seconds()
+        ), "pod_active_deadline must exceed pod_termination_grace_period"
+        return self
 
     def mounted_secret_names(self) -> Sequence[str]:
         """Secrets mounted as JSON files at /secrets/<name>.json in the pod."""
@@ -137,6 +148,14 @@ class Job(pydantic.BaseModel):
                                         "name": "WORKERS_TOTAL",
                                         "value": f"{self.workers_total}",
                                     },
+                                    {
+                                        "name": "POD_ACTIVE_DEADLINE_SECONDS",
+                                        "value": f"{int(self.pod_active_deadline.total_seconds())}",
+                                    },
+                                    {
+                                        "name": "POD_TERMINATION_GRACE_PERIOD_SECONDS",
+                                        "value": f"{int(self.pod_termination_grace_period.total_seconds())}",
+                                    },
                                 ],
                                 "image": f"{self.image}",
                                 "name": "worker",
@@ -178,7 +197,9 @@ class Job(pydantic.BaseModel):
                         "securityContext": {
                             "fsGroup": 999,  # this is the `app` group our app runs under
                         },
-                        "terminationGracePeriodSeconds": 30,
+                        "terminationGracePeriodSeconds": int(
+                            self.pod_termination_grace_period.total_seconds()
+                        ),
                         "activeDeadlineSeconds": int(
                             self.pod_active_deadline.total_seconds()
                         ),

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -4,6 +4,8 @@ See docs/parallel_processing.md for the overall design.
 """
 
 import json
+import os
+import re
 import time
 from collections.abc import Collection, Mapping, Sequence
 from pathlib import Path
@@ -21,6 +23,9 @@ from reformatters.common.storage import StoreFactory
 from reformatters.common.zarr import copy_zarr_metadata
 
 log = get_logger(__name__)
+
+_PROCESS_STARTED_AT = time.monotonic()
+_RESULT_FILE_PATTERN = re.compile(r"worker-(?P<worker_index>\d+)\.json")
 
 _WORKER_RESULTS_ADAPTER: TypeAdapter[dict[str, list[SourceFileResult]]] = TypeAdapter(
     dict[str, list[SourceFileResult]]
@@ -123,25 +128,45 @@ def parallel_setup(
 
 
 def wait_for_workers(
-    store_factory: StoreFactory, reformat_job_name: str, workers_total: int
+    store_factory: StoreFactory,
+    reformat_job_name: str,
+    workers_total: int,
+    deadline: float | None,
 ) -> None:
     # Poll until all workers write their results file. Backfills can have
-    # many thousands of workers, so count (cheap ls) rather than read.
-    # Rely on kubernetes pod_active_deadline for timeout.
+    # many thousands of workers, so list names (cheap ls) rather than read.
     if workers_total <= 1:
         return
-    while (
-        store_factory.count_coordination_files(reformat_job_name, "results")
-        < workers_total
-    ):
+    assert deadline is not None
+    while True:
+        result_files = store_factory.list_coordination_files(
+            reformat_job_name, "results"
+        )
+        reported_workers = {
+            int(match["worker_index"])
+            for result_file in result_files
+            if (match := _RESULT_FILE_PATTERN.fullmatch(result_file)) is not None
+        }
+        missing_workers = sorted(set(range(workers_total)) - reported_workers)
+        if not missing_workers:
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Timed out waiting for worker results for {reformat_job_name!r}; "
+                f"missing worker indexes: {missing_workers}"
+            )
         log.info("Waiting for all workers to complete...")
-        time.sleep(10)
+        time.sleep(min(10, remaining))
 
 
 def collect_results(
-    store_factory: StoreFactory, reformat_job_name: str, workers_total: int
+    store_factory: StoreFactory,
+    reformat_job_name: str,
+    workers_total: int,
+    deadline: float | None,
 ) -> Mapping[str, Sequence[SourceFileResult]]:
-    wait_for_workers(store_factory, reformat_job_name, workers_total)
+    wait_for_workers(store_factory, reformat_job_name, workers_total, deadline)
     result_files = store_factory.read_all_coordination_files(
         reformat_job_name, "results"
     )
@@ -151,6 +176,23 @@ def collect_results(
         for var_name, coords in _WORKER_RESULTS_ADAPTER.validate_json(data).items():
             merged.setdefault(var_name, []).extend(coords)
     return merged
+
+
+def coordination_deadline_from_environment(workers_total: int) -> float | None:
+    if workers_total <= 1:
+        return None
+    active_deadline = os.environ.get("POD_ACTIVE_DEADLINE_SECONDS")
+    termination_grace_period = os.environ.get("POD_TERMINATION_GRACE_PERIOD_SECONDS")
+    assert active_deadline is not None, "POD_ACTIVE_DEADLINE_SECONDS is required"
+    assert termination_grace_period is not None, (
+        "POD_TERMINATION_GRACE_PERIOD_SECONDS is required"
+    )
+    active_deadline_seconds = int(active_deadline)
+    termination_grace_period_seconds = int(termination_grace_period)
+    assert active_deadline_seconds > termination_grace_period_seconds >= 0
+    return (
+        _PROCESS_STARTED_AT + active_deadline_seconds - termination_grace_period_seconds
+    )
 
 
 def finalize(

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -55,6 +55,7 @@ def parallel_setup(
     tmp_store: Path,
     icechunk_repos: list[tuple[str, icechunk.Repository]],
     consolidated: bool,
+    deadline: float | None,
     exclude_coord_value_chunks: Collection[str] = (),
 ) -> SetupInfo:
     if is_first:
@@ -111,14 +112,21 @@ def parallel_setup(
             )
         return setup_info
 
-    # Poll until worker 0 completes setup. Rely on kubernetes pod_active_deadline for timeout.
+    # Poll until worker 0 completes setup.
     if workers_total > 1:
+        assert deadline is not None
         setup_files = store_factory.read_all_coordination_files(
             reformat_job_name, "setup"
         )
         while not setup_files:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Timed out waiting for worker index 0 to complete setup for "
+                    f"{reformat_job_name!r}"
+                )
             log.info("Waiting for worker 0 to complete setup...")
-            time.sleep(5)
+            time.sleep(min(5, remaining))
             setup_files = store_factory.read_all_coordination_files(
                 reformat_job_name, "setup"
             )

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -298,14 +298,14 @@ class StoreFactory(FrozenBaseModel):
         contents = fs.cat(files)
         return [contents[f] for f in sorted(files)]
 
-    def count_coordination_files(self, job_name: str, prefix: str) -> int:
+    def list_coordination_files(self, job_name: str, prefix: str) -> list[str]:
         base = f"{self._coordination_base_path()}/{job_name}/{prefix}"
         fs = self._coordination_fs()
         fs.invalidate_cache(base)
         try:
-            return len(fs.ls(base, detail=False))
+            return sorted(path.rsplit("/", 1)[-1] for path in fs.ls(base, detail=False))
         except FileNotFoundError:
-            return 0
+            return []
 
     def clear_coordination_files(self, job_name: str) -> None:
         path = f"{self._coordination_base_path()}/{job_name}"

--- a/tests/common/failure_injection_test.py
+++ b/tests/common/failure_injection_test.py
@@ -288,6 +288,7 @@ def _run_jobs(
         template_ds=template_ds,
         tmp_store=dataset._tmp_store(),
         update_template_with_results=update_template_with_results,
+        coordination_deadline=None,
     )
 
 

--- a/tests/common/kubernetes_test.py
+++ b/tests/common/kubernetes_test.py
@@ -113,6 +113,14 @@ def test_as_kubernetes_object_comprehensive() -> None:
                                 "name": "WORKERS_TOTAL",
                                 "value": "4",
                             },
+                            {
+                                "name": "POD_ACTIVE_DEADLINE_SECONDS",
+                                "value": "21600",
+                            },
+                            {
+                                "name": "POD_TERMINATION_GRACE_PERIOD_SECONDS",
+                                "value": "30",
+                            },
                         ],
                         "image": "weather-app:v1.0",
                         "name": "worker",
@@ -315,6 +323,20 @@ def test_as_kubernetes_object_with_custom_values() -> None:
         "resources"
     ]["requests"]["storage"]
     assert storage_request == "50G"
+
+
+def test_job_deadline_must_exceed_termination_grace_period() -> None:
+    with pytest.raises(ValidationError):
+        Job(
+            command=["validate"],
+            image="validator:latest",
+            dataset_id="custom_dataset",
+            cpu="1",
+            memory="1Gi",
+            workers_total=1,
+            parallelism=1,
+            pod_active_deadline=timedelta(seconds=30),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/common/parallel_coordination_test.py
+++ b/tests/common/parallel_coordination_test.py
@@ -183,6 +183,7 @@ class TestParallelSetupFirstWorker:
             tmp_store=tmp_path,
             icechunk_repos=[],
             consolidated=True,
+            deadline=None,
         )
 
         stub_io["write_metadata"].assert_called_once_with(
@@ -207,6 +208,7 @@ class TestParallelSetupFirstWorker:
             tmp_store=tmp_path,
             icechunk_repos=[],
             consolidated=True,
+            deadline=None,
         )
 
         assert result == {}
@@ -234,6 +236,7 @@ class TestParallelSetupFirstWorker:
             tmp_store=tmp_path,
             icechunk_repos=repos,  # ty: ignore[invalid-argument-type]
             consolidated=True,
+            deadline=None,
         )
 
         # Each repo had create_branch called with the main snapshot captured.
@@ -299,6 +302,7 @@ class TestParallelSetupFirstWorker:
             tmp_store=tmp_path,
             icechunk_repos=repos,  # ty: ignore[invalid-argument-type]
             consolidated=True,
+            deadline=None,
         )
 
         # setdefault must preserve the prior-attempt snapshot, not refresh from main.
@@ -327,6 +331,7 @@ class TestParallelSetupFirstWorker:
             tmp_store=tmp_path,
             icechunk_repos=[("primary", primary_repo)],  # ty: ignore[invalid-argument-type]
             consolidated=True,
+            deadline=None,
         )
 
         assert primary_repo.create_branch_calls == [
@@ -357,6 +362,7 @@ class TestParallelSetupFirstWorker:
             tmp_store=tmp_path,
             icechunk_repos=repos,  # ty: ignore[invalid-argument-type]
             consolidated=True,
+            deadline=None,
         )
 
         assert primary_repo.create_branch_calls == []
@@ -379,6 +385,7 @@ class TestParallelSetupLaterWorker:
             tmp_store=tmp_path,
             icechunk_repos=[],
             consolidated=True,
+            deadline=None,
         )
         assert result == {}
         stub_io["write_metadata"].assert_not_called()
@@ -412,10 +419,36 @@ class TestParallelSetupLaterWorker:
             tmp_store=tmp_path,
             icechunk_repos=[],
             consolidated=True,
+            deadline=float("inf"),
         )
 
         assert result == payload
         assert sleep_calls == [5]
+
+    def test_never_ready_worker_zero_times_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        factory = FakeStoreFactory()
+        monkeypatch.setattr(pc.time, "monotonic", lambda: 10)
+        monkeypatch.setattr(
+            pc.time,
+            "sleep",
+            lambda _: pytest.fail("setup wait continued past deadline"),
+        )
+
+        with pytest.raises(TimeoutError, match="worker index 0"):
+            pc.parallel_setup(
+                factory,  # ty: ignore[invalid-argument-type]
+                is_first=False,
+                workers_total=3,
+                reformat_job_name="job",
+                branch_name="temp",
+                template_ds=_template(),
+                tmp_store=tmp_path,
+                icechunk_repos=[],
+                consolidated=True,
+                deadline=10,
+            )
 
 
 class TestWaitForWorkers:

--- a/tests/common/parallel_coordination_test.py
+++ b/tests/common/parallel_coordination_test.py
@@ -50,8 +50,11 @@ class FakeStoreFactory:
         matching = {k: v for k, v in files.items() if k.startswith(f"{prefix}/")}
         return [matching[k] for k in sorted(matching)]
 
-    def count_coordination_files(self, job_name: str, prefix: str) -> int:
-        return len(self.read_all_coordination_files(job_name, prefix))
+    def list_coordination_files(self, job_name: str, prefix: str) -> list[str]:
+        files = self.files.get(job_name, {})
+        return sorted(
+            key.rsplit("/", 1)[-1] for key in files if key.startswith(f"{prefix}/")
+        )
 
     def clear_coordination_files(self, job_name: str) -> None:
         self.files.pop(job_name, None)
@@ -422,7 +425,7 @@ class TestWaitForWorkers:
         factory = FakeStoreFactory()
         # If time.sleep were called we'd notice — raise to fail loudly.
         monkeypatch.setattr(pc.time, "sleep", lambda *_: pytest.fail("should not poll"))
-        pc.wait_for_workers(factory, "job", workers_total=1)  # ty: ignore[invalid-argument-type]
+        pc.wait_for_workers(factory, "job", workers_total=1, deadline=0)  # ty: ignore[invalid-argument-type]
 
     def test_polls_until_all_results_present(
         self, monkeypatch: pytest.MonkeyPatch
@@ -439,10 +442,54 @@ class TestWaitForWorkers:
 
         monkeypatch.setattr(pc.time, "sleep", fake_sleep)
 
-        pc.wait_for_workers(factory, "job", workers_total=3)  # ty: ignore[invalid-argument-type]
+        pc.wait_for_workers(factory, "job", workers_total=3, deadline=float("inf"))  # ty: ignore[invalid-argument-type]
 
         # Started with 1 file, needs 3 → 2 polls.
         assert sleep_calls == [10, 10]
+
+    def test_never_reporting_worker_times_out_with_missing_indexes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        factory = FakeStoreFactory()
+        factory.write_coordination_file("job", "results/worker-1.json", b"x")
+        monkeypatch.setattr(pc.time, "monotonic", lambda: 10)
+        monkeypatch.setattr(
+            pc.time, "sleep", lambda _: pytest.fail("wait continued past deadline")
+        )
+
+        with pytest.raises(
+            TimeoutError,
+            match=r"missing worker indexes: \[0, 2\]",
+        ):
+            pc.wait_for_workers(
+                factory,  # ty: ignore[invalid-argument-type]
+                "job",
+                workers_total=3,
+                deadline=10,
+            )
+
+
+class TestCoordinationDeadline:
+    def test_single_worker_needs_no_kubernetes_deadline(self) -> None:
+        assert pc.coordination_deadline_from_environment(workers_total=1) is None
+
+    def test_multi_worker_requires_kubernetes_deadline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("POD_ACTIVE_DEADLINE_SECONDS", raising=False)
+        monkeypatch.delenv("POD_TERMINATION_GRACE_PERIOD_SECONDS", raising=False)
+
+        with pytest.raises(AssertionError, match="POD_ACTIVE_DEADLINE_SECONDS"):
+            pc.coordination_deadline_from_environment(workers_total=2)
+
+    def test_reserves_kubernetes_termination_grace_period(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("POD_ACTIVE_DEADLINE_SECONDS", "600")
+        monkeypatch.setenv("POD_TERMINATION_GRACE_PERIOD_SECONDS", "30")
+        monkeypatch.setattr(pc, "_PROCESS_STARTED_AT", 100.0)
+
+        assert pc.coordination_deadline_from_environment(workers_total=2) == 670
 
 
 class TestCollectResults:
@@ -471,7 +518,12 @@ class TestCollectResults:
             "job", "results/worker-1.json", pc.dump_worker_results_json(worker_1)
         )
 
-        merged = pc.collect_results(factory, "job", workers_total=2)  # ty: ignore[invalid-argument-type]
+        merged = pc.collect_results(
+            factory,  # ty: ignore[invalid-argument-type]
+            "job",
+            workers_total=2,
+            deadline=float("inf"),
+        )
 
         # URLs identify each result unambiguously; check the merged set per var.
         merged_urls = {v: [r.url for r in rs] for v, rs in merged.items()}

--- a/tests/common/parallel_writes_test.py
+++ b/tests/common/parallel_writes_test.py
@@ -230,6 +230,7 @@ class TestZarr3ParallelWrites:
             template_ds=template_ds,
             tmp_store=dataset._tmp_store(),
             update_template_with_results=False,
+            coordination_deadline=None,
         )
 
         result = xr.open_zarr(dataset.store_factory.primary_store())
@@ -261,6 +262,7 @@ class TestZarr3ParallelWrites:
                 template_ds=template_ds,
                 tmp_store=dataset._tmp_store(),
                 update_template_with_results=False,
+                coordination_deadline=float("inf"),
             )
 
         result = xr.open_zarr(dataset.store_factory.primary_store())
@@ -294,6 +296,7 @@ class TestZarr3ParallelWrites:
             template_ds=template_ds,
             tmp_store=dataset._tmp_store(),
             update_template_with_results=True,
+            coordination_deadline=float("inf"),
         )
 
         # Reader should still see original 2 time steps (metadata not yet expanded)
@@ -309,6 +312,7 @@ class TestZarr3ParallelWrites:
             template_ds=template_ds,
             tmp_store=dataset._tmp_store(),
             update_template_with_results=True,
+            coordination_deadline=float("inf"),
         )
 
         # Now reader should see expanded dataset
@@ -316,6 +320,47 @@ class TestZarr3ParallelWrites:
         assert result.sizes["time"] == 4
         for var in ["var0", "var1", "var2", "var3"]:
             assert np.all(result[var].values == 1.0)
+
+    def test_update_timeout_does_not_publish_partial_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        dataset = self._make_dataset(tmp_path)
+        template_ds = _create_template_ds()
+        template_utils.write_metadata(
+            _create_template_ds(num_time=0), dataset.store_factory
+        )
+        all_jobs = ParallelRegionJob.get_jobs(
+            tmp_store=dataset._tmp_store(),
+            template_ds=template_ds,
+            append_dim="time",
+            all_data_vars=ParallelTemplateConfig().data_vars,
+            reformat_job_name="test",
+        )
+
+        dataset._process_region_jobs(
+            all_jobs=all_jobs,
+            worker_index=0,
+            workers_total=3,
+            reformat_job_name="test",
+            template_ds=template_ds,
+            tmp_store=dataset._tmp_store(),
+            update_template_with_results=True,
+            coordination_deadline=float("inf"),
+        )
+        with pytest.raises(TimeoutError, match=r"missing worker indexes: \[1\]"):
+            dataset._process_region_jobs(
+                all_jobs=all_jobs,
+                worker_index=2,
+                workers_total=3,
+                reformat_job_name="test",
+                template_ds=template_ds,
+                tmp_store=dataset._tmp_store(),
+                update_template_with_results=True,
+                coordination_deadline=0,
+            )
+
+        reader_ds = xr.open_zarr(dataset.store_factory.primary_store())
+        assert reader_ds.sizes["time"] == 0
 
     def test_update_rejects_structural_drift(self, tmp_path: Path) -> None:
         """An operational update whose template changed a non-append structural field
@@ -348,6 +393,7 @@ class TestZarr3ParallelWrites:
                 template_ds=drifted_ds,
                 tmp_store=dataset._tmp_store(),
                 update_template_with_results=True,
+                coordination_deadline=None,
             )
 
         # Guard ran before any writes: the store is untouched (still 2 time steps).
@@ -376,6 +422,7 @@ class TestZarr3ParallelWrites:
                 template_ds=template_ds,
                 tmp_store=dataset._tmp_store(),
                 update_template_with_results=False,
+                coordination_deadline=float("inf"),
             )
 
         # Coordination files should be cleaned up after last worker
@@ -422,6 +469,7 @@ class TestIcechunkParallelWrites:
             template_ds=template_ds,
             tmp_store=dataset._tmp_store(),
             update_template_with_results=False,
+            coordination_deadline=None,
         )
 
         result = xr.open_zarr(dataset.store_factory.primary_store())
@@ -454,6 +502,7 @@ class TestIcechunkParallelWrites:
             template_ds=template_ds,
             tmp_store=dataset._tmp_store(),
             update_template_with_results=False,
+            coordination_deadline=float("inf"),
         )
 
         # Reader on main should see no new data yet
@@ -470,6 +519,7 @@ class TestIcechunkParallelWrites:
             template_ds=template_ds,
             tmp_store=dataset._tmp_store(),
             update_template_with_results=False,
+            coordination_deadline=float("inf"),
         )
 
         # Now reader on main should see all data
@@ -500,6 +550,7 @@ class TestIcechunkParallelWrites:
                 template_ds=template_ds,
                 tmp_store=dataset._tmp_store(),
                 update_template_with_results=False,
+                coordination_deadline=float("inf"),
             )
 
         # Temp branch should be cleaned up
@@ -555,6 +606,7 @@ class TestReplicaParallelWrites:
                 template_ds=template_ds,
                 tmp_store=dataset._tmp_store(),
                 update_template_with_results=False,
+                coordination_deadline=float("inf"),
             )
 
         # Both primary and replica should have all data
@@ -713,6 +765,7 @@ class TestWorkerEdgeCases:
                 template_ds=template_ds,
                 tmp_store=dataset._tmp_store(),
                 update_template_with_results=False,
+                coordination_deadline=float("inf"),
             )
 
         result = xr.open_zarr(dataset.store_factory.primary_store())
@@ -741,6 +794,7 @@ def _run_workers(
             template_ds=template_ds,
             tmp_store=dataset._tmp_store(),
             update_template_with_results=update_template_with_results,
+            coordination_deadline=float("inf"),
         )
 
 

--- a/tests/common/storage_test.py
+++ b/tests/common/storage_test.py
@@ -315,6 +315,10 @@ class TestCoordinationFiles:
         results = [json.loads(f) for f in files]
         assert {"a": 1} in results
         assert {"b": 2} in results
+        assert factory.list_coordination_files("test-job", "results") == [
+            "worker-0.json",
+            "worker-1.json",
+        ]
 
     def test_read_returns_empty_when_no_files(self, tmp_path: str) -> None:
         factory = _local_factory(tmp_path)

--- a/tests/common/virtual_multi_group_test.py
+++ b/tests/common/virtual_multi_group_test.py
@@ -682,6 +682,7 @@ def test_two_worker_backfill_disjoint(tmp_path: Path) -> None:
             template_ds=template_ds,
             tmp_store=tmp_path / f"worker-{worker_index}-tmp.zarr",
             update_template_with_results=False,
+            coordination_deadline=float("inf"),
         )
 
     _assert_all_values(dataset, n_inits=2)

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -1409,11 +1409,56 @@ def test_two_worker_backfill_disjoint(tmp_path: Path) -> None:
             # Distinct per worker, simulating separate pods
             tmp_store=tmp_path / f"worker-{worker_index}-tmp.zarr",
             update_template_with_results=False,
+            coordination_deadline=float("inf"),
         )
 
     _assert_all_values(dataset, n_inits=4)
     # Temp branch cleaned up after finalize.
     assert list(_primary_repo(dataset.store_factory).list_branches()) == ["main"]
+
+
+def test_backfill_timeout_does_not_publish_or_clear_temp_branch(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    repo = _primary_repo(dataset.store_factory)
+    main_before = repo.lookup_branch("main")
+    all_jobs = VirtualTestRegionJob.get_jobs(
+        tmp_store=dataset._tmp_store(),
+        template_ds=template_ds,
+        append_dim="init_time",
+        all_data_vars=dataset.template_config.data_vars,
+        reformat_job_name="test",
+    )
+
+    dataset._process_region_jobs(
+        all_jobs=all_jobs,
+        worker_index=0,
+        workers_total=4,
+        reformat_job_name="test",
+        template_ds=template_ds,
+        tmp_store=tmp_path / "worker-0-tmp.zarr",
+        update_template_with_results=False,
+        coordination_deadline=float("inf"),
+    )
+    with pytest.raises(TimeoutError, match=r"missing worker indexes: \[1, 2\]"):
+        dataset._process_region_jobs(
+            all_jobs=all_jobs,
+            worker_index=3,
+            workers_total=4,
+            reformat_job_name="test",
+            template_ds=template_ds,
+            tmp_store=tmp_path / "worker-3-tmp.zarr",
+            update_template_with_results=False,
+            coordination_deadline=0,
+        )
+
+    assert repo.lookup_branch("main") == main_before
+    assert "_job_test" in repo.list_branches()
+    assert dataset.store_factory.list_coordination_files("test", "results") == [
+        "worker-0.json",
+        "worker-3.json",
+    ]
 
 
 def test_virtual_operational_single_writer_expands_main(tmp_path: Path) -> None:
@@ -2056,6 +2101,7 @@ def test_virtual_backfill_then_fire_leaves_metadata_stable(tmp_path: Path) -> No
         template_ds=template_ds,
         tmp_store=tmp_path / "worker-tmp.zarr",
         update_template_with_results=False,
+        coordination_deadline=None,
     )
 
     root_metadata = _main_store_bytes(dataset.store_factory, "zarr.json")


### PR DESCRIPTION
## Summary

- derive one absolute coordination deadline from each Kubernetes Job pod active deadline, reserving its already-configured termination grace period
- time out result coordination with every missing worker index in the error, without finalizing or publishing partial data
- apply the same deadline to worker-0 setup polling in a separate commit
- require the injected deadline values for every multi-worker run rather than silently falling back to an unbounded wait

## Gap closed

#1029 makes one exception class publish-then-report, but _assert_probe_chunk_covered — the original incident trigger — the GEFS completeness assert, OOM, and any untyped raise still kill a worker; after retries that index writes no results file while wait_for_workers polls every 10 seconds forever. #1027 and #1029 fixed triggers. This PR fixes the mechanism.

## Deadline composition and safety

The Job model already requires pod_active_deadline (with a six-hour default), and every Job, CronJob, and ReformatCronJob that can reach multi-worker coordination inherits it. Backfill Jobs copy that value from the reformat resource. Local backfills are single-worker and do not coordinate. The manifest now also names the existing 30-second terminationGracePeriodSeconds setting, validates that the active deadline exceeds it, and injects both values into every worker.

At process startup the worker derives one monotonic deadline as:

    process start + pod active deadline - pod termination grace period

Processing, worker-0 setup polling, and final result polling all share that one deadline. The timeout cannot cause a failure that would not have happened anyway, since it fires strictly inside the window Kubernetes would have killed the pod in regardless. It does not shorten a healthy run; it converts a silent SIGKILL into a diagnosable Python error naming the missing indexes while preserving the configured grace window for logging and monitoring.

On result expiry, the coordinator lists results/worker-N.json and raises TimeoutError naming every missing index. It does not call finalize, reset Icechunk main, publish Zarr metadata, or clear the temporary branch or coordination files. collect_results delegates to the same wait, so materialized updates get identical behavior. Setup expiry similarly names worker index 0 and occurs before any waiting worker processes data.

## Verification

- uv run pytest -m "not slow" -n 4: 2632 passed
- tests/common/dynamical_dataset_test.py: 30 passed
- tests/common/failure_injection_test.py: 2 passed
- tests/common/parallel_writes_test.py: 22 passed
- tests/common/virtual_multi_group_test.py: 17 passed
- tests/common/virtual_region_job_test.py: 77 passed
- uv run ruff format
- uv run ruff check --fix
- uv run ty check --output-format concise

Mutation proof: in an isolated /tmp source copy, deleting the result-wait expiry branch made TestWaitForWorkers::test_never_reporting_worker_times_out_with_missing_indexes fail immediately with "wait continued past deadline". The shared worktree was never mutated for this proof.