### PR TITLE
Carry the helicity comment across the 0.5 degree GEFS virtual datasets

### DIFF
--- a/src/reformatters/noaa/gefs/forecast_16_day_0_5_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_16_day_0_5_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
@@ -40,6 +40,7 @@
     "long_name": "Storm relative helicity",
     "short_name": "hlcy",
     "units": "m2 s-2",
+    "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored. Some source values reach magnitudes near 100,000 m2 s-2, far above the roughly 1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values above 2,000.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_16_day_0_5_degree_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_16_day_0_5_degree_virtual/templates/latest.zarr/zarr.json
@@ -11535,6 +11535,7 @@
           "long_name": "Storm relative helicity",
           "short_name": "hlcy",
           "units": "m2 s-2",
+          "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored. Some source values reach magnitudes near 100,000 m2 s-2, far above the roughly 1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values above 2,000.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_35_day_0_5_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day_0_5_degree_virtual/templates/latest.zarr/storm_relative_helicity_3000_0m/zarr.json
@@ -40,6 +40,7 @@
     "long_name": "Storm relative helicity",
     "short_name": "hlcy",
     "units": "m2 s-2",
+    "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored. Some source values reach magnitudes near 100,000 m2 s-2, far above the roughly 1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values above 2,000.",
     "step_type": "instant",
     "coordinates": "expected_forecast_length spatial_ref valid_time",
     "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/forecast_35_day_0_5_degree_virtual/templates/latest.zarr/zarr.json
+++ b/src/reformatters/noaa/gefs/forecast_35_day_0_5_degree_virtual/templates/latest.zarr/zarr.json
@@ -11535,6 +11535,7 @@
           "long_name": "Storm relative helicity",
           "short_name": "hlcy",
           "units": "m2 s-2",
+          "comment": "Uses a right-moving storm motion in both hemispheres, so southern hemisphere values are positive-mean rather than mirrored. Some source values reach magnitudes near 100,000 m2 s-2, far above the roughly 1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values above 2,000.",
           "step_type": "instant",
           "coordinates": "expected_forecast_length spatial_ref valid_time",
           "_FillValue": "AAAAAAAA+H8="

--- a/src/reformatters/noaa/gefs/virtual_template_config.py
+++ b/src/reformatters/noaa/gefs/virtual_template_config.py
@@ -2186,6 +2186,13 @@ def _a_b_root_data_vars(
             short_name="hlcy",
             long_name="Storm relative helicity",
             units="m2 s-2",
+            comment=(
+                "Uses a right-moving storm motion in both hemispheres, so southern "
+                "hemisphere values are positive-mean rather than mirrored. Some source "
+                "values reach magnitudes near 100,000 m2 s-2, far above the roughly "
+                "1,500 m2 s-2 physical ceiling for this quantity. Mask absolute values "
+                "above 2,000."
+            ),
         ),
         var(
             "u_component_storm_motion_6000_0m",


### PR DESCRIPTION
Follow-up to #1041, which documented `storm_relative_helicity_3000_0m` on the 0.25° `s` file definition only. The 0.5° a/b file definition carried no comment at all, so the two GEFS virtual resolutions described the same variable differently.

I sampled the same 20 snapshots spanning the archive from the 0.5° b file source messages. The field behaves as the 0.25° one does:

| | 0.25° s file | 0.5° b file |
|---|---|---|
| global max \|value\| | 307,638 | 143,329 |
| `\|v\|>2000` rate | 1 in 184,000 | 1 in 193,000 |
| snapshots with any `\|v\|>2000` | 15/20 | 11/20 |
| distribution through the ceiling | continuous | continuous |

The same blow-up features appear at the same cycles and magnitudes — 143,329 against 143,314 at 2026-04-01, and 41,627 and 21,780 identical at 2025-01-20 and 2024-02-14 — which is expected since both products carry the same diagnostic from the same run. Northern and southern hemisphere means are both positive (76.4 and 40.5 with blow-ups excluded), so the right-moving storm motion sentence holds at 0.5° too.

Both definitions now carry the same comment, verified byte-identical across all four GEFS virtual datasets' `templates/latest.zarr`, so the 16-day and 35-day 0.5° forecast templates are regenerated alongside.

`ruff check`, `ty check` clean; 493 template/CF-compliance tests and 2,809 fast tests pass.

Out of scope but worth noting for a future pass: `noaa-gfs-*-virtual`'s helicity carries only the storm-motion sentence, and `noaa-hrrr-*-virtual`'s two helicity variables carry no comment. Both are the same upstream diagnostic and likely behave the same way, but I have not sampled them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LnC4iYNWF2KBVv4HL9M41


---
_Generated by [Claude Code](https://claude.ai/code/session_019LnC4iYNWF2KBVv4HL9M41)_