### PR TITLE
Back off exponentially between retries

### DIFF
--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -13,12 +13,12 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import httpx
-import numpy as np
 import obstore
 import requests
 from obstore.exceptions import GenericError, PermissionDeniedError
 
 from reformatters.common.logging import get_logger
+from reformatters.common.retry import sleep_before_retry
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
@@ -232,8 +232,6 @@ class RateLimiter:
 
 _DEFAULT_RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
 _MAX_RETRIES = 16
-_INIT_BACKOFF_SECONDS = 1.0
-_MAX_BACKOFF_SECONDS = 16.0
 _RETRY_TIMEOUT_SECONDS = 300.0
 
 
@@ -244,7 +242,6 @@ def _httpx_get_with_retry(
     retry_status_codes: set[int] = _DEFAULT_RETRY_STATUS_CODES,
 ) -> httpx.Response:
     client = _httpx_client()
-    rng = np.random.default_rng()
     start_time = time.monotonic()
 
     last_exception: Exception | None = None
@@ -253,11 +250,7 @@ def _httpx_get_with_retry(
             break
 
         if attempt > 0:
-            backoff = min(
-                _INIT_BACKOFF_SECONDS * (2 ** (attempt - 1)), _MAX_BACKOFF_SECONDS
-            )
-            jitter = rng.uniform(0.5, 1.5)
-            time.sleep(backoff * jitter)
+            sleep_before_retry(attempt - 1)
 
         if rate_limiter is not None:
             rate_limiter.wait()

--- a/src/reformatters/common/download.py
+++ b/src/reformatters/common/download.py
@@ -18,7 +18,7 @@ import requests
 from obstore.exceptions import GenericError, PermissionDeniedError
 
 from reformatters.common.logging import get_logger
-from reformatters.common.retry import sleep_before_retry
+from reformatters.common.retry import exponential_backoff_time
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
@@ -250,7 +250,7 @@ def _httpx_get_with_retry(
             break
 
         if attempt > 0:
-            sleep_before_retry(attempt - 1)
+            time.sleep(exponential_backoff_time(attempt - 1))
 
         if rate_limiter is not None:
             rate_limiter.wait()

--- a/src/reformatters/common/retry.py
+++ b/src/reformatters/common/retry.py
@@ -3,13 +3,22 @@ from collections.abc import Callable
 
 import numpy as np
 
+_INIT_BACKOFF_SECONDS = 1.0
+_MAX_BACKOFF_SECONDS = 16.0
+
+
+def sleep_before_retry(attempt: int) -> None:
+    """Sleep after the given 0-indexed failed attempt, backing off exponentially with jitter."""
+    backoff = min(_INIT_BACKOFF_SECONDS * 2**attempt, _MAX_BACKOFF_SECONDS)
+    time.sleep(backoff * np.random.default_rng().uniform(0.8, 1.2))
+
 
 def retry[T](
     func: Callable[[], T],
     max_attempts: int = 6,
     retryable_exceptions: tuple[type[Exception], ...] = (Exception,),
 ) -> T:
-    """Simple retry utility that sleeps for a short time between attempts."""
+    """Retry utility that backs off exponentially between attempts."""
     last_exception = None
     for attempt in range(max_attempts):
         try:
@@ -17,7 +26,6 @@ def retry[T](
         except retryable_exceptions as e:
             last_exception = e
             if attempt < max_attempts - 1:  # sleep unless we're out of attempts
-                rng = np.random.default_rng()
-                time.sleep(attempt * rng.uniform(0.8, 1.2) + 0.1)
+                sleep_before_retry(attempt)
 
     raise last_exception or AssertionError("unreachable")

--- a/src/reformatters/common/retry.py
+++ b/src/reformatters/common/retry.py
@@ -3,14 +3,14 @@ from collections.abc import Callable
 
 import numpy as np
 
-_INIT_BACKOFF_SECONDS = 1.0
 _MAX_BACKOFF_SECONDS = 16.0
 
 
-def sleep_before_retry(attempt: int) -> None:
-    """Sleep after the given 0-indexed failed attempt, backing off exponentially with jitter."""
-    backoff = min(_INIT_BACKOFF_SECONDS * 2**attempt, _MAX_BACKOFF_SECONDS)
-    time.sleep(backoff * np.random.default_rng().uniform(0.8, 1.2))
+def exponential_backoff_time(attempt: int) -> float:
+    """Seconds to sleep after the given 0-indexed failed attempt: 0.2s, then 1s
+    doubling to a 16s cap, each jittered down to as little as half its value."""
+    max_delay = 0.2 if attempt == 0 else min(2.0 ** (attempt - 1), _MAX_BACKOFF_SECONDS)
+    return float(np.random.default_rng().uniform(0.5 * max_delay, max_delay))
 
 
 def retry[T](
@@ -26,6 +26,6 @@ def retry[T](
         except retryable_exceptions as e:
             last_exception = e
             if attempt < max_attempts - 1:  # sleep unless we're out of attempts
-                sleep_before_retry(attempt)
+                time.sleep(exponential_backoff_time(attempt))
 
     raise last_exception or AssertionError("unreachable")

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -28,7 +28,7 @@ from reformatters.common.region_job import (
     RegionJob,
     SourceFileResult,
 )
-from reformatters.common.retry import sleep_before_retry
+from reformatters.common.retry import exponential_backoff_time
 from reformatters.common.types import AppendDim, DatetimeLike, Dim, Timedelta, Timestamp
 
 log = get_logger(__name__)
@@ -745,7 +745,7 @@ def _exists_many(
             return result
         pending = failed
         if attempt < max_attempts - 1:
-            sleep_before_retry(attempt)
+            time.sleep(exponential_backoff_time(attempt))
 
     assert last_exception is not None
     raise last_exception

--- a/src/reformatters/common/virtual_region_job.py
+++ b/src/reformatters/common/virtual_region_job.py
@@ -28,6 +28,7 @@ from reformatters.common.region_job import (
     RegionJob,
     SourceFileResult,
 )
+from reformatters.common.retry import sleep_before_retry
 from reformatters.common.types import AppendDim, DatetimeLike, Dim, Timedelta, Timestamp
 
 log = get_logger(__name__)
@@ -744,9 +745,7 @@ def _exists_many(
             return result
         pending = failed
         if attempt < max_attempts - 1:
-            rng = np.random.default_rng()
-            # First retry waits ~0.1s; back off only from the second retry onward.
-            time.sleep(max(0, attempt - 1) * rng.uniform(0.8, 1.2) + 0.1)
+            sleep_before_retry(attempt)
 
     assert last_exception is not None
     raise last_exception

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -225,7 +225,6 @@ def sync_to_store(store: Store, key: str, data: bytes) -> None:
             ),
             timeout=90,  # In seconds. Timeout needs to be long enough to upload a large shard.
         ),
-        # Transient object store 5xx bursts can outlast the default retry window.
         max_attempts=10,
     )
 

--- a/src/reformatters/common/zarr.py
+++ b/src/reformatters/common/zarr.py
@@ -225,7 +225,8 @@ def sync_to_store(store: Store, key: str, data: bytes) -> None:
             ),
             timeout=90,  # In seconds. Timeout needs to be long enough to upload a large shard.
         ),
-        max_attempts=6,
+        # Transient object store 5xx bursts can outlast the default retry window.
+        max_attempts=10,
     )
 
 

--- a/tests/common/retry_test.py
+++ b/tests/common/retry_test.py
@@ -2,36 +2,62 @@ from unittest.mock import Mock
 
 import pytest
 
+from reformatters.common import retry as retry_module
 from reformatters.common.retry import retry
 
 
-def test_retry_succeeds_on_first_attempt() -> None:
+@pytest.fixture
+def sleeps(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    recorded: list[float] = []
+    monkeypatch.setattr(retry_module.time, "sleep", recorded.append)
+    return recorded
+
+
+def test_retry_succeeds_on_first_attempt(sleeps: list[float]) -> None:
     mock_func = Mock(return_value="success")
     result = retry(mock_func)
     assert result == "success"
+    assert sleeps == []
 
 
-def test_retry_succeeds_after_failures() -> None:
+def test_retry_succeeds_after_failures(sleeps: list[float]) -> None:
     mock_func = Mock(side_effect=[ValueError("fail"), "success"])
     result = retry(mock_func, max_attempts=3)
     assert result == "success"
+    assert len(sleeps) == 1
 
 
-def test_retry_fails_after_max_attempts() -> None:
+def test_retry_fails_after_max_attempts(sleeps: list[float]) -> None:
     mock_func = Mock(side_effect=ValueError("persistent failure"))
     with pytest.raises(ValueError, match="persistent failure"):
         retry(mock_func, max_attempts=2)
+    assert len(sleeps) == 1
 
 
-def test_retryable_exceptions_retries_matching() -> None:
+def test_retryable_exceptions_retries_matching(sleeps: list[float]) -> None:
     mock_func = Mock(side_effect=[ValueError("transient"), "success"])
     result = retry(mock_func, max_attempts=3, retryable_exceptions=(ValueError,))
     assert result == "success"
     assert mock_func.call_count == 2
 
 
-def test_retryable_exceptions_propagates_non_matching() -> None:
+def test_retryable_exceptions_propagates_non_matching(sleeps: list[float]) -> None:
     mock_func = Mock(side_effect=TypeError("not retryable"))
     with pytest.raises(TypeError, match="not retryable"):
         retry(mock_func, max_attempts=3, retryable_exceptions=(ValueError,))
     assert mock_func.call_count == 1
+    assert sleeps == []
+
+
+def test_retry_backoff_grows_exponentially_then_caps(sleeps: list[float]) -> None:
+    mock_func = Mock(side_effect=OSError("transient"))
+    with pytest.raises(OSError, match="transient"):
+        retry(mock_func, max_attempts=8)
+
+    # Doubling from 1s, capped at 16s, each with +/-20% jitter.
+    expected_unjittered = [1, 2, 4, 8, 16, 16, 16]
+    assert len(sleeps) == len(expected_unjittered)
+    for slept, expected in zip(sleeps, expected_unjittered, strict=True):
+        assert 0.8 * expected <= slept <= 1.2 * expected
+    # Long enough in total to ride out a transient object store outage.
+    assert sum(sleeps) > 50

--- a/tests/common/retry_test.py
+++ b/tests/common/retry_test.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from reformatters.common import retry as retry_module
-from reformatters.common.retry import retry
+from reformatters.common.retry import exponential_backoff_time, retry
 
 
 @pytest.fixture
@@ -49,15 +49,21 @@ def test_retryable_exceptions_propagates_non_matching(sleeps: list[float]) -> No
     assert sleeps == []
 
 
-def test_retry_backoff_grows_exponentially_then_caps(sleeps: list[float]) -> None:
+def test_retry_sleeps_between_every_attempt(sleeps: list[float]) -> None:
     mock_func = Mock(side_effect=OSError("transient"))
     with pytest.raises(OSError, match="transient"):
         retry(mock_func, max_attempts=8)
 
-    # Doubling from 1s, capped at 16s, each with +/-20% jitter.
-    expected_unjittered = [1, 2, 4, 8, 16, 16, 16]
-    assert len(sleeps) == len(expected_unjittered)
-    for slept, expected in zip(sleeps, expected_unjittered, strict=True):
-        assert 0.8 * expected <= slept <= 1.2 * expected
+    assert len(sleeps) == 7
+
+
+def test_exponential_backoff_time_grows_then_caps() -> None:
+    max_delays = [0.2, 1, 2, 4, 8, 16, 16, 16]
+    for attempt, max_delay in enumerate(max_delays):
+        # Jitter takes each delay down to as little as half its maximum.
+        times = [exponential_backoff_time(attempt) for _ in range(50)]
+        assert all(0.5 * max_delay <= t <= max_delay for t in times)
+        assert min(times) < 0.75 * max_delay < max(times)
+
     # Long enough in total to ride out a transient object store outage.
-    assert sum(sleeps) > 50
+    assert sum(exponential_backoff_time(a) for a in range(9)) > 35


### PR DESCRIPTION
## What

Follow-up on [REFORMATTERS-JW](https://dynamical.sentry.io/issues/7714868749/): `PutObject` returning `InternalError` while copying metadata in the `nasa-smap-level3-36km-v9` update.

We *are* retrying that exception — `sync_to_store` wraps the write in `retry(..., max_attempts=6)` and `OSError` is retryable by default — but the retry window was far too short to be worth anything against a provider 5xx:

- `retry` slept `attempt * ~1s + 0.1`, so six attempts spanned ~10s of sleep total.
- By the time one of our attempts fails, s3fs/botocore has already exhausted its own 4 retries (`reached max retries: 4` in the event). Our layer's only job is to wait meaningfully longer, and ~10s isn't that.

## Changes

- One shared backoff schedule, `exponential_backoff_time(attempt) -> float`: 0.2s, then 1s doubling to a 16s cap, each jittered down to as little as half its value. Callers do the sleeping. `_exists_many` and `_httpx_get_with_retry` retry a subset of their work so they can't call `retry` directly, but they no longer carry their own backoff formulas.
- `sync_to_store` goes to 10 attempts: ~40–80s of sleep across attempts (plus each attempt's own client-level retries) instead of ~10s. It's the last-mile write that publishes an update, so a minute of retrying is cheap.

## Caveat on the linked issue

This does not claim to fix that particular run. The Sep 9 failures were six pod attempts of one k8s job (`backoffLimitPerIndex: 5`) failing at 06:02, 06:05, 06:08, 06:11, 06:18 and 06:23 — the same write failed across 21 minutes, longer than any sane in-process backoff. The 18:00 run succeeded. Sep 6 looks like the case this does help: two failures three minutes apart, then a later pod attempt succeeded.

Two things worth noting separately, not changed here:

- The store is Cloudflare R2 (`upstream-gridded-zarrs`), not S3, and `InternalError` on `PutObject` is a documented R2 failure mode; the 21-minute span looks like an R2 episode rather than a code fault.
- A `_copy_metadata_files` failure part-way through leaves a zarr v3 store with some arrays' `zarr.json` extended and others not. There is no crash-safe ordering for non-atomic metadata — that's what icechunk solves — and this dataset lives in `contrib/` so it isn't in the published catalogs, but it's why the retry window on this specific write matters.

## Testing

`uv run ruff format && uv run ruff check && uv run ty check` clean; `uv run pytest -m "not slow"` (2822 passed) and the slow tests under `tests/common/` (124 passed). Retry tests record sleeps instead of taking them, and pin the backoff schedule and its jitter band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012z3FKHrDZbqJPDSG1gnRdq