### PR TITLE
Document the GEFS 0.25 degree virtual helicity mask threshold

### DIFF
--- a/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
@@ -36,7 +36,7 @@
     "long_name": "Storm relative helicity",
     "short_name": "hlcy",
     "units": "m2 s-2",
-    "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored.",
+    "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored. Some source values reach magnitudes near 100,000 m2 s-2, far above the roughly 1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values above 2,000.",
     "step_type": "instant",
     "coordinates": "spatial_ref",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/analysis_0_25_degree_virtual/templates/latest.zarr/zarr.json
@@ -1623,7 +1623,7 @@
           "long_name": "Storm relative helicity",
           "short_name": "hlcy",
           "units": "m2 s-2",
-          "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored.",
+          "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored. Some source values reach magnitudes near 100,000 m2 s-2, far above the roughly 1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values above 2,000.",
           "step_type": "instant",
           "coordinates": "spatial_ref",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
@@ -40,7 +40,7 @@
     "long_name": "Storm relative helicity",
     "short_name": "hlcy",
     "units": "m2 s-2",
-    "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored.",
+    "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored. Some source values reach magnitudes near 100,000 m2 s-2, far above the roughly 1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values above 2,000.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_10_day_0_25_degree_virtual/templates/latest.zarr/zarr.json
@@ -2002,7 +2002,7 @@
           "long_name": "Storm relative helicity",
           "short_name": "hlcy",
           "units": "m2 s-2",
-          "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored.",
+          "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored. Some source values reach magnitudes near 100,000 m2 s-2, far above the roughly 1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values above 2,000.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/virtual_template_config.py
+++ b/src/reformatters/noaa/gefs/virtual_template_config.py
@@ -1035,7 +1035,10 @@ def _s_file_data_vars(
             units="m2 s-2",
             comment=(
                 "Uses a right-moving storm motion in both hemispheres, so southern "
-                "hemisphere values are positive-mean rather than mirrored."
+                "hemisphere values are positive-mean rather than mirrored. Some source "
+                "values reach magnitudes near 100,000 m2 s-2, far above the roughly "
+                "1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values "
+                "above 2,000."
             ),
         ),
         var(


### PR DESCRIPTION
Follow-up to #1039 from the same validation of `noaa-gefs-analysis-0-25-degree-virtual`.

`storm_relative_helicity_3000_0m` carries coherent patches of source values reaching magnitudes near 100,000 m² s⁻², against a physical ceiling near 1,500 m² s⁻² for 0–3 km storm-relative helicity. Sampled across 20 snapshots spanning the archive (20.8M cells): magnitudes above 2,000 occur in about 1 cell in 184,000 and appear in 15 of the 20 snapshots, with a maximum of 307,638. Decoding the source GRIB messages directly returns byte-identical values, so these come from upstream rather than from this archive's processing.

The distribution runs continuously through the physical ceiling — 1,500, 1,633, 1,808, 2,002, 2,318, 2,735, 3,103, 3,886 and up — so there is no gap to cut at and the threshold comes from the meteorology instead. 2,000 is conservative: it keeps genuine strong-shear fields (one sampled snapshot peaked coherently at 1,732) while removing the blow-ups.

Per AGENTS.md this is an intrinsic, always-true variable fact, so it goes in the variable's `comment` attr and gets no validation-report review note. The comment ends with the action, matching the shape of the sibling `percent_frozen_precipitation_surface` and `geopotential_height_cloud_ceiling` comments.

Scope: applied to the 0.25° `s` file definition only, which the GEFS virtual analysis and 10-day forecast datasets share, so both `templates/latest.zarr` are regenerated. The 0.5° a/b file definition added by #1017 and #1019 carries the same upstream diagnostic but was not sampled here, so it is left unchanged.

`ruff format`, `ruff check`, `ty check` clean; 493 template/CF-compliance tests and 2,809 fast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LnC4iYNWF2KBVv4HL9M41


---
_Generated by [Claude Code](https://claude.ai/code/session_019LnC4iYNWF2KBVv4HL9M41)_