### PR TITLE
Test that declared units agree with the decode filter chain

### DIFF
--- a/tests/common/datasets_cf_compliance_test.py
+++ b/tests/common/datasets_cf_compliance_test.py
@@ -9,8 +9,10 @@ import pytest
 import xarray as xr
 
 from reformatters.common import validation
+from reformatters.common.config_models import DataVar
 from reformatters.common.dynamical_dataset import DynamicalDataset
 from reformatters.common.types import Dim
+from reformatters.common.virtual_region_job import VirtualRegionJob
 from tests.dataset_helpers import IMPLEMENTED_DATASETS
 
 # Downloaded from https://codes.ecmwf.int/parameter-database/api/v1/param/?format=json
@@ -1669,4 +1671,147 @@ def test_metadata_consistency_across_datasets() -> None:
 
     assert not conflicts, (
         "Metadata inconsistencies found across datasets:\n\n" + "\n\n".join(conflicts)
+    )
+
+
+# --- Declared units vs. decode filter chain ---
+
+CELSIUS_UNITS = "degree_Celsius"
+KELVIN_TO_CELSIUS_OFFSET = -273.15
+
+# Placeholders emitted where the source could not name the parameter, left in place
+# by configs that locate their messages by some other key. They are not element
+# names: two genuinely different parameters can carry either string, so as a
+# grouping key they identify nothing and would group unrelated variables together.
+# Excluding a degenerate key is not an exception list -- it states that the key
+# does not identify anything there.
+DEGENERATE_GRIB_ELEMENT_KEYS = frozenset({"", "unknown"})
+
+
+def _has_kelvin_to_celsius_filter(var_config: DataVar[Any]) -> bool:
+    """Whether a variable's filter chain converts Kelvin to Celsius on read."""
+    return any(
+        codec.get("name") == "scale_offset"
+        and codec.get("configuration", {}).get("offset") == KELVIN_TO_CELSIUS_OFFSET
+        for codec in var_config.encoding.filters or ()
+    )
+
+
+def test_celsius_units_match_decode_filters() -> None:
+    """
+    One invariant: declaring degree_Celsius implies the Kelvin conversion happened.
+    Each dataset family performs it somewhere else, so the invariant is stated per
+    family rather than as two independent rules.
+
+    - A virtual dataset references the source GRIB bytes unchanged, and those are
+      Kelvin, so the conversion must be a decode-time ScaleOffset carrying
+      offset=-273.15.
+    - A materialized dataset converts in read_data before writing, so the stored
+      bytes are already Celsius and must carry no such filter, which would
+      subtract 273.15 a second time.
+
+    The asymmetry is deliberate: filter equality across the two families is false
+    by construction for every Celsius variable here, so do not "fix" it.
+
+    A regression fence, not a bug report -- it holds with no exceptions today. It
+    exists because the conversion cannot be read off a call site: the filter is
+    supplied by default from a per-element set, an explicit filters= argument
+    silently overrides that default, and an override omitting the offset publishes
+    Kelvin values declaring degree_Celsius with nothing raising. Absence of a
+    filters= argument likewise means "converted" for an element in that set and
+    means nothing for any element outside it. Which variables exercise which path
+    changes; the repo is the source of truth for that and this test does not
+    name them.
+    """
+    problems: list[str] = []
+    checked = 0
+
+    for dataset in IMPLEMENTED_DATASETS:
+        is_virtual = issubclass(dataset.region_job_class, VirtualRegionJob)
+        for var_config in dataset.template_config.data_vars:
+            if var_config.attrs.units != CELSIUS_UNITS:
+                continue
+            checked += 1
+            has_filter = _has_kelvin_to_celsius_filter(var_config)
+            if is_virtual and not has_filter:
+                problems.append(
+                    f"{dataset.dataset_id}/{var_config.path} declares "
+                    f"{CELSIUS_UNITS} in a virtual dataset but no ScaleOffset "
+                    f"applies offset={KELVIN_TO_CELSIUS_OFFSET}, so readers get "
+                    f"Kelvin labelled Celsius. filters={var_config.encoding.filters}"
+                )
+            elif not is_virtual and has_filter:
+                problems.append(
+                    f"{dataset.dataset_id}/{var_config.path} declares "
+                    f"{CELSIUS_UNITS} in a materialized dataset and also applies "
+                    f"offset={KELVIN_TO_CELSIUS_OFFSET} on read, subtracting "
+                    f"273.15 from values read_data already converted. "
+                    f"filters={var_config.encoding.filters}"
+                )
+
+    # A rename of units or of the filter dict shape would leave every branch above
+    # unreachable and this test passing on nothing, which is indistinguishable from
+    # passing on real data. 235 variables qualify today.
+    assert checked > 100, f"only {checked} {CELSIUS_UNITS} variables found to check"
+    assert not problems, "Celsius unit/filter mismatches found:\n" + "\n".join(problems)
+
+
+def test_same_grib_element_and_units_have_same_filters() -> None:
+    """
+    Within one dataset, two variables reading the same GRIB element and declaring
+    the same units must decode those bytes identically. The source bytes and the
+    declared destination units are the same on both sides, so any difference in
+    the filter chain means one of the two is mislabelled.
+
+    Same element with *different* declared units is legitimate and not checked
+    here: GRIB reuses an element across meanings, and a config may publish one
+    element as two variables in two units on purpose. Variables whose element is
+    a degenerate key are excluded, since there the key names no parameter.
+
+    A regression fence: it holds with no exceptions today. It has surface because
+    these configs repeat an element widely across separately maintained blocks,
+    per vertical level and per statistic, and the copies are never compared to
+    each other. When written, 21 elements appeared more than once in the GEFS
+    16 day virtual catalog and 35 did in the GFS forecast virtual catalog.
+    """
+    problems: list[str] = []
+    checked_groups = 0
+
+    for dataset in IMPLEMENTED_DATASETS:
+        vars_by_element_and_units: dict[tuple[str, str], list[DataVar[Any]]] = {}
+        for var_config in dataset.template_config.data_vars:
+            # Non-GRIB sources have no such field and are not applicable.
+            element = getattr(var_config.internal_attrs, "grib_element", None)
+            if element is None or element.strip().lower() in (
+                DEGENERATE_GRIB_ELEMENT_KEYS
+            ):
+                continue
+            vars_by_element_and_units.setdefault(
+                (element, var_config.attrs.units), []
+            ).append(var_config)
+
+        for (element, units), var_configs in vars_by_element_and_units.items():
+            if len(var_configs) < 2:
+                continue
+            checked_groups += 1
+            filters_to_vars: dict[str, list[str]] = {}
+            for var_config in var_configs:
+                key = repr(tuple(var_config.encoding.filters or ()))
+                filters_to_vars.setdefault(key, []).append(var_config.path)
+            if len(filters_to_vars) > 1:
+                detail = "\n".join(
+                    f"    {filters}: {', '.join(paths)}"
+                    for filters, paths in filters_to_vars.items()
+                )
+                problems.append(
+                    f"{dataset.dataset_id} reads GRIB element {element} as "
+                    f"units='{units}' with differing filters, so at most one of "
+                    f"these is correct:\n{detail}"
+                )
+
+    # Guards against the check silently covering nothing, e.g. if grib_element were
+    # renamed and the getattr above began skipping every variable. 256 groups today.
+    assert checked_groups > 100, f"only {checked_groups} groups found to check"
+    assert not problems, "GRIB element/units filter mismatches found:\n" + "\n".join(
+        problems
     )


