### PR TITLE
Log missing parallel worker indexes

### DIFF
--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -4,6 +4,7 @@ See docs/parallel_processing.md for the overall design.
 """
 
 import json
+import re
 import time
 from collections.abc import Collection, Mapping, Sequence
 from pathlib import Path
@@ -21,6 +22,8 @@ from reformatters.common.storage import StoreFactory
 from reformatters.common.zarr import copy_zarr_metadata
 
 log = get_logger(__name__)
+
+_RESULT_FILE_PATTERN = re.compile(r"worker-(?P<worker_index>\d+)\.json")
 
 _WORKER_RESULTS_ADAPTER: TypeAdapter[dict[str, list[SourceFileResult]]] = TypeAdapter(
     dict[str, list[SourceFileResult]]
@@ -130,11 +133,22 @@ def wait_for_workers(
     # Rely on kubernetes pod_active_deadline for timeout.
     if workers_total <= 1:
         return
-    while (
-        store_factory.count_coordination_files(reformat_job_name, "results")
-        < workers_total
-    ):
-        log.info("Waiting for all workers to complete...")
+    while True:
+        result_files = store_factory.list_coordination_files(
+            reformat_job_name, "results"
+        )
+        reported_workers = {
+            int(match["worker_index"])
+            for result_file in result_files
+            if (match := _RESULT_FILE_PATTERN.fullmatch(result_file)) is not None
+        }
+        missing_workers = sorted(set(range(workers_total)) - reported_workers)
+        if not missing_workers:
+            return
+        log.info(
+            f"Waiting for {len(missing_workers)} of {workers_total} workers to "
+            f"complete; missing worker indexes: {missing_workers[:10]}"
+        )
         time.sleep(10)
 
 

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -146,7 +146,7 @@ def wait_for_workers(
             return
         log.info(
             f"Waiting for {len(missing_workers)} of {workers_total} workers to "
-            f"complete; missing worker indexes: {missing_workers[:10]}"
+            f"complete; missing worker indexes: {missing_workers[:50]}"
         )
         time.sleep(10)
 

--- a/src/reformatters/common/parallel_coordination.py
+++ b/src/reformatters/common/parallel_coordination.py
@@ -128,8 +128,7 @@ def parallel_setup(
 def wait_for_workers(
     store_factory: StoreFactory, reformat_job_name: str, workers_total: int
 ) -> None:
-    # Poll until all workers write their results file. Backfills can have
-    # many thousands of workers, so count (cheap ls) rather than read.
+    # Poll result filenames for every worker index without reading file contents.
     # Rely on kubernetes pod_active_deadline for timeout.
     if workers_total <= 1:
         return

--- a/src/reformatters/common/storage.py
+++ b/src/reformatters/common/storage.py
@@ -298,14 +298,14 @@ class StoreFactory(FrozenBaseModel):
         contents = fs.cat(files)
         return [contents[f] for f in sorted(files)]
 
-    def count_coordination_files(self, job_name: str, prefix: str) -> int:
+    def list_coordination_files(self, job_name: str, prefix: str) -> list[str]:
         base = f"{self._coordination_base_path()}/{job_name}/{prefix}"
         fs = self._coordination_fs()
         fs.invalidate_cache(base)
         try:
-            return len(fs.ls(base, detail=False))
+            return sorted(path.rsplit("/", 1)[-1] for path in fs.ls(base, detail=False))
         except FileNotFoundError:
-            return 0
+            return []
 
     def clear_coordination_files(self, job_name: str) -> None:
         path = f"{self._coordination_base_path()}/{job_name}"

--- a/tests/common/parallel_coordination_test.py
+++ b/tests/common/parallel_coordination_test.py
@@ -50,8 +50,11 @@ class FakeStoreFactory:
         matching = {k: v for k, v in files.items() if k.startswith(f"{prefix}/")}
         return [matching[k] for k in sorted(matching)]
 
-    def count_coordination_files(self, job_name: str, prefix: str) -> int:
-        return len(self.read_all_coordination_files(job_name, prefix))
+    def list_coordination_files(self, job_name: str, prefix: str) -> list[str]:
+        files = self.files.get(job_name, {})
+        return sorted(
+            key.rsplit("/", 1)[-1] for key in files if key.startswith(f"{prefix}/")
+        )
 
     def clear_coordination_files(self, job_name: str) -> None:
         self.files.pop(job_name, None)
@@ -425,7 +428,7 @@ class TestWaitForWorkers:
         pc.wait_for_workers(factory, "job", workers_total=1)  # ty: ignore[invalid-argument-type]
 
     def test_polls_until_all_results_present(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
         factory = FakeStoreFactory()
         factory.write_coordination_file("job", "results/worker-0.json", b"x")
@@ -439,10 +442,33 @@ class TestWaitForWorkers:
 
         monkeypatch.setattr(pc.time, "sleep", fake_sleep)
 
-        pc.wait_for_workers(factory, "job", workers_total=3)  # ty: ignore[invalid-argument-type]
+        with caplog.at_level(logging.INFO):
+            pc.wait_for_workers(factory, "job", workers_total=3)  # ty: ignore[invalid-argument-type]
 
         # Started with 1 file, needs 3 → 2 polls.
         assert sleep_calls == [10, 10]
+        assert "Waiting for 2 of 3 workers" in caplog.text
+        assert "missing worker indexes: [1, 2]" in caplog.text
+
+    def test_missing_worker_log_caps_indexes(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        factory = FakeStoreFactory()
+
+        def fake_sleep(_: float) -> None:
+            for worker_index in range(12):
+                factory.write_coordination_file(
+                    "job", f"results/worker-{worker_index}.json", b"x"
+                )
+
+        monkeypatch.setattr(pc.time, "sleep", fake_sleep)
+
+        with caplog.at_level(logging.INFO):
+            pc.wait_for_workers(factory, "job", workers_total=12)  # ty: ignore[invalid-argument-type]
+
+        assert "Waiting for 12 of 12 workers" in caplog.text
+        assert "missing worker indexes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]" in caplog.text
+        assert "10, 11" not in caplog.text
 
 
 class TestCollectResults:

--- a/tests/common/parallel_coordination_test.py
+++ b/tests/common/parallel_coordination_test.py
@@ -453,10 +453,12 @@ class TestWaitForWorkers:
     def test_missing_worker_log_caps_indexes(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
+        # More workers than the 50-index cap, so the logged list is really cut.
+        workers_total = 60
         factory = FakeStoreFactory()
 
         def fake_sleep(_: float) -> None:
-            for worker_index in range(12):
+            for worker_index in range(workers_total):
                 factory.write_coordination_file(
                     "job", f"results/worker-{worker_index}.json", b"x"
                 )
@@ -464,11 +466,17 @@ class TestWaitForWorkers:
         monkeypatch.setattr(pc.time, "sleep", fake_sleep)
 
         with caplog.at_level(logging.INFO):
-            pc.wait_for_workers(factory, "job", workers_total=12)  # ty: ignore[invalid-argument-type]
+            pc.wait_for_workers(factory, "job", workers_total=workers_total)  # ty: ignore[invalid-argument-type]
 
-        assert "Waiting for 12 of 12 workers" in caplog.text
-        assert "missing worker indexes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]" in caplog.text
-        assert "10, 11" not in caplog.text
+        # Exactly one poll logs, since fake_sleep completes every worker.
+        (message,) = [m for m in caplog.messages if "missing worker indexes" in m]
+        # The count reports all 60 missing while the list stops at 50 — asserting
+        # both is what pins the cap. Match on the message, not caplog.text, whose
+        # "file.py:lineno" prefix can itself contain the digits under test.
+        assert f"Waiting for {workers_total} of {workers_total} workers" in message
+        assert f"missing worker indexes: {list(range(50))}" in message
+        # Index 50 is the first past the cap and must not be logged.
+        assert "50" not in message
 
 
 class TestCollectResults:

--- a/tests/common/parallel_coordination_test.py
+++ b/tests/common/parallel_coordination_test.py
@@ -467,7 +467,7 @@ class TestWaitForWorkers:
             pc.wait_for_workers(factory, "job", workers_total=12)  # ty: ignore[invalid-argument-type]
 
         assert "Waiting for 12 of 12 workers" in caplog.text
-        assert "missing worker indexes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]" in caplog.text
+        assert "missing worker indexes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]" in caplog.text
         assert "10, 11" not in caplog.text
 
 

--- a/tests/common/storage_test.py
+++ b/tests/common/storage_test.py
@@ -315,6 +315,10 @@ class TestCoordinationFiles:
         results = [json.loads(f) for f in files]
         assert {"a": 1} in results
         assert {"b": 2} in results
+        assert factory.list_coordination_files("test-job", "results") == [
+            "worker-0.json",
+            "worker-1.json",
+        ]
 
     def test_read_returns_empty_when_no_files(self, tmp_path: str) -> None:
         factory = _local_factory(tmp_path)


### PR DESCRIPTION
## Summary

- list the exact worker indexes that have not reported results yet
- cap each log entry at the first 10 missing indexes
- keep the result poll as an object-store listing without reading result contents

## Why this is separate

This diagnostic was pulled out of #1035 so it can merge without waiting on the job-wide timeout redesign. During the recent incident, the finalizer logged only `Waiting for all workers to complete...` every 10 seconds for eight hours even though the identity of the one missing index was available from the same object-store listing. This change makes that stall actionable on the first poll.

## Follow-up: centralize the worker result filename format

The `worker-{i}.json` format is duplicated: `dynamical_dataset.py` builds it while `parallel_coordination.py` parses it with a separately maintained regex. Both new tests also hand-write the literal in their fakes instead of exercising the producer, so a rename can break the wait loop without failing a test. A shared `worker_result_file_key(i)` used by the writer and regex closes the gap in about four lines, and `dynamical_dataset.py` already imports `parallel_coordination`, so it adds no dependency. This is deliberately deferred because #1036 should merge today.

## Merge order

#1036 lands first. The `gfs-worker-wait-timeout` branch for #1035 already contains this exact hunk plus a deadline parameter, so #1035 must rebase onto #1036 before it lands; whichever branch lands second otherwise conflicts in `wait_for_workers`.

## Verification

- `uv run --no-sync pytest -n 4 tests/common/parallel_coordination_test.py tests/common/storage_test.py` (95 passed)
- `uv run --no-sync ruff format` on changed files
- `uv run --no-sync ruff check` on changed files
- `uv run --no-sync ty check --output-format concise` on changed files
