### PR TITLE
Document the GEFS virtual visibility clip

### DIFF
--- a/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/visibility_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/visibility_surface/zarr.json
@@ -37,6 +37,7 @@
     "short_name": "vis",
     "standard_name": "visibility_in_air",
     "units": "m",
+    "comment": "Clipped at the maximum visibility this field encodes, about 24 km, where a large fraction of cells sit. The true visibility there is at least that far, not absent.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/zarr.json
@@ -2055,6 +2055,7 @@
           "short_name": "vis",
           "standard_name": "visibility_in_air",
           "units": "m",
+          "comment": "Clipped at the maximum visibility this field encodes, about 24 km, where a large fraction of cells sit. The true visibility there is at least that far, not absent.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/visibility_surface/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/visibility_surface/zarr.json
@@ -41,6 +41,7 @@
     "short_name": "vis",
     "standard_name": "visibility_in_air",
     "units": "m",
+    "comment": "Clipped at the maximum visibility this field encodes, about 24 km, where a large fraction of cells sit. The true visibility there is at least that far, not absent.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/zarr.json
@@ -2478,6 +2478,7 @@
           "short_name": "vis",
           "standard_name": "visibility_in_air",
           "units": "m",
+          "comment": "Clipped at the maximum visibility this field encodes, about 24 km, where a large fraction of cells sit. The true visibility there is at least that far, not absent.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/virtual_template_config.py
+++ b/src/reformatters/noaa/gefs/virtual_template_config.py
@@ -483,6 +483,11 @@ def _s_file_data_vars(
             long_name="Visibility",
             units="m",
             standard_name="visibility_in_air",
+            comment=(
+                "Clipped at the maximum visibility this field encodes, about 24 km, "
+                "where a large fraction of cells sit. The true visibility there is at "
+                "least that far, not absent."
+            ),
             available_from=GEFS_B22_TRANSITION_DATE,
         ),
         var(


### PR DESCRIPTION
Validation of `noaa-gefs-analysis-0-25-degree-virtual` found `visibility_surface` clipped at exactly 24,100 m, where 67–75% of cells sit (checked at 2024-06-15T12, 2023-01-15T00 and 2025-11-20T18), and quantized to 100 m steps — 242 distinct values, 0 … 24,100. Cells at the cap mean visibility is at least that far, not that it is absent, so a reader needs the bound to interpret the field.

The `noaa-gfs-forecast-virtual` and `noaa-gfs-analysis-virtual` datasets already document this on their equivalent variable, so this matches their wording rather than introducing new phrasing. Per AGENTS.md this is an intrinsic, always-true variable fact, so it belongs in the variable's `comment` attr rather than in a validation report note.

The variable is shared by the GEFS virtual analysis and 10-day forecast datasets, so both `templates/latest.zarr` are regenerated. Neither dataset is in the production or staging catalog yet, and adding an attribute is a non-breaking addition in any case.

`ruff format`, `ruff check`, `ty check` clean; `tests/common/common_template_config_subclasses_test.py` and `tests/common/datasets_cf_compliance_test.py` pass (459 tests), as does the fast suite.

Note: `noaa-hrrr-*-virtual`'s `visibility_surface` has the same clip and no comment. Left out of this PR to keep it to the dataset under validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LnC4iYNWF2KBVv4HL9M41


---
_Generated by [Claude Code](https://claude.ai/code/session_019LnC4iYNWF2KBVv4HL9M41)_