### PR TITLE
Parse the AIFS index without pandas dtype inference

### DIFF
--- a/src/reformatters/ecmwf/aifs_single/forecast_virtual/region_job.py
+++ b/src/reformatters/ecmwf/aifs_single/forecast_virtual/region_job.py
@@ -1,4 +1,6 @@
+import json
 from collections.abc import Mapping, Sequence
+from decimal import Decimal, InvalidOperation
 from typing import ClassVar
 
 import icechunk
@@ -21,7 +23,6 @@ from reformatters.common.virtual_source_listing import (
 from reformatters.ecmwf.aifs_single.template_config import (
     aifs_single_stream_path,
 )
-from reformatters.ecmwf.ecmwf_grib_index import parse_index_file
 
 from .template_config import (
     EcmwfAifsSingleVirtualDataVar,
@@ -31,6 +32,29 @@ log = get_logger(__name__)
 
 SOURCE_LOCATION_PREFIX = "s3://ecmwf-forecasts/"
 SOURCE_REGION = "eu-central-1"
+type _IndexRow = tuple[str, str, bool, int | None, int, int]
+
+
+def _index_integer(value: object) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, str) and value.isdecimal():
+        return int(value)
+    raise ValueError(f"non-integer index field {value!r}")
+
+
+def _index_level(value: object) -> tuple[bool, int | None]:
+    if value is None:
+        return True, None
+    if isinstance(value, bool):
+        raise ValueError("boolean is not an index level")
+    try:
+        level = Decimal(str(value))
+    except InvalidOperation:
+        return False, None
+    if not level.is_finite() or level != level.to_integral_value():
+        return False, None
+    return True, int(level)
 
 
 def aifs_single_virtual_chunk_containers() -> tuple[
@@ -136,7 +160,22 @@ class EcmwfAifsSingleForecastVirtualRegionJob(
             coord.get_index_url(), self.dataset_id, region=SOURCE_REGION
         )
         try:
-            index_df = parse_index_file(index_path, ensemble=False)
+            index_rows: list[_IndexRow] = []
+            for line in index_path.read_text().splitlines():
+                if not line.strip():
+                    continue
+                row: dict[str, object] = json.loads(line)
+                level_matches, level = _index_level(row.get("levelist"))
+                index_rows.append(
+                    (
+                        str(row["param"]),
+                        str(row["levtype"]),
+                        level_matches,
+                        level,
+                        _index_integer(row["_offset"]),
+                        _index_integer(row["_length"]),
+                    )
+                )
         finally:
             index_path.unlink()
 
@@ -144,20 +183,12 @@ class EcmwfAifsSingleForecastVirtualRegionJob(
         out_loc_base = dict(coord.out_loc())
         location = coord.get_url()
         refs = []
-        entries = index_df.reset_index()
-        for param, levtype, levelist, raw_offset, raw_length in zip(
-            entries["param"],
-            entries["levtype"],
-            entries["levelist"],
-            entries["_offset"],
-            entries["_length"],
-            strict=True,
-        ):
-            level = None if pd.isna(levelist) else int(levelist)
-            matches = lookup.get((str(param), str(levtype), level))
+        for param, levtype, level_matches, level, offset, length in index_rows:
+            if not level_matches:
+                continue
+            matches = lookup.get((param, levtype, level))
             if not matches:
                 continue
-            offset, length = int(raw_offset), int(raw_length)
             # Byte ranges past the data file mean a stale/mismatched index; skip it.
             if length <= 0 or offset + length > file_size:
                 log.warning(

--- a/tests/ecmwf/aifs_single/forecast_virtual/region_job_test.py
+++ b/tests/ecmwf/aifs_single/forecast_virtual/region_job_test.py
@@ -71,9 +71,9 @@ def _index_line(
     levtype: str,
     offset: int,
     length: int,
-    levelist: str | None = None,
+    levelist: object | None = None,
 ) -> str:
-    entry = {
+    entry: dict[str, object] = {
         "domain": "g",
         "date": "20250301",
         "time": "0000",
@@ -243,6 +243,99 @@ def test_file_refs_missing_level_yields_no_ref(
     refs = job.file_refs(_coord([var]), file_size=1000)
 
     assert [ref.out_loc["pressure_level"] for ref in refs] == [1000]
+
+
+@pytest.mark.parametrize("field", ["_offset", "_length"])
+@pytest.mark.parametrize("row_index", [0, 1])
+def test_file_refs_rejects_boolean_byte_range_in_every_row(
+    template_ds: xr.DataTree,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    field: str,
+    row_index: int,
+) -> None:
+    entries = [
+        json.loads(_index_line("2t", "sfc", 0, 1000)),
+        json.loads(_index_line("skt", "sfc", 1000, 200)),
+    ]
+    entries[row_index][field] = True
+    _fake_index(
+        monkeypatch,
+        tmp_path,
+        "".join(json.dumps(entry) + "\n" for entry in entries),
+    )
+    data_vars = [get_var("temperature_2m")]
+    job = make_job(template_ds, data_vars=data_vars)
+
+    with pytest.raises(ValueError, match="non-integer index field"):
+        job.file_refs(_coord(data_vars), file_size=1200)
+
+
+@pytest.mark.parametrize(("field", "value"), [("_offset", 0.5), ("_length", 1.5)])
+def test_file_refs_rejects_non_integral_byte_range(
+    template_ds: xr.DataTree,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    field: str,
+    value: float,
+) -> None:
+    entry = json.loads(_index_line("2t", "sfc", 0, 1000))
+    entry[field] = value
+    _fake_index(monkeypatch, tmp_path, json.dumps(entry) + "\n")
+    data_vars = [get_var("temperature_2m")]
+    job = make_job(template_ds, data_vars=data_vars)
+
+    with pytest.raises(ValueError, match="non-integer index field"):
+        job.file_refs(_coord(data_vars), file_size=1200)
+
+
+def test_file_refs_rejects_boolean_level(
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    index = _index_line("t", "pl", 0, 1000, levelist=True) + _index_line(
+        "t", "pl", 1000, 200, levelist="500"
+    )
+    _fake_index(monkeypatch, tmp_path, index)
+    data_vars = [get_var("pressure_level/temperature")]
+    job = make_job(template_ds, data_vars=data_vars)
+
+    with pytest.raises(ValueError, match="boolean is not an index level"):
+        job.file_refs(_coord(data_vars), file_size=1200)
+
+
+def test_file_refs_ignores_non_integral_level_in_mixed_column(
+    template_ds: xr.DataTree, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    index = _index_line("t", "pl", 0, 1000, levelist="500") + _index_line(
+        "t", "pl", 1000, 200, levelist="0.7"
+    )
+    _fake_index(monkeypatch, tmp_path, index)
+    data_vars = [get_var("pressure_level/temperature")]
+    job = make_job(template_ds, data_vars=data_vars)
+
+    refs = job.file_refs(_coord(data_vars), file_size=1200)
+
+    assert [
+        (ref.out_loc["pressure_level"], ref.offset, ref.length) for ref in refs
+    ] == [(500, 0, 1000)]
+
+
+@pytest.mark.parametrize("level", [500, 500.0, "500.0", " 500"])
+def test_file_refs_preserves_accepted_level_representations(
+    template_ds: xr.DataTree,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    level: object,
+) -> None:
+    _fake_index(monkeypatch, tmp_path, _index_line("t", "pl", 0, 1000, levelist=level))
+    data_vars = [get_var("pressure_level/temperature")]
+    job = make_job(template_ds, data_vars=data_vars)
+
+    refs = job.file_refs(_coord(data_vars), file_size=1000)
+
+    assert [
+        (ref.out_loc["pressure_level"], ref.offset, ref.length) for ref in refs
+    ] == [(500, 0, 1000)]
 
 
 def test_file_refs_skips_stale_index_past_eof(


### PR DESCRIPTION
An AIFS index parsed through pandas can infer byte-range column dtypes across rows, coercing a boolean offset or length to an integer and producing a clean-looking reference to the wrong bytes; this was reproduced through the production `file_refs` path. Parse each JSON-lines row directly to preserve raw scalar types, strictly validate byte ranges, and preserve exact-integral level matching.