### PR TITLE
Replace an ECDS job whose result has expired or whose polling is exhausted

### DIFF
--- a/src/reformatters/ecmwf/archive_gribs/ecds_client.py
+++ b/src/reformatters/ecmwf/archive_gribs/ecds_client.py
@@ -26,9 +26,17 @@ log = get_logger(__name__)
 
 ECDS_API_URL: Final[str] = "https://ecds.ecmwf.int/api"
 S2S_FORECASTS_PROCESS: Final[str] = "s2s-forecasts"
-TERMINAL_FAILURE_STATUSES: Final[frozenset[str]] = frozenset(
+ECDS_FAILURE_STATUSES: Final[frozenset[str]] = frozenset(
     {"failed", "rejected", "dismissed", "cancelled"}
 )
+# Assigned by this client, not ECDS: the job or its result is gone from ECDS, or
+# polling gave up on it. Either way the job is never resumed, only replaced.
+EXPIRED_STATUS: Final[str] = "expired"
+ABANDONED_STATUS: Final[str] = "abandoned"
+TERMINAL_FAILURE_STATUSES: Final[frozenset[str]] = ECDS_FAILURE_STATUSES | {
+    EXPIRED_STATUS,
+    ABANDONED_STATUS,
+}
 REQUEST_TIMEOUT_SECONDS: Final[float] = 60
 DOWNLOAD_TIMEOUT_SECONDS: Final[float] = 120
 MAXIMUM_POLL_BACKOFF_EXPONENT: Final[int] = 6
@@ -37,7 +45,7 @@ RESUBMIT_BUDGET_SECONDS: Final[float] = 3600
 
 
 class EcdsJobFailedError(Exception):
-    """ECDS ran the job and ended it in a terminal failure status."""
+    """The job ended in a terminal status: ECDS failed it, or its result is gone."""
 
 
 @dataclass
@@ -160,33 +168,49 @@ class EcdsRequest:
         ECDS result expires without a published SLA, so a second download of the same
         result may be impossible.
 
-        A job ECDS fails is submitted again after `resubmit_wait_seconds`, doubling each
-        time. No job is submitted once `resubmit_budget_seconds` have passed since this
-        call began; the failure is raised as `EcdsJobFailedError` instead.
+        A job ECDS fails, or no longer holds, is submitted again after
+        `resubmit_wait_seconds`, doubling each time. No job is submitted once
+        `resubmit_budget_seconds` have passed since this call began; the failure is
+        raised as `EcdsJobFailedError` instead. A job still incomplete after
+        `maximum_polls` is abandoned and replaced once; a second such job raises
+        `TimeoutError`.
         """
         state = self.state_store.read_if_exists()
         if state is None or state.payload != dict(payload):
-            self.submit(payload)
+            self._submit_replacing(payload, target)
         elif _downloaded_blob_is_intact(state, target):
             log.info("Reusing the %s already downloaded for this request", target)
             return target
         elif state.status in TERMINAL_FAILURE_STATUSES:
-            self.submit(payload)
+            self._submit_replacing(payload, target)
         deadline = time.monotonic() + resubmit_budget_seconds
         wait_seconds = resubmit_wait_seconds
+        replaced_after_timeout = False
         while True:
             try:
                 _, result_url = self.poll_until_complete(poll_seconds, maximum_polls)
-                break
+                self.download(target, result_url)
+                return target
             except EcdsJobFailedError as e:
                 if time.monotonic() + wait_seconds >= deadline:
                     raise
                 log.warning("%s; submitting it again in %.0f s", e, wait_seconds)
                 time.sleep(wait_seconds)
-                self.submit(payload)
+                self._submit_replacing(payload, target)
                 wait_seconds *= 2
-        self.download(target, result_url)
-        return target
+            except TimeoutError as e:
+                if replaced_after_timeout:
+                    raise
+                replaced_after_timeout = True
+                log.warning("%s; submitting it again", e)
+                self._submit_replacing(payload, target)
+
+    def _submit_replacing(
+        self, payload: Mapping[str, Any], target: Path
+    ) -> RequestState:
+        """Submit a job for `target`, discarding any partial download of an earlier job's result."""
+        _partial_path(target).unlink(missing_ok=True)
+        return self.submit(payload)
 
     def submit(self, payload: Mapping[str, Any]) -> RequestState:
         assert self.session.headers.get("PRIVATE-TOKEN"), (
@@ -217,6 +241,8 @@ class EcdsRequest:
     def poll_once(self) -> tuple[RequestState, str | None]:
         state = self.state_store.read()
         response = self.session.get(state.status_url, timeout=REQUEST_TIMEOUT_SECONDS)
+        if response.status_code == requests.codes.not_found:
+            return self._expire(state, f"job {state.status_url}"), None
         response.raise_for_status()
         body = response.json()
         status = body.get("status") or body.get("state")
@@ -242,12 +268,21 @@ class EcdsRequest:
             results_response = self.session.get(
                 results_url, timeout=REQUEST_TIMEOUT_SECONDS
             )
+            if results_response.status_code == requests.codes.not_found:
+                return self._expire(state, f"results {results_url}"), None
             results_response.raise_for_status()
             result_url = _result_url(results_response.json())
         if result_url is not None:
             state.result_url = result_url
         self.state_store.write(state)
         return state, result_url
+
+    def _expire(self, state: RequestState, what: str) -> RequestState:
+        """Record that ECDS no longer holds the job or its result."""
+        state.status = EXPIRED_STATUS
+        state.errors.append(f"404 Not Found: {what}")
+        self.state_store.write(state)
+        return state
 
     def poll_until_complete(
         self, poll_seconds: float, maximum_polls: int
@@ -282,8 +317,12 @@ class EcdsRequest:
             if state.status == "successful" and result_url is not None:
                 return state, result_url
             _sleep_bounded(poll_seconds, deadline)
+        state = self.state_store.read()
+        state.status = ABANDONED_STATUS
+        self.state_store.write(state)
         raise TimeoutError(
-            f"ECDS job did not complete within {maximum_polls} polls of {poll_seconds}s"
+            f"ECDS job {state.request_id} did not complete within {maximum_polls} "
+            f"polls of {poll_seconds}s"
         )
 
     def download(self, target: Path, result_url: str | None = None) -> RequestState:
@@ -293,7 +332,7 @@ class EcdsRequest:
             "Poll the request to completion before downloading"
         )
         target.parent.mkdir(parents=True, exist_ok=True)
-        partial_path = target.with_suffix(f"{target.suffix}.partial")
+        partial_path = _partial_path(target)
         existing_bytes = partial_path.stat().st_size if partial_path.exists() else 0
         headers = {"Range": f"bytes={existing_bytes}-"} if existing_bytes else {}
         started = time.monotonic()
@@ -306,6 +345,14 @@ class EcdsRequest:
             response.close()
             response = self.session.get(
                 result_url, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS
+            )
+        if response.status_code == requests.codes.not_found:
+            # The signed URL is left out of the record: it is a credential.
+            response.close()
+            self._expire(state, "result download")
+            raise EcdsJobFailedError(
+                f"ECDS job {state.request_id} ended with status {EXPIRED_STATUS}: "
+                "its result is no longer downloadable"
             )
         response.raise_for_status()
         # A server that ignores the Range header replies 200 with the whole body,
@@ -356,6 +403,10 @@ def _downloaded_blob_is_intact(state: RequestState, target: Path) -> bool:
         )
         return False
     return True
+
+
+def _partial_path(target: Path) -> Path:
+    return target.with_suffix(f"{target.suffix}.partial")
 
 
 def _sleep_bounded(seconds: float, deadline: float) -> None:

--- a/tests/ecmwf/archive_gribs/ecds_client_test.py
+++ b/tests/ecmwf/archive_gribs/ecds_client_test.py
@@ -538,3 +538,200 @@ def test_constraints_and_costing_post_to_the_unauthenticated_endpoints() -> None
     assert session.post.call_args.args[0].endswith(
         "/retrieve/v1/processes/s2s-forecasts/costing"
     )
+
+
+def test_a_job_whose_results_are_gone_is_submitted_again(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    """ECDS purges a finished job's result; a resumed job whose result has expired must be replaced, not polled."""
+    payload = {"variable": ["total_precipitation"]}
+    state_store = StateStore(tmp_path / "state.json")
+    state_store.write(RequestState("job-1", payload, "now", "status"))
+    session = session_mock()
+    session.post.return_value = response({"jobID": "job-2"})
+    download_response = response({})
+    download_response.iter_content.return_value = [grib_message()]
+    session.get.side_effect = [
+        response(
+            {"status": "successful", "links": [{"rel": "results", "href": "results"}]}
+        ),
+        response({"title": "Not Found"}, status_code=404),
+        response({"status": "successful", "asset": {"value": {"href": "blob"}}}),
+        download_response,
+    ]
+
+    EcdsRequest(state_store, session=session).retrieve(
+        payload, tmp_path / "blob.grib2", poll_seconds=30, resubmit_wait_seconds=60
+    )
+
+    assert clock.sleeps == [60]
+    session.post.assert_called_once()
+    assert state_store.read().request_id == "job-2"
+    assert (tmp_path / "blob.grib2").exists()
+
+
+def test_a_job_ecds_no_longer_knows_is_submitted_again(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    payload = {"variable": ["total_precipitation"]}
+    state_store = StateStore(tmp_path / "state.json")
+    state_store.write(RequestState("job-1", payload, "now", "status"))
+    session = session_mock()
+    session.post.return_value = response({"jobID": "job-2"})
+    download_response = response({})
+    download_response.iter_content.return_value = [grib_message()]
+    session.get.side_effect = [
+        response({"title": "Not Found"}, status_code=404),
+        response({"status": "successful", "asset": {"value": {"href": "blob"}}}),
+        download_response,
+    ]
+
+    EcdsRequest(state_store, session=session).retrieve(
+        payload, tmp_path / "blob.grib2", poll_seconds=30, resubmit_wait_seconds=60
+    )
+
+    session.post.assert_called_once()
+    assert state_store.read().request_id == "job-2"
+
+
+def test_an_expired_job_is_recorded_as_terminal(tmp_path: Path) -> None:
+    state_store = StateStore(tmp_path / "state.json")
+    state_store.write(RequestState("job-1", {}, "now", "status"))
+    session = session_mock()
+    session.get.return_value = response({"title": "Not Found"}, status_code=404)
+
+    with pytest.raises(EcdsJobFailedError, match="job-1 ended with status expired"):
+        EcdsRequest(state_store, session=session).poll_until_complete(30, 240)
+
+    state = state_store.read()
+    assert state.status == "expired"
+    assert "404" in state.errors[-1]
+
+
+def test_retrieve_replaces_a_job_whose_polling_is_exhausted(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    payload = {"variable": ["total_precipitation"]}
+    state_store = StateStore(tmp_path / "state.json")
+    session = session_mock()
+    session.post.side_effect = [
+        response({"jobID": "job-1"}),
+        response({"jobID": "job-2"}),
+    ]
+    download_response = response({})
+    download_response.iter_content.return_value = [grib_message()]
+    running = response({"status": "running"})
+    session.get.side_effect = [running] * 240 + [
+        response({"status": "successful", "asset": {"value": {"href": "blob"}}}),
+        download_response,
+    ]
+
+    EcdsRequest(state_store, session=session).retrieve(
+        payload, tmp_path / "blob.grib2", poll_seconds=30, maximum_polls=240
+    )
+
+    assert clock.now >= 30 * 240
+    assert session.post.call_count == 2
+    assert state_store.read().request_id == "job-2"
+    assert (tmp_path / "blob.grib2").exists()
+
+
+def test_retrieve_gives_up_after_the_replacement_job_also_exhausts_polling(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    payload = {"variable": ["total_precipitation"]}
+    state_store = StateStore(tmp_path / "state.json")
+    session = session_mock()
+    session.post.side_effect = [response({"jobID": f"job-{n}"}) for n in range(1, 6)]
+    session.get.return_value = response({"status": "running"})
+
+    with pytest.raises(TimeoutError, match="did not complete within 3 polls"):
+        EcdsRequest(state_store, session=session).retrieve(
+            payload, tmp_path / "blob.grib2", poll_seconds=30, maximum_polls=3
+        )
+
+    assert session.post.call_count == 2
+    assert state_store.read().status == "abandoned"
+
+    session.post.reset_mock()
+    with pytest.raises(TimeoutError):
+        EcdsRequest(state_store, session=session).retrieve(
+            payload, tmp_path / "blob.grib2", poll_seconds=30, maximum_polls=3
+        )
+
+    assert session.post.call_args_list[0].kwargs["json"] == {"inputs": payload}
+
+
+def test_a_replacement_job_does_not_resume_the_abandoned_jobs_partial_download(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    payload = {"variable": ["total_precipitation"]}
+    target = tmp_path / "blob.grib2"
+    target.with_suffix(".grib2.partial").write_bytes(b"bytes of job-1")
+    state_store = StateStore(tmp_path / "state.json")
+    state_store.write(RequestState("job-1", payload, "now", "status", status="failed"))
+    session = session_mock()
+    session.post.return_value = response({"jobID": "job-2"})
+    download_response = response({})
+    download_response.iter_content.return_value = [grib_message()]
+    session.get.side_effect = [
+        response({"status": "successful", "asset": {"value": {"href": "blob"}}}),
+        download_response,
+    ]
+
+    EcdsRequest(state_store, session=session).retrieve(payload, target, poll_seconds=0)
+
+    assert session.get.call_args.kwargs["headers"] == {}
+    assert target.read_bytes() == grib_message()
+
+
+def test_a_result_that_is_gone_at_download_time_is_submitted_again(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    payload = {"variable": ["total_precipitation"]}
+    state_store = StateStore(tmp_path / "state.json")
+    state_store.write(RequestState("job-1", payload, "now", "status"))
+    session = session_mock()
+    session.post.return_value = response({"jobID": "job-2"})
+    successful = response(
+        {"status": "successful", "asset": {"value": {"href": "blob"}}}
+    )
+    gone = response({}, status_code=404)
+    download_response = response({})
+    download_response.iter_content.return_value = [grib_message()]
+    session.get.side_effect = [successful, gone, successful, download_response]
+
+    EcdsRequest(state_store, session=session).retrieve(
+        payload, tmp_path / "blob.grib2", poll_seconds=30, resubmit_wait_seconds=60
+    )
+
+    gone.close.assert_called_once_with()
+    assert clock.sleeps == [60]
+    assert state_store.read().request_id == "job-2"
+    assert (tmp_path / "blob.grib2").read_bytes() == grib_message()
+
+
+def test_a_result_that_keeps_disappearing_exhausts_the_budget(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    payload = {"variable": ["total_precipitation"]}
+    state_store = StateStore(tmp_path / "state.json")
+    session = session_mock()
+    session.post.side_effect = [response({"jobID": f"job-{n}"}) for n in range(1, 10)]
+    successful = response(
+        {"status": "successful", "asset": {"value": {"href": "blob"}}}
+    )
+    session.get.side_effect = [successful, response({}, status_code=404)] * 9
+
+    with pytest.raises(EcdsJobFailedError, match="job-4 ended with status expired"):
+        EcdsRequest(state_store, session=session).retrieve(
+            payload,
+            tmp_path / "blob.grib2",
+            poll_seconds=0,
+            resubmit_wait_seconds=10,
+            resubmit_budget_seconds=100,
+        )
+
+    assert clock.sleeps == [10, 20, 40]
+    assert state_store.read().status == "expired"
+    assert not any("blob" in error for error in state_store.read().errors)

--- a/tests/ecmwf/archive_gribs/ecds_client_test.py
+++ b/tests/ecmwf/archive_gribs/ecds_client_test.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 import requests
@@ -653,13 +653,18 @@ def test_retrieve_gives_up_after_the_replacement_job_also_exhausts_polling(
     assert session.post.call_count == 2
     assert state_store.read().status == "abandoned"
 
-    session.post.reset_mock()
+    session.reset_mock()
     with pytest.raises(TimeoutError):
         EcdsRequest(state_store, session=session).retrieve(
             payload, tmp_path / "blob.grib2", poll_seconds=30, maximum_polls=3
         )
 
-    assert session.post.call_args_list[0].kwargs["json"] == {"inputs": payload}
+    # An abandoned job is replaced before any poll, not resumed for another budget.
+    assert session.mock_calls[0] == call.post(
+        "https://ecds.ecmwf.int/api/retrieve/v1/processes/s2s-forecasts/execution",
+        json={"inputs": payload},
+        timeout=60,
+    )
 
 
 def test_a_replacement_job_does_not_resume_the_abandoned_jobs_partial_download(


### PR DESCRIPTION
## Why

The ECMWF IFS ENS 46-day GRIB history walk (the `archive-grib-files` process on `ecmwf-backfill`) wrote nothing after 2026-09-05T04:55Z. It died with:

```
TimeoutError: ECDS job did not complete within 240 polls of 30s
```

**Root cause: resuming request state whose ECDS result had expired.** Eight selections of 2026-02-11 still had `request_state.json` files from the walk of 2026-08-28 (that process was killed mid-download for the #978 restart). On 2026-09-05 `EcdsRequest.retrieve` found the same payload, not `downloaded`, not in a terminal status, so it resumed those 8-day-old jobs. ECDS still reports them `successful` but their results are gone: each state file on the host records nine `404 Client Error: Not Found for url: .../jobs/<id>/results`. The client treated the 404 as a transient transport error, backed off to the 2 h poll deadline, and raised `TimeoutError`, which nothing catches. Seven of eight pool threads were stuck this way; only one was submitting fresh jobs. A 404 on a job's result is not a slow job, it is a job that must be replaced.

**Why nothing restarted it.** The host's `ecmwf-46d-backfill.service` (`Restart=on-failure`, `RestartSec=5min`) runs `run.sh`, which still invokes `main ecmwf-ifs-ens-forecast-46-day-1-5-degree archive-grib-files`; the archiver's typer has been `ecmwf-ifs-ens-46-day-gribs` since #926, so every start exits 2 with `No such command` (1038 times since the walk died). The 2026-09-04 run was started by hand in tmux.

## What

- `poll_once`: a 404 from the job's status URL or its results link marks the job `expired`; `download`: a 404 on the result marks it `expired` and raises `EcdsJobFailedError`. `expired` and `abandoned` (below) join `TERMINAL_FAILURE_STATUSES`, so `retrieve` resubmits them within the existing 1 h budget, in-process and on a later run alike.
- `poll_until_complete` marks a job `abandoned` before raising `TimeoutError`; `retrieve` replaces an abandoned job once and lets a second `TimeoutError` through.
- Download moves inside `retrieve`'s resubmission loop, so a result gone at download time is replaced too (the #1005 "not in this PR" case).
- Every resubmission discards the previous job's `.partial` download, so a new result is never range-resumed onto another job's bytes.
- `archive.py` unchanged: a persistent problem still stops the walk and systemd restarts it.

Tests with the fake clock: results 404, status 404 and download 404 each lead to one resubmission and a download; a persistent download 404 exhausts the budget; polling exhaustion is replaced once and a second exhaustion raises with `abandoned` persisted, after which a fresh `retrieve` submits; a replacement does not resume the abandoned partial. The three 404 tests and the two exhaustion tests fail on main.

## Deploy

**The walk on the host must be relaunched with the renamed command.** Recipe (also in the session report): stop the unit, `git pull --ff-only && uv sync`, `rm -rf data/download/ecmwf-s2s-archive/2026-02-11` (eight expired 2026-08-28 states and 9 GB of their partials, nothing downloaded whole), change `run.sh` to `main ecmwf-ifs-ens-46-day-gribs archive-grib-files s2s-backfill --init-times-back 1300`, start the unit. 1300 reaches the 2023-06-28 floor from today's newest init (1167 needed) with headroom; `init_times_to_archive` drops dates before the floor.

## Plan

- [x] Root cause from the log and the host's request-state files
- [x] Expired / abandoned statuses, replacement in `retrieve`, partial discarded on resubmission
- [x] Red/green tests with the fake clock
- [x] `ruff format`, `ruff check`, `ty check`, archiver tests (85 passed)
- [x] `pytest -m "not slow"` (2817 passed)
- [x] Codex review; one P3 taken (the restart test now pins that an abandoned job is POSTed before any GET; verified it fails with `abandoned` removed from the terminal set)
- [x] Ready for review
- [ ] Merge, then relaunch the walk on the host with the recipe above

## Log

### 2026-09-08 — diagnosed and fixed

Host inspected read-only over ssh: unit, `run.sh`, tmux panes, the eight state files (all `successful`, 9 poll failures, 404 on results), no stale state elsewhere. Second-look (Codex) challenged the design: one terminal set rather than a flag, download 404 folded in, partial cleanup before every submission, recipe hardened (absolute paths, verify the `sed` matched).

### 2026-09-08 — review and retro

Codex reviewer found no production defect; its one finding was a test that passed for the wrong reason, now fixed. Retro: the log alone pointed at a "slow ECDS job"; the host's `request_state.json` files settled it in one ssh read (404 on results, 8-day-old jobs). Reading the launcher on the host, not inferring it from the log, is what turned a proposed new systemd unit into a one-line `run.sh` edit.

https://claude.ai/code/session_01SUTcgDaKwreufZXRSFpwEP

