### PR TITLE
Retry terminal Sentry cron check-ins

### DIFF
--- a/src/reformatters/common/monitoring.py
+++ b/src/reformatters/common/monitoring.py
@@ -46,21 +46,26 @@ def monitor_cron(
     monitor_slug = os.getenv("CRON_JOB_NAME") or cron_job.name
 
     def capture_checkin(status: Literal["ok", "in_progress", "error"]) -> None:
-        sentry_sdk.crons.capture_checkin(
-            monitor_slug=monitor_slug,
-            check_in_id=digest([reformat_job_name], length=32),
-            status=status,
-            monitor_config={
-                "schedule": {"type": "crontab", "value": cron_job.schedule},
-                "timezone": "UTC",
-                "checkin_margin": 10,
-                "max_runtime": int(cron_job.pod_active_deadline.total_seconds() / 60),
-                "failure_issue_threshold": 1,
-                "recovery_threshold": 1,
-            },
-        )
-        if status != "in_progress":
-            sentry_sdk.flush(timeout=15)  # make sure final events reach sentry
+        check_in_id = digest([reformat_job_name], length=32)
+        attempts = 1 if status == "in_progress" else 2
+        for _ in range(attempts):
+            sentry_sdk.crons.capture_checkin(
+                monitor_slug=monitor_slug,
+                check_in_id=check_in_id,
+                status=status,
+                monitor_config={
+                    "schedule": {"type": "crontab", "value": cron_job.schedule},
+                    "timezone": "UTC",
+                    "checkin_margin": 10,
+                    "max_runtime": int(
+                        cron_job.pod_active_deadline.total_seconds() / 60
+                    ),
+                    "failure_issue_threshold": 1,
+                    "recovery_threshold": 1,
+                },
+            )
+            if status != "in_progress":
+                sentry_sdk.flush(timeout=15)  # make sure final events reach sentry
 
     if send_in_progress:
         capture_checkin("in_progress")

--- a/tests/common/monitoring_test.py
+++ b/tests/common/monitoring_test.py
@@ -1,7 +1,7 @@
 import logging
 import signal
 from datetime import timedelta
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 import sentry_sdk
@@ -35,12 +35,13 @@ def test_monitor_cron_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None
     with monitor_cron(_CRON_JOB, "job-name"):
         pass
     statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
-    assert statuses == ["in_progress", "ok"]
+    assert statuses == ["in_progress", "ok", "ok"]
+    assert len({c.kwargs["check_in_id"] for c in mock_capture.call_args_list}) == 1
 
     call_kwargs = mock_capture.call_args_list[0].kwargs
     assert call_kwargs["monitor_config"]["schedule"]["value"] == "0 4 * * *"
     assert call_kwargs["monitor_config"]["max_runtime"] == 120
-    mock_flush.assert_called_once_with(timeout=15)
+    assert mock_flush.call_args_list == [call(timeout=15)] * 2
 
     mock_capture.reset_mock()
     mock_flush.reset_mock()
@@ -48,8 +49,8 @@ def test_monitor_cron_success_and_error(monkeypatch: pytest.MonkeyPatch) -> None
         with monitor_cron(_CRON_JOB, "job-name"):
             raise ValueError("failure")
     statuses = [c.kwargs["status"] for c in mock_capture.call_args_list]
-    assert statuses == ["in_progress", "error"]
-    mock_flush.assert_called_once_with(timeout=15)
+    assert statuses == ["in_progress", "error", "error"]
+    assert mock_flush.call_args_list == [call(timeout=15)] * 2
 
 
 def test_monitor_cron_without_sentry(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
The 06:20 UTC HRRR analysis virtual validation completed successfully after #1050 was deployed, but Sentry again retained only its `in_progress` check-in. A longer flush wait cannot recover an HTTP send that the Sentry SDK has already dropped; the SDK does not retry failed envelopes. This matches getsentry/sentry-python#5423.

Send each terminal `ok` or `error` update twice with the same deterministic check-in ID, flushing for up to 15 seconds after each attempt. The repeated update is idempotent in Sentry and gives a transient failed send another chance without creating another logical run.

Validation:
- `uv run pytest tests/common/monitoring_test.py`
- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check --output-format concise`