### PR DESCRIPTION
Two cross-dataset assertions added to the existing CF compliance module. **Neither found a
defect. Both are regression fences** — each holds with zero exceptions across all 30
checked-in templates today, and exists to keep it that way.

Test-only: +141 lines in one file, `tests/common/datasets_cf_compliance_test.py`. No new
module, no new abstraction, no production-code change, no unit-conversion table, no exception
list.

## The class being fenced

A variable's declared unit and the filter chain that produces that unit can disagree with
nothing raising. The mechanism: the Celsius conversion is supplied **by default from a
per-element set**, an explicit `filters=` argument **silently overrides that default**, and an
override that omits the offset publishes kelvin values declaring `degree_Celsius` with nothing
raising. The counterpart is why it cannot be eyeballed — an **absent** `filters=` argument
means "converted" for an element inside that set and means nothing at all for an element
outside it. Same absent argument, opposite meanings, decided entirely by set membership.

## Test 1 — declared Celsius implies the conversion happened

One invariant, stated per family because each family performs the conversion somewhere else:

- A **virtual** dataset references the source GRIB bytes unchanged, and those are kelvin, so
  the conversion must be a decode-time `ScaleOffset` carrying `offset=-273.15`.
- A **materialized** dataset converts in `read_data` before writing, so the stored bytes are
  already Celsius and must carry no such filter, which would subtract 273.15 a second time.

Cross-family filter equality is therefore **false by construction** for every Celsius variable
in the repo. The test says so explicitly so that nobody later "fixes" the asymmetry.

**What a passing run CANNOT detect:** it only checks variables that *declare*
`degree_Celsius`, so a Celsius variable mislabelled `units="K"` passes clean — the declared
unit is the input to the check, never the thing checked.

## Test 2 — same GRIB element and same declared units implies identical filters

Within one dataset, two variables reading the same element and declaring the same units must
decode those bytes identically: same source, same declared destination, so any difference in
the filter chain mislabels one of them. Same element with *different* declared units is
legitimate and not checked — GRIB reuses an element across meanings.

