### PR TITLE
Resolve virtual probe chunk keys per variable, not per source file

### DIFF
--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from functools import cached_property
+from functools import cache, cached_property
 from itertools import groupby
 from pathlib import Path
 from typing import Any, ClassVar, Final, Generic, Literal, NamedTuple, cast
@@ -187,22 +187,25 @@ class VirtualRegionJob(
     @cached_property
     def _multi_chunk_dim_first_labels(
         self,
-    ) -> Mapping[str, Mapping[Dim, CoordinateValue]]:
-        """Per variable path, the first label along each of its multi-chunk dims.
+    ) -> Callable[[str], Mapping[Dim, CoordinateValue]]:
+        """The first label along each multi-chunk dim of a variable, by variable path.
 
-        Resolved once per job: a job probes thousands of coords against a handful of
-        variables, and repeating these DataTree lookups per coord dominates probe CPU.
+        Memoized for the life of the job: a job probes thousands of coords against a
+        handful of variables, and repeating this DataTree lookup per coord dominates
+        probe CPU.
         """
-        labels: dict[str, Mapping[Dim, CoordinateValue]] = {}
-        for var in self.data_vars:
-            template_var = self.template_ds[var.path]
+
+        @cache
+        def first_labels(var_path: str) -> Mapping[Dim, CoordinateValue]:
+            template_var = self.template_ds[var_path]
             chunks = tuple(template_var.encoding["chunks"])
-            labels[var.path] = {
+            return {
                 (dim := cast("Dim", str(dim_name))): template_var.get_index(dim)[0]
                 for dim_name, chunk_size in zip(template_var.dims, chunks, strict=True)
                 if chunk_size < int(template_var.sizes[str(dim_name)])
             }
-        return labels
+
+        return first_labels
 
     def representative_probe_loc(
         self, coord: SOURCE_FILE_COORD, var: DataVar[Any]
@@ -211,7 +214,7 @@ class VirtualRegionJob(
         out_loc plus the first label along each multi-chunk dim of `var` that out_loc
         leaves unpinned. Override when a file covers only part of such a dim.
         """
-        return {**self._multi_chunk_dim_first_labels[var.path], **coord.out_loc()}
+        return {**self._multi_chunk_dim_first_labels(var.path), **coord.out_loc()}
 
     def filter_already_present(
         self,

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from functools import cached_property
 from itertools import groupby
 from pathlib import Path
 from typing import Any, ClassVar, Final, Generic, Literal, NamedTuple, cast
@@ -183,6 +184,26 @@ class VirtualRegionJob(
             file_vars[0],
         )
 
+    @cached_property
+    def _multi_chunk_dim_first_labels(
+        self,
+    ) -> Mapping[str, Mapping[Dim, CoordinateValue]]:
+        """Per variable path, the first label along each of its multi-chunk dims.
+
+        Resolved once per job: a job probes thousands of coords against a handful of
+        variables, and repeating these DataTree lookups per coord dominates probe CPU.
+        """
+        labels: dict[str, Mapping[Dim, CoordinateValue]] = {}
+        for var in self.data_vars:
+            template_var = self.template_ds[var.path]
+            chunks = tuple(template_var.encoding["chunks"])
+            labels[var.path] = {
+                (dim := cast("Dim", str(dim_name))): template_var.get_index(dim)[0]
+                for dim_name, chunk_size in zip(template_var.dims, chunks, strict=True)
+                if chunk_size < int(template_var.sizes[str(dim_name)])
+            }
+        return labels
+
     def representative_probe_loc(
         self, coord: SOURCE_FILE_COORD, var: DataVar[Any]
     ) -> Mapping[Dim, CoordinateValue]:
@@ -190,14 +211,7 @@ class VirtualRegionJob(
         out_loc plus the first label along each multi-chunk dim of `var` that out_loc
         leaves unpinned. Override when a file covers only part of such a dim.
         """
-        loc = dict(coord.out_loc())
-        template_var = self.template_ds[var.path]
-        chunks = tuple(template_var.encoding["chunks"])
-        for dim_name, chunk_size in zip(template_var.dims, chunks, strict=True):
-            dim = cast("Dim", str(dim_name))
-            if dim not in loc and chunk_size < int(template_var.sizes[dim]):
-                loc[dim] = template_var.get_index(dim)[0]
-        return loc
+        return {**self._multi_chunk_dim_first_labels[var.path], **coord.out_loc()}
 
     def filter_already_present(
         self,
@@ -217,17 +231,19 @@ class VirtualRegionJob(
                 for coord, var in zip(candidates, rep_vars, strict=True)
             ]
         )
+        # Resolved per distinct variable, not per candidate: each group lookup is a
+        # zarr metadata read, and a job probes thousands of files against a handful
+        # of variables.
+        encode_key = {
+            var_path: _chunk_key_encoder(group, var_path)
+            for var_path in {var.path for var in rep_vars}
+        }
         keyed: list[tuple[SOURCE_FILE_COORD, str | None]] = []
         for coord, var, index in zip(candidates, rep_vars, indices, strict=True):
             if index is None:
                 keyed.append((coord, None))
                 continue
-            array = group[var.path]
-            assert isinstance(array, zarr.Array)
-            metadata = array.metadata
-            assert isinstance(metadata, ArrayV3Metadata)
-            key = f"{array.path}/{metadata.chunk_key_encoding.encode_chunk_key(index)}"
-            keyed.append((coord, key))
+            keyed.append((coord, encode_key[var.path](index)))
 
         present = _exists_many(store, [key for _, key in keyed if key is not None])
         return [coord for coord, key in keyed if key is None or not present[key]]
@@ -681,6 +697,19 @@ class _NoRegion:
 
 
 _NO_REGION: Final = _NoRegion()
+
+
+def _chunk_key_encoder(
+    group: zarr.Group, var_path: str
+) -> Callable[[tuple[int, ...]], str]:
+    """Map a chunk index of `var_path` to its store key."""
+    array = group[var_path]
+    assert isinstance(array, zarr.Array)
+    metadata = array.metadata
+    assert isinstance(metadata, ArrayV3Metadata)
+    return lambda index: (
+        f"{array.path}/{metadata.chunk_key_encoding.encode_chunk_key(index)}"
+    )
 
 
 def _exists_many(

--- a/tests/common/virtual_multi_group_test.py
+++ b/tests/common/virtual_multi_group_test.py
@@ -704,6 +704,52 @@ class _PressureProbeRegionJob(MultiGroupRegionJob):
         return next(v for v in self.data_vars if v.group == "pressure_level")
 
 
+class _VariableProbeCoord(MultiGroupSourceFileCoord):
+    data_vars: Sequence[DataVar[BaseInternalAttrs]]
+
+    def out_loc(self) -> Mapping[Dim, CoordinateValue]:
+        return {"init_time": self.init_time, "lead_time": self.lead_time}
+
+
+def _memory_store_with_multi_group_arrays() -> tuple[
+    MemoryStore, zarr.Array, zarr.Array
+]:
+    store = MemoryStore()
+    group = zarr.open_group(store, mode="w")
+    root_array = group.create_array(
+        "temperature_2m",
+        shape=(2, N_LEADS, N_LAT, N_LON),
+        chunks=(1, 1, N_LAT, N_LON),
+        dtype="float64",
+    )
+    pressure_array = group.require_group("pressure_level").create_array(
+        "temperature",
+        shape=(2, N_LEADS, N_LAT, N_LON, N_LEVELS),
+        chunks=(1, 1, N_LAT, N_LON, 1),
+        dtype="float64",
+    )
+    return store, root_array, pressure_array
+
+
+def test_filter_already_present_uses_representative_of_multi_var_file() -> None:
+    template_ds = _create_template_ds(2)
+    job = _make_region_job(template_ds, region=slice(0, 2))
+    coord = job.source_file_coords()[0]
+    store, root_array, pressure_array = _memory_store_with_multi_group_arrays()
+    pressure_array[0, 0, :, :, :] = 1.0
+    icechunk_store = cast("icechunk.IcechunkStore", store)
+
+    representative = job.representative_var(coord)
+    assert representative.path == "temperature_2m"
+    assert dict(job.representative_probe_loc(coord, representative)) == dict(
+        coord.out_loc()
+    )
+    assert job.filter_already_present([coord], icechunk_store) == [coord]
+
+    root_array[0, 0, :, :] = 1.0
+    assert job.filter_already_present([coord], icechunk_store) == []
+
+
 def test_filter_already_present_probes_group_array(tmp_path: Path) -> None:
     # A backfill over init 0 only writes pressure_level/temperature chunks for init 0.
     dataset = _make_dataset(tmp_path, n_inits=2)
@@ -746,6 +792,203 @@ def test_filter_already_present_probes_group_array(tmp_path: Path) -> None:
     assert present not in remaining  # already in the manifest
     assert absent in remaining  # not yet written
     assert out_of_coords in remaining  # not a position in the dataset
+
+
+def _three_way_temperature_fixture(
+    first_levels: tuple[int, int, int] = (10, 1, 1000),
+) -> tuple[xr.DataTree, list[DataVar[BaseInternalAttrs]], MemoryStore]:
+    init_times = pd.date_range(APPEND_DIM_START, periods=2, freq=APPEND_DIM_FREQ)
+    shared_coords = {
+        "init_time": ("init_time", init_times),
+        "lead_time": ("lead_time", LEAD_TIMES),
+        "latitude": ("latitude", np.arange(N_LAT, dtype="float64")),
+        "longitude": ("longitude", np.arange(N_LON, dtype="float64")),
+    }
+    groups = (
+        "height_above_mean_sea_level",
+        "model_level",
+        "pressure_level",
+    )
+    level_values = {
+        group: np.array([first_level, first_level + 1])
+        for group, first_level in zip(groups, first_levels, strict=True)
+    }
+    nodes: dict[str, xr.Dataset] = {"/": xr.Dataset(coords=shared_coords)}
+    data_vars: list[DataVar[BaseInternalAttrs]] = []
+    store = MemoryStore()
+    zarr_root = zarr.open_group(store, mode="w")
+    for group in groups:
+        dims = ("init_time", "lead_time", "latitude", "longitude", group)
+        shape = (2, N_LEADS, N_LAT, N_LON, 2)
+        chunks = (1, 1, N_LAT, N_LON, 1)
+        nodes[f"/{group}"] = xr.Dataset(
+            {
+                "temperature": xr.Variable(
+                    dims,
+                    dask.array.full(shape, np.nan, dtype="float64", chunks=-1),
+                    encoding={
+                        "dtype": "float64",
+                        "chunks": chunks,
+                        "fill_value": np.nan,
+                        "compressors": None,
+                        "filters": None,
+                    },
+                )
+            },
+            coords={**shared_coords, group: (group, level_values[group])},
+        )
+        data_vars.append(PressureDataVar(name="temperature", group=group))
+        zarr_root.require_group(group).create_array(
+            "temperature", shape=shape, chunks=chunks, dtype="float64"
+        )
+    return xr.DataTree.from_dict(nodes), data_vars, store
+
+
+def test_filter_already_present_memoizes_probe_locations_by_data_var_path() -> None:
+    template_ds, data_vars, store = _three_way_temperature_fixture()
+    job = MultiGroupRegionJob(
+        tmp_store=Path("unused-tmp.zarr"),
+        template_ds=template_ds,
+        data_vars=data_vars,
+        append_dim="init_time",
+        region=slice(0, 2),
+        reformat_job_name="test",
+    )
+    coords = [
+        _VariableProbeCoord(
+            init_time=APPEND_DIM_START,
+            lead_time=LEAD_TIMES[0],
+            data_vars=[var],
+        )
+        for var in data_vars
+    ]
+    probe_locs = {
+        var.path: dict(job.representative_probe_loc(coord, var))
+        for coord, var in zip(coords, data_vars, strict=True)
+    }
+    assert probe_locs == {
+        "height_above_mean_sea_level/temperature": {
+            **dict(coords[0].out_loc()),
+            "height_above_mean_sea_level": 10,
+        },
+        "model_level/temperature": {
+            **dict(coords[1].out_loc()),
+            "model_level": 1,
+        },
+        "pressure_level/temperature": {
+            **dict(coords[2].out_loc()),
+            "pressure_level": 1000,
+        },
+    }
+
+    zarr_root = zarr.open_group(store, mode="r+")
+    height_array = zarr_root["height_above_mean_sea_level/temperature"]
+    assert isinstance(height_array, zarr.Array)
+    height_array[0, 0, :, :, :] = 1.0
+    candidates = [coords[2], coords[0], coords[1]]
+    remaining = job.filter_already_present(
+        candidates, cast("icechunk.IcechunkStore", store)
+    )
+
+    assert [job.representative_var(coord).path for coord in remaining] == [
+        "pressure_level/temperature",
+        "model_level/temperature",
+    ]
+
+
+def test_filter_already_present_accepts_var_outside_job_data_vars() -> None:
+    template_ds, data_vars, store = _three_way_temperature_fixture()
+    job = MultiGroupRegionJob(
+        tmp_store=Path("unused-tmp.zarr"),
+        template_ds=template_ds,
+        data_vars=[data_vars[0]],
+        append_dim="init_time",
+        region=slice(0, 2),
+        reformat_job_name="test",
+    )
+    pressure_var = data_vars[2]
+    coord = _VariableProbeCoord(
+        init_time=APPEND_DIM_START,
+        lead_time=LEAD_TIMES[0],
+        data_vars=[pressure_var],
+    )
+    zarr_root = zarr.open_group(store, mode="r+")
+    pressure_array = zarr_root[pressure_var.path]
+    assert isinstance(pressure_array, zarr.Array)
+    pressure_array[0, 0, :, :, :] = 1.0
+
+    assert job.representative_var(coord).path == pressure_var.path
+    assert (
+        job.filter_already_present([coord], cast("icechunk.IcechunkStore", store)) == []
+    )
+
+
+def test_probe_label_cache_is_per_job_instance() -> None:
+    template_a, data_vars_a, _ = _three_way_temperature_fixture((10, 1, 1000))
+    template_b, data_vars_b, _ = _three_way_temperature_fixture((20, 2, 925))
+    jobs_and_vars = [
+        (
+            MultiGroupRegionJob(
+                tmp_store=Path("unused-tmp.zarr"),
+                template_ds=template,
+                data_vars=data_vars,
+                append_dim="init_time",
+                region=slice(0, 2),
+                reformat_job_name="test",
+            ),
+            data_vars[0],
+        )
+        for template, data_vars in (
+            (template_a, data_vars_a),
+            (template_b, data_vars_b),
+        )
+    ]
+    coord = MultiGroupSourceFileCoord(
+        init_time=APPEND_DIM_START, lead_time=LEAD_TIMES[0]
+    )
+
+    assert [
+        (
+            var.path,
+            job.representative_probe_loc(coord, var)["height_above_mean_sea_level"],
+        )
+        for job, var in jobs_and_vars
+    ] == [
+        ("height_above_mean_sea_level/temperature", 10),
+        ("height_above_mean_sea_level/temperature", 20),
+    ]
+
+
+def test_filter_does_not_resolve_probe_labels_for_unused_unindexed_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    template_ds = _create_template_ds(2)
+    pressure_node = template_ds["pressure_level"]
+    assert isinstance(pressure_node, xr.DataTree)
+    pressure = pressure_node.to_dataset(inherit=False).drop_vars("pressure_level")
+    template_ds = xr.DataTree.from_dict(
+        {"/": template_ds.to_dataset(inherit=False), "/pressure_level": pressure}
+    )
+    pressure_var = template_ds["pressure_level/temperature"]
+    assert isinstance(pressure_var, xr.DataArray)
+    assert "pressure_level" not in pressure_var.indexes
+    assert list(pressure_var.get_index("pressure_level")) == list(range(N_LEVELS))
+
+    job = _make_region_job(template_ds, region=slice(0, 2))
+    coord = job.source_file_coords()[0]
+    store, _, _ = _memory_store_with_multi_group_arrays()
+    original_get_index = xr.DataArray.get_index
+    queried: list[tuple[Any, str]] = []
+
+    def record_get_index(self: xr.DataArray, key: str) -> pd.Index:
+        queried.append((self.name, key))
+        return original_get_index(self, key)
+
+    monkeypatch.setattr(xr.DataArray, "get_index", record_get_index)
+    assert job.filter_already_present(
+        [coord], cast("icechunk.IcechunkStore", store)
+    ) == [coord]
+    assert ("temperature", "pressure_level") not in queried
 
 
 def test_virtual_operational_expands_both_groups(tmp_path: Path) -> None:

--- a/tests/common/virtual_region_job_test.py
+++ b/tests/common/virtual_region_job_test.py
@@ -1089,6 +1089,28 @@ def test_filter_skips_already_present_refs(tmp_path: Path) -> None:
     assert job.filter_already_present(candidates, readonly) == []
 
 
+def test_filter_already_present_no_candidates(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    job = _make_region_job(template_ds, region=slice(0, 4))
+    readonly = _primary_repo(dataset.store_factory).readonly_session("main").store
+
+    assert job.filter_already_present([], readonly) == []
+
+
+def test_filter_already_present_none_present_preserves_order(tmp_path: Path) -> None:
+    dataset = _make_dataset(tmp_path)
+    template_ds = _create_template_ds(4)
+    template_utils.write_metadata(template_ds, dataset.store_factory)
+    job = _make_region_job(template_ds, region=slice(0, 4))
+    source_coords = job.source_file_coords()
+    candidates = [source_coords[3], source_coords[0], source_coords[-1]]
+    readonly = _primary_repo(dataset.store_factory).readonly_session("main").store
+
+    assert job.filter_already_present(candidates, readonly) == candidates
+
+
 def test_overwrite_chunks_rewrites_already_present_refs(tmp_path: Path) -> None:
     """Without this, a variable whose refs all point at the wrong source file could
     never be corrected: its own stale refs mark every file as already done."""


### PR DESCRIPTION
`VirtualRegionJob.filter_already_present` did two per-candidate lookups that only ever vary by variable:

- `group[var.path]` — a zarr metadata read, once per source file
- `representative_probe_loc`'s `template_ds[var.path]` / `encoding["chunks"]` / `get_index(dim)[0]` — a DataTree lookup, once per source file

A region job probes thousands of files against a handful of variables, so both repeated the same work thousands of times. Both now resolve once per distinct variable.

## Why it matters

Found while running `run-all` on `noaa-gefs-forecast-10-day-0-25-degree-virtual`, whose archive is 8,671 init times × 31 members × 81 leads (2,511 source files per position, ~21.8M probes). The whole-archive manifest scan was running at 3.9 positions/min — a ~37 hour projection — and could not finish.

cProfile over two real probe jobs put `zarr.core.group.Group.__getitem__` at 8.6 s of 12.3 s (70%), 2,511 calls per job for 38 distinct variables, with `representative_probe_loc` a further 20%. The probes themselves were never the bottleneck: `store.exists` measured 692 keys/s cold and 6,385/s warm from a separate process while the scan was saturating the box.

Because the work was Python-side, it serialized on the GIL and the 48-thread probe pool delivered roughly one core of throughput.

## Measurements

| | before | after |
| --- | --- | --- |
| `_probe_job` (2 real jobs, cProfile) | 6.2 s/job | 0.5 s/job |
| `availability` on a 2-day window, end to end | 62 s | 31 s |

After the change the remaining per-job time is `_exists_many` itself, which releases the GIL, so the probe thread pool can actually parallelize.

## Scope and risk

`filter_already_present` is on the operational write path — backfills and updates use it to skip already-present files — not validation-only code. The change is pure memoization: same chunk keys, same results.

The second commit fixes a bug in the first: `representative_probe_loc` resolves *any* variable against the template, not only the ones its job carries, so keying the memo off `self.data_vars` raised `KeyError` for a coord whose variable the job does not list. `tests/noaa/hrrr/forecast_48_hour_virtual/region_job_test.py::test_group_file_probe_loc_carries_first_level` caught it; the memo is now on-demand by variable path.

## Verification

- `uv run pytest -m "not slow"` — 2,626 passed
- `uv run ruff format && ruff check && ty check` — clean
- `availability` on the 2-day window returns the identical result (`all 12 positions ≥ 100%`)

No template, metadata, or encoding change, so no `update-template` and no compatibility implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrubXPWAPkGjr815kgKWqe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrubXPWAPkGjr815kgKWqe)_