### PR TITLE
Allow Sentry check-ins 15 seconds to flush

### DIFF
--- a/src/reformatters/common/monitoring.py
+++ b/src/reformatters/common/monitoring.py
@@ -60,7 +60,7 @@ def monitor_cron(
             },
         )
         if status != "in_progress":
-            sentry_sdk.flush()  # make sure final events reach sentry
+            sentry_sdk.flush(timeout=15)  # make sure final events reach sentry
 
     if send_in_progress:
         capture_checkin("in_progress")

--- a/tests/common/monitoring_test.py
+++ b/tests/common/monitoring_test.py
@@ -28,7 +28,9 @@ _CRON_JOB = CronJob(
 def test_monitor_cron_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(type(Config), "is_sentry_enabled", True)
     mock_capture = Mock()
+    mock_flush = Mock()
     monkeypatch.setattr(sentry_sdk.crons, "capture_checkin", mock_capture)
+    monkeypatch.setattr(sentry_sdk, "flush", mock_flush)
 
     with monitor_cron(_CRON_JOB, "job-name"):
         pass
@@ -38,13 +40,16 @@ def test_monitor_cron_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None
     call_kwargs = mock_capture.call_args_list[0].kwargs
     assert call_kwargs["monitor_config"]["schedule"]["value"] == "0 4 * * *"
     assert call_kwargs["monitor_config"]["max_runtime"] == 120
+    mock_flush.assert_called_once_with(timeout=15)
 
     mock_capture.reset_mock()
+    mock_flush.reset_mock()
     with pytest.raises(ValueError, match="failure"):  # noqa: SIM117
         with monitor_cron(_CRON_JOB, "job-name"):
             raise ValueError("failure")
     statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
     assert statuses == ["in_progress", "error"]
+    mock_flush.assert_called_once_with(timeout=15)
 
 
 def test_monitor_cron_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Two successful validation pods recently lost their final Sentry `ok` check-in and were reported as timed out. The SDK's default flush allowance is two seconds, so a brief transport delay can outlive the process.

Allow terminal cron check-ins 15 seconds to flush before shutdown, and verify the timeout for both `ok` and `error` results.

Validation:
- `uv run pytest tests/common/monitoring_test.py`
- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check --output-format concise`