It has real surface: elements repeat widely across separately maintained per-level and
per-statistic blocks that are never compared to each other (21 elements appear more than once
in the GEFS 16-day virtual catalog, 35 in the GFS forecast virtual catalog, 32 in each HRRR
virtual).

**Degenerate keys are excluded, which is not an exception list.** `""` and `"unknown"` are not
element names — they are non-identifying placeholders left where the source could not name the
parameter, which means two genuinely different parameters can share either string. Excluding
such a key states that the key does not identify anything there. The census is closed and
small: `""` ×35 (all in `ecmwf-aifs-single-forecast-virtual`, which locates messages by another
key entirely), `"unknown"` ×1 `ecmwf-aifs-ens-forecast`, ×1 `ecmwf-aifs-single-forecast`, ×2
`ecmwf-ifs-ens-forecast-15-day-0-25-degree`. Without the exclusion, geopotential (m²/s², scaled
by 9.80665 to metres) and sub-gridscale orography std-dev (already metres) collide on
`element=""`/`units="m"` — both correct, flagged only because the key names nothing.

**What a passing run CANNOT detect:** it is intra-dataset and compares only variables that
already agree on declared units, so two copies that are consistently wrong in the same way
pass, as does any disagreement where the units strings also differ.

## Deliberately NOT built

The check that catches the class these two do not is the **cross-dataset** consistency check
extended to `encoding.filters` — same variable name across datasets must carry identical
filters. It is blocked on the known bare-name-versus-`DataVar.path` keying fix, which is
scheduled separately, so it is not free and is not in this PR.

## The set every number was computed over

Commit `14dc3b31`, `DYNAMICAL_DATASETS` = 30, `IMPLEMENTED_DATASETS` = 30, template-not-
implemented skips = 0, 2054 `data_vars`. No `try/except` in the derivation, so nothing was
silently dropped.

Family split is 12 **virtual** / 18 **materialized**, overlap empty, decided by
`issubclass(region_job_class, VirtualRegionJob)` — the same test `dynamical_dataset.py:582`
already uses.

- Test 1: **235** `degree_Celsius` arrays (190 virtual + 45 materialized), **0 violations**, 0
  skipped. Only 12 of the 18 materialized datasets declare any Celsius variable.
  `degree_Celsius` is the sole Celsius spelling in the repo.
- Test 2: **256** multi-variable `(element, units)` groups asserted on, **0 violations**.
  Accounting: 1934 vars considered + 39 degenerate-key + 81 with no `grib_element` field at all
  (the 10 non-GRIB datasets) = 2054, every var. The 81 are not-applicable, not swallowed.

These numbers come from the **source config objects** (`template_config.data_vars`), which is
what the guard asserts on. Note `DataVar.encoding.filters` is the *resolved* chain, post-
default: it cannot say whether a filter was passed explicitly or supplied by the per-element
default. "Was this explicit" lives in the source; "what does a reader get" lives in the
template.

## Coverage floors, and proof the tests can fail

Both tests read their key by string compare (`units`) and by `getattr` (`grib_element`), so a
rename would make them examine **nothing** and pass forever — a silent pass and a real answer
are indistinguishable at the point of use. Each test therefore asserts a floor on how much it
examined (`>100` against 235 and 256 today): loose enough not to churn as datasets are added,
tight enough that a collapse to zero fails.

Six in-process falsifications (monkeypatch, no on-disk edit), all failed as expected: strip the
offset from a virtual Celsius var; add the offset to a materialized one (both branches proven
live); `offset=-273.0` instead of `-273.15` (the value, not mere presence); perturb one member
of a real group (GFS `PRES`/`Pa`); and both coverage floors.

## Checks

`ruff format` 504 files unchanged, `ruff check --fix` passed, `ty check` passed. Full not-slow
suite `-n 4`: **2811 passed, 0 failed**. No config-constant change, so the slow-module sweep
does not apply.

Template-diff proof: all 30 templates regenerated, **byte-identical, empty diff**. Trivially
expected for a test-only change — run and stated anyway, because "no production change" is a
claim about the diff while "templates regenerate byte-identical" is a claim about the encoding,
and only the second is evidence about what readers get.

## Two things for @aldenks before merge

- **The commit is UNSIGNED.** Signing failed in this shell with `1Password: failed to fill
  whole buffer`, so it was made with `--no-gpg-sign`. Please re-sign if your merge path
  requires it.
- Branch point: rebased onto real `main` at `14dc3b31` (fetched over HTTPS via `gh`
  credentials, since `git fetch` over SSH times out here). The full derivation and the not-slow
  suite were re-run after the rebase and every number above is unchanged from the original
  `eb550bf2` measurement.
